### PR TITLE
examples: add vercel ai sdk and langchain.js cookbook recipes

### DIFF
--- a/typescript/examples/README.md
+++ b/typescript/examples/README.md
@@ -1,0 +1,57 @@
+# Asqav TypeScript Examples
+
+Runnable cookbook recipes that show how to wrap popular agent frameworks
+with `@asqav/sdk` so every tool execution produces an ML-DSA-signed audit
+record.
+
+## Common setup
+
+1. Get an API key at [asqav.com](https://asqav.com).
+2. Export it once per shell:
+
+   ```bash
+   export ASQAV_API_KEY=sk_...
+   export OPENAI_API_KEY=sk-...
+   ```
+
+3. From the `typescript/` directory, install the deps for the example you
+   want to run (each example lists its own install command at the top of
+   the file). Then run with `tsx`:
+
+   ```bash
+   npx tsx examples/<file>.ts
+   ```
+
+## Recipes
+
+### vercel-ai-sdk.ts
+
+Wraps a Vercel AI SDK `tool({ execute })` so the `execute` body calls
+`agent.sign()` before any side effect. Demonstrates `init()`,
+`Agent.create()`, `startSession()`, signed tool execution via
+`generateText({ model, tools, prompt })`, and `endSession()`.
+
+Install:
+
+```bash
+npm install @asqav/sdk ai @ai-sdk/openai zod
+```
+
+### langchain-js.ts
+
+Same pattern for LangChain.js. Defines a `tool(async (args) => {...}, { name, description, schema })`, binds it to `ChatOpenAI` with
+`.bindTools([refund])`, and signs every invocation through Asqav before
+the Stripe side effect runs.
+
+Install:
+
+```bash
+npm install @asqav/sdk @langchain/core @langchain/openai zod
+```
+
+## Pattern
+
+Both recipes follow the same rule: call `agent.sign({ actionType, context })`
+**before** the side effect. The signed intent lands in the Asqav audit
+trail even if the downstream API call throws, so you always know what the
+agent decided to do.

--- a/typescript/examples/langchain-js.ts
+++ b/typescript/examples/langchain-js.ts
@@ -1,0 +1,109 @@
+/**
+ * LangChain.js + Asqav cookbook recipe
+ *
+ * Wraps a LangChain tool so every call produces an ML-DSA-signed audit
+ * record on Asqav before the side effect runs. The signed intent persists
+ * even if the underlying API call throws.
+ *
+ * Install:
+ *   npm install @asqav/sdk @langchain/core @langchain/openai zod
+ *
+ * Env:
+ *   export ASQAV_API_KEY=sk_...   # from https://asqav.com
+ *   export OPENAI_API_KEY=sk-...
+ *
+ * Run:
+ *   tsx examples/langchain-js.ts
+ */
+
+import { tool } from "@langchain/core/tools";
+import { ChatOpenAI } from "@langchain/openai";
+import { z } from "zod";
+import { init, Agent } from "@asqav/sdk";
+
+// Stripe stub. Replace with the real Stripe call in production.
+async function stripeRefundStub(args: {
+  chargeId: string;
+  amountCents: number;
+  reason: string;
+}): Promise<{ refundId: string; status: string }> {
+  return {
+    refundId: `re_test_${Date.now()}`,
+    status: "succeeded",
+  };
+}
+
+async function main(): Promise<void> {
+  init({ apiKey: process.env.ASQAV_API_KEY });
+
+  const agent = await Agent.create({
+    name: "support-bot",
+    capabilities: ["refunds:issue"],
+  });
+
+  await agent.startSession();
+
+  const refundSchema = z.object({
+    chargeId: z.string().describe("The Stripe charge id, like ch_..."),
+    amountCents: z.number().int().positive().describe("Amount to refund in cents"),
+    reason: z.string().describe("Short reason for the refund"),
+  });
+
+  const refund = tool(
+    async (args: z.infer<typeof refundSchema>) => {
+      // Sign the intent FIRST. If the side effect throws, the audit
+      // record still proves what the agent decided to do.
+      const sig = await agent.sign({
+        actionType: "stripe:refund",
+        context: {
+          chargeId: args.chargeId,
+          amountCents: args.amountCents,
+          reason: args.reason,
+          model: "gpt-4o",
+        },
+      });
+
+      const result = await stripeRefundStub(args);
+
+      return JSON.stringify({
+        ...result,
+        asqavSignatureId: sig.signatureId,
+        asqavVerificationUrl: sig.verificationUrl,
+      });
+    },
+    {
+      name: "refund",
+      description:
+        "Refund a Stripe charge. Use only when the customer explicitly requests one.",
+      schema: refundSchema,
+    },
+  );
+
+  const model = new ChatOpenAI({ model: "gpt-4o", temperature: 0 });
+  const modelWithTools = model.bindTools([refund]);
+
+  const response = await modelWithTools.invoke([
+    {
+      role: "user",
+      content:
+        "Customer asked for a refund of 1299 cents on charge ch_test_abc because the item arrived broken. Issue the refund.",
+    },
+  ]);
+
+  console.log("Model tool calls:", JSON.stringify(response.tool_calls, null, 2));
+
+  // Execute any tool calls the model proposed.
+  for (const call of response.tool_calls ?? []) {
+    if (call.name === "refund") {
+      const result = await refund.invoke(call);
+      console.log("Tool result:", result);
+    }
+  }
+
+  await agent.endSession();
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/examples/vercel-ai-sdk.ts
+++ b/typescript/examples/vercel-ai-sdk.ts
@@ -1,0 +1,88 @@
+/**
+ * Vercel AI SDK + Asqav cookbook recipe
+ *
+ * Wraps a Vercel AI SDK tool so every invocation produces an ML-DSA-signed
+ * audit record on Asqav before the side effect runs. If the side effect
+ * throws, the signed intent still exists in the audit trail.
+ *
+ * Install:
+ *   npm install @asqav/sdk ai @ai-sdk/openai zod
+ *
+ * Env:
+ *   export ASQAV_API_KEY=sk_...   # from https://asqav.com
+ *   export OPENAI_API_KEY=sk-...
+ *
+ * Run:
+ *   tsx examples/vercel-ai-sdk.ts
+ */
+
+import { tool, generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+import { init, Agent } from "@asqav/sdk";
+
+// Stripe stub. Replace with the real Stripe call in production.
+async function stripeRefundStub(args: {
+  chargeId: string;
+  amountCents: number;
+  reason: string;
+}): Promise<{ refundId: string; status: string }> {
+  return {
+    refundId: `re_test_${Date.now()}`,
+    status: "succeeded",
+  };
+}
+
+async function main(): Promise<void> {
+  init({ apiKey: process.env.ASQAV_API_KEY });
+
+  const agent = await Agent.create({
+    name: "support-bot",
+    capabilities: ["refunds:issue"],
+  });
+
+  await agent.startSession();
+
+  const refund = tool({
+    description:
+      "Refund a Stripe charge. Use only when the customer explicitly requests one.",
+    inputSchema: z.object({
+      chargeId: z.string().describe("The Stripe charge id, like ch_..."),
+      amountCents: z.number().int().positive().describe("Amount to refund in cents"),
+      reason: z.string().describe("Short reason for the refund"),
+    }),
+    execute: async ({ chargeId, amountCents, reason }) => {
+      // Sign the intent FIRST. If the side effect throws, the audit
+      // record still proves what the agent decided to do.
+      const sig = await agent.sign({
+        actionType: "stripe:refund",
+        context: { chargeId, amountCents, reason, model: "gpt-4o" },
+      });
+
+      const result = await stripeRefundStub({ chargeId, amountCents, reason });
+
+      return {
+        ...result,
+        asqavSignatureId: sig.signatureId,
+        asqavVerificationUrl: sig.verificationUrl,
+      };
+    },
+  });
+
+  const { text, toolResults } = await generateText({
+    model: openai("gpt-4o"),
+    tools: { refund },
+    prompt:
+      "Customer asked for a refund of 1299 cents on charge ch_test_abc because the item arrived broken. Issue the refund.",
+  });
+
+  console.log("Model reply:", text);
+  console.log("Tool results:", JSON.stringify(toolResults, null, 2));
+
+  await agent.endSession();
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds two runnable TypeScript cookbook recipes under `typescript/examples/` that show how to wrap popular agent frameworks with `@asqav/sdk` so every tool execution produces an ML-DSA-signed audit record:

- `examples/vercel-ai-sdk.ts` - wraps a Vercel AI SDK `tool({ inputSchema, execute })` and runs it through `generateText`
- `examples/langchain-js.ts` - wraps a LangChain.js `tool(fn, { name, description, schema })` and binds it to `ChatOpenAI` via `.bindTools([...])`
- `examples/README.md` - index with common setup, env vars, and per-recipe install commands

## Pattern

Both recipes follow the same rule: `agent.sign({ actionType, context })` runs **before** the side effect (a Stripe refund stub in these examples). If the downstream call throws, the signed intent still lands in the Asqav audit trail, so you always know what the agent decided to do.

## Why now

The recently published blog post [Asqav TypeScript SDK](https://www.asqav.com/blog/posts/asqav-typescript-sdk) promises framework integrations for the two most-asked agent stacks. These examples deliver on that promise and give users a working starting point.

## API verification

- Vercel AI SDK: verified `tool({ description, inputSchema, execute })` shape and `generateText({ model, tools, prompt })` against https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- LangChain.js: verified `tool(func, { name, description, schema })` and `model.bindTools([...])` against https://docs.langchain.com/oss/javascript/langchain/tools
- `@asqav/sdk` exports: verified `init`, `Agent.create`, `agent.sign`, `agent.startSession`, `agent.endSession` against `typescript/src/index.ts`

## Test plan

- [ ] `cd typescript && npm install @asqav/sdk ai @ai-sdk/openai zod tsx` then `npx tsx examples/vercel-ai-sdk.ts` with `ASQAV_API_KEY` and `OPENAI_API_KEY` set; confirm a signature id is returned and visible in the Asqav dashboard
- [ ] `cd typescript && npm install @asqav/sdk @langchain/core @langchain/openai zod tsx` then `npx tsx examples/langchain-js.ts` with same env; confirm tool call is signed
- [ ] No changes under `typescript/src/` so existing tests and build are unaffected