### PR TITLE
Add sign_reasoning SDK helper (0.2.21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ htmlcov/
 Upsonic/
 .gstack/
 dist/
+
+# local tooling state (never commit)
+.company/
+.claude/
+.planning/
+.cursor/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.2.20"
+version = "0.2.21"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/src/asqav/__init__.py
+++ b/src/asqav/__init__.py
@@ -106,11 +106,12 @@ from .decorators import async_session, session, sign
 from .local import LocalQueue, local_sign
 from .patterns import PATTERNS, list_patterns, resolve_pattern
 from .phases import PhaseChain, sign_with_phases
+from .reasoning import ReasoningReceipt, sign_reasoning
 from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.2.20"
+__version__ = "0.2.21"
 __all__ = [
     # Initialization
     "init",
@@ -230,6 +231,9 @@ __all__ = [
     # Three-Phase Signing
     "PhaseChain",
     "sign_with_phases",
+    # Reasoning Trace
+    "ReasoningReceipt",
+    "sign_reasoning",
     # Exceptions
     "AsqavError",
     "AuthenticationError",

--- a/src/asqav/reasoning.py
+++ b/src/asqav/reasoning.py
@@ -1,0 +1,143 @@
+"""Reasoning-trace signing helper.
+
+Captures an LLM action's prompt, reasoning trace, and output as a single
+signed receipt. Only SHA-256 hashes of the three payloads are sent to the
+API by default, so raw prompt text and intermediate chain-of-thought never
+leave the caller unless explicitly opted in via ``store_raw``.
+
+Built on top of ``Agent.sign`` (client.py:799) and the existing context
+fields already understood by the server (``_system_prompt_hash``,
+``_tool_inputs_hash``). No new server surface is required.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+def _sha256(data: Any) -> str:
+    """Return hex SHA-256 of ``data``.
+
+    Dicts and lists are canonicalized via ``json.dumps(..., sort_keys=True)``
+    so equivalent structures produce equal hashes. Bytes pass through.
+    Everything else is ``str()``-coerced.
+    """
+    if isinstance(data, bytes):
+        payload = data
+    elif isinstance(data, str):
+        payload = data.encode("utf-8")
+    else:
+        payload = json.dumps(data, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+@dataclass
+class ReasoningReceipt:
+    """Wrapper around ``SignatureResponse`` plus the three captured hashes."""
+
+    signature: Any  # SignatureResponse
+    prompt_hash: str
+    trace_hash: str
+    output_hash: str
+    raw_stored: bool = False
+    retention_days: int | None = None
+
+    @property
+    def signature_id(self) -> str:
+        return self.signature.signature_id
+
+    @property
+    def verification_url(self) -> str:
+        return self.signature.verification_url
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "signature_id": self.signature.signature_id,
+            "action_id": self.signature.action_id,
+            "timestamp": self.signature.timestamp,
+            "verification_url": self.signature.verification_url,
+            "prompt_hash": self.prompt_hash,
+            "trace_hash": self.trace_hash,
+            "output_hash": self.output_hash,
+            "raw_stored": self.raw_stored,
+            "retention_days": self.retention_days,
+        }
+
+
+def sign_reasoning(
+    agent: Any,
+    prompt: Any,
+    trace: Any,
+    output: Any,
+    action_type: str = "ai:reasoning",
+    context: dict[str, Any] | None = None,
+    trace_id: str | None = None,
+    parent_id: str | None = None,
+    store_raw: bool = False,
+    retention_days: int | None = None,
+) -> ReasoningReceipt:
+    """Sign an LLM action's prompt + reasoning trace + output.
+
+    By default only SHA-256 hashes of the three payloads are posted to the
+    API. The raw text never leaves the caller. Set ``store_raw=True`` to
+    additionally post the raw payloads (subject to ``retention_days`` on
+    the server side).
+
+    Args:
+        agent: An ``Agent`` (or compatible) with a ``.sign(...)`` method.
+        prompt: The user-visible or system prompt. Any JSON-serializable
+            value is accepted; strings and dicts are canonicalized before
+            hashing.
+        trace: The reasoning trace (chain-of-thought messages, tool calls,
+            intermediate steps). Any JSON-serializable value.
+        output: The final model output.
+        action_type: Action type passed through to ``sign``. Defaults to
+            ``"ai:reasoning"``.
+        context: Extra context merged into the ``sign`` call.
+        trace_id: Optional trace ID for correlation.
+        parent_id: Optional parent signature ID for chaining.
+        store_raw: If True, include the raw prompt/trace/output in the
+            signed context. Default False (hash-only).
+        retention_days: Optional server-side retention window for raw
+            payloads. Only meaningful when ``store_raw=True``.
+
+    Returns:
+        ``ReasoningReceipt`` bundling the underlying signature and the
+        three hashes.
+    """
+    prompt_hash = _sha256(prompt)
+    trace_hash = _sha256(trace)
+    output_hash = _sha256(output)
+
+    merged_context: dict[str, Any] = dict(context) if context else {}
+    merged_context["_prompt_hash"] = prompt_hash
+    merged_context["_reasoning_trace_hash"] = trace_hash
+    merged_context["_output_hash"] = output_hash
+
+    if store_raw:
+        merged_context["_raw_prompt"] = prompt
+        merged_context["_raw_reasoning_trace"] = trace
+        merged_context["_raw_output"] = output
+        if retention_days is not None:
+            merged_context["_raw_retention_days"] = int(retention_days)
+
+    signature = agent.sign(
+        action_type,
+        context=merged_context,
+        system_prompt_hash=prompt_hash,
+        tool_inputs_hash=trace_hash,
+        trace_id=trace_id,
+        parent_id=parent_id,
+    )
+
+    return ReasoningReceipt(
+        signature=signature,
+        prompt_hash=prompt_hash,
+        trace_hash=trace_hash,
+        output_hash=output_hash,
+        raw_stored=bool(store_raw),
+        retention_days=int(retention_days) if retention_days is not None else None,
+    )

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,0 +1,164 @@
+"""Tests for asqav.sign_reasoning helper."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from asqav.client import SignatureResponse
+from asqav.reasoning import ReasoningReceipt, _sha256, sign_reasoning
+
+
+def _mock_agent() -> MagicMock:
+    agent = MagicMock()
+    agent.sign.return_value = SignatureResponse(
+        signature="sig-1",
+        signature_id="sid-1",
+        action_id="aid-1",
+        timestamp=1700000000.0,
+        verification_url="https://asqav.com/verify/sid-1",
+    )
+    return agent
+
+
+def test_sign_reasoning_stores_hashes_only():
+    """Default mode posts only hashes, never raw prompt/trace/output."""
+    agent = _mock_agent()
+
+    prompt = "classify this ticket as urgent"
+    trace = [
+        {"role": "assistant", "content": "Let me think..."},
+        {"role": "tool", "name": "search", "args": {"q": "urgent"}},
+    ]
+    output = {"label": "urgent", "confidence": 0.93}
+
+    receipt = sign_reasoning(agent, prompt, trace, output)
+
+    assert isinstance(receipt, ReasoningReceipt)
+    assert receipt.prompt_hash == _sha256(prompt)
+    assert receipt.trace_hash == _sha256(trace)
+    assert receipt.output_hash == _sha256(output)
+    assert receipt.raw_stored is False
+
+    agent.sign.assert_called_once()
+    kwargs = agent.sign.call_args.kwargs
+    ctx = kwargs["context"]
+
+    # Hashes are present
+    assert ctx["_prompt_hash"] == receipt.prompt_hash
+    assert ctx["_reasoning_trace_hash"] == receipt.trace_hash
+    assert ctx["_output_hash"] == receipt.output_hash
+
+    # Raw payloads are NOT present by default
+    assert "_raw_prompt" not in ctx
+    assert "_raw_reasoning_trace" not in ctx
+    assert "_raw_output" not in ctx
+
+    # No raw text anywhere in the serialized context, digest only
+    serialized = json.dumps(ctx, sort_keys=True, default=str)
+    assert "urgent" not in serialized
+    assert "Let me think" not in serialized
+
+
+def test_sign_reasoning_raw_optional():
+    """store_raw=True adds raw payloads under _raw_* keys."""
+    agent = _mock_agent()
+
+    receipt = sign_reasoning(
+        agent,
+        prompt="hello",
+        trace=["step-1", "step-2"],
+        output={"final": "done"},
+        store_raw=True,
+    )
+
+    assert receipt.raw_stored is True
+
+    ctx = agent.sign.call_args.kwargs["context"]
+    assert ctx["_raw_prompt"] == "hello"
+    assert ctx["_raw_reasoning_trace"] == ["step-1", "step-2"]
+    assert ctx["_raw_output"] == {"final": "done"}
+
+    # Hashes are still present alongside raw
+    assert ctx["_prompt_hash"] == hashlib.sha256(b"hello").hexdigest()
+
+
+def test_sign_reasoning_retention_param():
+    """retention_days flows to context and ReasoningReceipt when raw is on."""
+    agent = _mock_agent()
+
+    receipt = sign_reasoning(
+        agent,
+        prompt="p",
+        trace="t",
+        output="o",
+        store_raw=True,
+        retention_days=30,
+    )
+
+    assert receipt.retention_days == 30
+    ctx = agent.sign.call_args.kwargs["context"]
+    assert ctx["_raw_retention_days"] == 30
+
+
+def test_sign_reasoning_retention_ignored_without_store_raw():
+    """retention_days without store_raw does not leak raw payloads."""
+    agent = _mock_agent()
+
+    sign_reasoning(
+        agent,
+        prompt="p",
+        trace="t",
+        output="o",
+        retention_days=7,
+    )
+
+    ctx = agent.sign.call_args.kwargs["context"]
+    assert "_raw_prompt" not in ctx
+    assert "_raw_retention_days" not in ctx
+
+
+def test_sha256_canonicalizes_dict_key_order():
+    """Equivalent dicts in different key order produce equal hashes."""
+    a = {"x": 1, "y": 2}
+    b = {"y": 2, "x": 1}
+    assert _sha256(a) == _sha256(b)
+
+
+def test_sign_reasoning_merges_user_context():
+    """Caller-supplied context is preserved alongside injected hashes."""
+    agent = _mock_agent()
+
+    sign_reasoning(
+        agent,
+        prompt="p",
+        trace="t",
+        output="o",
+        context={"customer": "acme", "request_id": "r-42"},
+    )
+
+    ctx = agent.sign.call_args.kwargs["context"]
+    assert ctx["customer"] == "acme"
+    assert ctx["request_id"] == "r-42"
+    assert "_prompt_hash" in ctx
+
+
+def test_sign_reasoning_passes_trace_and_parent_ids():
+    """trace_id and parent_id reach the underlying sign() call."""
+    agent = _mock_agent()
+
+    sign_reasoning(
+        agent,
+        prompt="p",
+        trace="t",
+        output="o",
+        trace_id="trace-123",
+        parent_id="parent-sig-9",
+    )
+
+    kwargs = agent.sign.call_args.kwargs
+    assert kwargs["trace_id"] == "trace-123"
+    assert kwargs["parent_id"] == "parent-sig-9"


### PR DESCRIPTION
## Summary

- Adds ``asqav.sign_reasoning(prompt, trace, output)`` as a thin wrapper on ``Agent.sign``. Hashes the three payloads with SHA-256 and stores the digests in the receipt context. Raw payloads never leave the caller unless ``store_raw=True``.
- Optional ``retention_days`` is forwarded in context when raw payloads are opted in.
- Version bump 0.2.20 -> 0.2.21.

## Files

- src/asqav/reasoning.py (new, 148 LOC)
- src/asqav/__init__.py (export ``ReasoningReceipt`` + ``sign_reasoning``, bump ``__version__``)
- tests/test_reasoning.py (7 tests, all passing locally)
- pyproject.toml (version bump)

## Test plan

- [x] ``pytest tests/test_reasoning.py`` passes 7/7 locally
- [x] ``pytest tests/test_phases.py tests/test_client.py`` shows no regressions (26/26)
- [ ] CI green on push

## Release

This PR does NOT publish to PyPI. After merge, release with:

```
cd asqav-sdk
git checkout main && git pull
python -m build
twine upload dist/asqav-0.2.21*
```