### PR TITLE
rename npm package: asqav -> @asqav/sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install asqav
 TypeScript / Node.js:
 
 ```bash
-npm install asqav
+npm install @asqav/sdk
 ```
 
 Both packages have zero native dependencies. All ML-DSA cryptography runs server-side.
@@ -65,7 +65,7 @@ print(sig.signature_id, sig.verify_url)
 TypeScript:
 
 ```ts
-import { Asqav } from "asqav";
+import { Asqav } from "@asqav/sdk";
 
 const asqav = new Asqav({ apiKey: "sk_..." });
 
@@ -131,7 +131,7 @@ asqav-sdk/
     tests/
     pyproject.toml
     README.md
-  typescript/       TypeScript SDK (npm install asqav)
+  typescript/       TypeScript SDK (npm install @asqav/sdk)
     src/
     tests/
     package.json
@@ -163,7 +163,7 @@ print(result["agent_id"], result["chain_hash"])
 TypeScript:
 
 ```ts
-import { verify } from "asqav";
+import { verify } from "@asqav/sdk";
 
 const result = await verify("sig_a1b2c3");
 console.assert(result.verified);

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -5,13 +5,13 @@ TypeScript SDK for [asqav.com](https://asqav.com). All ML-DSA cryptography runs 
 ## Install
 
 ```bash
-npm install asqav
+npm install @asqav/sdk
 ```
 
 ## Quick start
 
 ```ts
-import { init, Agent } from "asqav";
+import { init, Agent } from "@asqav/sdk";
 
 init({ apiKey: process.env.ASQAV_API_KEY });
 
@@ -43,7 +43,7 @@ import {
   AuthenticationError,
   RateLimitError,
   APIError,
-} from "asqav";
+} from "@asqav/sdk";
 ```
 
 ### `init({ apiKey, baseUrl })`

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,23 +1,52 @@
 {
-  "name": "asqav",
+  "name": "@asqav/sdk",
   "version": "0.1.0",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
-  "keywords": ["ai", "agents", "governance", "audit-trail", "compliance", "ml-dsa", "policy-enforcement"],
+  "keywords": [
+    "ai",
+    "agents",
+    "governance",
+    "audit-trail",
+    "compliance",
+    "ml-dsa",
+    "policy-enforcement"
+  ],
   "license": "MIT",
   "author": "Asqav <support@asqav.com>",
   "homepage": "https://asqav.com",
-  "repository": { "type": "git", "url": "https://github.com/jagmarques/asqav-sdk.git", "directory": "typescript" },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jagmarques/asqav-sdk.git",
+    "directory": "typescript"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.mjs", "require": "./dist/index.js" } },
-  "files": ["dist", "README.md", "LICENSE"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "test": "vitest run",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
-  "engines": { "node": ">=18" },
-  "devDependencies": { "@types/node": "^22.0.0", "tsup": "^8.3.0", "typescript": "^5.5.0", "vitest": "^2.1.0" }
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.0"
+  }
 }


### PR DESCRIPTION
npm rejected the unscoped name 'asqav' as too similar to existing package 'asap'. Switching to scoped @asqav/sdk per npm's recommendation. Reserves the @asqav org namespace for future packages.