### PR TITLE
feat(sign): counterparty identity + conformance vectors

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,48 @@
+# Asqav Conformance Vectors
+
+Reference inputs for any third-party implementation that wants to verify an Asqav signed record. Use these vectors to confirm that your canonicalization and hashing match ours, bit-for-bit.
+
+## What these vectors cover
+
+1. The exact JSON canonicalization rule we use before signing.
+2. The SHA-256 digest of the canonical bytes.
+3. The shape of the `_counterparty` field.
+
+These vectors intentionally do NOT pin ML-DSA-65 signature bytes. FIPS 204 supports both deterministic and randomized signing; our server uses the randomized variant so signatures vary across calls for the same input. Verification is still deterministic, which is the property auditors care about.
+
+## Canonicalization rule
+
+Asqav uses RFC 8785 JSON Canonicalization Scheme (JCS):
+
+- UTF-8 encoded.
+- Object keys sorted lexicographically by Unicode code point.
+- No insignificant whitespace between tokens.
+- Numbers serialized per ECMAScript `ToString(ToNumber(x))`.
+- Strings escaped per JSON RFC 8259.
+
+Before signing, the server canonicalizes `{"action_type": ..., "context": ...}` (plus server-side metadata) and hashes with SHA-256. The hash is what ML-DSA-65 signs.
+
+## Verifying an Asqav signature
+
+1. Fetch the record: `GET https://api.asqav.com/api/v1/verify/{signature_id}`.
+2. Re-build the canonical bytes from the returned `payload` using your JCS implementation.
+3. SHA-256 the canonical bytes; compare to the `chain_hash` field.
+4. Verify the `signature` bytes against the agent `public_key` using any FIPS 204 / ML-DSA-65 library (liboqs, BoringSSL, pqcrypto, OpenSSL 3.5+).
+
+## Vectors
+
+See `vectors.json`. Each vector has:
+
+- `input`: the raw action payload.
+- `canonical`: the JCS-canonical byte sequence, shown as a UTF-8 string.
+- `sha256`: the SHA-256 of the canonical bytes, hex-encoded.
+
+If your implementation produces the same `canonical` and `sha256` for each `input`, you are ready to verify live Asqav records.
+
+## Reporting mismatches
+
+If your implementation produces a different `canonical` or `sha256` for one of the provided inputs, open an issue at https://github.com/jagmarques/asqav-sdk/issues with your implementation, language, and JCS library name.
+
+## License
+
+These vectors are public domain (CC0).

--- a/conformance/vectors.json
+++ b/conformance/vectors.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "canonicalization": "RFC 8785 JCS",
+  "hash_algorithm": "SHA-256",
+  "vectors": [
+    {
+      "name": "minimal_read",
+      "description": "Simplest read action, no context.",
+      "input": {
+        "action_type": "read:data",
+        "context": {}
+      },
+      "canonical": "{\"action_type\":\"read:data\",\"context\":{}}",
+      "sha256": "991033e23a3e0939c258e10f2f8f88183d9bcdb08de62ef02446e11e0819c671"
+    },
+    {
+      "name": "tool_call_with_counterparty",
+      "description": "Action with counterparty TLS fingerprint bound into the record.",
+      "input": {
+        "action_type": "api:call",
+        "context": {
+          "_counterparty": {
+            "kind": "tls_spki_sha256",
+            "value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          },
+          "tool": "database.query",
+          "args_hash": "sha256:9f2e0b1c4a"
+        }
+      },
+      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"_counterparty\":{\"kind\":\"tls_spki_sha256\",\"value\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\"},\"args_hash\":\"sha256:9f2e0b1c4a\",\"tool\":\"database.query\"}}",
+      "sha256": "a6c39c3b6e09761a141148c0862edbeaeb59642b4e0a1e4a85d6fba63f634ff4"
+    },
+    {
+      "name": "traced_child_action",
+      "description": "Child action with trace_id + parent_id linking to a workflow.",
+      "input": {
+        "action_type": "api:call",
+        "context": {
+          "_trace_id": "tr_01HVZABC",
+          "_parent_id": "act_01HVZPARENT",
+          "_system_prompt_hash": "sha256:aaa"
+        }
+      },
+      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"_parent_id\":\"act_01HVZPARENT\",\"_system_prompt_hash\":\"sha256:aaa\",\"_trace_id\":\"tr_01HVZABC\"}}",
+      "sha256": "9294075a29c366f9dfc54b8b7f8fa0054c290fef20e8931e93e94b2bee921d22"
+    }
+  ]
+}

--- a/src/asqav/client.py
+++ b/src/asqav/client.py
@@ -805,6 +805,7 @@ class Agent:
         tool_inputs_hash: str | None = None,
         trace_id: str | None = None,
         parent_id: str | None = None,
+        counterparty: dict[str, Any] | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -825,13 +826,30 @@ class Agent:
                 a multi-step workflow. Use generate_trace_id() to create one.
             parent_id: Optional parent action ID for linking child actions
                 to their parent in a workflow.
+            counterparty: Optional identity of the endpoint the agent is
+                calling. Included in the signed record so an auditor can
+                verify the agent reached a specific endpoint, not an
+                imposter. Recommended shape::
+
+                    {"kind": "tls_spki_sha256", "value": "<hex>"}
+                    {"kind": "pubkey_fingerprint", "value": "<hex>"}
+                    {"kind": "url_sni", "value": "api.example.com"}
+
+                Any dict is accepted; unknown kinds are recorded verbatim.
 
         Returns:
             SignatureResponse with the signature.
         """
         action_type = resolve_pattern(action_type)
 
-        if system_prompt_hash or model_params or tool_inputs_hash or trace_id or parent_id:
+        if (
+            system_prompt_hash
+            or model_params
+            or tool_inputs_hash
+            or trace_id
+            or parent_id
+            or counterparty
+        ):
             context = dict(context) if context else {}
             if system_prompt_hash:
                 context["_system_prompt_hash"] = system_prompt_hash
@@ -843,6 +861,8 @@ class Agent:
                 context["_trace_id"] = trace_id
             if parent_id:
                 context["_parent_id"] = parent_id
+            if counterparty:
+                context["_counterparty"] = counterparty
 
         data = _post(
             f"/agents/{self.agent_id}/sign",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -259,6 +259,34 @@ def test_sign_method_returns_signature_response_annotation() -> None:
     assert "SignatureResponse" in str(sig.return_annotation)
 
 
+def test_sign_accepts_counterparty_kwarg() -> None:
+    """sign() exposes a counterparty kwarg for endpoint-identity binding."""
+    import inspect
+
+    sig = inspect.signature(asqav.Agent.sign)
+    assert "counterparty" in sig.parameters
+    assert sig.parameters["counterparty"].default is None
+
+
+@patch("asqav.client._post")
+def test_sign_passes_counterparty_into_context(mock_post: object) -> None:
+    """counterparty kwarg lands in context under _counterparty."""
+    mock_post.return_value = {  # type: ignore[attr-defined]
+        "signature": "sig_bytes",
+        "signature_id": "sig_01",
+        "action_id": "act_01",
+        "timestamp": "2026-04-22T10:00:00Z",
+        "verification_url": "https://api.asqav.com/api/v1/verify/sig_01",
+    }
+    agent = _make_agent()
+    cp = {"kind": "tls_spki_sha256", "value": "abc123"}
+    agent.sign(action_type="api:call", counterparty=cp)
+
+    call_kwargs = mock_post.call_args  # type: ignore[attr-defined]
+    sent_body = call_kwargs[0][1]
+    assert sent_body["context"]["_counterparty"] == cp
+
+
 # ---------------------------------------------------------------------------
 # Agent.sign_batch
 # ---------------------------------------------------------------------------

--- a/tests/test_conformance_vectors.py
+++ b/tests/test_conformance_vectors.py
@@ -1,0 +1,49 @@
+"""Verify conformance vectors are internally consistent.
+
+Any third-party implementation should be able to reproduce the canonical bytes
+and SHA-256 for each input. If this test fails, vectors.json was edited without
+regenerating the derived fields.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+VECTORS_PATH = Path(__file__).parent.parent / "conformance" / "vectors.json"
+
+
+def _jcs(obj: object) -> str:
+    return json.dumps(obj, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+
+
+def test_vectors_file_exists() -> None:
+    assert VECTORS_PATH.exists(), f"missing {VECTORS_PATH}"
+
+
+def test_vectors_schema_metadata() -> None:
+    d = json.loads(VECTORS_PATH.read_text())
+    assert d["version"] == 1
+    assert d["canonicalization"] == "RFC 8785 JCS"
+    assert d["hash_algorithm"] == "SHA-256"
+    assert isinstance(d["vectors"], list)
+    assert len(d["vectors"]) >= 3
+
+
+def test_each_vector_canonical_matches_input() -> None:
+    d = json.loads(VECTORS_PATH.read_text())
+    for v in d["vectors"]:
+        expected_canon = _jcs(v["input"])
+        assert v["canonical"] == expected_canon, (
+            f"{v['name']}: canonical drift. Regenerate vectors.json."
+        )
+
+
+def test_each_vector_sha256_matches_canonical() -> None:
+    d = json.loads(VECTORS_PATH.read_text())
+    for v in d["vectors"]:
+        expected_hash = hashlib.sha256(v["canonical"].encode("utf-8")).hexdigest()
+        assert v["sha256"] == expected_hash, (
+            f"{v['name']}: sha256 drift. Regenerate vectors.json."
+        )


### PR DESCRIPTION
## Summary

Two additions, same branch:

### 1. counterparty kwarg on sign()
Optional endpoint-identity field that lands in the signed record under context._counterparty. Lets an auditor bind each action to the endpoint it was sent to (TLS SPKI hash, pubkey fingerprint, SNI). No new protocol, no new handshake. Documented shape in the docstring.

### 2. conformance/ directory
- README.md: explains JCS canonicalization, SHA-256, and how to verify an Asqav record with any FIPS 204 library.
- vectors.json: 3 test vectors with input, canonical form, and SHA-256. Reproducible by any JCS-compatible implementation. Enables JS, Go, Rust SDKs built by the community.
- tests/test_conformance_vectors.py: CI guard, fails if vectors drift from their inputs.

### Not in this PR (deliberate)
- Mutual-auth handshake. Redundant given our A2A Agent Cards are already signed with ML-DSA-65.
- JS SDK. Distribution play, not a compliance need.
- Bounded clock-skew window. signature_id uniqueness already prevents server-side replay.

### Tests
6 new, all pass locally. Ruff clean.
