### PR TITLE
add pypi trusted publisher workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/asqav
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install build
+      - run: python -m build
+      - run: ls -la dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
OIDC publish via pypa/gh-action-pypi-publish on tag v* push. Uses environment name 'pypi'. If PyPI Trusted Publishing config does not match this workflow filename/environment, the first run will fail with a clear error and we adjust.