### PR TITLE
bump python to 0.2.22

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.2.21"
+version = "0.2.22"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"


### PR DESCRIPTION
First release after monorepo restructure. Triggers PyPI publish via py-v0.2.22 tag.