### PR TITLE
SDK tier parity: Response fields + lifecycle methods + pricing refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ assert result["valid"] and result["all_valid"]
 
 ## Free tier
 
-Get started at no cost. Free tier includes 50K signatures/month, agent lifecycle, three-tier enforcement, policies, audit export, OpenTimestamps anchoring, MCP server, and framework integrations. Content scanning, Replay API, managed KMS, and OpenTelemetry on Pro ($19/mo annual). Compliance reports, quarantine mode, multi-party signing, and incident management on Business ($79/mo annual). See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
+Get started at no cost. Free includes 50K signatures/month, 20 agents, 10 policies, 3 team members, OpenTimestamps, MCP server, audit export, and framework integrations. Content scanning, OpenTelemetry, managed KMS, and Replay API on Pro ($19/mo annual). Quarantine, incident management, multi-party signing, compliance reports, and RFC 3161 timestamps on Business ($79/mo annual). See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
 
 ## Discovery
 

--- a/src/asqav/client.py
+++ b/src/asqav/client.py
@@ -161,6 +161,11 @@ class SignatureResponse:
     action_id: str
     timestamp: float
     verification_url: str
+    algorithm: str | None = None
+    chain_hash: str | None = None
+    rfc3161_tsa: str | None = None
+    rfc3161_serial: str | None = None
+    scan_result: dict[str, Any] | None = None
 
 
 @dataclass
@@ -818,6 +823,11 @@ class Agent:
             action_id=data["action_id"],
             timestamp=data["timestamp"],
             verification_url=data["verification_url"],
+            algorithm=data.get("algorithm"),
+            chain_hash=data.get("chain_hash") or data.get("record_hash"),
+            rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
+            rfc3161_serial=(data.get("rfc3161_timestamp") or {}).get("serial_number"),
+            scan_result=data.get("scan_result"),
         )
 
     def sign_batch(
@@ -875,6 +885,11 @@ class Agent:
                         action_id=sig["action_id"],
                         timestamp=sig["timestamp"],
                         verification_url=sig["verification_url"],
+                        algorithm=sig.get("algorithm"),
+                        chain_hash=sig.get("chain_hash") or sig.get("record_hash"),
+                        rfc3161_tsa=(sig.get("rfc3161_timestamp") or {}).get("tsa"),
+                        rfc3161_serial=(sig.get("rfc3161_timestamp") or {}).get("serial_number"),
+                        scan_result=sig.get("scan_result"),
                     )
                 )
         return results
@@ -1014,14 +1029,23 @@ class Agent:
         return _post(f"/agents/{self.agent_id}/suspend", payload)
 
     def unsuspend(self) -> dict[str, Any]:
-        """Remove suspension from this agent.
-
-        Restores the agent to active status.
-
-        Returns:
-            Dict with updated agent status.
-        """
+        """Remove suspension from this agent."""
         return _post(f"/agents/{self.agent_id}/unsuspend", {})
+
+    def decommission(self, reason: str = "manual") -> dict[str, Any]:
+        """Permanently retire this agent (keys archived, no further activity)."""
+        return _post(
+            f"/agents/{self.agent_id}/decommission",
+            {"reason": reason},
+        )
+
+    def quarantine(self) -> dict[str, Any]:
+        """Block signing and token issuance, keep read + verify. Business+."""
+        return _post(f"/agents/{self.agent_id}/quarantine", {})
+
+    def unquarantine(self) -> dict[str, Any]:
+        """Restore normal signing and token issuance after quarantine."""
+        return _post(f"/agents/{self.agent_id}/unquarantine", {})
 
     def delegate(
         self,


### PR DESCRIPTION
## Summary
- `SignatureResponse` now includes `algorithm`, `chain_hash`, `rfc3161_tsa`, `rfc3161_serial`, and `scan_result` so the server-side payload isn't dropped on deserialization. README JSON sample lines already documented these, dataclass now matches.
- New `Agent` methods: `decommission(reason)`, `quarantine()`, `unquarantine()` hitting the existing backend routes. Closes the lifecycle/quarantine gap for Business+ users driving state from the SDK.
- README "Free tier" paragraph updated to current pricing ($19/$79 annual, 50K free signatures, FEATURE_REPLAY + RFC 3161 at the right tiers).

## Test plan
- [x] No breaking changes: new fields are Optional with None defaults.
- [ ] Ship 0.2.17 patch once merged.