### PR TITLE
use support@asqav.com, hello@ does not exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
-    { name = "Asqav", email = "hello@asqav.com" }
+    { name = "Asqav", email = "support@asqav.com" }
 ]
 keywords = [
     "ai",


### PR DESCRIPTION
## Summary
- `hello@asqav.com` is not a routed alias in Cloudflare Email Routing (catch-all is off), so mail bounces with 550.
- Update package metadata author email to `support@asqav.com`, which is an active, monitored alias.

## Test plan
- [ ] `pyproject.toml` author email is `support@asqav.com`.
- [ ] `grep -rn "hello@asqav" .` returns no results.
- [ ] Next PyPI release will publish with the working support address.