### PR TITLE
docs: refresh sdk readme value prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Each signed action returns:
 | Any agent can do anything | Policies block dangerous actions in real-time |
 | One person approves everything | Multi-party authorization for critical actions |
 | Manual compliance reports | Automated EU AI Act and DORA reports |
-| Breaks when quantum computers arrive | Quantum-safe from day one |
+| Reasoning lost after the run | Prompt, trace, and output signed and replayable |
 
 ## Decorators and context managers
 


### PR DESCRIPTION
Replaces stale quantum-safe pitch line with reasoning-trace value prop, matching shipped 0.2.21 sign_reasoning helper.