### PR TITLE
feat: add smolagents (Hugging Face) integration

### DIFF
--- a/examples/smolagents_example.py
+++ b/examples/smolagents_example.py
@@ -1,0 +1,94 @@
+"""smolagents integration example for asqav.
+
+Demonstrates how to wrap smolagents tools with asqav governance so every
+tool invocation is signed and recorded in the audit trail.
+
+Requirements:
+    pip install asqav[smolagents]
+
+Usage:
+    ASQAV_API_KEY=sk_... python examples/smolagents_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import asqav
+from asqav.extras.smolagents import AsqavSmolagentsHook
+
+try:
+    from smolagents import CodeAgent, HfApiModel, tool
+except ImportError:
+    raise SystemExit(
+        "smolagents is required for this example.\n"
+        "Install with: pip install asqav[smolagents]"
+    )
+
+# ---------------------------------------------------------------------------
+# Initialise asqav
+# ---------------------------------------------------------------------------
+
+api_key = os.environ.get("ASQAV_API_KEY", "")
+if not api_key:
+    raise SystemExit(
+        "Set the ASQAV_API_KEY environment variable before running this example.\n"
+        "Get your key at https://asqav.com"
+    )
+
+asqav.init(api_key=api_key)
+
+# Create a governance hook - one hook can wrap multiple tools.
+hook = AsqavSmolagentsHook(agent_name="smolagents-demo")
+
+# ---------------------------------------------------------------------------
+# Define tools and wrap them with asqav signing
+# ---------------------------------------------------------------------------
+
+
+@tool
+def search_web(query: str) -> str:
+    """Search the web for up-to-date information.
+
+    Args:
+        query: The search query string.
+    """
+    # Replace with a real search implementation.
+    return f"Search results for: {query}"
+
+
+@tool
+def read_file(path: str) -> str:
+    """Read the contents of a local file.
+
+    Args:
+        path: Absolute or relative path to the file.
+    """
+    try:
+        with open(path) as f:
+            return f.read()
+    except OSError as exc:
+        return f"Error reading file: {exc}"
+
+
+# Wrap each tool - this patches tool.forward to sign every call.
+signed_search = hook.wrap_tool(search_web)
+signed_read = hook.wrap_tool(read_file)
+
+# ---------------------------------------------------------------------------
+# Build and run the agent
+# ---------------------------------------------------------------------------
+
+model = HfApiModel()  # Uses the HF Inference API; set HF_TOKEN env var.
+
+agent = CodeAgent(
+    tools=[signed_search, signed_read],
+    model=model,
+)
+
+print("Running smolagents agent with asqav governance...")
+result = agent.run("Search for the latest news on AI safety and summarise it.")
+
+print("\nAgent result:")
+print(result)
+print("\nView the signed audit trail at https://asqav.com/dashboard")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ keywords = [
     "openai-agents",
     "haystack",
     "llamaindex",
+    "smolagents",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -55,6 +56,7 @@ litellm = ["litellm>=1.0.0"]
 haystack = ["haystack-ai>=2.0.0"]
 openai-agents = ["openai-agents>=0.1.0"]
 llamaindex = ["llama-index-core>=0.10.0"]
+smolagents = ["smolagents>=1.0.0"]
 all = [
     "httpx>=0.24.0",
     "typer>=0.12.0",
@@ -64,6 +66,7 @@ all = [
     "haystack-ai>=2.0.0",
     "openai-agents>=0.1.0",
     "llama-index-core>=0.10.0",
+    "smolagents>=1.0.0",
 ]
 dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0", "ruff>=0.5.0", "mypy>=1.10.0"]
 

--- a/src/asqav/__init__.py
+++ b/src/asqav/__init__.py
@@ -27,6 +27,7 @@ With Decorators:
 Get your API key at asqav.com
 """
 
+from .async_client import AsyncAgent
 from .client import (
     Agent,
     AgentResponse,
@@ -94,12 +95,10 @@ from .client import (
     span,
     update_risk_rule,
     update_signing_group,
-    verify_output,
     verify_attestation,
+    verify_output,
     verify_signature,
 )
-
-from .async_client import AsyncAgent
 from .decorators import async_session, session, sign
 from .local import LocalQueue, local_sign
 from .retry import with_async_retry, with_retry

--- a/src/asqav/async_client.py
+++ b/src/asqav/async_client.py
@@ -15,22 +15,17 @@ Example:
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from typing import Any
 
 from .client import (
-    AgentResponse,
     APIError,
     AsqavError,
     AuthenticationError,
-    CertificateResponse,
     PreflightResult,
     RateLimitError,
-    SDTokenResponse,
     SessionResponse,
     SignatureResponse,
-    TokenResponse,
     VerificationResponse,
     _api_base,
     _api_key,
@@ -57,7 +52,6 @@ def _ensure_httpx() -> None:
 
 def _ensure_initialized() -> None:
     """Ensure the SDK is initialized."""
-    from .client import _api_key
 
     if not _api_key:
         raise AuthenticationError("Call asqav.init() first. Get your API key at asqav.com")
@@ -69,7 +63,6 @@ def _get_config() -> tuple[str, str]:
     Returns:
         Tuple of (api_base, api_key).
     """
-    from .client import _api_base, _api_key
 
     if not _api_key:
         raise AuthenticationError("Call asqav.init() first. Get your API key at asqav.com")

--- a/src/asqav/client.py
+++ b/src/asqav/client.py
@@ -1051,14 +1051,14 @@ class Agent:
 
 def health_check() -> dict[str, Any]:
     """Check API connectivity and return server status.
-    
+
     Returns:
         Dict with server status info.
-    
+
     Raises:
         AuthenticationError: If API key is invalid.
         APIError: If the API is unreachable.
-    
+
     Example:
         status = asqav.health_check()
         print(f"API version: {status['version']}")

--- a/src/asqav/decorators.py
+++ b/src/asqav/decorators.py
@@ -26,11 +26,11 @@ from __future__ import annotations
 
 import functools
 import inspect
-from contextlib import asynccontextmanager, contextmanager
 from collections.abc import AsyncGenerator, Generator
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any, TypeVar
 
-from .client import Agent, AsqavError, SignatureResponse, SessionResponse, get_agent, _post
+from .client import Agent, SessionResponse, SignatureResponse, get_agent
 
 F = TypeVar("F")
 

--- a/src/asqav/extras/__init__.py
+++ b/src/asqav/extras/__init__.py
@@ -7,5 +7,6 @@ Install specific extras:
     pip install asqav[haystack]
     pip install asqav[openai-agents]
     pip install asqav[llamaindex]
+    pip install asqav[smolagents]
     pip install asqav[all]
 """

--- a/src/asqav/extras/smolagents.py
+++ b/src/asqav/extras/smolagents.py
@@ -1,0 +1,128 @@
+"""smolagents (Hugging Face) integration for asqav.
+
+Install: pip install asqav[smolagents]
+
+Usage::
+
+    from smolagents import tool, CodeAgent, HfApiModel
+    from asqav.extras.smolagents import AsqavSmolagentsHook
+
+    hook = AsqavSmolagentsHook(agent_name="my-smolagent")
+
+    @tool
+    def search_web(query: str) -> str:
+        \"\"\"Search the web for information.
+
+        Args:
+            query: The search query string.
+        \"\"\"
+        return "results"
+
+    signed_search = hook.wrap_tool(search_web)
+    agent = CodeAgent(tools=[signed_search], model=HfApiModel())
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    import smolagents  # noqa: F401
+except ImportError:
+    raise ImportError(
+        "smolagents integration requires smolagents. "
+        "Install with: pip install asqav[smolagents]"
+    )
+
+from ._base import AsqavAdapter
+
+logger = logging.getLogger("asqav")
+
+_MAX_LEN = 200
+
+
+class AsqavSmolagentsHook(AsqavAdapter):
+    """Hook that signs smolagents tool call events.
+
+    Wraps smolagents Tool instances to sign ``tool:start``, ``tool:end``,
+    and ``tool:error`` governance events on every tool invocation. All
+    signing is fail-open - governance failures are logged but never
+    interrupt tool or agent execution.
+
+    Args:
+        api_key: Optional API key override (uses ``asqav.init()`` default).
+        agent_name: Name for a new asqav agent (calls ``Agent.create``).
+        agent_id: ID of an existing asqav agent (calls ``Agent.get``).
+    """
+
+    def wrap_tool(self, tool: Any) -> Any:
+        """Wrap a smolagents Tool instance to sign its calls.
+
+        Patches the ``forward`` method on the tool instance so every
+        invocation records signed governance events. The original tool
+        object is returned so it can be passed directly to smolagents
+        agents unchanged.
+
+        Args:
+            tool: A smolagents Tool instance (from the ``@tool`` decorator
+                  or a ``Tool`` subclass).
+
+        Returns:
+            The same tool instance with signing wired into ``forward``.
+        """
+        hook = self
+        original_forward = tool.forward
+        tool_name: str = getattr(tool, "name", type(tool).__name__)
+
+        def _signed_forward(*args: Any, **kwargs: Any) -> Any:
+            # Build a concise input preview for the audit record.
+            if args:
+                input_preview = str(args[0])[:_MAX_LEN]
+            elif kwargs:
+                input_preview = str(next(iter(kwargs.values())))[:_MAX_LEN]
+            else:
+                input_preview = ""
+
+            try:
+                hook._sign_action(
+                    "tool:start",
+                    {"tool": tool_name, "input": input_preview},
+                )
+            except Exception as exc:
+                logger.warning("asqav tool:start signing failed (fail-open): %s", exc)
+
+            try:
+                result = original_forward(*args, **kwargs)
+            except Exception as exc:
+                try:
+                    hook._sign_action(
+                        "tool:error",
+                        {
+                            "tool": tool_name,
+                            "error_type": type(exc).__name__,
+                            "error": str(exc)[:_MAX_LEN],
+                        },
+                    )
+                except Exception as sign_exc:
+                    logger.warning(
+                        "asqav tool:error signing failed (fail-open): %s", sign_exc
+                    )
+                raise
+
+            try:
+                hook._sign_action(
+                    "tool:end",
+                    {
+                        "tool": tool_name,
+                        "output_type": type(result).__name__,
+                        "output_length": len(str(result)),
+                    },
+                )
+            except Exception as exc:
+                logger.warning("asqav tool:end signing failed (fail-open): %s", exc)
+
+            return result
+
+        tool.forward = _signed_forward
+        return tool

--- a/src/asqav/local.py
+++ b/src/asqav/local.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from typing import Any, Callable
 from uuid import uuid4
 
-
 _DEFAULT_QUEUE_DIR = os.path.join(os.path.expanduser("~"), ".asqav", "queue")
 
 

--- a/tests/test_smolagents_integration.py
+++ b/tests/test_smolagents_integration.py
@@ -1,0 +1,316 @@
+"""Tests for smolagents AsqavSmolagentsHook integration.
+
+Uses a mock smolagents module injected into sys.modules so tests run
+without smolagents installed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Inject a fake smolagents module before importing the hook
+# ---------------------------------------------------------------------------
+
+_fake_smolagents = types.ModuleType("smolagents")
+sys.modules["smolagents"] = _fake_smolagents
+sys.modules.pop("asqav.extras.smolagents", None)
+
+from asqav.extras.smolagents import AsqavSmolagentsHook  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool(name: str, forward_result: Any = "result") -> MagicMock:
+    """Create a minimal mock smolagents Tool."""
+    tool = MagicMock()
+    tool.name = name
+    tool.forward = MagicMock(return_value=forward_result)
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def hook() -> AsqavSmolagentsHook:
+    """Create an AsqavSmolagentsHook with mocked Agent internals."""
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        h = AsqavSmolagentsHook(agent_name="test-smolagents")
+    h._sign_action = MagicMock(return_value=None)
+    return h
+
+
+# ---------------------------------------------------------------------------
+# wrap_tool: tool:start
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_tool_signs_tool_start(hook: AsqavSmolagentsHook) -> None:
+    """wrap_tool signs tool:start with tool name and input preview."""
+    tool = _make_tool("web_search", forward_result="some result")
+    hook.wrap_tool(tool)
+    tool.forward("python tutorials")
+
+    first_call = hook._sign_action.call_args_list[0]
+    assert first_call[0][0] == "tool:start"
+    ctx = first_call[0][1]
+    assert ctx["tool"] == "web_search"
+    assert ctx["input"] == "python tutorials"
+
+
+def test_wrap_tool_signs_tool_start_with_kwargs(hook: AsqavSmolagentsHook) -> None:
+    """wrap_tool signs tool:start using the first kwarg value as input preview."""
+    tool = _make_tool("named_tool")
+    hook.wrap_tool(tool)
+    tool.forward(query="hello world")
+
+    start_ctx = hook._sign_action.call_args_list[0][0][1]
+    assert start_ctx["input"] == "hello world"
+
+
+def test_wrap_tool_signs_tool_start_no_args(hook: AsqavSmolagentsHook) -> None:
+    """wrap_tool signs tool:start with empty input when called with no args."""
+    tool = _make_tool("no_args_tool")
+    hook.wrap_tool(tool)
+    tool.forward()
+
+    start_ctx = hook._sign_action.call_args_list[0][0][1]
+    assert start_ctx["input"] == ""
+
+
+# ---------------------------------------------------------------------------
+# wrap_tool: tool:end
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_tool_signs_tool_end(hook: AsqavSmolagentsHook) -> None:
+    """wrap_tool signs tool:end with output type and length."""
+    tool = _make_tool("calculator", forward_result="42")
+    hook.wrap_tool(tool)
+    tool.forward("6 * 7")
+
+    last_call = hook._sign_action.call_args_list[-1]
+    assert last_call[0][0] == "tool:end"
+    ctx = last_call[0][1]
+    assert ctx["tool"] == "calculator"
+    assert ctx["output_type"] == "str"
+    assert ctx["output_length"] == 2
+
+
+def test_wrap_tool_returns_original_result(hook: AsqavSmolagentsHook) -> None:
+    """wrap_tool does not alter the tool's return value."""
+    tool = _make_tool("fetch", forward_result={"key": "value"})
+    hook.wrap_tool(tool)
+    result = tool.forward("url")
+    assert result == {"key": "value"}
+
+
+def test_wrap_tool_signs_two_actions_per_successful_call(
+    hook: AsqavSmolagentsHook,
+) -> None:
+    """A successful tool call produces exactly tool:start + tool:end."""
+    tool = _make_tool("search")
+    hook.wrap_tool(tool)
+    tool.forward("query")
+    assert hook._sign_action.call_count == 2
+    assert hook._sign_action.call_args_list[0][0][0] == "tool:start"
+    assert hook._sign_action.call_args_list[1][0][0] == "tool:end"
+
+
+# ---------------------------------------------------------------------------
+# wrap_tool: tool:error
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_tool_signs_tool_error_on_exception(hook: AsqavSmolagentsHook) -> None:
+    """wrap_tool signs tool:error when forward raises."""
+    tool = _make_tool("unstable_tool")
+    tool.forward.side_effect = RuntimeError("connection failed")
+    hook.wrap_tool(tool)
+
+    with pytest.raises(RuntimeError):
+        tool.forward("input")
+
+    error_call = hook._sign_action.call_args_list[-1]
+    assert error_call[0][0] == "tool:error"
+    ctx = error_call[0][1]
+    assert ctx["tool"] == "unstable_tool"
+    assert ctx["error_type"] == "RuntimeError"
+    assert ctx["error"] == "connection failed"
+
+
+def test_wrap_tool_reraises_original_exception(hook: AsqavSmolagentsHook) -> None:
+    """wrap_tool re-raises the original exception unchanged."""
+    tool = _make_tool("crasher")
+    tool.forward.side_effect = ValueError("bad input")
+    hook.wrap_tool(tool)
+
+    with pytest.raises(ValueError, match="bad input"):
+        tool.forward("x")
+
+
+def test_wrap_tool_signs_start_and_error_on_failure(
+    hook: AsqavSmolagentsHook,
+) -> None:
+    """A failed tool call produces exactly tool:start + tool:error."""
+    tool = _make_tool("failing_tool")
+    tool.forward.side_effect = RuntimeError("boom")
+    hook.wrap_tool(tool)
+
+    with pytest.raises(RuntimeError):
+        tool.forward("input")
+
+    assert hook._sign_action.call_count == 2
+    assert hook._sign_action.call_args_list[0][0][0] == "tool:start"
+    assert hook._sign_action.call_args_list[1][0][0] == "tool:error"
+
+
+# ---------------------------------------------------------------------------
+# Truncation
+# ---------------------------------------------------------------------------
+
+
+def test_input_truncated_to_200_chars(hook: AsqavSmolagentsHook) -> None:
+    """Inputs longer than 200 chars are truncated in the audit record."""
+    tool = _make_tool("search")
+    hook.wrap_tool(tool)
+    tool.forward("q" * 500)
+
+    start_ctx = hook._sign_action.call_args_list[0][0][1]
+    assert len(start_ctx["input"]) == 200
+
+
+def test_error_message_truncated_to_200_chars(hook: AsqavSmolagentsHook) -> None:
+    """Error messages longer than 200 chars are truncated in the audit record."""
+    tool = _make_tool("erroring")
+    tool.forward.side_effect = RuntimeError("e" * 500)
+    hook.wrap_tool(tool)
+
+    with pytest.raises(RuntimeError):
+        tool.forward("x")
+
+    error_ctx = hook._sign_action.call_args_list[-1][0][1]
+    assert len(error_ctx["error"]) == 200
+
+
+# ---------------------------------------------------------------------------
+# Fail-open: signing must never block tool execution
+# ---------------------------------------------------------------------------
+
+
+def test_fail_open_tool_start_does_not_block_execution(
+    hook: AsqavSmolagentsHook,
+) -> None:
+    """If tool:start signing raises, the tool still executes and returns its result."""
+    tool = _make_tool("important_tool", forward_result="success")
+    hook._sign_action.side_effect = Exception("service unavailable")
+    hook.wrap_tool(tool)
+
+    result = tool.forward("input")
+    assert result == "success"
+
+
+def test_fail_open_tool_end_does_not_suppress_result(
+    hook: AsqavSmolagentsHook,
+) -> None:
+    """If tool:end signing raises, the result is still returned to the caller."""
+    tool = _make_tool("end_failing_tool", forward_result="the result")
+    call_count = 0
+
+    def sign_side_effect(action_type: str, ctx: dict) -> None:
+        nonlocal call_count
+        call_count += 1
+        if action_type == "tool:end":
+            raise Exception("end signing failed")
+
+    hook._sign_action.side_effect = sign_side_effect
+    hook.wrap_tool(tool)
+
+    result = tool.forward("input")
+    assert result == "the result"
+
+
+def test_fail_open_tool_error_does_not_swallow_exception(
+    hook: AsqavSmolagentsHook,
+) -> None:
+    """If tool:error signing raises, the original tool exception is still re-raised."""
+    tool = _make_tool("double_failing_tool")
+    tool.forward.side_effect = ValueError("tool broke")
+    hook._sign_action.side_effect = Exception("signing also broke")
+    hook.wrap_tool(tool)
+
+    with pytest.raises(ValueError, match="tool broke"):
+        tool.forward("input")
+
+
+# ---------------------------------------------------------------------------
+# Multiple tools tracked independently
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_tools_tracked_independently(hook: AsqavSmolagentsHook) -> None:
+    """Each wrapped tool is signed independently under its own name."""
+    tool_a = _make_tool("tool_a", forward_result="a_result")
+    tool_b = _make_tool("tool_b", forward_result="b_result")
+
+    hook.wrap_tool(tool_a)
+    hook.wrap_tool(tool_b)
+
+    tool_a.forward("arg_a")
+    tool_b.forward("arg_b")
+
+    calls = hook._sign_action.call_args_list
+    # tool_a: start + end (indices 0, 1), tool_b: start + end (indices 2, 3)
+    assert calls[0][0][1]["tool"] == "tool_a"
+    assert calls[1][0][1]["tool"] == "tool_a"
+    assert calls[2][0][1]["tool"] == "tool_b"
+    assert calls[3][0][1]["tool"] == "tool_b"
+
+
+# ---------------------------------------------------------------------------
+# Tool name fallback
+# ---------------------------------------------------------------------------
+
+
+def test_tool_name_falls_back_to_class_name(hook: AsqavSmolagentsHook) -> None:
+    """wrap_tool uses the class name when the tool has no .name attribute."""
+    tool = MagicMock(spec=["forward"])  # no .name attribute
+    tool.forward = MagicMock(return_value="ok")
+    type(tool).__name__ = "MyCustomTool"
+
+    hook.wrap_tool(tool)
+    tool.forward("x")
+
+    start_ctx = hook._sign_action.call_args_list[0][0][1]
+    assert start_ctx["tool"] == "MyCustomTool"
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _cleanup_smolagents_module() -> Any:
+    """Remove fake smolagents from sys.modules after all tests."""
+    yield
+    sys.modules.pop("smolagents", None)
+    sys.modules.pop("asqav.extras.smolagents", None)


### PR DESCRIPTION
## Description

Adds `AsqavSmolagentsHook` for Hugging Face's smolagents framework. The hook's
`wrap_tool()` method patches any smolagents `Tool` instance to sign `tool:start`,
`tool:end`, and `tool:error` governance events on every invocation. Signing is
fail-open and never interrupts tool or agent execution.

Closes #37

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] New integration
- [ ] Documentation
- [ ] Tests
- [ ] Refactoring

## Testing

- [x] Tests pass locally (`pytest`)
- [x] New tests added for new functionality
- [x] Existing tests still pass

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] No new warnings
- [x] Documentation updated if needed