### PR TITLE
feat: surface tool_name, model_name, parent_id in metadata bag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.3.2 / TypeScript 0.2.2] - 2026-04-30
+
+### Added
+- tool_name, model_name, parent_id surfaced into the hash-only metadata bag automatically when present in context (via `_tool_name` / `_model_name` / `_parent_id` keys) or passed as explicit kwargs to sign(). Powers the new agent graph view in the dashboard. No prompt or tool-arg content leaks; only the names.
+
 ## [Python 0.3.1 / TypeScript 0.2.1] - 2026-04-28
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.1"
+version = "0.3.2"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -230,17 +230,32 @@ class AsyncAgent:
         self,
         action_type: str,
         context: dict[str, Any] | None = None,
+        tool_name: str | None = None,
+        model_name: str | None = None,
+        parent_id: str | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically (async).
 
         Args:
             action_type: Type of action (e.g., "read:data", "api:call").
             context: Additional context for the action.
+            tool_name: Optional tool name when this action is a tool call.
+            model_name: Optional model name when this action is an LLM call.
+            parent_id: Optional parent action ID for the agent graph view.
 
         Returns:
             SignatureResponse with the signature.
         """
         from .client import _build_sign_body
+
+        if tool_name or model_name or parent_id:
+            context = dict(context) if context else {}
+            if tool_name:
+                context["_tool_name"] = tool_name
+            if model_name:
+                context["_model_name"] = model_name
+            if parent_id:
+                context["_parent_id"] = parent_id
 
         body = _build_sign_body(
             action_type=action_type,

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -112,7 +112,7 @@ _org_salt: bytes | None = None
 # enforces its own whitelist; this mirrors the conservative default so we
 # don't accidentally leak fields the customer didn't intend to share.
 _HASH_ONLY_METADATA_WHITELIST: frozenset[str] = frozenset(
-    {"agent_id", "session_id", "action_type", "model_name", "tool_name"}
+    {"agent_id", "session_id", "action_type", "model_name", "tool_name", "parent_id"}
 )
 
 
@@ -675,10 +675,16 @@ def _build_sign_body(
         }
         if session_id is not None:
             metadata["session_id"] = session_id
-        # Pull optional model_name / tool_name from context if the caller
-        # opted in by adding underscored sentinel keys. Other context keys
-        # are NEVER copied; that's the whole point of hash-only.
-        for src_key, dst_key in (("_model_name", "model_name"), ("_tool_name", "tool_name")):
+        # Pull optional model_name / tool_name / parent_id from context if
+        # the caller opted in by adding underscored sentinel keys. Other
+        # context keys are NEVER copied; that's the whole point of
+        # hash-only. These three identifiers power the agent graph view
+        # in the dashboard (no prompt or tool-arg content travels).
+        for src_key, dst_key in (
+            ("_model_name", "model_name"),
+            ("_tool_name", "tool_name"),
+            ("_parent_id", "parent_id"),
+        ):
             if context and src_key in context:
                 value = context[src_key]
                 if isinstance(value, str):
@@ -868,6 +874,8 @@ class Agent:
         trace_id: str | None = None,
         parent_id: str | None = None,
         counterparty: dict[str, Any] | None = None,
+        tool_name: str | None = None,
+        model_name: str | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -887,7 +895,7 @@ class Agent:
             trace_id: Optional trace ID for correlating actions across
                 a multi-step workflow. Use generate_trace_id() to create one.
             parent_id: Optional parent action ID for linking child actions
-                to their parent in a workflow.
+                to their parent in a workflow. Powers the agent graph view.
             counterparty: Optional identity of the endpoint the agent is
                 calling. Included in the signed record so an auditor can
                 verify the agent reached a specific endpoint, not an
@@ -898,6 +906,12 @@ class Agent:
                     {"kind": "url_sni", "value": "api.example.com"}
 
                 Any dict is accepted; unknown kinds are recorded verbatim.
+            tool_name: Optional name of the tool being invoked when this
+                action is a tool call. Surfaced in the dashboard graph.
+                Only the name string travels; tool arguments do not.
+            model_name: Optional name of the model being called when this
+                action is an LLM call (e.g. "gpt-4", "claude-opus-4-7").
+                Only the name string travels; the prompt does not.
 
         Returns:
             SignatureResponse with the signature.
@@ -911,6 +925,8 @@ class Agent:
             or trace_id
             or parent_id
             or counterparty
+            or tool_name
+            or model_name
         ):
             context = dict(context) if context else {}
             if system_prompt_hash:
@@ -925,6 +941,10 @@ class Agent:
                 context["_parent_id"] = parent_id
             if counterparty:
                 context["_counterparty"] = counterparty
+            if tool_name:
+                context["_tool_name"] = tool_name
+            if model_name:
+                context["_model_name"] = model_name
 
         # Dispatch before-hooks (fail-open).
         try:

--- a/python/tests/test_client_hash_mode.py
+++ b/python/tests/test_client_hash_mode.py
@@ -132,6 +132,82 @@ def test_hash_only_includes_optional_model_name_when_opted_in() -> None:
     assert body["metadata"]["tool_name"] == "search"
 
 
+def test_hash_only_surfaces_parent_id_from_context_sentinel() -> None:
+    """``_parent_id`` in context auto-surfaces to metadata bag."""
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"prompt": "hi", "_parent_id": "act_parent_42"})
+
+    _, body = mock_post.call_args[0]
+    assert body["metadata"]["parent_id"] == "act_parent_42"
+
+
+def test_hash_only_explicit_tool_name_kwarg_appears_in_metadata() -> None:
+    """Passing tool_name=... to sign() surfaces it in the wire metadata bag."""
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"prompt": "hi"}, tool_name="web_search")
+
+    _, body = mock_post.call_args[0]
+    assert body["metadata"]["tool_name"] == "web_search"
+
+
+def test_hash_only_explicit_model_name_kwarg_appears_in_metadata() -> None:
+    """Passing model_name=... to sign() surfaces it in the wire metadata bag."""
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"prompt": "hi"}, model_name="claude-opus-4-7")
+
+    _, body = mock_post.call_args[0]
+    assert body["metadata"]["model_name"] == "claude-opus-4-7"
+
+
+def test_hash_only_explicit_parent_id_kwarg_appears_in_metadata() -> None:
+    """Passing parent_id=... to sign() surfaces it in the wire metadata bag."""
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"prompt": "hi"}, parent_id="act_parent_99")
+
+    _, body = mock_post.call_args[0]
+    assert body["metadata"]["parent_id"] == "act_parent_99"
+
+
+def test_full_payload_keeps_telemetry_in_context_only_not_duplicated() -> None:
+    """In full-payload mode the three fields ride inside context (as
+    ``_tool_name`` / ``_model_name`` / ``_parent_id``) and the body must
+    not also carry a top-level metadata bag duplicating them."""
+    client_mod._mode = "full-payload"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign(
+            "api:call",
+            {"prompt": "hi"},
+            tool_name="web_search",
+            model_name="gpt-4",
+            parent_id="act_parent_1",
+        )
+
+    _, body = mock_post.call_args[0]
+    assert "metadata" not in body
+    assert body["context"]["_tool_name"] == "web_search"
+    assert body["context"]["_model_name"] == "gpt-4"
+    assert body["context"]["_parent_id"] == "act_parent_1"
+
+
 def test_hash_only_uses_hmac_when_org_salt_set() -> None:
     """A non-None org_salt swaps SHA-256 for HMAC-SHA-256 with the same shape."""
     agent = _make_agent()

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -29,6 +29,7 @@ const HASH_ONLY_METADATA_WHITELIST = new Set<string>([
   "action_type",
   "model_name",
   "tool_name",
+  "parent_id",
 ]);
 
 interface Config {
@@ -109,6 +110,15 @@ export interface AgentCreateOptions {
 export interface SignOptions {
   actionType: string;
   context?: Record<string, unknown>;
+  /** Optional tool name when this action is a tool call. Surfaced in
+   * the dashboard graph view. Only the name travels; tool args do not. */
+  toolName?: string;
+  /** Optional model name when this action is an LLM call (e.g. "gpt-4").
+   * Only the name travels; the prompt does not. */
+  modelName?: string;
+  /** Optional parent action ID for linking child actions to their parent
+   * in a workflow. Powers the agent graph view. */
+  parentId?: string;
 }
 
 export interface SignatureResponse {
@@ -291,11 +301,15 @@ async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, un
       action_type: args.actionType,
     };
     if (args.sessionId !== null) metadata.session_id = args.sessionId;
-    // Optional opt-in: caller adds ``_model_name`` / ``_tool_name`` to
-    // the context. Other context keys are NEVER copied.
+    // Optional opt-in: caller adds ``_model_name`` / ``_tool_name`` /
+    // ``_parent_id`` to the context. Other context keys are NEVER
+    // copied. These three identifiers power the agent graph view in
+    // the dashboard - only the name strings travel, never prompts or
+    // tool args.
     const ctx = args.context as Record<string, unknown>;
     if (typeof ctx._model_name === "string") metadata.model_name = ctx._model_name;
     if (typeof ctx._tool_name === "string") metadata.tool_name = ctx._tool_name;
+    if (typeof ctx._parent_id === "string") metadata.parent_id = ctx._parent_id;
     // Defensive: drop anything that snuck in outside the whitelist.
     for (const k of Object.keys(metadata)) {
       if (!HASH_ONLY_METADATA_WHITELIST.has(k)) delete metadata[k];
@@ -369,7 +383,19 @@ export class Agent {
   }
 
   async sign(options: SignOptions): Promise<SignatureResponse> {
-    const initialContext = options.context ?? {};
+    let initialContext = options.context ?? {};
+    // Surface explicit kwargs into the underscored sentinel keys so the
+    // hash-only metadata builder picks them up. Mirrors the Python SDK.
+    if (
+      options.toolName !== undefined
+      || options.modelName !== undefined
+      || options.parentId !== undefined
+    ) {
+      initialContext = { ...initialContext };
+      if (options.toolName !== undefined) initialContext._tool_name = options.toolName;
+      if (options.modelName !== undefined) initialContext._model_name = options.modelName;
+      if (options.parentId !== undefined) initialContext._parent_id = options.parentId;
+    }
     const finalContext = _dispatchBefore(options.actionType, initialContext);
 
     const body = await buildSignBody({

--- a/typescript/tests/clientHashMode.test.ts
+++ b/typescript/tests/clientHashMode.test.ts
@@ -141,6 +141,110 @@ describe("Agent.sign body shape across modes", () => {
     expect(body.metadata.tool_name).toBe("search");
   });
 
+  it("hash-only surfaces _parent_id from context sentinel", async () => {
+    _setModeForTests("hash-only");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { prompt: "hi", _parent_id: "act_parent_42" },
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.metadata.parent_id).toBe("act_parent_42");
+  });
+
+  it("hash-only surfaces explicit toolName kwarg in metadata", async () => {
+    _setModeForTests("hash-only");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { prompt: "hi" },
+      toolName: "web_search",
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.metadata.tool_name).toBe("web_search");
+  });
+
+  it("hash-only surfaces explicit modelName kwarg in metadata", async () => {
+    _setModeForTests("hash-only");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { prompt: "hi" },
+      modelName: "claude-opus-4-7",
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.metadata.model_name).toBe("claude-opus-4-7");
+  });
+
+  it("hash-only surfaces explicit parentId kwarg in metadata", async () => {
+    _setModeForTests("hash-only");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { prompt: "hi" },
+      parentId: "act_parent_99",
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.metadata.parent_id).toBe("act_parent_99");
+  });
+
+  it("full-payload keeps telemetry in context only, no duplicate metadata bag", async () => {
+    _setModeForTests("full-payload");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { prompt: "hi" },
+      toolName: "web_search",
+      modelName: "gpt-4",
+      parentId: "act_parent_1",
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.metadata).toBeUndefined();
+    expect(body.context._tool_name).toBe("web_search");
+    expect(body.context._model_name).toBe("gpt-4");
+    expect(body.context._parent_id).toBe("act_parent_1");
+  });
+
   it("hash-only with org salt produces a different hash than without", async () => {
     const agent = await makeAgent();
 


### PR DESCRIPTION
## Summary

- Both SDKs (Python 0.3.2 / TypeScript 0.2.2) now auto-populate `tool_name`, `model_name`, `parent_id` in the hash-only metadata bag.
- Surface paths: explicit kwargs to `sign()` (`tool_name=` / `model_name=` / `parent_id=` in Python, `toolName` / `modelName` / `parentId` in TypeScript), or context sentinels (`_tool_name` / `_model_name` / `_parent_id`) which agno-style frameworks already populate.
- `parent_id` added to the SDK's hash-only metadata whitelist (was already covered for the others).
- Hash-only safety preserved: only the identifier strings travel, never prompts or tool args.

This unblocks the agent graph view in the dashboard - without these fields the graph is empty.

## Test plan
- [x] `pytest tests/test_client_hash_mode.py tests/test_canonicalize.py` - 32 passed
- [x] `npm test` - 74 passed across 5 files
- [x] Pre-flight: 0 em dashes, 0 marketing fluff matches, 0 exclamations in markdown
- [x] Existing API preserved (new optional kwargs only)
- [x] Full-payload mode keeps fields in `context` only, no duplicate `metadata` bag (covered by new test)

## Versions
- Python: 0.3.1 -> 0.3.2
- TypeScript: 0.2.1 -> 0.2.2

DevOps will tag `py-v0.3.2` and `ts-v0.2.2` after merge to trigger publish.