### PR TITLE
feat: add DSPy integration (#42)

### DIFF
--- a/examples/dspy_example.py
+++ b/examples/dspy_example.py
@@ -1,0 +1,77 @@
+"""DSPy integration example for asqav.
+
+Demonstrates how to register AsqavDSPyCallback with DSPy so every module
+execution, LM call, and tool invocation is automatically signed and recorded
+in the audit trail.
+
+Requirements:
+    pip install asqav[dspy]
+
+Usage:
+    ASQAV_API_KEY=sk_... python examples/dspy_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import asqav
+from asqav.extras.dspy import AsqavDSPyCallback
+
+try:
+    import dspy
+except ImportError:
+    raise SystemExit(
+        "dspy is required for this example.\n"
+        "Install with: pip install asqav[dspy]"
+    )
+
+# ---------------------------------------------------------------------------
+# Initialise asqav
+# ---------------------------------------------------------------------------
+
+api_key = os.environ.get("ASQAV_API_KEY", "")
+if not api_key:
+    raise SystemExit(
+        "Set the ASQAV_API_KEY environment variable before running this example.\n"
+        "Get your key at https://asqav.com"
+    )
+
+asqav.init(api_key=api_key)
+
+# Register the callback once — DSPy calls it automatically for every
+# module, LM, and tool invocation from this point on.
+dspy.configure(
+    lm=dspy.LM("openai/gpt-4o"),
+    callbacks=[AsqavDSPyCallback(agent_name="dspy-demo")],
+)
+
+# ---------------------------------------------------------------------------
+# Define a DSPy program
+# ---------------------------------------------------------------------------
+
+
+class RAGPipeline(dspy.Module):
+    """Simple retrieve-then-answer pipeline."""
+
+    def __init__(self) -> None:
+        self.retrieve = dspy.Retrieve(k=3)
+        self.generate = dspy.ChainOfThought("context, question -> answer")
+
+    def forward(self, question: str) -> dspy.Prediction:
+        context = self.retrieve(question).passages
+        return self.generate(context=context, question=question)
+
+
+# ---------------------------------------------------------------------------
+# Run the program
+# ---------------------------------------------------------------------------
+
+pipeline = RAGPipeline()
+
+print("Running DSPy pipeline with asqav governance...")
+result = pipeline(question="What is AI governance and why does it matter?")
+
+print("\nAnswer:")
+print(result.answer)
+print("\nView the signed audit trail at https://asqav.com/dashboard")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ keywords = [
     "haystack",
     "llamaindex",
     "smolagents",
+    "dspy",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -57,6 +58,7 @@ haystack = ["haystack-ai>=2.0.0"]
 openai-agents = ["openai-agents>=0.1.0"]
 llamaindex = ["llama-index-core>=0.10.0"]
 smolagents = ["smolagents>=1.0.0"]
+dspy = ["dspy>=2.5.0"]
 all = [
     "httpx>=0.24.0",
     "typer>=0.12.0",
@@ -67,6 +69,7 @@ all = [
     "openai-agents>=0.1.0",
     "llama-index-core>=0.10.0",
     "smolagents>=1.0.0",
+    "dspy>=2.5.0",
 ]
 dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0", "ruff>=0.5.0", "mypy>=1.10.0"]
 

--- a/src/asqav/extras/__init__.py
+++ b/src/asqav/extras/__init__.py
@@ -8,5 +8,6 @@ Install specific extras:
     pip install asqav[openai-agents]
     pip install asqav[llamaindex]
     pip install asqav[smolagents]
+    pip install asqav[dspy]
     pip install asqav[all]
 """

--- a/src/asqav/extras/dspy.py
+++ b/src/asqav/extras/dspy.py
@@ -1,0 +1,183 @@
+"""DSPy integration for asqav.
+
+Install: pip install asqav[dspy]
+
+Usage::
+
+    import asqav
+    import dspy
+    from asqav.extras.dspy import AsqavDSPyCallback
+
+    asqav.init(api_key="...")
+    dspy.configure(callbacks=[AsqavDSPyCallback(agent_name="my-agent")])
+
+    # All subsequent DSPy module, LM, and tool calls are automatically signed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from dspy.utils.callback import BaseCallback
+except ImportError:
+    raise ImportError(
+        "DSPy integration requires dspy. "
+        "Install with: pip install asqav[dspy]"
+    )
+
+from ._base import AsqavAdapter
+
+
+def _safe_class_name(instance: Any) -> str:
+    """Best-effort class name extraction for audit context."""
+    try:
+        return type(instance).__name__
+    except Exception:
+        return "unknown"
+
+
+def _exception_name(exception: BaseException | None) -> str | None:
+    if exception is None:
+        return None
+    try:
+        return type(exception).__name__
+    except Exception:
+        return "Exception"
+
+
+class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
+    """DSPy callback that signs module, LM, and tool events via asqav.
+
+    Implements ``dspy.utils.callback.BaseCallback`` and records signed
+    governance events for every module execution, LM call, and tool
+    invocation. Signing is fail-open: asqav failures are logged but never
+    raised, so DSPy pipelines keep running even when asqav is unreachable.
+
+    Args:
+        api_key: Optional API key override (uses ``asqav.init()`` default).
+        agent_name: Name for a new asqav agent (calls ``Agent.create``).
+        agent_id: ID of an existing asqav agent (calls ``Agent.get``).
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        agent_name: str | None = None,
+        agent_id: str | None = None,
+    ) -> None:
+        AsqavAdapter.__init__(
+            self, api_key=api_key, agent_name=agent_name, agent_id=agent_id
+        )
+        BaseCallback.__init__(self)
+
+    # ------------------------------------------------------------------
+    # Module handlers
+    # ------------------------------------------------------------------
+
+    def on_module_start(
+        self,
+        call_id: str,
+        instance: Any,
+        inputs: dict[str, Any],
+    ) -> None:
+        """Sign a dspy.module.start event."""
+        self._sign_action(
+            "dspy.module.start",
+            {
+                "call_id": call_id,
+                "module": _safe_class_name(instance),
+                "input_keys": sorted(inputs.keys()) if isinstance(inputs, dict) else [],
+            },
+        )
+
+    def on_module_end(
+        self,
+        call_id: str,
+        outputs: Any | None,
+        exception: Exception | None = None,
+    ) -> None:
+        """Sign a dspy.module.end event."""
+        self._sign_action(
+            "dspy.module.end",
+            {
+                "call_id": call_id,
+                "ok": exception is None,
+                "exception": _exception_name(exception),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # LM handlers
+    # ------------------------------------------------------------------
+
+    def on_lm_start(
+        self,
+        call_id: str,
+        instance: Any,
+        inputs: dict[str, Any],
+    ) -> None:
+        """Sign a dspy.lm.start event with model name if available."""
+        self._sign_action(
+            "dspy.lm.start",
+            {
+                "call_id": call_id,
+                "lm": _safe_class_name(instance),
+                "model": getattr(instance, "model", None),
+                "input_keys": sorted(inputs.keys()) if isinstance(inputs, dict) else [],
+            },
+        )
+
+    def on_lm_end(
+        self,
+        call_id: str,
+        outputs: dict[str, Any] | None,
+        exception: Exception | None = None,
+    ) -> None:
+        """Sign a dspy.lm.end event."""
+        self._sign_action(
+            "dspy.lm.end",
+            {
+                "call_id": call_id,
+                "ok": exception is None,
+                "exception": _exception_name(exception),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Tool handlers
+    # ------------------------------------------------------------------
+
+    def on_tool_start(
+        self,
+        call_id: str,
+        instance: Any,
+        inputs: dict[str, Any],
+    ) -> None:
+        """Sign a dspy.tool.start event."""
+        tool_name = getattr(instance, "name", None) or _safe_class_name(instance)
+        self._sign_action(
+            "dspy.tool.start",
+            {
+                "call_id": call_id,
+                "tool": tool_name,
+                "input_keys": sorted(inputs.keys()) if isinstance(inputs, dict) else [],
+            },
+        )
+
+    def on_tool_end(
+        self,
+        call_id: str,
+        outputs: dict[str, Any] | None,
+        exception: Exception | None = None,
+    ) -> None:
+        """Sign a dspy.tool.end event."""
+        self._sign_action(
+            "dspy.tool.end",
+            {
+                "call_id": call_id,
+                "ok": exception is None,
+                "exception": _exception_name(exception),
+            },
+        )

--- a/tests/test_dspy_integration.py
+++ b/tests/test_dspy_integration.py
@@ -1,0 +1,285 @@
+"""Tests for DSPy AsqavDSPyCallback integration.
+
+Uses mock dspy modules injected into sys.modules so tests run without
+dspy installed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# ---------------------------------------------------------------------------
+# Inject fake dspy modules before importing the callback
+# ---------------------------------------------------------------------------
+
+_MISSING = object()
+_original_modules: dict[str, ModuleType | object] = {}
+
+
+def _install_dspy_mocks() -> type:
+    """Inject fake dspy module tree and return the BaseCallback class."""
+    for mod_name in ("dspy", "dspy.utils", "dspy.utils.callback"):
+        _original_modules[mod_name] = sys.modules.get(mod_name, _MISSING)
+
+    class BaseCallback:
+        """Mock dspy BaseCallback."""
+
+        def __init__(self) -> None:
+            pass
+
+    dspy = ModuleType("dspy")
+    dspy_utils = ModuleType("dspy.utils")
+    dspy_utils_callback = ModuleType("dspy.utils.callback")
+
+    dspy_utils_callback.BaseCallback = BaseCallback  # type: ignore[attr-defined]
+    dspy_utils.callback = dspy_utils_callback  # type: ignore[attr-defined]
+    dspy.utils = dspy_utils  # type: ignore[attr-defined]
+
+    sys.modules["dspy"] = dspy
+    sys.modules["dspy.utils"] = dspy_utils
+    sys.modules["dspy.utils.callback"] = dspy_utils_callback
+
+    return BaseCallback
+
+
+def _remove_dspy_mocks() -> None:
+    for mod_name, original in _original_modules.items():
+        if original is _MISSING:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = original  # type: ignore[assignment]
+    sys.modules.pop("asqav.extras.dspy", None)
+
+
+BaseCallback = _install_dspy_mocks()
+
+from asqav.extras.dspy import AsqavDSPyCallback  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def cb() -> AsqavDSPyCallback:
+    """Create an AsqavDSPyCallback with mocked Agent internals."""
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        callback = AsqavDSPyCallback(agent_name="test-dspy")
+    callback._sign_action = MagicMock(return_value=None)
+    return callback
+
+
+# ---------------------------------------------------------------------------
+# Subclass check
+# ---------------------------------------------------------------------------
+
+
+def test_is_base_callback_subclass() -> None:
+    """AsqavDSPyCallback must be a subclass of dspy's BaseCallback."""
+    assert issubclass(AsqavDSPyCallback, BaseCallback)
+
+
+# ---------------------------------------------------------------------------
+# Module handlers
+# ---------------------------------------------------------------------------
+
+
+def test_on_module_start_signs_action(cb: AsqavDSPyCallback) -> None:
+    """on_module_start signs dspy.module.start with module name and input keys."""
+
+    class MyModule:
+        pass
+
+    cb.on_module_start("call-1", MyModule(), {"question": "hi", "context": "..."})
+    cb._sign_action.assert_called_once_with(
+        "dspy.module.start",
+        {"call_id": "call-1", "module": "MyModule", "input_keys": ["context", "question"]},
+    )
+
+
+def test_on_module_end_signs_ok(cb: AsqavDSPyCallback) -> None:
+    """on_module_end signs dspy.module.end with ok=True on success."""
+    cb.on_module_end("call-1", {"answer": "hello"}, None)
+    cb._sign_action.assert_called_once_with(
+        "dspy.module.end",
+        {"call_id": "call-1", "ok": True, "exception": None},
+    )
+
+
+def test_on_module_end_signs_exception(cb: AsqavDSPyCallback) -> None:
+    """on_module_end signs dspy.module.end with ok=False and exception name on error."""
+    cb.on_module_end("call-2", None, ValueError("bad input"))
+    cb._sign_action.assert_called_once_with(
+        "dspy.module.end",
+        {"call_id": "call-2", "ok": False, "exception": "ValueError"},
+    )
+
+
+def test_on_module_start_empty_inputs(cb: AsqavDSPyCallback) -> None:
+    """on_module_start handles empty inputs dict gracefully."""
+    cb.on_module_start("call-x", object(), {})
+    ctx = cb._sign_action.call_args[0][1]
+    assert ctx["input_keys"] == []
+
+
+def test_on_module_start_non_dict_inputs(cb: AsqavDSPyCallback) -> None:
+    """on_module_start handles non-dict inputs without raising."""
+    cb.on_module_start("call-x", object(), None)  # type: ignore[arg-type]
+    ctx = cb._sign_action.call_args[0][1]
+    assert ctx["input_keys"] == []
+
+
+# ---------------------------------------------------------------------------
+# LM handlers
+# ---------------------------------------------------------------------------
+
+
+def test_on_lm_start_signs_action(cb: AsqavDSPyCallback) -> None:
+    """on_lm_start signs dspy.lm.start with model name and input keys."""
+
+    class OpenAI:
+        model = "gpt-4o"
+
+    cb.on_lm_start("call-2", OpenAI(), {"prompt": "x", "temperature": 0.7})
+    cb._sign_action.assert_called_once_with(
+        "dspy.lm.start",
+        {
+            "call_id": "call-2",
+            "lm": "OpenAI",
+            "model": "gpt-4o",
+            "input_keys": ["prompt", "temperature"],
+        },
+    )
+
+
+def test_on_lm_start_no_model_attr(cb: AsqavDSPyCallback) -> None:
+    """on_lm_start uses None for model when instance has no .model attribute."""
+    cb.on_lm_start("call-x", object(), {})
+    ctx = cb._sign_action.call_args[0][1]
+    assert ctx["model"] is None
+
+
+def test_on_lm_end_signs_ok(cb: AsqavDSPyCallback) -> None:
+    """on_lm_end signs dspy.lm.end with ok=True on success."""
+    cb.on_lm_end("call-2", {"text": "result"}, None)
+    cb._sign_action.assert_called_once_with(
+        "dspy.lm.end",
+        {"call_id": "call-2", "ok": True, "exception": None},
+    )
+
+
+def test_on_lm_end_signs_exception(cb: AsqavDSPyCallback) -> None:
+    """on_lm_end signs dspy.lm.end with ok=False on error."""
+    cb.on_lm_end("call-2", None, TimeoutError("rate limit"))
+    ctx = cb._sign_action.call_args[0][1]
+    assert ctx["ok"] is False
+    assert ctx["exception"] == "TimeoutError"
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+def test_on_tool_start_signs_action(cb: AsqavDSPyCallback) -> None:
+    """on_tool_start signs dspy.tool.start with tool name and input keys."""
+
+    class SearchTool:
+        name = "web_search"
+
+    cb.on_tool_start("call-3", SearchTool(), {"query": "asqav"})
+    cb._sign_action.assert_called_once_with(
+        "dspy.tool.start",
+        {"call_id": "call-3", "tool": "web_search", "input_keys": ["query"]},
+    )
+
+
+def test_on_tool_start_falls_back_to_class_name(cb: AsqavDSPyCallback) -> None:
+    """on_tool_start uses class name when instance has no .name attribute."""
+
+    class CalculatorTool:
+        pass
+
+    cb.on_tool_start("call-x", CalculatorTool(), {})
+    ctx = cb._sign_action.call_args[0][1]
+    assert ctx["tool"] == "CalculatorTool"
+
+
+def test_on_tool_end_signs_ok(cb: AsqavDSPyCallback) -> None:
+    """on_tool_end signs dspy.tool.end with ok=True on success."""
+    cb.on_tool_end("call-3", {"results": ["a", "b"]}, None)
+    cb._sign_action.assert_called_once_with(
+        "dspy.tool.end",
+        {"call_id": "call-3", "ok": True, "exception": None},
+    )
+
+
+def test_on_tool_end_signs_exception(cb: AsqavDSPyCallback) -> None:
+    """on_tool_end signs dspy.tool.end with ok=False on error."""
+    cb.on_tool_end("call-3", None, RuntimeError("tool failed"))
+    ctx = cb._sign_action.call_args[0][1]
+    assert ctx["ok"] is False
+    assert ctx["exception"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# Input keys are sorted
+# ---------------------------------------------------------------------------
+
+
+def test_input_keys_are_sorted(cb: AsqavDSPyCallback) -> None:
+    """Input keys are always sorted alphabetically in audit records."""
+    cb.on_module_start("call-s", object(), {"z": 1, "a": 2, "m": 3})
+    ctx = cb._sign_action.call_args[0][1]
+    assert ctx["input_keys"] == ["a", "m", "z"]
+
+
+# ---------------------------------------------------------------------------
+# Fail-open: signing must never block DSPy execution
+# ---------------------------------------------------------------------------
+
+
+def test_fail_open_on_asqav_error(cb: AsqavDSPyCallback) -> None:
+    """AsqavError from the real _sign_action is swallowed (fail-open)."""
+    from asqav.client import AsqavError
+
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent = MagicMock()
+        mock_agent.sign.side_effect = AsqavError("network down")
+        mock_agent_cls.create.return_value = mock_agent
+        live_cb = AsqavDSPyCallback(agent_name="fail-open-test")
+
+    # None of these should raise
+    live_cb.on_module_start("c", object(), {"k": "v"})
+    live_cb.on_module_end("c", None, None)
+    live_cb.on_lm_start("c", object(), {})
+    live_cb.on_lm_end("c", None, None)
+    live_cb.on_tool_start("c", object(), {})
+    live_cb.on_tool_end("c", None, None)
+
+    assert mock_agent.sign.call_count == 6
+    assert len(live_cb._signatures) == 0
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+def teardown_module() -> None:
+    _remove_dspy_mocks()


### PR DESCRIPTION
## Description

Bundles the DSPy integration directly into the SDK as `asqav[dspy]`, ported
from the standalone `asqav-dspy` reference package. Adds `AsqavDSPyCallback`,
a `dspy.utils.callback.BaseCallback` subclass that automatically signs
`dspy.module.start/end`, `dspy.lm.start/end`, and `dspy.tool.start/end`
governance events. Register once with `dspy.configure(callbacks=[...])` and
all subsequent DSPy operations are covered.

Closes #42

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] New integration
- [ ] Documentation
- [ ] Tests
- [ ] Refactoring

## Testing

- [x] Tests pass locally (`pytest`)
- [x] New tests added for new functionality
- [x] Existing tests still pass

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] No new warnings
- [x] Documentation updated if needed