### PR TITLE
feat: 0.2.20 - governance fields + BitcoinAnchor on SignatureResponse, tier-corrected README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [0.2.19] - 2026-04-20
+
+### Added
+- `SignatureResponse` now exposes `policy_digest`, `policy_decision`, `authorization_ref` so third parties can reconstruct the JCS bytes that were signed and re-verify offline. Populated by both `Agent.sign` and `Agent.sign_batch` (and the async client).
+
 ## [0.2.18] - 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [0.2.20] - 2026-04-20
+
+### Added
+- `BitcoinAnchor` dataclass and `SignatureResponse.bitcoin_anchor` field. Status is one of `none`, `pending`, `confirmed`, `failed` so callers can branch before treating a signature as Bitcoin-anchored. Addresses a gap where the ML-DSA `signature` was present but anchoring state was invisible to client code.
+
+### Changed
+- README tier clarification: removed stale "managed KMS on Pro" claim, added an Enterprise sentence covering Managed KMS and bring-your-own KMS. Reflects cloud v0.2.10 tier move.
+
 ## [0.2.19] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -382,6 +382,20 @@ result = asqav.verify_output(sig.signature_id, output)
 assert result["verified"]
 ```
 
+## Governance fields on signatures
+
+Every `SignatureResponse` carries the governance context that produced it, so a third party can reconstruct the exact JCS bytes that were signed and re-verify offline:
+
+```python
+sig = agent.sign("tool:call", {"name": "search"})
+
+sig.policy_digest       # sha256 of the policy attestation snapshot
+sig.policy_decision     # "permit" or "deny"
+sig.authorization_ref   # approval_id when a HITL approval authorized the action, else None
+```
+
+`policy_decision` defaults to `"permit"`. When an action is denied, the API raises and you get a signed deny envelope through the standard error path.
+
 ## Budget tracking
 
 Client-side spend tracker that persists every cost as a signed record. Fails closed when the limit would be exceeded:

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ assert result["valid"] and result["all_valid"]
 
 ## Free tier
 
-Get started at no cost. Free includes 50K signatures/month, 20 agents, 10 policies, 3 team members, OpenTimestamps, MCP server, audit export, and framework integrations. Content scanning, OpenTelemetry, managed KMS, and Replay API on Pro ($19/mo annual). Quarantine, incident management, multi-party signing, compliance reports, and RFC 3161 timestamps on Business ($79/mo annual). See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
+Get started at no cost. Free includes 50K signatures/month, 20 agents, 10 policies, 3 team members, OpenTimestamps, MCP server, audit export, and framework integrations. Content scanning, OpenTelemetry, and Replay API on Pro ($19/mo annual). Quarantine, incident management, multi-party signing, compliance reports, and RFC 3161 timestamps on Business ($79/mo annual). Managed KMS, SSO, IP allowlist, and bring-your-own KMS on Enterprise. See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
 
 ## Discovery
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.2.19"
+version = "0.2.20"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.2.18"
+version = "0.2.19"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/src/asqav/__init__.py
+++ b/src/asqav/__init__.py
@@ -110,7 +110,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.2.18"
+__version__ = "0.2.19"
 __all__ = [
     # Initialization
     "init",

--- a/src/asqav/__init__.py
+++ b/src/asqav/__init__.py
@@ -110,7 +110,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.2.19"
+__version__ = "0.2.20"
 __all__ = [
     # Initialization
     "init",

--- a/src/asqav/async_client.py
+++ b/src/asqav/async_client.py
@@ -254,6 +254,14 @@ class AsyncAgent:
             action_id=data["action_id"],
             timestamp=data["timestamp"],
             verification_url=data["verification_url"],
+            algorithm=data.get("algorithm"),
+            chain_hash=data.get("chain_hash") or data.get("record_hash"),
+            rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
+            rfc3161_serial=(data.get("rfc3161_timestamp") or {}).get("serial_number"),
+            scan_result=data.get("scan_result"),
+            policy_digest=data.get("policy_digest"),
+            policy_decision=data.get("policy_decision", "permit"),
+            authorization_ref=data.get("authorization_ref"),
         )
 
     async def start_session(self) -> SessionResponse:

--- a/src/asqav/async_client.py
+++ b/src/asqav/async_client.py
@@ -29,6 +29,7 @@ from .client import (
     VerificationResponse,
     _api_base,
     _api_key,
+    _parse_bitcoin_anchor,
     _parse_timestamp,
 )
 from .retry import with_async_retry
@@ -262,6 +263,7 @@ class AsyncAgent:
             policy_digest=data.get("policy_digest"),
             policy_decision=data.get("policy_decision", "permit"),
             authorization_ref=data.get("authorization_ref"),
+            bitcoin_anchor=_parse_bitcoin_anchor(data.get("bitcoin_anchor")),
         )
 
     async def start_session(self) -> SessionResponse:

--- a/src/asqav/client.py
+++ b/src/asqav/client.py
@@ -152,9 +152,41 @@ class TokenResponse:
     algorithm: str
 
 
+def _parse_bitcoin_anchor(raw: dict[str, Any] | None) -> "BitcoinAnchor | None":
+    """Turn the JSON bitcoin_anchor block from the API into a typed value."""
+    if not raw:
+        return None
+    return BitcoinAnchor(
+        status=raw.get("status") or "none",
+        bitcoin_tx=raw.get("bitcoin_tx"),
+        bitcoin_block=raw.get("bitcoin_block"),
+    )
+
+
+@dataclass
+class BitcoinAnchor:
+    """Bitcoin anchor state for a signed action.
+
+    Branch on ``status`` before treating the signature as Bitcoin-anchored:
+    - ``none``: no OpenTimestamps proof was attached (free tier path).
+    - ``pending``: OTS stamp submitted, not yet included in a Bitcoin block.
+    - ``confirmed``: OTS calendar upgraded the proof to a specific block.
+    - ``failed``: OTS upgrade failed permanently; treat as unanchored.
+    """
+
+    status: str
+    bitcoin_tx: str | None = None
+    bitcoin_block: int | None = None
+
+
 @dataclass
 class SignatureResponse:
-    """Response from signing operation."""
+    """Response from signing operation.
+
+    The ML-DSA ``signature`` is always present. ``bitcoin_anchor`` carries
+    the anchoring state separately so callers can distinguish a
+    cryptographically signed action from one that is also Bitcoin-anchored.
+    """
 
     signature: str
     signature_id: str
@@ -169,6 +201,7 @@ class SignatureResponse:
     policy_digest: str | None = None
     policy_decision: str = "permit"
     authorization_ref: str | None = None
+    bitcoin_anchor: BitcoinAnchor | None = None
 
 
 @dataclass
@@ -834,6 +867,7 @@ class Agent:
             policy_digest=data.get("policy_digest"),
             policy_decision=data.get("policy_decision", "permit"),
             authorization_ref=data.get("authorization_ref"),
+            bitcoin_anchor=_parse_bitcoin_anchor(data.get("bitcoin_anchor")),
         )
 
     def sign_batch(
@@ -899,6 +933,7 @@ class Agent:
                         policy_digest=sig.get("policy_digest"),
                         policy_decision=sig.get("policy_decision", "permit"),
                         authorization_ref=sig.get("authorization_ref"),
+                        bitcoin_anchor=_parse_bitcoin_anchor(sig.get("bitcoin_anchor")),
                     )
                 )
         return results

--- a/src/asqav/client.py
+++ b/src/asqav/client.py
@@ -166,6 +166,9 @@ class SignatureResponse:
     rfc3161_tsa: str | None = None
     rfc3161_serial: str | None = None
     scan_result: dict[str, Any] | None = None
+    policy_digest: str | None = None
+    policy_decision: str = "permit"
+    authorization_ref: str | None = None
 
 
 @dataclass
@@ -828,6 +831,9 @@ class Agent:
             rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
             rfc3161_serial=(data.get("rfc3161_timestamp") or {}).get("serial_number"),
             scan_result=data.get("scan_result"),
+            policy_digest=data.get("policy_digest"),
+            policy_decision=data.get("policy_decision", "permit"),
+            authorization_ref=data.get("authorization_ref"),
         )
 
     def sign_batch(
@@ -890,6 +896,9 @@ class Agent:
                         rfc3161_tsa=(sig.get("rfc3161_timestamp") or {}).get("tsa"),
                         rfc3161_serial=(sig.get("rfc3161_timestamp") or {}).get("serial_number"),
                         scan_result=sig.get("scan_result"),
+                        policy_digest=sig.get("policy_digest"),
+                        policy_decision=sig.get("policy_decision", "permit"),
+                        authorization_ref=sig.get("authorization_ref"),
                     )
                 )
         return results


### PR DESCRIPTION
## Summary
Supersedes closed #78. Combines two scopes shipped together in cloud 0.2.10.

**SignatureResponse additions:**
- `policy_digest`, `policy_decision`, `authorization_ref` for offline JCS re-verification.
- `bitcoin_anchor: BitcoinAnchor | None` with explicit `status` enum (`none` / `pending` / `confirmed` / `failed`). Closes a gap where the ML-DSA signature was present but anchoring state was invisible, which caused downstream consumers to misinterpret pending anchors as Bitcoin-confirmed.

**Other:**
- `Agent.sign`, `Agent.sign_batch`, and `AsyncAgent.sign` now populate all new fields.
- README tier sentence corrected: `Managed KMS` moved from Pro to Enterprise, with explicit `bring-your-own KMS` note. Mirrors cloud v0.2.10 (Managed KMS is Enterprise-only).
- Version: 0.2.18 -> 0.2.20.

## Test plan
- [ ] 4 required CI checks green.
- [ ] `asqav demo` still opens the local dashboard.
- [ ] Against prod `api.asqav.com` after cloud v0.2.10 deploy lands: `Agent.sign(...).bitcoin_anchor.status in {"none","pending","confirmed"}` is truthy; `policy_digest` is a hex string; `policy_decision == "permit"` for an unapproved action.