### PR TITLE
feat: add health_check() function for API connectivity

### DIFF
--- a/src/asqav/__init__.py
+++ b/src/asqav/__init__.py
@@ -74,6 +74,7 @@ from .client import (
     get_session_signatures,
     get_signing_group,
     group_sign,
+    health_check,
     init,
     list_delegations,
     list_entities,
@@ -96,6 +97,7 @@ __version__ = "0.2.6"
 __all__ = [
     # Initialization
     "init",
+    "health_check",
     # Agent
     "Agent",
     "AgentResponse",

--- a/src/asqav/client.py
+++ b/src/asqav/client.py
@@ -923,6 +923,23 @@ class Agent:
         )
 
 
+def health_check() -> dict[str, Any]:
+    """Check API connectivity and return server status.
+    
+    Returns:
+        Dict with server status info.
+    
+    Raises:
+        AuthenticationError: If API key is invalid.
+        APIError: If the API is unreachable.
+    
+    Example:
+        status = asqav.health_check()
+        print(f"API version: {status['version']}")
+    """
+    return _get("/health")
+
+
 def init(
     api_key: str | None = None,
     base_url: str | None = None,


### PR DESCRIPTION
Add health_check() function to verify API connectivity and return server status.

**Changes:**
- Add `health_check()` function that calls `/health` endpoint
- Returns server status information
- Useful for testing API access before making requests
- Exported in public API

**Related:** Part of API reliability improvements (#14)