### PR TITLE
feat: 0.2.19 - governance fields on SignatureResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [0.2.19] - 2026-04-20
+
+### Added
+- `SignatureResponse` now exposes `policy_digest`, `policy_decision`, `authorization_ref` so third parties can reconstruct the JCS bytes that were signed and re-verify offline. Populated by both `Agent.sign` and `Agent.sign_batch` (and the async client).
+
 ## [0.2.18] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -382,6 +382,20 @@ result = asqav.verify_output(sig.signature_id, output)
 assert result["verified"]
 ```
 
+## Governance fields on signatures
+
+Every `SignatureResponse` carries the governance context that produced it, so a third party can reconstruct the exact JCS bytes that were signed and re-verify offline:
+
+```python
+sig = agent.sign("tool:call", {"name": "search"})
+
+sig.policy_digest       # sha256 of the policy attestation snapshot
+sig.policy_decision     # "permit" or "deny"
+sig.authorization_ref   # approval_id when a HITL approval authorized the action, else None
+```
+
+`policy_decision` defaults to `"permit"`. When an action is denied, the API raises and you get a signed deny envelope through the standard error path.
+
 ## Budget tracking
 
 Client-side spend tracker that persists every cost as a signed record. Fails closed when the limit would be exceeded:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.2.18"
+version = "0.2.19"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/src/asqav/__init__.py
+++ b/src/asqav/__init__.py
@@ -110,7 +110,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.2.18"
+__version__ = "0.2.19"
 __all__ = [
     # Initialization
     "init",

--- a/src/asqav/async_client.py
+++ b/src/asqav/async_client.py
@@ -254,6 +254,14 @@ class AsyncAgent:
             action_id=data["action_id"],
             timestamp=data["timestamp"],
             verification_url=data["verification_url"],
+            algorithm=data.get("algorithm"),
+            chain_hash=data.get("chain_hash") or data.get("record_hash"),
+            rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
+            rfc3161_serial=(data.get("rfc3161_timestamp") or {}).get("serial_number"),
+            scan_result=data.get("scan_result"),
+            policy_digest=data.get("policy_digest"),
+            policy_decision=data.get("policy_decision", "permit"),
+            authorization_ref=data.get("authorization_ref"),
         )
 
     async def start_session(self) -> SessionResponse:

--- a/src/asqav/client.py
+++ b/src/asqav/client.py
@@ -166,6 +166,9 @@ class SignatureResponse:
     rfc3161_tsa: str | None = None
     rfc3161_serial: str | None = None
     scan_result: dict[str, Any] | None = None
+    policy_digest: str | None = None
+    policy_decision: str = "permit"
+    authorization_ref: str | None = None
 
 
 @dataclass
@@ -828,6 +831,9 @@ class Agent:
             rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
             rfc3161_serial=(data.get("rfc3161_timestamp") or {}).get("serial_number"),
             scan_result=data.get("scan_result"),
+            policy_digest=data.get("policy_digest"),
+            policy_decision=data.get("policy_decision", "permit"),
+            authorization_ref=data.get("authorization_ref"),
         )
 
     def sign_batch(
@@ -890,6 +896,9 @@ class Agent:
                         rfc3161_tsa=(sig.get("rfc3161_timestamp") or {}).get("tsa"),
                         rfc3161_serial=(sig.get("rfc3161_timestamp") or {}).get("serial_number"),
                         scan_result=sig.get("scan_result"),
+                        policy_digest=sig.get("policy_digest"),
+                        policy_decision=sig.get("policy_decision", "permit"),
+                        authorization_ref=sig.get("authorization_ref"),
                     )
                 )
         return results


### PR DESCRIPTION
## Summary
- `SignatureResponse` dataclass (sync + async) gains `policy_digest`, `policy_decision`, `authorization_ref`.
- `Agent.sign`, `Agent.sign_batch`, and `AsyncAgent.sign` populate these from the API body.
- `policy_decision` defaults to `"permit"`; third parties can now reconstruct the exact JCS bytes the Cloud API signed and re-verify offline.
- Bumps PyPI version 0.2.18 -> 0.2.19.

## Test plan
- [ ] CI green across all 4 required checks.
- [ ] Smoke: `asqav demo` still opens the local dashboard.
- [ ] Against prod: `Agent.sign(...)` returns a `SignatureResponse` where `policy_digest` is a hex string, `policy_decision == "permit"`, and `authorization_ref is None` for an unapproved action.