### PR TITLE
feat: hash-only / full-payload mode (GDPR data minimization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.3.1 / TypeScript 0.2.1] - 2026-04-28
+
+### Added
+- `mode` client config: `auto` (default), `hash-only`, `full-payload`. SDK auto-detects cloud endpoints (`*.asqav.com`) and uses hash-only by default for GDPR data minimization. Self-hosted deployments keep full-payload.
+- Public `canonicalize()` and `hash_action()` helpers (Python) and `canonicalize()` / `hashAction()` (TypeScript). Implements RFC 8785 JCS + SHA-256 (or HMAC-SHA-256 with optional org salt).
+- Cross-language conformance: both SDKs verified against the same `conformance/vectors.json`.
+
+### Changed
+- When `api_base_url` points at `*.asqav.com`, the SDK hashes context locally before sending. Set `mode="full-payload"` (or `ASQAV_MODE=full-payload`) to keep the previous behavior.
+
 ## Unreleased
 
 - repo restructure: split Python and TypeScript SDKs into `python/` and `typescript/` subdirectories. Python users unaffected (`pip install asqav` continues working). TypeScript SDK introduced - `npm install @asqav/sdk`.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ Each signed action returns a receipt like:
 
 The agent now has a cryptographic identity, a signed audit trail, and a verifiable action record.
 
+## Data handling modes
+
+The SDK auto-detects whether you're pointing at the Asqav cloud or a self-hosted deployment, and selects the safer default for each:
+
+- **Cloud (`*.asqav.com`)**: hash-only by default. The SDK canonicalizes your action context, computes a SHA-256 hash locally, and sends only the hash plus a small metadata bag (action_type, agent_id, session_id, model_name, tool_name). Raw prompts and tool arguments stay on your side.
+- **Self-hosted**: full-payload by default. The server can run policy checks, PII redaction, and richer audit. Recommended when you control the deployment.
+
+Override anytime:
+
+```python
+# Python
+asqav.init(api_key="...", base_url="https://api.asqav.com", mode="hash-only")
+```
+
+```ts
+// TypeScript
+await init({ apiKey: "...", baseUrl: "https://api.asqav.com", mode: "hash-only" });
+```
+
+The canonicalization is RFC 8785-style sorted JSON with no whitespace, hashed with SHA-256. See `docs/canonicalization.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
+
 ## Why governance
 
 | Without governance | With Asqav |

--- a/docs/canonicalization.md
+++ b/docs/canonicalization.md
@@ -1,0 +1,96 @@
+# Asqav Context Canonicalization Spec (v2)
+
+This spec defines exactly how to compute the `hash` field that Asqav cloud accepts in place of a raw `context` dict on the `/sign` endpoint. Any developer can implement it from this document alone, in any language, with no Asqav SDK installed.
+
+The output of this spec is a string of the form:
+
+```
+sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+```
+
+You send that string as the `hash` field. Asqav signs it with your agent's ML-DSA key and returns a signature. You (or any third party) can later recompute the hash from the original `(action_type, context)` pair and verify the signature.
+
+## Algorithm
+
+```python
+import hashlib, json
+
+def hash_action(action_type: str, context: dict) -> str:
+    payload = {"action_type": action_type, "context": context or {}}
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+```
+
+Stdlib only. No third-party packages.
+
+## Inputs
+
+- **`action_type`**: short string identifying the action (e.g. `"read:data"`, `"api:call"`). The same string you would have sent in full-payload mode.
+- **`context`**: the action payload dict. Any JSON-serializable Python value. May be an empty dict.
+
+The hash is computed over the combined object `{"action_type": ..., "context": ...}` so action_type cannot be tampered with independently of the context bytes.
+
+## What "canonical JSON" means here
+
+We use `json.dumps(sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)`. The same rules express in any language:
+
+- **Object keys**: sorted lexicographically by Unicode code point (Python's `sorted()` default).
+- **Whitespace**: none, anywhere.
+- **Strings**: emitted verbatim as UTF-8 (no `\uXXXX` escaping for characters above U+001F).
+- **Numbers**: serialized via Python's `json` module rules. Integers as integers (`42`), floats in shortest round-trip form (`1.5`, not `1.50`).
+- **Null / true / false**: lowercase.
+- **Arrays**: order preserved.
+- **Nested objects and arrays**: recurse, same rules.
+- **NaN / Infinity / -Infinity**: rejected (`allow_nan=False`). Filter or convert to `None` before hashing.
+
+## Worked example
+
+```python
+action_type = "read:data"
+context = {}
+
+# Combined payload, canonicalized:
+canonical = b'{"action_type":"read:data","context":{}}'
+
+# SHA-256:
+# sha256:991033e23a3e0939c258e10f2f8f88183d9bcdb08de62ef02446e11e0819c671
+```
+
+See `tests/conformance/vectors.json` for additional worked examples.
+
+## Subtleties (read these)
+
+1. **Float precision**. `0.1 + 0.2 == 0.30000000000000004` in IEEE 754. Python's `json.dumps` emits `0.30000000000000004`. If you want to hash `0.3`, pass `0.3` literally; do not arithmetic to get there. If your domain needs exact decimals, send strings or scaled integers, not floats.
+2. **Unicode normalization**. We do NOT normalize Unicode. `"café"` (single codepoint U+00E9) and `"café"` (e + combining acute) hash differently. If your input might be in either form, NFC-normalize before hashing: `unicodedata.normalize("NFC", s)`.
+3. **Key ordering of nested dicts**. Recursive: every dict at every depth is sorted independently.
+4. **List of dicts**. Lists preserve input order. Each dict inside is canonicalized. So `[{"b":1,"a":2},{"a":3}]` becomes `[{"a":2,"b":1},{"a":3}]` (inner keys sorted, outer order preserved).
+5. **Empty values**. `{}` -> `{}`. `[]` -> `[]`. Both hash to a stable value.
+6. **`None` / `null`**. Allowed. Serializes as `null`.
+7. **Tuples**. Python tuples serialize as arrays. So `(1,2,3)` and `[1,2,3]` produce the same canonical bytes. If your code relies on the difference, convert to lists first.
+8. **Keys must be strings**. JSON forbids non-string keys. `{1: "x"}` will raise. Convert to `{"1": "x"}` or fail loudly.
+9. **`NaN`, `Infinity`, `-Infinity`**. Rejected by `allow_nan=False`. Filter or convert to `None` before hashing.
+10. **bytes**. Not JSON. Base64-encode and pass as a string.
+11. **datetime / Decimal / UUID**. Not JSON. Convert to string (ISO 8601, str(decimal), str(uuid)) before hashing. Whatever convention you pick, pick it once and stick to it.
+12. **`tool_name` and `model_name`**. These should be static identifiers (e.g. `"database.query"`, `"gpt-4o"`), not user input or PII. The metadata whitelist passes them through unchanged so a name like `"lookup_user_email_for_alice@example.com"` would land in the audit trail verbatim.
+
+## Replay protection
+
+Signatures are NOT replay-stable: re-sending the same `(action_type, context)` produces a fresh signature with a new `server_timestamp` and `action_id`. Verifiers MUST track `action_id` uniqueness within their freshness window and reject duplicates.
+
+## Verifying mode
+
+Each signed record has a `mode` field on `signature_records` with value `"hash"` or `"payload"`. Verifiers SHOULD read `signature_records.mode` to determine which canonical form to expect, rather than inspecting the signed bytes. The hash-mode signing input includes `"v": 1` and `"mode": "hash"` for self-description; the payload-mode signing input keeps the legacy shape unchanged for backward compatibility.
+
+## Test vectors
+
+See `tests/conformance/vectors.json`. The hash-mode happy-path vectors (`minimal_read`, `tool_call_with_counterparty`, `traced_child_action`) are the ones that exercise this spec; the remaining vectors cover the agent-card verification feature, not GDPR hash signing.
+
+## Versioning
+
+This spec is version 2. The `vectors.json` file declares `version: 2` to align. Hash-mode signing input includes `"v": 1` (the wire version of the signing-input schema, distinct from this spec version) so a future v2 wire format will be distinguishable from v1 in every signature.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.0"
+version = "0.3.1"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -28,6 +28,7 @@ Get your API key at asqav.com
 """
 
 from .async_client import AsyncAgent
+from .canonicalize import canonicalize, hash_action
 from .client import (
     Agent,
     AgentResponse,
@@ -112,11 +113,14 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __all__ = [
     # Initialization
     "init",
     "health_check",
+    # Canonicalization
+    "canonicalize",
+    "hash_action",
     # Agent
     "Agent",
     "AgentResponse",

--- a/python/src/asqav/_mode.py
+++ b/python/src/asqav/_mode.py
@@ -1,0 +1,96 @@
+"""Mode resolver for hash-only vs full-payload signing.
+
+The asqav SDK supports two signing wire formats:
+
+* ``"full-payload"``: send the raw ``context`` dict to the server. This is
+  what every release before 0.3.1 did, and remains the default for
+  self-hosted deployments where the server already holds the data.
+* ``"hash-only"``: hash the canonical ``{action_type, context}`` locally
+  and send only the hash plus a small whitelisted metadata bag. This is
+  the GDPR data-minimization mode used by the asqav cloud (api.asqav.com).
+
+Resolution precedence (highest first):
+
+1. Explicit constructor / init kwarg (``mode="hash-only"``).
+2. Environment variable ``ASQAV_MODE``.
+3. Auto-detection from ``api_base_url``: hostnames matching the asqav
+   cloud (``api.asqav.com`` or any ``*.asqav.com`` API host) default to
+   hash-only. Anything else (localhost, custom domains, ``myasqav.com``,
+   subdomain attacks like ``asqav.com.evil.com``) defaults to
+   full-payload.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+from urllib.parse import urlparse
+
+Mode = Literal["hash-only", "full-payload"]
+_VALID_EXPLICIT = {"auto", "hash-only", "full-payload"}
+_VALID_ENV = {"hash-only", "full-payload"}
+
+
+def _is_asqav_cloud_host(hostname: str | None) -> bool:
+    """True if ``hostname`` is the asqav cloud API.
+
+    Matches ``api.asqav.com`` exactly, or any subdomain of ``asqav.com``
+    (e.g. ``staging.asqav.com``). Rejects look-alikes such as
+    ``myasqav.com`` (different domain) and ``asqav.com.evil.com``
+    (subdomain attack: the registrable domain is ``evil.com``).
+    """
+    if not hostname:
+        return False
+    h = hostname.lower().strip().rstrip(".")
+    if h == "asqav.com":
+        return False  # marketing site, not the API
+    return h == "api.asqav.com" or h.endswith(".asqav.com")
+
+
+def _resolve_mode(
+    api_base_url: str | None,
+    env: str | None,
+    explicit: str | None = "auto",
+) -> Mode:
+    """Resolve the wire mode for a client.
+
+    Args:
+        api_base_url: The configured API URL (may be ``None``).
+        env: Value of the ``ASQAV_MODE`` environment variable, or ``None``.
+        explicit: Explicit mode passed by the caller. ``"auto"`` (the
+            default) defers to env then auto-detection.
+
+    Returns:
+        Either ``"hash-only"`` or ``"full-payload"``.
+
+    Raises:
+        ValueError: If ``explicit`` is not one of ``auto``, ``hash-only``,
+            ``full-payload``.
+    """
+    if explicit is None:
+        explicit = "auto"
+    if explicit not in _VALID_EXPLICIT:
+        raise ValueError(
+            f"mode must be one of {sorted(_VALID_EXPLICIT)}, got {explicit!r}"
+        )
+    if explicit != "auto":
+        return explicit  # type: ignore[return-value]
+
+    if env:
+        env_norm = env.strip().lower()
+        if env_norm in _VALID_ENV:
+            return env_norm  # type: ignore[return-value]
+        # silently ignore garbage env values; fall through to auto
+
+    hostname: str | None = None
+    if api_base_url:
+        try:
+            parsed = urlparse(
+                api_base_url
+                if "://" in api_base_url
+                else f"https://{api_base_url}"
+            )
+            hostname = parsed.hostname
+        except Exception:  # pragma: no cover - extremely defensive
+            hostname = None
+
+    return "hash-only" if _is_asqav_cloud_host(hostname) else "full-payload"

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -240,14 +240,15 @@ class AsyncAgent:
         Returns:
             SignatureResponse with the signature.
         """
-        data = await _async_post(
-            f"/agents/{self.agent_id}/sign",
-            {
-                "action_type": action_type,
-                "context": context or {},
-                "session_id": self._session_id,
-            },
+        from .client import _build_sign_body
+
+        body = _build_sign_body(
+            action_type=action_type,
+            context=context,
+            session_id=self._session_id,
+            agent_id=self.agent_id,
         )
+        data = await _async_post(f"/agents/{self.agent_id}/sign", body)
 
         return SignatureResponse(
             signature=data["signature"],

--- a/python/src/asqav/canonicalize.py
+++ b/python/src/asqav/canonicalize.py
@@ -1,0 +1,94 @@
+"""Canonical JSON + content hashing for the asqav SDK.
+
+This module exposes the byte-for-byte canonicalization used by the asqav
+backend to produce the bytes that get signed (and, in hash-only mode, the
+bytes that the SDK hashes locally before sending to the cloud).
+
+Two helpers are provided:
+
+* :func:`canonicalize` returns canonical JSON bytes for any
+  JSON-serializable Python value, following the conventions in
+  ``conformance/vectors.json`` (RFC 8785 JCS subset: keys sorted, no
+  whitespace, raw UTF-8, no trailing newline).
+* :func:`hash_action` returns a self-describing hash string of the form
+  ``"sha256:<64hex>"`` over a canonical ``{action_type, context}`` dict.
+  An optional ``salt`` switches it to HMAC-SHA-256 for organizations that
+  use a per-org keyed hash.
+
+Customers without an asqav SDK can reproduce these helpers in a few lines
+of stdlib Python (see ``docs/canonicalization.md``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+__all__ = ["canonicalize", "hash_action"]
+
+
+def canonicalize(obj: Any) -> bytes:
+    """Return canonical JSON bytes for ``obj``.
+
+    Implementation: ``json.dumps`` with ``sort_keys=True``,
+    ``separators=(",", ":")`` and ``ensure_ascii=False``. This is a
+    faithful subset of RFC 8785 (JCS) for the value types the asqav
+    cloud actually accepts (``dict``, ``list``, ``str``, ``int``,
+    ``float``, ``bool``, ``None``). The conformance vectors at
+    ``conformance/vectors.json`` are generated with the exact same
+    rules so SDKs written against this helper agree with the backend
+    byte-for-byte.
+
+    Notes:
+        * Object keys are sorted lexicographically (Python ``sorted``).
+        * No whitespace anywhere.
+        * Unicode characters above U+001F are emitted as raw UTF-8.
+        * ``NaN`` / ``Infinity`` are not legal JSON; ``json.dumps`` will
+          raise unless the caller pre-filtered them.
+
+    Args:
+        obj: Any JSON-serializable value.
+
+    Returns:
+        UTF-8 encoded canonical JSON bytes.
+    """
+    return json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def hash_action(
+    action_type: str,
+    context: dict[str, Any] | None = None,
+    salt: bytes | None = None,
+) -> str:
+    """Return ``"sha256:<hex>"`` for the canonical bytes of an action.
+
+    The hashed object is ``{"action_type": action_type, "context": context}``
+    canonicalized via :func:`canonicalize`. This matches the conformance
+    vectors and the backend's hash-only ingestion shape.
+
+    With ``salt`` set, returns HMAC-SHA-256 instead of plain SHA-256.
+    Use the per-organization salt fetched from the asqav dashboard.
+
+    Args:
+        action_type: The action type string (e.g. ``"api:call"``).
+        context: The action's context dict (any JSON-serializable shape).
+        salt: Optional 32-byte per-org salt for keyed hashing.
+
+    Returns:
+        Self-describing hash string ``"sha256:<64 hex chars>"``.
+    """
+    payload = {"action_type": action_type, "context": context or {}}
+    canonical = canonicalize(payload)
+    if salt is not None:
+        digest = hmac.new(salt, canonical, hashlib.sha256).hexdigest()
+    else:
+        digest = hashlib.sha256(canonical).hexdigest()
+    return f"sha256:{digest}"

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -105,6 +105,15 @@ except ImportError:
 _api_key: str | None = None
 _api_base: str = os.environ.get("ASQAV_API_URL", "https://api.asqav.com/api/v1")
 _client: Any = None
+# Hybrid GDPR mode: resolved at init() time, overridable per-call. See _mode.py.
+_mode: str = "full-payload"
+_org_salt: bytes | None = None
+# Metadata keys allowed to ride alongside a hash-only request. The server
+# enforces its own whitelist; this mirrors the conservative default so we
+# don't accidentally leak fields the customer didn't intend to share.
+_HASH_ONLY_METADATA_WHITELIST: frozenset[str] = frozenset(
+    {"agent_id", "session_id", "action_type", "model_name", "tool_name"}
+)
 
 
 class AsqavError(Exception):
@@ -643,6 +652,56 @@ def flush_spans() -> None:
         pass  # Don't fail on export errors
 
 
+def _build_sign_body(
+    *,
+    action_type: str,
+    context: dict[str, Any] | None,
+    session_id: str | None,
+    agent_id: str,
+) -> dict[str, Any]:
+    """Build the JSON body for a ``POST /agents/{id}/sign`` request.
+
+    Branches on the SDK-level ``_mode``: full-payload sends ``context``
+    as before; hash-only sends a ``hash`` field plus a whitelisted
+    ``metadata`` bag.
+    """
+    if _mode == "hash-only":
+        from .canonicalize import hash_action
+
+        digest = hash_action(action_type, context or {}, salt=_org_salt)
+        metadata: dict[str, Any] = {
+            "agent_id": agent_id,
+            "action_type": action_type,
+        }
+        if session_id is not None:
+            metadata["session_id"] = session_id
+        # Pull optional model_name / tool_name from context if the caller
+        # opted in by adding underscored sentinel keys. Other context keys
+        # are NEVER copied; that's the whole point of hash-only.
+        for src_key, dst_key in (("_model_name", "model_name"), ("_tool_name", "tool_name")):
+            if context and src_key in context:
+                value = context[src_key]
+                if isinstance(value, str):
+                    metadata[dst_key] = value
+        # Defensive: only ship whitelisted keys even if a future caller
+        # mutates `metadata` above.
+        metadata = {k: v for k, v in metadata.items() if k in _HASH_ONLY_METADATA_WHITELIST}
+        return {
+            "action_type": action_type,
+            "hash": digest,
+            "hash_algo": "sha256",
+            "metadata": metadata,
+            "session_id": session_id,
+        }
+
+    # full-payload (default for self-hosted)
+    return {
+        "action_type": action_type,
+        "context": context or {},
+        "session_id": session_id,
+    }
+
+
 @dataclass
 class Agent:
     """Agent representation from asqav Cloud.
@@ -876,14 +935,13 @@ class Agent:
         except Exception:
             logger.warning("asqav before-hook dispatch failed (fail-open)", exc_info=True)
 
-        data = _post(
-            f"/agents/{self.agent_id}/sign",
-            {
-                "action_type": action_type,
-                "context": context or {},
-                "session_id": self._session_id,
-            },
+        body = _build_sign_body(
+            action_type=action_type,
+            context=context,
+            session_id=self._session_id,
+            agent_id=self.agent_id,
         )
+        data = _post(f"/agents/{self.agent_id}/sign", body)
 
         response = SignatureResponse(
             signature=data["signature"],
@@ -1351,12 +1409,23 @@ def emergency_halt(reason: str = "emergency") -> list[dict]:
 def init(
     api_key: str | None = None,
     base_url: str | None = None,
+    *,
+    mode: str = "auto",
+    org_salt: bytes | None = None,
 ) -> None:
     """Initialize the asqav SDK.
 
     Args:
         api_key: Your asqav API key. Can also be set via ASQAV_API_KEY env var.
         base_url: Override API base URL (for testing).
+        mode: Wire format for ``Agent.sign``. One of ``"auto"`` (default),
+            ``"hash-only"``, or ``"full-payload"``. ``auto`` resolves to
+            ``hash-only`` for the asqav cloud (``*.asqav.com``) and
+            ``full-payload`` for self-hosted deployments. The
+            ``ASQAV_MODE`` env var is consulted when ``mode="auto"``.
+        org_salt: Optional 32-byte per-organization salt. When set, the
+            SDK uses HMAC-SHA-256 instead of plain SHA-256 for hash-only
+            requests. Fetch yours from the asqav dashboard.
 
     Raises:
         AuthenticationError: If no API key is provided.
@@ -1370,8 +1439,11 @@ def init(
         # Using environment variable
         os.environ["ASQAV_API_KEY"] = "sk_..."
         asqav.init()
+
+        # Force hash-only against a custom URL
+        asqav.init(api_key="sk_...", mode="hash-only", org_salt=bytes.fromhex("..."))
     """
-    global _api_key, _api_base, _client
+    global _api_key, _api_base, _client, _mode, _org_salt
 
     _api_key = api_key or os.environ.get("ASQAV_API_KEY")
 
@@ -1382,6 +1454,15 @@ def init(
 
     if base_url:
         _api_base = base_url
+
+    from ._mode import _resolve_mode
+
+    _mode = _resolve_mode(
+        api_base_url=_api_base,
+        env=os.environ.get("ASQAV_MODE"),
+        explicit=mode,
+    )
+    _org_salt = org_salt
 
     # Initialize HTTP client
     if _HTTPX_AVAILABLE:

--- a/python/tests/test_canonicalize.py
+++ b/python/tests/test_canonicalize.py
@@ -1,0 +1,90 @@
+"""Verify the SDK canonicalizer agrees with conformance/vectors.json byte-for-byte.
+
+If this file fails, either:
+
+1. ``canonicalize.py`` drifted from RFC 8785 JCS subset, or
+2. ``conformance/vectors.json`` was edited without regenerating derived
+   fields (hash, canonical).
+
+A test in ``test_conformance_vectors.py`` already checks the vectors are
+internally consistent. This file additionally checks that the SDK's
+public helpers match those vectors, which is what customers rely on.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from asqav.canonicalize import canonicalize, hash_action
+
+VECTORS_PATH = Path(__file__).parent.parent.parent / "conformance" / "vectors.json"
+
+
+def _load_vectors() -> list[dict]:
+    return json.loads(VECTORS_PATH.read_text())["vectors"]
+
+
+@pytest.mark.parametrize("vector", _load_vectors(), ids=lambda v: v["name"])
+def test_canonicalize_matches_vector(vector: dict) -> None:
+    """The SDK's canonicalize() must produce the same bytes as vectors.json."""
+    expected = vector["canonical"]
+    actual = canonicalize(vector["input"]).decode("utf-8")
+    assert actual == expected, f"{vector['name']}: canonical drift"
+
+
+@pytest.mark.parametrize("vector", _load_vectors(), ids=lambda v: v["name"])
+def test_sha256_matches_vector(vector: dict) -> None:
+    """SHA-256 of the SDK's canonical bytes must match vectors.json."""
+    canonical_bytes = canonicalize(vector["input"])
+    actual = hashlib.sha256(canonical_bytes).hexdigest()
+    assert actual == vector["sha256"], f"{vector['name']}: sha256 drift"
+
+
+def test_hash_action_no_salt_matches_action_context_vector() -> None:
+    """For vectors shaped {action_type, context}, hash_action() must agree."""
+    vectors = _load_vectors()
+    happy = [
+        v for v in vectors
+        if set(v["input"].keys()) == {"action_type", "context"}
+    ]
+    assert happy, "expected at least one {action_type, context} vector"
+    for v in happy:
+        result = hash_action(v["input"]["action_type"], v["input"]["context"])
+        assert result == f"sha256:{v['sha256']}", f"{v['name']}: hash_action drift"
+
+
+def test_hash_action_with_salt_uses_hmac() -> None:
+    """With a salt, hash_action returns HMAC-SHA-256 not plain SHA-256."""
+    salt = bytes.fromhex(
+        "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+    )
+    plain = hash_action("api:call", {"k": 3})
+    keyed = hash_action("api:call", {"k": 3}, salt=salt)
+    assert plain != keyed
+    assert plain.startswith("sha256:")
+    assert keyed.startswith("sha256:")
+    assert len(keyed) == len("sha256:") + 64
+
+
+def test_canonicalize_is_deterministic_across_key_order() -> None:
+    """Inserting keys in a different order yields the same canonical bytes."""
+    a = {"b": 1, "a": 2, "c": [{"y": 1, "x": 2}]}
+    b = {"a": 2, "c": [{"x": 2, "y": 1}], "b": 1}
+    assert canonicalize(a) == canonicalize(b)
+
+
+def test_canonicalize_preserves_unicode_raw() -> None:
+    """Non-ASCII chars are emitted as raw UTF-8, not \\uXXXX escapes."""
+    out = canonicalize({"name": "café"})
+    assert "café".encode("utf-8") in out
+    assert b"\\u" not in out
+
+
+def test_canonicalize_rejects_nan() -> None:
+    """NaN/Infinity are not valid JSON and must raise."""
+    with pytest.raises(ValueError):
+        canonicalize({"x": float("nan")})

--- a/python/tests/test_client_hash_mode.py
+++ b/python/tests/test_client_hash_mode.py
@@ -1,0 +1,176 @@
+"""Verify Agent.sign() request body shape across modes.
+
+We patch the module-level ``_post`` helper in ``asqav.client`` and assert
+on the body it would have sent. Avoiding ``httpx.MockTransport`` keeps
+this test independent of the optional httpx dep and matches the existing
+``patch("asqav.client._post")`` pattern used elsewhere in the test suite.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav  # noqa: E402
+from asqav import client as client_mod  # noqa: E402
+from asqav.client import Agent  # noqa: E402
+
+# A canned response that satisfies SignatureResponse decoding.
+MOCK_SIGN_RESPONSE: dict = {
+    "signature": "sig-bytes",
+    "signature_id": "sig_001",
+    "action_id": "act_001",
+    "timestamp": "2026-04-28T12:00:00Z",
+    "verification_url": "https://verify.asqav.com/sig_001",
+    "algorithm": "ml-dsa-65",
+    "chain_hash": "ch_abc",
+    "rfc3161_timestamp": None,
+    "scan_result": None,
+    "policy_digest": "pd",
+    "policy_decision": "permit",
+    "authorization_ref": None,
+    "bitcoin_anchor": None,
+}
+
+
+def _make_agent() -> Agent:
+    return Agent(
+        agent_id="agt_001",
+        name="t",
+        public_key="pk",
+        key_id="kid",
+        algorithm="ml-dsa-65",
+        capabilities=[],
+        created_at=0.0,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_state() -> None:
+    """Reset SDK module state between tests."""
+    saved = (client_mod._mode, client_mod._org_salt, client_mod._api_key)
+    client_mod._api_key = "sk_test"
+    yield
+    client_mod._mode, client_mod._org_salt, client_mod._api_key = saved
+
+
+def test_full_payload_mode_sends_context() -> None:
+    client_mod._mode = "full-payload"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"prompt": "hi", "user_id": "u_001"})
+
+    path, body = mock_post.call_args[0]
+    assert path == "/agents/agt_001/sign"
+    assert "context" in body
+    assert "hash" not in body
+    assert body["context"] == {"prompt": "hi", "user_id": "u_001"}
+    assert body["action_type"] == "api:call"
+
+
+def test_hash_only_mode_sends_hash_not_context() -> None:
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"prompt": "hi", "user_id": "u_001"})
+
+    _path, body = mock_post.call_args[0]
+    assert "hash" in body, "hash-only mode must include hash"
+    assert "context" not in body, "hash-only mode must NOT leak context"
+    assert body["hash"].startswith("sha256:")
+    assert len(body["hash"]) == len("sha256:") + 64
+    assert body["hash_algo"] == "sha256"
+    assert body["action_type"] == "api:call"
+
+
+def test_hash_only_metadata_does_not_leak_user_fields() -> None:
+    """user_id, ip, prompt, etc. in context must NOT appear in metadata."""
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    sensitive_context = {
+        "prompt": "secret",
+        "user_id": "u_001",
+        "ip": "1.2.3.4",
+        "request_id": "req_xyz",
+    }
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", sensitive_context)
+
+    _, body = mock_post.call_args[0]
+    metadata = body["metadata"]
+    for leak in ("user_id", "ip", "prompt", "request_id"):
+        assert leak not in metadata, f"sensitive key {leak!r} leaked into metadata"
+    assert metadata["agent_id"] == "agt_001"
+    assert metadata["action_type"] == "api:call"
+
+
+def test_hash_only_includes_optional_model_name_when_opted_in() -> None:
+    """If caller adds ``_model_name`` sentinel to context, surface in metadata."""
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign(
+            "api:call",
+            {"prompt": "hi", "_model_name": "gpt-4", "_tool_name": "search"},
+        )
+
+    _, body = mock_post.call_args[0]
+    assert body["metadata"]["model_name"] == "gpt-4"
+    assert body["metadata"]["tool_name"] == "search"
+
+
+def test_hash_only_uses_hmac_when_org_salt_set() -> None:
+    """A non-None org_salt swaps SHA-256 for HMAC-SHA-256 with the same shape."""
+    agent = _make_agent()
+    plain_hash = None
+    salted_hash = None
+
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"k": 3})
+        plain_hash = mock_post.call_args[0][1]["hash"]
+
+    client_mod._org_salt = b"\x01" * 32
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"k": 3})
+        salted_hash = mock_post.call_args[0][1]["hash"]
+
+    assert plain_hash != salted_hash
+    assert plain_hash.startswith("sha256:") and salted_hash.startswith("sha256:")
+
+
+def test_init_resolves_mode_from_url() -> None:
+    """asqav.init() should set _mode from the api_base_url when mode=auto."""
+    saved_base = client_mod._api_base
+    try:
+        # Cloud URL -> hash-only
+        asqav.init(api_key="sk_test", base_url="https://api.asqav.com/api/v1")
+        assert client_mod._mode == "hash-only"
+
+        # Self-hosted URL -> full-payload
+        asqav.init(api_key="sk_test", base_url="http://localhost:8000")
+        assert client_mod._mode == "full-payload"
+
+        # Explicit override
+        asqav.init(
+            api_key="sk_test",
+            base_url="https://api.asqav.com/api/v1",
+            mode="full-payload",
+        )
+        assert client_mod._mode == "full-payload"
+    finally:
+        client_mod._api_base = saved_base

--- a/python/tests/test_mode_resolver.py
+++ b/python/tests/test_mode_resolver.py
@@ -1,0 +1,108 @@
+"""Tests for the hash-only / full-payload mode resolver."""
+
+from __future__ import annotations
+
+import pytest
+
+from asqav._mode import _is_asqav_cloud_host, _resolve_mode
+
+
+# ---------------------------------------------------------------------------
+# Cloud host detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        ("api.asqav.com", True),
+        ("API.ASQAV.COM", True),
+        ("staging.asqav.com", True),
+        ("app.asqav.com", True),
+        ("foo.bar.asqav.com", True),
+        ("asqav.com", False),  # marketing site, not API
+        ("myasqav.com", False),  # different domain entirely
+        ("asqav.com.evil.com", False),  # subdomain attack
+        ("evilasqav.com", False),
+        ("localhost", False),
+        ("127.0.0.1", False),
+        ("internal.example.com", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_asqav_cloud_host(host: str | None, expected: bool) -> None:
+    assert _is_asqav_cloud_host(host) is expected
+
+
+# ---------------------------------------------------------------------------
+# Resolution precedence
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_overrides_env_and_url() -> None:
+    """Explicit always wins."""
+    assert _resolve_mode(
+        api_base_url="https://api.asqav.com/api/v1",
+        env="full-payload",
+        explicit="hash-only",
+    ) == "hash-only"
+    assert _resolve_mode(
+        api_base_url="https://localhost:8000",
+        env="hash-only",
+        explicit="full-payload",
+    ) == "full-payload"
+
+
+def test_env_overrides_auto_detection() -> None:
+    """When explicit is auto, env wins over URL."""
+    assert _resolve_mode(
+        api_base_url="https://localhost:8000",
+        env="hash-only",
+        explicit="auto",
+    ) == "hash-only"
+    assert _resolve_mode(
+        api_base_url="https://api.asqav.com/api/v1",
+        env="full-payload",
+        explicit="auto",
+    ) == "full-payload"
+
+
+def test_garbage_env_falls_through_to_auto() -> None:
+    """Unknown env values are silently ignored."""
+    assert _resolve_mode(
+        api_base_url="https://api.asqav.com/api/v1",
+        env="banana",
+        explicit="auto",
+    ) == "hash-only"
+
+
+def test_invalid_explicit_raises() -> None:
+    with pytest.raises(ValueError):
+        _resolve_mode(api_base_url=None, env=None, explicit="banana")
+
+
+# ---------------------------------------------------------------------------
+# Auto detection scenarios
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://api.asqav.com/api/v1", "hash-only"),
+        ("https://app.asqav.com", "hash-only"),
+        ("https://staging.asqav.com/api/v1", "hash-only"),
+        ("http://localhost:8000", "full-payload"),
+        ("http://localhost:8000/api/v1", "full-payload"),
+        ("https://internal.example.com", "full-payload"),
+        ("https://myasqav.com/api/v1", "full-payload"),
+        ("https://asqav.com.evil.com", "full-payload"),
+        ("https://asqav.com", "full-payload"),  # marketing, not API
+        ("api.asqav.com/api/v1", "hash-only"),  # missing scheme
+        (None, "full-payload"),
+        ("", "full-payload"),
+    ],
+)
+def test_auto_resolves_correctly(url: str | None, expected: str) -> None:
+    assert _resolve_mode(api_base_url=url, env=None, explicit="auto") == expected

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -26,6 +26,21 @@ console.log(sig.verificationUrl);
 
 Each signed action is recorded server-side with an ML-DSA (FIPS 204) signature, a chain hash, and a public verification URL.
 
+## Data handling modes
+
+The SDK auto-detects whether you're pointing at the Asqav cloud or a self-hosted deployment, and selects the safer default for each:
+
+- **Cloud (`*.asqav.com`)**: hash-only by default. The SDK canonicalizes your action context, computes a SHA-256 hash locally, and sends only the hash plus a small metadata bag (action_type, agent_id, session_id, model_name, tool_name). Raw prompts and tool arguments stay on your side.
+- **Self-hosted**: full-payload by default. The server can run policy checks, PII redaction, and richer audit. Recommended when you control the deployment.
+
+Override anytime:
+
+```ts
+await init({ apiKey: "...", baseUrl: "https://api.asqav.com", mode: "hash-only" });
+```
+
+The canonicalization is RFC 8785-style sorted JSON with no whitespace, hashed with SHA-256. See `docs/canonicalization.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
+
 ## Why
 
 Without governance, an AI agent can do anything and leave no trace. With asqav, every action is signed, every policy is enforced in real time, and every audit query returns a verifiable record.

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "asqav",
-  "version": "0.1.0",
+  "name": "@asqav/sdk",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "asqav",
-      "version": "0.1.0",
+      "name": "@asqav/sdk",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/canonicalize.ts
+++ b/typescript/src/canonicalize.ts
@@ -1,0 +1,133 @@
+/**
+ * Canonical JSON + content hashing for the @asqav/sdk TypeScript client.
+ *
+ * Mirrors the Python ``asqav.canonicalize`` module byte-for-byte. The
+ * conformance vectors at ``conformance/vectors.json`` are validated against
+ * both implementations, so a hash computed in Node and a hash computed in
+ * Python over the same dict are guaranteed to agree.
+ *
+ * RFC 8785 (JCS) subset:
+ *   - object keys sorted lexicographically
+ *   - no whitespace anywhere
+ *   - non-ASCII strings emitted as raw UTF-8
+ *   - integers as integers (no trailing ``.0``)
+ *   - finite floats only (NaN / Infinity rejected)
+ */
+
+import { createHash, createHmac } from "node:crypto";
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * Canonicalize a JSON-serializable value into UTF-8 bytes.
+ *
+ * Throws on values that aren't representable in JSON (functions, undefined,
+ * BigInt, Symbol) and on non-finite numbers (NaN / Infinity), matching
+ * the behavior of Python's ``json.dumps(allow_nan=False)``.
+ */
+export function canonicalize(value: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalString(value));
+}
+
+function canonicalString(value: unknown): string {
+  if (value === null) return "null";
+  if (value === true) return "true";
+  if (value === false) return "false";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("NaN / Infinity are not allowed in canonical JSON");
+    }
+    // Integers serialize without trailing .0; finite floats use the
+    // shortest round-trip representation, which is what V8's Number.toString
+    // already produces and what RFC 8785 specifies via ECMAScript.
+    return numberToCanonical(value);
+  }
+  if (typeof value === "string") {
+    return jsonString(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(canonicalString).join(",") + "]";
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const parts: string[] = [];
+    for (const k of keys) {
+      parts.push(jsonString(k) + ":" + canonicalString(obj[k]));
+    }
+    return "{" + parts.join(",") + "}";
+  }
+  throw new TypeError(`Not JSON-serializable: ${typeof value}`);
+}
+
+function numberToCanonical(n: number): string {
+  // For integers within safe range, plain toString matches Python's repr.
+  if (Number.isInteger(n) && Number.isSafeInteger(n)) {
+    return n.toString();
+  }
+  return n.toString();
+}
+
+/**
+ * RFC 8259 / RFC 8785 string serialization.
+ *
+ * Escapes control chars below U+0020, plus the two characters that JSON
+ * requires (`"` and `\`). Everything U+0020 and above (including all
+ * non-ASCII letters) is emitted as raw UTF-8. This matches Python's
+ * ``json.dumps(ensure_ascii=False)`` which is what the conformance
+ * vectors are generated with.
+ */
+function jsonString(s: string): string {
+  let out = '"';
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    const ch = s[i];
+    if (ch === '"') {
+      out += '\\"';
+    } else if (ch === "\\") {
+      out += "\\\\";
+    } else if (code === 0x08) {
+      out += "\\b";
+    } else if (code === 0x09) {
+      out += "\\t";
+    } else if (code === 0x0a) {
+      out += "\\n";
+    } else if (code === 0x0c) {
+      out += "\\f";
+    } else if (code === 0x0d) {
+      out += "\\r";
+    } else if (code < 0x20) {
+      out += "\\u" + code.toString(16).padStart(4, "0");
+    } else {
+      out += ch;
+    }
+  }
+  out += '"';
+  return out;
+}
+
+/**
+ * Compute the self-describing hash for an action.
+ *
+ * Hashes ``{action_type, context}`` in canonical JSON form and returns
+ * the result as ``"sha256:<64 hex chars>"``. With ``salt`` set, uses
+ * HMAC-SHA-256 instead of plain SHA-256 (per the asqav cloud per-org
+ * keyed-hash protocol).
+ */
+export async function hashAction(
+  actionType: string,
+  context: Record<string, unknown> = {},
+  salt?: Uint8Array,
+): Promise<string> {
+  const canonical = canonicalize({ action_type: actionType, context });
+  const hex = salt
+    ? createHmac("sha256", Buffer.from(salt)).update(canonical).digest("hex")
+    : createHash("sha256").update(canonical).digest("hex");
+  return `sha256:${hex}`;
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -11,21 +11,38 @@
  *   const sig = await agent.sign({ actionType: "api:call", context: { model: "gpt-4" } });
  */
 
+import { canonicalize, hashAction } from "./canonicalize.js";
 import { _dispatchAfter, _dispatchBefore } from "./hooks.js";
+import { type Mode, resolveMode } from "./mode.js";
 
 export { clearHooks, registerAfter, registerBefore } from "./hooks.js";
 export type { AfterHook, BeforeHook } from "./hooks.js";
+export { canonicalize, hashAction } from "./canonicalize.js";
+export { resolveMode, isAsqavCloudHost, type Mode } from "./mode.js";
 
 const DEFAULT_BASE_URL = "https://api.asqav.com/api/v1";
+/** Metadata keys allowed alongside a hash-only request. Mirrors the
+ * Python whitelist; the server enforces its own. */
+const HASH_ONLY_METADATA_WHITELIST = new Set<string>([
+  "agent_id",
+  "session_id",
+  "action_type",
+  "model_name",
+  "tool_name",
+]);
 
 interface Config {
   apiKey: string | null;
   baseUrl: string;
+  mode: Mode;
+  orgSalt: Uint8Array | null;
 }
 
 const config: Config = {
   apiKey: null,
   baseUrl: DEFAULT_BASE_URL,
+  mode: "full-payload",
+  orgSalt: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -69,6 +86,18 @@ export class APIError extends AsqavError {
 export interface InitOptions {
   apiKey?: string;
   baseUrl?: string;
+  /**
+   * Wire mode for ``Agent.sign``. Defaults to ``"auto"``: hash-only for
+   * ``*.asqav.com`` cloud URLs, full-payload otherwise. Set to
+   * ``"hash-only"`` or ``"full-payload"`` to override. Also reads the
+   * ``ASQAV_MODE`` env var when ``"auto"``.
+   */
+  mode?: "auto" | "hash-only" | "full-payload";
+  /**
+   * Optional 32-byte per-organization salt. When set, hash-only mode
+   * uses HMAC-SHA-256 instead of plain SHA-256.
+   */
+  orgSalt?: Uint8Array;
 }
 
 export interface AgentCreateOptions {
@@ -139,6 +168,12 @@ export function init(options: InitOptions = {}): void {
   }
   config.apiKey = apiKey;
   config.baseUrl = options.baseUrl ?? config.baseUrl ?? DEFAULT_BASE_URL;
+  config.mode = resolveMode(
+    config.baseUrl,
+    process.env.ASQAV_MODE ?? null,
+    options.mode ?? "auto",
+  );
+  config.orgSalt = options.orgSalt ?? null;
 }
 
 function ensureInitialized(): void {
@@ -234,6 +269,53 @@ export async function request<T = unknown>(
 }
 
 // ---------------------------------------------------------------------------
+// Sign body builder (mode-aware)
+// ---------------------------------------------------------------------------
+
+interface BuildSignBodyArgs {
+  actionType: string;
+  context: Record<string, unknown>;
+  sessionId: string | null;
+  agentId: string;
+}
+
+async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, unknown>> {
+  if (config.mode === "hash-only") {
+    const digest = await hashAction(
+      args.actionType,
+      args.context,
+      config.orgSalt ?? undefined,
+    );
+    const metadata: Record<string, unknown> = {
+      agent_id: args.agentId,
+      action_type: args.actionType,
+    };
+    if (args.sessionId !== null) metadata.session_id = args.sessionId;
+    // Optional opt-in: caller adds ``_model_name`` / ``_tool_name`` to
+    // the context. Other context keys are NEVER copied.
+    const ctx = args.context as Record<string, unknown>;
+    if (typeof ctx._model_name === "string") metadata.model_name = ctx._model_name;
+    if (typeof ctx._tool_name === "string") metadata.tool_name = ctx._tool_name;
+    // Defensive: drop anything that snuck in outside the whitelist.
+    for (const k of Object.keys(metadata)) {
+      if (!HASH_ONLY_METADATA_WHITELIST.has(k)) delete metadata[k];
+    }
+    return {
+      action_type: args.actionType,
+      hash: digest,
+      hash_algo: "sha256",
+      metadata,
+      session_id: args.sessionId,
+    };
+  }
+  return {
+    action_type: args.actionType,
+    context: args.context,
+    session_id: args.sessionId,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Agent
 // ---------------------------------------------------------------------------
 
@@ -290,6 +372,13 @@ export class Agent {
     const initialContext = options.context ?? {};
     const finalContext = _dispatchBefore(options.actionType, initialContext);
 
+    const body = await buildSignBody({
+      actionType: options.actionType,
+      context: finalContext,
+      sessionId: this.sessionId,
+      agentId: this.agentId,
+    });
+
     const data = await request<{
       signature: string;
       signature_id: string;
@@ -299,11 +388,7 @@ export class Agent {
       algorithm?: string;
       chain_hash?: string;
       record_hash?: string;
-    }>("POST", `/agents/${this.agentId}/sign`, {
-      action_type: options.actionType,
-      context: finalContext,
-      session_id: this.sessionId,
-    });
+    }>("POST", `/agents/${this.agentId}/sign`, body);
 
     const response: SignatureResponse = {
       signature: data.signature,
@@ -446,4 +531,17 @@ export async function exportAuditJson(
 export function _resetForTests(): void {
   config.apiKey = null;
   config.baseUrl = DEFAULT_BASE_URL;
+  config.mode = "full-payload";
+  config.orgSalt = null;
+}
+
+/** @internal - inspect or override mode in tests. */
+export function _setModeForTests(mode: Mode, orgSalt?: Uint8Array | null): void {
+  config.mode = mode;
+  config.orgSalt = orgSalt ?? null;
+}
+
+/** @internal - read current mode in tests. */
+export function _getModeForTests(): Mode {
+  return config.mode;
 }

--- a/typescript/src/mode.ts
+++ b/typescript/src/mode.ts
@@ -1,0 +1,59 @@
+/**
+ * Mode resolver for hash-only vs full-payload signing.
+ *
+ * Mirrors ``asqav._mode`` in the Python SDK exactly: same precedence
+ * (explicit > env > URL auto-detection) and same "is this an asqav cloud
+ * URL?" rule.
+ */
+
+export type Mode = "hash-only" | "full-payload";
+
+const VALID_EXPLICIT = new Set<string>(["auto", "hash-only", "full-payload"]);
+const VALID_ENV = new Set<string>(["hash-only", "full-payload"]);
+
+/** True if ``hostname`` is the asqav cloud API. Subdomain-attack-safe. */
+export function isAsqavCloudHost(hostname: string | null | undefined): boolean {
+  if (!hostname) return false;
+  const h = hostname.toLowerCase().trim().replace(/\.+$/, "");
+  if (h === "asqav.com") return false; // marketing site
+  if (h === "api.asqav.com") return true;
+  return h.endsWith(".asqav.com");
+}
+
+/**
+ * Resolve the wire mode for a client.
+ *
+ * @param apiBaseUrl  The configured API URL.
+ * @param env         Value of ASQAV_MODE env var (or null).
+ * @param explicit    Caller-passed mode. ``"auto"`` defers to env then URL.
+ */
+export function resolveMode(
+  apiBaseUrl: string | null | undefined,
+  env: string | null | undefined,
+  explicit: string | null | undefined = "auto",
+): Mode {
+  const exp = (explicit ?? "auto").trim();
+  if (!VALID_EXPLICIT.has(exp)) {
+    throw new Error(
+      `mode must be one of auto / hash-only / full-payload, got ${JSON.stringify(exp)}`,
+    );
+  }
+  if (exp !== "auto") return exp as Mode;
+
+  if (env) {
+    const e = env.trim().toLowerCase();
+    if (VALID_ENV.has(e)) return e as Mode;
+    // garbage env value -> ignore, fall through
+  }
+
+  let hostname: string | null = null;
+  if (apiBaseUrl) {
+    try {
+      const withScheme = /:\/\//.test(apiBaseUrl) ? apiBaseUrl : `https://${apiBaseUrl}`;
+      hostname = new URL(withScheme).hostname;
+    } catch {
+      hostname = null;
+    }
+  }
+  return isAsqavCloudHost(hostname) ? "hash-only" : "full-payload";
+}

--- a/typescript/tests/canonicalize.test.ts
+++ b/typescript/tests/canonicalize.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Cross-language conformance: the TypeScript canonicalizer must agree
+ * with conformance/vectors.json byte-for-byte (which is generated and
+ * also validated by the Python tests).
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { canonicalize, hashAction } from "../src/canonicalize.js";
+
+interface Vector {
+  name: string;
+  input: unknown;
+  canonical: string;
+  sha256: string;
+}
+
+const vectorsPath = resolve(__dirname, "..", "..", "conformance", "vectors.json");
+const { vectors } = JSON.parse(readFileSync(vectorsPath, "utf8")) as {
+  vectors: Vector[];
+};
+
+describe("canonicalize() against conformance vectors", () => {
+  for (const v of vectors) {
+    it(`canonical bytes match for ${v.name}`, () => {
+      const actual = new TextDecoder().decode(canonicalize(v.input));
+      expect(actual).toBe(v.canonical);
+    });
+
+    it(`SHA-256 matches for ${v.name}`, () => {
+      const bytes = canonicalize(v.input);
+      const hex = createHash("sha256").update(bytes).digest("hex");
+      expect(hex).toBe(v.sha256);
+    });
+  }
+});
+
+describe("hashAction()", () => {
+  it("matches sha256 for {action_type, context}-shaped vectors", async () => {
+    const happy = vectors.filter((v) => {
+      const keys = Object.keys(v.input as object);
+      return keys.length === 2 && keys.includes("action_type") && keys.includes("context");
+    });
+    expect(happy.length).toBeGreaterThan(0);
+    for (const v of happy) {
+      const input = v.input as { action_type: string; context: Record<string, unknown> };
+      const result = await hashAction(input.action_type, input.context);
+      expect(result).toBe(`sha256:${v.sha256}`);
+    }
+  });
+
+  it("uses HMAC when a salt is provided", async () => {
+    const salt = Buffer.from(
+      "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+      "hex",
+    );
+    const plain = await hashAction("api:call", { k: 3 });
+    const keyed = await hashAction("api:call", { k: 3 }, new Uint8Array(salt));
+    expect(plain).not.toBe(keyed);
+    expect(keyed.startsWith("sha256:")).toBe(true);
+    expect(keyed.length).toBe("sha256:".length + 64);
+  });
+});
+
+describe("canonicalize() invariants", () => {
+  it("is deterministic across key insertion order", () => {
+    const a = { b: 1, a: 2, c: [{ y: 1, x: 2 }] };
+    const b = { a: 2, c: [{ x: 2, y: 1 }], b: 1 };
+    expect(canonicalize(a)).toEqual(canonicalize(b));
+  });
+
+  it("emits non-ASCII as raw UTF-8", () => {
+    const out = canonicalize({ name: "café" });
+    const utf8 = new TextEncoder().encode("café");
+    const haystack = Buffer.from(out);
+    expect(haystack.includes(Buffer.from(utf8))).toBe(true);
+    expect(new TextDecoder().decode(out)).not.toContain("\\u");
+  });
+
+  it("rejects NaN", () => {
+    expect(() => canonicalize({ x: Number.NaN })).toThrow();
+  });
+});

--- a/typescript/tests/clientHashMode.test.ts
+++ b/typescript/tests/clientHashMode.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  _getModeForTests,
+  _resetForTests,
+  _setModeForTests,
+  init,
+} from "../src/index.js";
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const SIGN_RESPONSE = {
+  signature: "sig-bytes",
+  signature_id: "sig_001",
+  action_id: "act_001",
+  timestamp: "2026-04-28T12:00:00Z",
+  verification_url: "https://verify.asqav.com/sig_001",
+  algorithm: "ml-dsa-65",
+};
+
+const AGENT_DATA = {
+  agent_id: "agt_001",
+  name: "test",
+  public_key: "pk",
+  key_id: "kid",
+  algorithm: "ml-dsa-65",
+  capabilities: [],
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+async function makeAgent(): Promise<Agent> {
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(mockJsonResponse(AGENT_DATA));
+  const agent = await Agent.create({ name: "test" });
+  fetchSpy.mockRestore();
+  return agent;
+}
+
+describe("Agent.sign body shape across modes", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("full-payload mode sends context, no hash", async () => {
+    _setModeForTests("full-payload");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { prompt: "hi", user_id: "u_001" },
+    });
+
+    const calledInit = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const body = JSON.parse(calledInit.body as string);
+    expect(body.context).toEqual({ prompt: "hi", user_id: "u_001" });
+    expect(body.hash).toBeUndefined();
+    expect(body.action_type).toBe("api:call");
+  });
+
+  it("hash-only mode sends hash, no context", async () => {
+    _setModeForTests("hash-only");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { prompt: "hi", user_id: "u_001" },
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.context).toBeUndefined();
+    expect(typeof body.hash).toBe("string");
+    expect(body.hash.startsWith("sha256:")).toBe(true);
+    expect(body.hash.length).toBe("sha256:".length + 64);
+    expect(body.hash_algo).toBe("sha256");
+    expect(body.action_type).toBe("api:call");
+  });
+
+  it("hash-only mode does not leak context fields into metadata", async () => {
+    _setModeForTests("hash-only");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { prompt: "secret", user_id: "u_001", ip: "1.2.3.4", request_id: "req_xyz" },
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    const metadata = body.metadata as Record<string, unknown>;
+    for (const k of ["user_id", "ip", "prompt", "request_id"]) {
+      expect(metadata[k]).toBeUndefined();
+    }
+    expect(metadata.agent_id).toBe("agt_001");
+    expect(metadata.action_type).toBe("api:call");
+  });
+
+  it("hash-only surfaces _model_name / _tool_name when caller opts in", async () => {
+    _setModeForTests("hash-only");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { prompt: "hi", _model_name: "gpt-4", _tool_name: "search" },
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.metadata.model_name).toBe("gpt-4");
+    expect(body.metadata.tool_name).toBe("search");
+  });
+
+  it("hash-only with org salt produces a different hash than without", async () => {
+    const agent = await makeAgent();
+
+    _setModeForTests("hash-only");
+    let fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+    await agent.sign({ actionType: "api:call", context: { k: 3 } });
+    const plain = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    ).hash;
+    fetchSpy.mockRestore();
+
+    _setModeForTests("hash-only", new Uint8Array(32).fill(1));
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+    await agent.sign({ actionType: "api:call", context: { k: 3 } });
+    const salted = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    ).hash;
+
+    expect(plain).not.toBe(salted);
+    expect(plain.startsWith("sha256:")).toBe(true);
+    expect(salted.startsWith("sha256:")).toBe(true);
+  });
+});
+
+describe("init() resolves mode from baseUrl", () => {
+  beforeEach(() => {
+    _resetForTests();
+    delete process.env.ASQAV_MODE;
+  });
+
+  it("auto -> hash-only for *.asqav.com", () => {
+    init({ apiKey: "sk_test", baseUrl: "https://api.asqav.com/api/v1" });
+    expect(_getModeForTests()).toBe("hash-only");
+  });
+
+  it("auto -> full-payload for localhost", () => {
+    init({ apiKey: "sk_test", baseUrl: "http://localhost:8000" });
+    expect(_getModeForTests()).toBe("full-payload");
+  });
+
+  it("explicit override wins over URL", () => {
+    init({
+      apiKey: "sk_test",
+      baseUrl: "https://api.asqav.com/api/v1",
+      mode: "full-payload",
+    });
+    expect(_getModeForTests()).toBe("full-payload");
+  });
+});

--- a/typescript/tests/mode.test.ts
+++ b/typescript/tests/mode.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { isAsqavCloudHost, resolveMode } from "../src/mode.js";
+
+describe("isAsqavCloudHost", () => {
+  const cases: Array<[string | null, boolean]> = [
+    ["api.asqav.com", true],
+    ["API.ASQAV.COM", true],
+    ["staging.asqav.com", true],
+    ["app.asqav.com", true],
+    ["foo.bar.asqav.com", true],
+    ["asqav.com", false],
+    ["myasqav.com", false],
+    ["asqav.com.evil.com", false],
+    ["evilasqav.com", false],
+    ["localhost", false],
+    ["127.0.0.1", false],
+    ["", false],
+    [null, false],
+  ];
+  for (const [host, expected] of cases) {
+    it(`${JSON.stringify(host)} -> ${expected}`, () => {
+      expect(isAsqavCloudHost(host)).toBe(expected);
+    });
+  }
+});
+
+describe("resolveMode precedence", () => {
+  it("explicit overrides env and url", () => {
+    expect(resolveMode("https://api.asqav.com/api/v1", "full-payload", "hash-only")).toBe(
+      "hash-only",
+    );
+    expect(resolveMode("http://localhost:8000", "hash-only", "full-payload")).toBe(
+      "full-payload",
+    );
+  });
+
+  it("env overrides auto detection", () => {
+    expect(resolveMode("http://localhost:8000", "hash-only", "auto")).toBe("hash-only");
+    expect(resolveMode("https://api.asqav.com/api/v1", "full-payload", "auto")).toBe(
+      "full-payload",
+    );
+  });
+
+  it("garbage env falls through to url-based auto", () => {
+    expect(resolveMode("https://api.asqav.com/api/v1", "banana", "auto")).toBe("hash-only");
+  });
+
+  it("invalid explicit raises", () => {
+    expect(() => resolveMode(null, null, "banana")).toThrow();
+  });
+});
+
+describe("resolveMode auto", () => {
+  const cases: Array<[string | null, "hash-only" | "full-payload"]> = [
+    ["https://api.asqav.com/api/v1", "hash-only"],
+    ["https://app.asqav.com", "hash-only"],
+    ["https://staging.asqav.com/api/v1", "hash-only"],
+    ["http://localhost:8000", "full-payload"],
+    ["http://localhost:8000/api/v1", "full-payload"],
+    ["https://internal.example.com", "full-payload"],
+    ["https://myasqav.com/api/v1", "full-payload"],
+    ["https://asqav.com.evil.com", "full-payload"],
+    ["https://asqav.com", "full-payload"],
+    ["api.asqav.com/api/v1", "hash-only"], // missing scheme
+    [null, "full-payload"],
+    ["", "full-payload"],
+  ];
+  for (const [url, expected] of cases) {
+    it(`${JSON.stringify(url)} -> ${expected}`, () => {
+      expect(resolveMode(url, null, "auto")).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- New `mode` config: `auto` (default), `hash-only`, `full-payload`.
- Auto-detect: `*.asqav.com` -> hash-only; everything else -> full-payload.
- Override via `mode=` argument, `ASQAV_MODE` env, or per-init.
- Public helpers: `canonicalize()` and `hash_action()` (Python) / `hashAction()` (TypeScript).
- Cross-language conformance: both SDKs verified against `conformance/vectors.json` byte-for-byte.

## Versions

- Python: 0.3.0 -> 0.3.1
- TypeScript: 0.2.0 -> 0.2.1

## Test plan
- [ ] python: `pytest python/tests` passes (19 new tests across canonicalize / mode_resolver / client_hash_mode)
- [ ] typescript: `npm --prefix typescript test` passes (26 new tests across canonicalize / mode / clientHashMode)
- [ ] Verify against backend hybrid-mode PR (https://github.com/jagmarques/asqav/pull/62)
- [ ] After merge: `pip install asqav==0.3.1` and `npm install @asqav/sdk@0.2.1` after maintainer publishes