### PR TITLE
fix: exclude compromised litellm versions 1.82.7 and 1.82.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ httpx = ["httpx>=0.24.0"]
 cli = ["typer>=0.12.0", "httpx>=0.24.0"]
 langchain = ["langchain-core>=0.2.0"]
 crewai = ["crewai>=0.41.0"]
-litellm = ["litellm>=1.0.0"]
+litellm = ["litellm>=1.0.0,!=1.82.7,!=1.82.8"]
 haystack = ["haystack-ai>=2.0.0"]
 openai-agents = ["openai-agents>=0.1.0"]
 llamaindex = ["llama-index-core>=0.10.0"]
@@ -64,7 +64,7 @@ all = [
     "typer>=0.12.0",
     "langchain-core>=0.2.0",
     "crewai>=0.41.0",
-    "litellm>=1.0.0",
+    "litellm>=1.0.0,!=1.82.7,!=1.82.8",
     "haystack-ai>=2.0.0",
     "openai-agents>=0.1.0",
     "llama-index-core>=0.10.0",


### PR DESCRIPTION
## Summary
- Excludes litellm versions **1.82.7** and **1.82.8** from both the `litellm` optional dependency and the `all` extra in `pyproject.toml`
- These versions were compromised in a supply chain attack (March 2026) by TeamPCP, injecting a multi-stage credential harvester that stole SSH keys, cloud credentials, crypto wallets, and `.env` files
- The constraint `!=1.82.7,!=1.82.8` prevents pip from ever resolving to those malicious releases

## References
- [Sonatype: Compromised litellm PyPI Package](https://www.sonatype.com/blog/compromised-litellm-pypi-package-delivers-multi-stage-credential-stealer)
- [Wiz: TeamPCP Trojanizes LiteLLM](https://www.wiz.io/blog/threes-a-crowd-teampcp-trojanizes-litellm-in-continuation-of-campaign)

## Test plan
- [ ] Verify `pip install asqav-sdk[litellm]` resolves to a safe version (not 1.82.7 or 1.82.8)
- [ ] Verify `pip install asqav-sdk[all]` resolves to a safe version

🤖 Generated with [Claude Code](https://claude.com/claude-code)