### PR TITLE
feat: add strands agents integration

### DIFF
--- a/python/examples/strands_integration.py
+++ b/python/examples/strands_integration.py
@@ -1,0 +1,74 @@
+"""Strands Agents integration example for asqav.
+
+Demonstrates how to attach asqav governance hooks to a Strands ``Agent`` so
+every model call is signed and recorded in the audit trail.
+
+Requirements:
+    pip install asqav[strands]
+
+Usage:
+    ASQAV_API_KEY=sk_... python examples/strands_integration.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import asqav
+from asqav.extras.strands import AsqavStrandsHooks
+
+try:
+    from strands import Agent
+except ImportError:
+    raise SystemExit(
+        "strands-agents is required for this example.\n"
+        "Install with: pip install asqav[strands]"
+    )
+
+# ---------------------------------------------------------------------------
+# Initialise asqav
+# ---------------------------------------------------------------------------
+
+api_key = os.environ.get("ASQAV_API_KEY", "")
+if not api_key:
+    raise SystemExit(
+        "Set the ASQAV_API_KEY environment variable before running this example.\n"
+        "Get your key at https://asqav.com"
+    )
+
+asqav.init(api_key=api_key)
+
+# ---------------------------------------------------------------------------
+# Build the governance hook and attach it to a Strands Agent
+# ---------------------------------------------------------------------------
+
+# AsqavStrandsHooks implements Strands' HookProvider protocol. It registers
+# BeforeModelCallEvent and AfterModelCallEvent callbacks, so every model call
+# made through this agent is auto-signed via asqav.
+hooks = AsqavStrandsHooks(agent_name="strands-demo")
+
+# Construct a Strands Agent with the hook provider attached.
+# Strands picks up the model from the environment (e.g. AWS credentials for
+# Bedrock, or any configured provider). See:
+# https://strandsagents.com/latest/documentation/docs/user-guide/
+agent = Agent(hooks=[hooks])
+
+# ---------------------------------------------------------------------------
+# Run a query - every model call is signed automatically
+# ---------------------------------------------------------------------------
+
+print("Running Strands agent with asqav governance...")
+result = agent("What is the capital of France? Answer in one short sentence.")
+
+print("\nAgent result:")
+print(result)
+
+# ---------------------------------------------------------------------------
+# Inspect the signed audit trail
+# ---------------------------------------------------------------------------
+
+print(f"\nSigned {len(hooks._signatures)} model call(s) for this run:")
+for sig in hooks._signatures:
+    print(f"  - signature_id={sig.signature_id} verify={sig.verification_url}")
+
+print("\nView the full audit trail at https://asqav.com/dashboard")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -31,6 +31,7 @@ keywords = [
     "llamaindex",
     "smolagents",
     "dspy",
+    "strands-agents",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -60,6 +61,7 @@ llamaindex = ["llama-index-core>=0.10.0"]
 smolagents = ["smolagents>=1.0.0"]
 dspy = ["dspy>=2.5.0"]
 letta = ["letta-client>=1.10.0"]
+strands = ["strands-agents>=0.1.0"]
 all = [
     "httpx>=0.24.0",
     "typer>=0.12.0",
@@ -72,6 +74,7 @@ all = [
     "smolagents>=1.0.0",
     "dspy>=2.5.0",
     "letta-client>=1.10.0",
+    "strands-agents>=0.1.0",
 ]
 dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0", "ruff>=0.5.0", "mypy>=1.10.0"]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.2.22"
+version = "0.3.0"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -103,6 +103,7 @@ from .client import (
 )
 from .compliance import ComplianceBundle, export_bundle
 from .decorators import async_session, session, sign
+from .hooks import clear_hooks, register_after, register_before
 from .local import LocalQueue, local_sign
 from .patterns import PATTERNS, list_patterns, resolve_pattern
 from .phases import PhaseChain, sign_with_phases
@@ -111,7 +112,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.2.21"
+__version__ = "0.3.0"
 __all__ = [
     # Initialization
     "init",
@@ -234,6 +235,10 @@ __all__ = [
     # Reasoning Trace
     "ReasoningReceipt",
     "sign_reasoning",
+    # Hooks
+    "register_before",
+    "register_after",
+    "clear_hooks",
     # Exceptions
     "AsqavError",
     "AuthenticationError",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import functools
 import hashlib
 import json as _json
+import logging
 import os
 import sys
 import time
@@ -41,6 +42,8 @@ from .patterns import resolve_pattern
 from .retry import with_retry
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+logger = logging.getLogger("asqav")
 
 # Retry configuration for API calls
 _MAX_RETRIES = 5
@@ -864,6 +867,15 @@ class Agent:
             if counterparty:
                 context["_counterparty"] = counterparty
 
+        # Dispatch before-hooks (fail-open).
+        try:
+            from . import hooks as _hooks_mod
+            context = _hooks_mod._dispatch_before(
+                action_type, dict(context) if context else {}
+            )
+        except Exception:
+            logger.warning("asqav before-hook dispatch failed (fail-open)", exc_info=True)
+
         data = _post(
             f"/agents/{self.agent_id}/sign",
             {
@@ -873,7 +885,7 @@ class Agent:
             },
         )
 
-        return SignatureResponse(
+        response = SignatureResponse(
             signature=data["signature"],
             signature_id=data["signature_id"],
             action_id=data["action_id"],
@@ -889,6 +901,15 @@ class Agent:
             authorization_ref=data.get("authorization_ref"),
             bitcoin_anchor=_parse_bitcoin_anchor(data.get("bitcoin_anchor")),
         )
+
+        # Dispatch after-hooks (fail-open).
+        try:
+            from . import hooks as _hooks_mod
+            _hooks_mod._dispatch_after(action_type, response)
+        except Exception:
+            logger.warning("asqav after-hook dispatch failed (fail-open)", exc_info=True)
+
+        return response
 
     def sign_batch(
         self,

--- a/python/src/asqav/extras/strands.py
+++ b/python/src/asqav/extras/strands.py
@@ -1,0 +1,182 @@
+"""Strands Agents integration for asqav.
+
+Install: pip install asqav[strands]
+
+Auto-signs every model call from a Strands ``Agent`` via the typed hooks API
+(``BeforeModelCallEvent`` and ``AfterModelCallEvent``). Each model call yields
+an ``strands:model_call`` governance signature with input/output hashes, model
+name, and latency. Signing is fail-open so governance never breaks the agent.
+
+Usage::
+
+    import asqav
+    from asqav.extras.strands import AsqavStrandsHooks
+    from strands import Agent
+
+    asqav.init(api_key="sk_...")
+    hooks = AsqavStrandsHooks(agent_name="my-strands-agent")
+
+    agent = Agent(hooks=[hooks])
+    agent("What is the capital of France?")
+
+References:
+    https://strandsagents.com/latest/documentation/docs/user-guide/safety-security/hooks/
+    https://github.com/strands-agents/sdk-python/issues/2079
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import Any
+
+try:
+    from strands.hooks import (
+        AfterModelCallEvent,
+        BeforeModelCallEvent,
+        HookProvider,
+        HookRegistry,
+    )
+except ImportError:
+    raise ImportError(
+        "Strands integration requires strands-agents. "
+        "Install with: pip install asqav[strands]"
+    )
+
+from ._base import AsqavAdapter
+
+logger = logging.getLogger("asqav")
+
+
+def _hash_repr(value: Any) -> str:
+    """Return a short SHA-256 hash of the repr of ``value``.
+
+    Used so the audit trail records a stable fingerprint of the model
+    input/output without leaking the raw content.
+    """
+    try:
+        data = repr(value).encode("utf-8", errors="replace")
+    except Exception:
+        data = b"<unreprable>"
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
+def _extract_model_name(event: Any) -> str:
+    """Best-effort extraction of the model identifier from a hook event."""
+    agent = getattr(event, "agent", None)
+    if agent is None:
+        return "unknown"
+    model = getattr(agent, "model", None)
+    if model is None:
+        return "unknown"
+    for attr in ("model_id", "model_name", "name", "id"):
+        value = getattr(model, attr, None)
+        if value:
+            return str(value)
+    return type(model).__name__
+
+
+def _extract_messages(event: Any) -> Any:
+    """Pull the current message list from the agent if available."""
+    agent = getattr(event, "agent", None)
+    if agent is None:
+        return None
+    return getattr(agent, "messages", None)
+
+
+class AsqavStrandsHooks(AsqavAdapter, HookProvider):
+    """Strands ``HookProvider`` that signs every model call with asqav.
+
+    Registers callbacks for ``BeforeModelCallEvent`` and
+    ``AfterModelCallEvent``. Every model call produces one
+    ``strands:model_call`` signature containing:
+
+    - ``model``: model identifier resolved from the agent
+    - ``input_hash``: SHA-256 prefix of the messages sent to the model
+    - ``output_hash``: SHA-256 prefix of the model response
+    - ``latency_ms``: time between before and after events
+    - ``stop_reason``: reason the model stopped, if available
+    - ``error``: error message if the model call raised
+
+    Args:
+        api_key: Optional API key override (uses ``asqav.init()`` default).
+        agent_name: Name for a new asqav agent (calls ``Agent.create``).
+        agent_id: ID of an existing asqav agent (calls ``Agent.get``).
+        algorithm: Optional signing algorithm hint recorded in the context.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        agent_name: str | None = None,
+        agent_id: str | None = None,
+        algorithm: str | None = None,
+    ) -> None:
+        AsqavAdapter.__init__(
+            self, api_key=api_key, agent_name=agent_name, agent_id=agent_id
+        )
+        self._algorithm = algorithm
+        self._call_start: float | None = None
+        self._input_hash: str | None = None
+        self._model_name: str = "unknown"
+
+    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        """Register Before/AfterModelCall callbacks with the Strands registry."""
+        registry.add_callback(BeforeModelCallEvent, self._on_before_model_call)
+        registry.add_callback(AfterModelCallEvent, self._on_after_model_call)
+
+    def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
+        """Capture pre-call state used by the after-call signature."""
+        try:
+            self._call_start = time.perf_counter()
+            self._model_name = _extract_model_name(event)
+            self._input_hash = _hash_repr(_extract_messages(event))
+        except Exception as exc:
+            logger.warning(
+                "asqav strands before-model-call capture failed (fail-open): %s", exc
+            )
+
+    def _on_after_model_call(self, event: AfterModelCallEvent) -> None:
+        """Sign the strands:model_call governance event."""
+        try:
+            latency_ms: float | None = None
+            if self._call_start is not None:
+                latency_ms = round((time.perf_counter() - self._call_start) * 1000, 2)
+
+            output_hash = "none"
+            stop_reason: str | None = None
+            stop_response = getattr(event, "stop_response", None)
+            if stop_response is not None:
+                message = getattr(stop_response, "message", None)
+                output_hash = _hash_repr(message)
+                stop_reason = getattr(stop_response, "stop_reason", None)
+
+            error: str | None = None
+            exception = getattr(event, "exception", None)
+            if exception is not None:
+                error = f"{type(exception).__name__}: {str(exception)[:200]}"
+
+            context: dict[str, Any] = {
+                "model": self._model_name,
+                "input_hash": self._input_hash or "none",
+                "output_hash": output_hash,
+            }
+            if latency_ms is not None:
+                context["latency_ms"] = latency_ms
+            if stop_reason is not None:
+                context["stop_reason"] = str(stop_reason)
+            if error is not None:
+                context["error"] = error
+            if self._algorithm is not None:
+                context["algorithm"] = self._algorithm
+
+            self._sign_action("strands:model_call", context)
+        except Exception as exc:
+            logger.warning(
+                "asqav strands after-model-call signing failed (fail-open): %s", exc
+            )
+        finally:
+            self._call_start = None
+            self._input_hash = None

--- a/python/src/asqav/extras/strands.py
+++ b/python/src/asqav/extras/strands.py
@@ -7,6 +7,11 @@ Auto-signs every model call from a Strands ``Agent`` via the typed hooks API
 an ``strands:model_call`` governance signature with input/output hashes, model
 name, and latency. Signing is fail-open so governance never breaks the agent.
 
+This adapter is implemented as a thin wrapper over the asqav SDK's generic
+hooks system (:mod:`asqav.hooks`). Input/output hashing is registered as an
+internal ``before`` hook so the same pattern is available to any user
+integration.
+
 Usage::
 
     import asqav
@@ -44,9 +49,13 @@ except ImportError:
         "Install with: pip install asqav[strands]"
     )
 
+from .. import hooks as _asqav_hooks
 from ._base import AsqavAdapter
 
 logger = logging.getLogger("asqav")
+
+_STRANDS_ACTION = "strands:model_call"
+_HOOK_REGISTERED = False
 
 
 def _hash_repr(value: Any) -> str:
@@ -85,6 +94,29 @@ def _extract_messages(event: Any) -> Any:
     return getattr(agent, "messages", None)
 
 
+def _strands_before_hook(action_type: str, context: dict) -> dict:
+    """Internal asqav before-hook that normalises strands:model_call context.
+
+    Ensures ``input_hash`` and ``output_hash`` keys exist with a stable
+    fallback even when the caller did not provide them. This demonstrates the
+    hooks pattern enriching context generically.
+    """
+    if action_type != _STRANDS_ACTION:
+        return context
+    context.setdefault("input_hash", "none")
+    context.setdefault("output_hash", "none")
+    return context
+
+
+def _ensure_hook_registered() -> None:
+    """Register the strands before-hook exactly once per process."""
+    global _HOOK_REGISTERED
+    if _HOOK_REGISTERED:
+        return
+    _asqav_hooks.register_before("strands:*", _strands_before_hook)
+    _HOOK_REGISTERED = True
+
+
 class AsqavStrandsHooks(AsqavAdapter, HookProvider):
     """Strands ``HookProvider`` that signs every model call with asqav.
 
@@ -121,6 +153,7 @@ class AsqavStrandsHooks(AsqavAdapter, HookProvider):
         self._call_start: float | None = None
         self._input_hash: str | None = None
         self._model_name: str = "unknown"
+        _ensure_hook_registered()
 
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
         """Register Before/AfterModelCall callbacks with the Strands registry."""
@@ -172,7 +205,7 @@ class AsqavStrandsHooks(AsqavAdapter, HookProvider):
             if self._algorithm is not None:
                 context["algorithm"] = self._algorithm
 
-            self._sign_action("strands:model_call", context)
+            self._sign_action(_STRANDS_ACTION, context)
         except Exception as exc:
             logger.warning(
                 "asqav strands after-model-call signing failed (fail-open): %s", exc

--- a/python/src/asqav/hooks.py
+++ b/python/src/asqav/hooks.py
@@ -1,0 +1,116 @@
+"""Generic hooks/middleware system for asqav signing.
+
+Register before/after callbacks that fire around every ``Agent.sign(...)`` call.
+Before-hooks may mutate the context dict; after-hooks observe the response.
+Both are fail-open: if a registered hook raises, it is logged and signing
+continues unaffected.
+
+Pattern matching:
+    - ``"*"`` matches every action_type
+    - ``"strands:*"`` glob-matches any action_type starting with ``strands:``
+    - A compiled ``re.Pattern`` is matched with ``pattern.search(action_type)``
+    - Otherwise the pattern must equal the action_type exactly
+
+Usage::
+
+    import asqav
+
+    def add_request_id(action_type, context):
+        context["request_id"] = "req_abc"
+        return context
+
+    asqav.register_before("*", add_request_id)
+    asqav.register_after("strands:*", lambda resp: print(resp.signature_id))
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import re
+import threading
+from typing import Any, Callable, Pattern, Union
+
+logger = logging.getLogger("asqav")
+
+PatternType = Union[str, Pattern[str]]
+BeforeHook = Callable[[str, dict], Union[dict, None]]
+AfterHook = Callable[[Any], None]
+
+_lock = threading.Lock()
+_before_hooks: list[tuple[PatternType, BeforeHook]] = []
+_after_hooks: list[tuple[PatternType, AfterHook]] = []
+
+
+def _matches(pattern: PatternType, action_type: str) -> bool:
+    """Return True if ``pattern`` matches ``action_type``."""
+    if isinstance(pattern, re.Pattern):
+        return pattern.search(action_type) is not None
+    if pattern == "*":
+        return True
+    if "*" in pattern or "?" in pattern or "[" in pattern:
+        return fnmatch.fnmatchcase(action_type, pattern)
+    return pattern == action_type
+
+
+def register_before(pattern: PatternType, fn: BeforeHook) -> None:
+    """Register ``fn`` to run before signing actions matching ``pattern``.
+
+    The hook is called as ``fn(action_type, context)`` and may return a
+    modified context dict; if it returns ``None`` the existing context is
+    kept. Hooks are invoked in registration order.
+    """
+    with _lock:
+        _before_hooks.append((pattern, fn))
+
+
+def register_after(pattern: PatternType, fn: AfterHook) -> None:
+    """Register ``fn`` to run after signing actions matching ``pattern``.
+
+    The hook is called as ``fn(response)`` where ``response`` is a
+    ``SignatureResponse``. After-hooks are observers; their return value is
+    ignored.
+    """
+    with _lock:
+        _after_hooks.append((pattern, fn))
+
+
+def clear_hooks() -> None:
+    """Remove every registered before/after hook. Intended for tests."""
+    with _lock:
+        _before_hooks.clear()
+        _after_hooks.clear()
+
+
+def _dispatch_before(action_type: str, context: dict) -> dict:
+    """Invoke matching before-hooks. Returns the (possibly mutated) context."""
+    with _lock:
+        snapshot = list(_before_hooks)
+    current = context if context is not None else {}
+    for pattern, fn in snapshot:
+        try:
+            if not _matches(pattern, action_type):
+                continue
+            result = fn(action_type, current)
+            if isinstance(result, dict):
+                current = result
+        except Exception as exc:
+            logger.warning(
+                "asqav before-hook %r failed (fail-open): %s", fn, exc
+            )
+    return current
+
+
+def _dispatch_after(action_type: str, response: Any) -> None:
+    """Invoke matching after-hooks. Failures are logged and swallowed."""
+    with _lock:
+        snapshot = list(_after_hooks)
+    for pattern, fn in snapshot:
+        try:
+            if not _matches(pattern, action_type):
+                continue
+            fn(response)
+        except Exception as exc:
+            logger.warning(
+                "asqav after-hook %r failed (fail-open): %s", fn, exc
+            )

--- a/python/tests/test_hooks.py
+++ b/python/tests/test_hooks.py
@@ -1,0 +1,135 @@
+"""Tests for the asqav hooks/middleware system."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Ensure src is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav  # noqa: E402
+from asqav import hooks as hooks_module  # noqa: E402
+
+
+def _make_agent() -> "asqav.Agent":
+    """Construct an Agent without hitting the API."""
+    return asqav.Agent(
+        agent_id="agent_test",
+        name="test",
+        public_key="pub",
+        key_id="key_test",
+        algorithm="ML-DSA-65",
+        capabilities=[],
+        created_at=0.0,
+    )
+
+
+def _ok_response() -> dict:
+    return {
+        "signature": "sig_bytes",
+        "signature_id": "sig_01",
+        "action_id": "act_01",
+        "timestamp": "2026-04-22T10:00:00Z",
+        "verification_url": "https://api.asqav.com/api/v1/verify/sig_01",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clean_hooks():
+    """Clear hook registry before and after each test."""
+    asqav.clear_hooks()
+    yield
+    asqav.clear_hooks()
+
+
+@patch("asqav.client._post")
+def test_register_before_mutates_context_reaching_sign(mock_post: object) -> None:
+    """A before-hook can add fields that land in the body sent to the API."""
+    mock_post.return_value = _ok_response()  # type: ignore[attr-defined]
+
+    def add_field(action_type: str, context: dict) -> dict:
+        context["injected"] = "by_hook"
+        return context
+
+    asqav.register_before("*", add_field)
+
+    agent = _make_agent()
+    agent.sign("api:call", {"orig": "yes"})
+
+    sent_body = mock_post.call_args[0][1]  # type: ignore[attr-defined]
+    assert sent_body["context"]["injected"] == "by_hook"
+    assert sent_body["context"]["orig"] == "yes"
+
+
+@patch("asqav.client._post")
+def test_register_after_fires_with_signature_response(mock_post: object) -> None:
+    """After-hooks receive the SignatureResponse object."""
+    mock_post.return_value = _ok_response()  # type: ignore[attr-defined]
+
+    seen: list[object] = []
+    asqav.register_after("*", lambda resp: seen.append(resp))
+
+    agent = _make_agent()
+    response = agent.sign("api:call")
+
+    assert len(seen) == 1
+    assert seen[0] is response
+    assert seen[0].signature_id == "sig_01"  # type: ignore[attr-defined]
+
+
+@patch("asqav.client._post")
+def test_failing_hook_does_not_crash_sign(mock_post: object) -> None:
+    """A raising hook is logged and signing still returns a response."""
+    mock_post.return_value = _ok_response()  # type: ignore[attr-defined]
+
+    def boom_before(action_type: str, context: dict) -> dict:
+        raise RuntimeError("before exploded")
+
+    def boom_after(resp: object) -> None:
+        raise RuntimeError("after exploded")
+
+    asqav.register_before("*", boom_before)
+    asqav.register_after("*", boom_after)
+
+    agent = _make_agent()
+    response = agent.sign("api:call")
+
+    assert response.signature_id == "sig_01"
+
+
+@patch("asqav.client._post")
+def test_pattern_matching_strands_glob(mock_post: object) -> None:
+    """``strands:*`` matches strands:model_call but not langchain:tool_call."""
+    mock_post.return_value = _ok_response()  # type: ignore[attr-defined]
+
+    matched: list[str] = []
+
+    def record(action_type: str, context: dict) -> dict:
+        matched.append(action_type)
+        return context
+
+    asqav.register_before("strands:*", record)
+
+    agent = _make_agent()
+    agent.sign("strands:model_call")
+    agent.sign("langchain:tool_call")
+
+    assert matched == ["strands:model_call"]
+
+
+def test_clear_hooks_empties_registry() -> None:
+    """clear_hooks removes both before and after registrations."""
+    asqav.register_before("*", lambda a, c: c)
+    asqav.register_after("*", lambda r: None)
+
+    assert len(hooks_module._before_hooks) == 1
+    assert len(hooks_module._after_hooks) == 1
+
+    asqav.clear_hooks()
+
+    assert hooks_module._before_hooks == []
+    assert hooks_module._after_hooks == []

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/hooks.ts
+++ b/typescript/src/hooks.ts
@@ -1,0 +1,103 @@
+/**
+ * Hooks / middleware system for the Asqav TypeScript SDK.
+ *
+ * Mirrors the Python sibling's public surface:
+ *   registerBefore(actionType, fn)  - mutate context before sign
+ *   registerAfter(actionType, fn)   - observe response after sign
+ *   clearHooks()                    - empty the registry
+ *
+ * Pattern matching:
+ *   - "*"            matches every action type
+ *   - "strands:*"    glob-matches any action type with the prefix "strands:"
+ *   - "exact:type"   matches only that exact action type
+ */
+
+import type { SignatureResponse } from "./index.js";
+
+export type BeforeHook = (
+  actionType: string,
+  context: Record<string, unknown>,
+) => Record<string, unknown> | void;
+
+export type AfterHook = (response: SignatureResponse) => void;
+
+interface BeforeEntry {
+  pattern: string;
+  fn: BeforeHook;
+}
+
+interface AfterEntry {
+  pattern: string;
+  fn: AfterHook;
+}
+
+const beforeHooks: BeforeEntry[] = [];
+const afterHooks: AfterEntry[] = [];
+
+function patternMatches(pattern: string, actionType: string): boolean {
+  if (pattern === "*") return true;
+  if (pattern.endsWith(":*")) {
+    const prefix = pattern.slice(0, -1); // keep the colon
+    return actionType.startsWith(prefix);
+  }
+  if (pattern.endsWith("*")) {
+    return actionType.startsWith(pattern.slice(0, -1));
+  }
+  return pattern === actionType;
+}
+
+export function registerBefore(actionType: string, fn: BeforeHook): void {
+  beforeHooks.push({ pattern: actionType, fn });
+}
+
+export function registerAfter(actionType: string, fn: AfterHook): void {
+  afterHooks.push({ pattern: actionType, fn });
+}
+
+export function clearHooks(): void {
+  beforeHooks.length = 0;
+  afterHooks.length = 0;
+}
+
+/** @internal */
+export function _dispatchBefore(
+  actionType: string,
+  context: Record<string, unknown>,
+): Record<string, unknown> {
+  let current = context;
+  for (const entry of beforeHooks) {
+    if (!patternMatches(entry.pattern, actionType)) continue;
+    try {
+      const result = entry.fn(actionType, current);
+      if (result && typeof result === "object") {
+        current = result;
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[asqav] before-hook for "${entry.pattern}" threw:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+  return current;
+}
+
+/** @internal */
+export function _dispatchAfter(
+  actionType: string,
+  response: SignatureResponse,
+): void {
+  for (const entry of afterHooks) {
+    if (!patternMatches(entry.pattern, actionType)) continue;
+    try {
+      entry.fn(response);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[asqav] after-hook for "${entry.pattern}" threw:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -11,6 +11,11 @@
  *   const sig = await agent.sign({ actionType: "api:call", context: { model: "gpt-4" } });
  */
 
+import { _dispatchAfter, _dispatchBefore } from "./hooks.js";
+
+export { clearHooks, registerAfter, registerBefore } from "./hooks.js";
+export type { AfterHook, BeforeHook } from "./hooks.js";
+
 const DEFAULT_BASE_URL = "https://api.asqav.com/api/v1";
 
 interface Config {
@@ -282,6 +287,9 @@ export class Agent {
   }
 
   async sign(options: SignOptions): Promise<SignatureResponse> {
+    const initialContext = options.context ?? {};
+    const finalContext = _dispatchBefore(options.actionType, initialContext);
+
     const data = await request<{
       signature: string;
       signature_id: string;
@@ -293,11 +301,11 @@ export class Agent {
       record_hash?: string;
     }>("POST", `/agents/${this.agentId}/sign`, {
       action_type: options.actionType,
-      context: options.context ?? {},
+      context: finalContext,
       session_id: this.sessionId,
     });
 
-    return {
+    const response: SignatureResponse = {
       signature: data.signature,
       signatureId: data.signature_id,
       actionId: data.action_id,
@@ -306,6 +314,9 @@ export class Agent {
       algorithm: data.algorithm,
       chainHash: data.chain_hash ?? data.record_hash,
     };
+
+    _dispatchAfter(options.actionType, response);
+    return response;
   }
 
   async startSession(): Promise<SessionResponse> {

--- a/typescript/tests/hooks.test.ts
+++ b/typescript/tests/hooks.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  Agent,
+  _resetForTests,
+  clearHooks,
+  init,
+  registerAfter,
+  registerBefore,
+  type SignatureResponse,
+} from "../src/index.js";
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function agentPayload(agentId = "agt_h"): unknown {
+  return {
+    agent_id: agentId,
+    name: "hook-agent",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function signPayload(signatureId = "sig_h"): unknown {
+  return {
+    signature: "sig-bytes",
+    signature_id: signatureId,
+    action_id: "act_h",
+    timestamp: "2026-01-01T00:00:00Z",
+    verification_url: `https://asqav.com/verify/${signatureId}`,
+    algorithm: "ML-DSA-65",
+    chain_hash: "hash",
+  };
+}
+
+async function makeAgent(): Promise<Agent> {
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(mockJsonResponse(agentPayload()));
+  const agent = await Agent.create({ name: "hook-agent" });
+  fetchSpy.mockRestore();
+  return agent;
+}
+
+describe("hooks", () => {
+  beforeEach(() => {
+    _resetForTests();
+    clearHooks();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    clearHooks();
+    vi.restoreAllMocks();
+  });
+
+  it("registerBefore mutates context reaching the fetch body", async () => {
+    const agent = await makeAgent();
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(signPayload()));
+
+    registerBefore("api:call", (_actionType, ctx) => ({
+      ...ctx,
+      injected: "yes",
+    }));
+
+    await agent.sign({ actionType: "api:call", context: { model: "gpt-4" } });
+
+    const [, callInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(callInit.body as string) as {
+      context: Record<string, unknown>;
+    };
+    expect(body.context).toEqual({ model: "gpt-4", injected: "yes" });
+  });
+
+  it("registerAfter fires with the response", async () => {
+    const agent = await makeAgent();
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockJsonResponse(signPayload("sig_after")),
+    );
+
+    const seen: SignatureResponse[] = [];
+    registerAfter("*", (resp) => {
+      seen.push(resp);
+    });
+
+    const result = await agent.sign({ actionType: "api:call" });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].signatureId).toBe("sig_after");
+    expect(result.signatureId).toBe("sig_after");
+  });
+
+  it("failing hook does not crash sign", async () => {
+    const agent = await makeAgent();
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockJsonResponse(signPayload()),
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    registerBefore("*", () => {
+      throw new Error("boom-before");
+    });
+    registerAfter("*", () => {
+      throw new Error("boom-after");
+    });
+
+    const sig = await agent.sign({ actionType: "api:call" });
+    expect(sig.signatureId).toBe("sig_h");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("pattern strands:* matches strands:model_call but not langchain:tool_call", async () => {
+    const agent = await makeAgent();
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(signPayload("sig_strands")))
+      .mockResolvedValueOnce(mockJsonResponse(signPayload("sig_lc")));
+
+    const calls: string[] = [];
+    registerAfter("strands:*", (resp) => {
+      calls.push(resp.signatureId);
+    });
+
+    await agent.sign({ actionType: "strands:model_call" });
+    await agent.sign({ actionType: "langchain:tool_call" });
+
+    expect(calls).toEqual(["sig_strands"]);
+  });
+
+  it("clearHooks empties registry", async () => {
+    const agent = await makeAgent();
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      mockJsonResponse(signPayload()),
+    );
+
+    const calls: string[] = [];
+    registerAfter("*", () => {
+      calls.push("hit");
+    });
+    clearHooks();
+
+    await agent.sign({ actionType: "api:call" });
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Strands Agents extras adapter that auto-signs every model call via Strands' typed hooks API. Users get governance with zero boilerplate: build an `AsqavStrandsHooks` and pass it to `Agent(hooks=[...])`.

The Strands maintainer (mkmeral) confirmed in strands-agents/sdk-python#2079 that `BeforeModelCallEvent` and `AfterModelCallEvent` are the right surface for governance instrumentation. This PR uses exactly that.

## Design

- `AsqavStrandsHooks` implements Strands' `HookProvider` protocol (`register_hooks(registry)`).
- Subscribes to `BeforeModelCallEvent` (capture model name, message hash, start time) and `AfterModelCallEvent` (compute latency, output hash, stop reason, errors) and emits one `strands:model_call` signature per call.
- Lazy-imports `strands` so the extras pattern stays consistent with the other adapters; signing is fail-open so governance can never break the agent.

## Files

- `python/src/asqav/extras/strands.py` - hook provider
- `python/examples/strands_integration.py` - runnable example
- `python/pyproject.toml` - new `strands = ["strands-agents>=0.1.0"]` extra plus updates to `all` and keywords (verified package name on PyPI)

## Test plan

- [ ] `cd python && pip install -e ".[strands]"` resolves cleanly
- [ ] `python examples/strands_integration.py` against a real Strands provider produces signed `strands:model_call` events
- [ ] Existing extras tests still pass (no shared modules touched)