### PR TITLE
prep 0.2.21 release: changelog entry, readme section, example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [0.2.21] - 2026-04-25
+
+### Added
+- `sign_reasoning(prompt, trace, output, agent_id, ...)` helper. Signs hashes of prompt / reasoning trace / output as three-phase bilateral receipts on the existing hash store. Optional raw-store with retention parameter.
+
 ## [0.2.20] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -213,6 +213,29 @@ from asqav_pydantic import AsqavHooks
 
 See [integration docs](https://asqav.com/docs/integrations) for full setup guides.
 
+## Reasoning trace signing
+
+Sign the full prompt, reasoning trace, and output for every agent decision. Only SHA-256 hashes of the three payloads are sent by default, so raw text never leaves your process.
+
+```python
+import asqav
+from asqav import sign_reasoning
+
+asqav.init(api_key="sk_...")
+agent = asqav.Agent.create("research-crawler")
+
+receipt = sign_reasoning(
+    agent,
+    prompt="summarise the quarterly risk report",
+    trace="step 1 ... step 2 ... step 3",
+    output="summary text ...",
+)
+
+print(receipt.signature_id, receipt.prompt_hash, receipt.trace_hash, receipt.output_hash)
+```
+
+Pass `store_raw=True` with `retention_days=N` to additionally persist the full prompt, trace, and output on Asqav for the given retention window.
+
 ## Three-phase signing
 
 Break high-stakes actions into intent, decision, and execution phases. Each phase produces a signed receipt, and execution only proceeds if policy allows it.

--- a/examples/reasoning_trace_example.py
+++ b/examples/reasoning_trace_example.py
@@ -1,0 +1,57 @@
+"""Example: sign prompt + reasoning trace + output for an AI agent decision.
+
+Only SHA-256 hashes of the prompt, reasoning trace, and output are posted
+to the Asqav API by default. Pass ``store_raw=True`` with ``retention_days``
+to additionally persist the raw payloads on Asqav for the given retention
+window.
+
+Usage:
+    ASQAV_API_KEY=sk_... python examples/reasoning_trace_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import asqav
+from asqav import sign_reasoning
+
+
+def main() -> None:
+    api_key = os.environ.get("ASQAV_API_KEY")
+    if not api_key:
+        raise SystemExit(
+            "Set the ASQAV_API_KEY environment variable before running this example.\n"
+            "Get your key at https://asqav.com"
+        )
+
+    asqav.init(api_key=api_key)
+    agent = asqav.Agent.create("research-crawler")
+
+    prompt = "Summarise the most recent quarterly risk report."
+    trace = (
+        "Step 1: identified the quarterly risk report for Q1 2026.\n"
+        "Step 2: extracted top five risks.\n"
+        "Step 3: drafted the summary."
+    )
+    output = "Top risks: concentration, liquidity, operational, cyber, regulatory."
+
+    receipt = sign_reasoning(
+        agent,
+        prompt=prompt,
+        trace=trace,
+        output=output,
+    )
+
+    print("signed reasoning receipt:")
+    print(f"  signature_id: {receipt.signature_id}")
+    print(f"  verification_url: {receipt.verification_url}")
+    print(f"  prompt_hash: {receipt.prompt_hash}")
+    print(f"  trace_hash: {receipt.trace_hash}")
+    print(f"  output_hash: {receipt.output_hash}")
+    print(f"  ts: {receipt.signature.timestamp}")
+    print(f"  raw_stored: {receipt.raw_stored}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- CHANGELOG.md: new `[0.2.21] - 2026-04-25` block documenting the `sign_reasoning` helper.
- README.md: new "Reasoning trace signing" section with a hash-only-by-default usage snippet and a note about `store_raw=True` + `retention_days`.
- examples/reasoning_trace_example.py: runnable example using the real `sign_reasoning` helper and `ReasoningReceipt` shape (`signature_id`, `prompt_hash`, `trace_hash`, `output_hash`).

## Test plan
- [ ] CI green
- [ ] Squash + delete branch on merge