### PR TITLE
feat: multi-party countersigning (co_signers + countersign)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.3.3 / TypeScript 0.2.3] - 2026-04-28
+
+### Added
+- Multi-party countersigning. `agent.sign(co_signers=[...])` records a list of peer agent_ids the original signer expects to countersign. Each peer calls `agent.countersign(signature_id)` and the server signs the SAME canonical bytes with that peer's ML-DSA key, then appends to the record's `co_signatures`. Mirror API in TypeScript: `agent.sign({coSigners: [...]})` and `agent.countersign(signatureId)`. No prompts or tool args travel during countersign; only signatures are added. Requires backend with co-signature support.
+
 ## [Python 0.3.2 / TypeScript 0.2.2] - 2026-04-30
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.2"
+version = "0.3.3"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -233,6 +233,8 @@ class AsyncAgent:
         tool_name: str | None = None,
         model_name: str | None = None,
         parent_id: str | None = None,
+        *,
+        co_signers: list[str] | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically (async).
 
@@ -242,6 +244,9 @@ class AsyncAgent:
             tool_name: Optional tool name when this action is a tool call.
             model_name: Optional model name when this action is an LLM call.
             parent_id: Optional parent action ID for the agent graph view.
+            co_signers: Optional list of agent_ids in the same org expected
+                to countersign this record. The other agents fetch the
+                record by id and call ``agent.countersign(signature_id)``.
 
         Returns:
             SignatureResponse with the signature.
@@ -263,6 +268,8 @@ class AsyncAgent:
             session_id=self._session_id,
             agent_id=self.agent_id,
         )
+        if co_signers:
+            body["co_signers"] = list(co_signers)
         data = await _async_post(f"/agents/{self.agent_id}/sign", body)
 
         return SignatureResponse(
@@ -280,6 +287,43 @@ class AsyncAgent:
             policy_decision=data.get("policy_decision", "permit"),
             authorization_ref=data.get("authorization_ref"),
             bitcoin_anchor=_parse_bitcoin_anchor(data.get("bitcoin_anchor")),
+            required_co_signers=data.get("required_co_signers"),
+            co_signatures=data.get("co_signatures"),
+            countersign_url=data.get("countersign_url"),
+        )
+
+    async def countersign(self, signature_id: str) -> SignatureResponse:
+        """Countersign an existing signature record (async).
+
+        Args:
+            signature_id: The ``sig_...`` id returned by the original
+                ``sign(co_signers=[...])`` call.
+
+        Returns:
+            SignatureResponse with the updated record (including this
+            agent's signature appended to ``co_signatures``).
+        """
+        data = await _async_post(
+            f"/agents/{self.agent_id}/countersign/{signature_id}",
+            {},
+        )
+        return SignatureResponse(
+            signature=data["signature"],
+            signature_id=data["signature_id"],
+            action_id=data["action_id"],
+            timestamp=data["timestamp"],
+            verification_url=data["verification_url"],
+            algorithm=data.get("algorithm"),
+            chain_hash=data.get("chain_hash") or data.get("record_hash"),
+            rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
+            rfc3161_serial=(data.get("rfc3161_timestamp") or {}).get("serial_number"),
+            policy_digest=data.get("policy_digest"),
+            policy_decision=data.get("policy_decision", "permit"),
+            authorization_ref=data.get("authorization_ref"),
+            bitcoin_anchor=_parse_bitcoin_anchor(data.get("bitcoin_anchor")),
+            required_co_signers=data.get("required_co_signers"),
+            co_signatures=data.get("co_signatures"),
+            countersign_url=data.get("countersign_url"),
         )
 
     async def start_session(self) -> SessionResponse:

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -214,6 +214,12 @@ class SignatureResponse:
     policy_decision: str = "permit"
     authorization_ref: str | None = None
     bitcoin_anchor: BitcoinAnchor | None = None
+    # Multi-party countersigning (optional). When the caller passed
+    # `co_signers=[...]` to `agent.sign()`, the server records the list and
+    # surfaces it back so peers know they need to countersign.
+    required_co_signers: list[str] | None = None
+    co_signatures: list[dict[str, Any]] | None = None
+    countersign_url: str | None = None
 
 
 @dataclass
@@ -876,6 +882,8 @@ class Agent:
         counterparty: dict[str, Any] | None = None,
         tool_name: str | None = None,
         model_name: str | None = None,
+        *,
+        co_signers: list[str] | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -961,6 +969,8 @@ class Agent:
             session_id=self._session_id,
             agent_id=self.agent_id,
         )
+        if co_signers:
+            body["co_signers"] = list(co_signers)
         data = _post(f"/agents/{self.agent_id}/sign", body)
 
         response = SignatureResponse(
@@ -978,6 +988,9 @@ class Agent:
             policy_decision=data.get("policy_decision", "permit"),
             authorization_ref=data.get("authorization_ref"),
             bitcoin_anchor=_parse_bitcoin_anchor(data.get("bitcoin_anchor")),
+            required_co_signers=data.get("required_co_signers"),
+            co_signatures=data.get("co_signatures"),
+            countersign_url=data.get("countersign_url"),
         )
 
         # Dispatch after-hooks (fail-open).
@@ -988,6 +1001,47 @@ class Agent:
             logger.warning("asqav after-hook dispatch failed (fail-open)", exc_info=True)
 
         return response
+
+    def countersign(self, signature_id: str) -> SignatureResponse:
+        """Countersign an existing signature record.
+
+        The server looks up ``signature_id``, verifies that this agent is
+        in the original ``required_co_signers`` list and shares the same
+        organization, then signs the SAME canonical bytes the original
+        signer signed. No new prompts or tool args travel over the wire;
+        only signatures are added.
+
+        Args:
+            signature_id: The ``sig_...`` id returned by the original
+                ``sign(co_signers=[...])`` call.
+
+        Returns:
+            SignatureResponse describing the updated record, including
+            the full ``co_signatures`` list after this agent's signature
+            was appended.
+        """
+        data = _post(
+            f"/agents/{self.agent_id}/countersign/{signature_id}",
+            {},
+        )
+        return SignatureResponse(
+            signature=data["signature"],
+            signature_id=data["signature_id"],
+            action_id=data["action_id"],
+            timestamp=data["timestamp"],
+            verification_url=data["verification_url"],
+            algorithm=data.get("algorithm"),
+            chain_hash=data.get("chain_hash") or data.get("record_hash"),
+            rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
+            rfc3161_serial=(data.get("rfc3161_timestamp") or {}).get("serial_number"),
+            policy_digest=data.get("policy_digest"),
+            policy_decision=data.get("policy_decision", "permit"),
+            authorization_ref=data.get("authorization_ref"),
+            bitcoin_anchor=_parse_bitcoin_anchor(data.get("bitcoin_anchor")),
+            required_co_signers=data.get("required_co_signers"),
+            co_signatures=data.get("co_signatures"),
+            countersign_url=data.get("countersign_url"),
+        )
 
     def sign_batch(
         self,

--- a/python/tests/test_co_signers.py
+++ b/python/tests/test_co_signers.py
@@ -1,0 +1,175 @@
+"""Tests for multi-party countersigning (sync + async)."""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+import asqav
+from asqav.async_client import AsyncAgent
+
+
+def _make_agent() -> "asqav.Agent":
+    return asqav.Agent(
+        agent_id="agent_alice",
+        name="alice",
+        public_key="pub",
+        key_id="key_alice",
+        algorithm="ML-DSA-65",
+        capabilities=[],
+        created_at=0.0,
+    )
+
+
+def _make_async_agent() -> AsyncAgent:
+    return AsyncAgent(
+        agent_id="agent_bob",
+        name="bob",
+        public_key="pub",
+        key_id="key_bob",
+        algorithm="ML-DSA-65",
+        capabilities=[],
+        created_at=0.0,
+    )
+
+
+def test_sign_accepts_co_signers_kwarg() -> None:
+    sig = inspect.signature(asqav.Agent.sign)
+    assert "co_signers" in sig.parameters
+    assert sig.parameters["co_signers"].default is None
+    # keyword-only
+    assert sig.parameters["co_signers"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_async_sign_accepts_co_signers_kwarg() -> None:
+    sig = inspect.signature(AsyncAgent.sign)
+    assert "co_signers" in sig.parameters
+    assert sig.parameters["co_signers"].kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_countersign_method_exists() -> None:
+    assert hasattr(asqav.Agent, "countersign")
+    sig = inspect.signature(asqav.Agent.countersign)
+    assert "signature_id" in sig.parameters
+
+
+def test_async_countersign_method_exists() -> None:
+    assert hasattr(AsyncAgent, "countersign")
+    sig = inspect.signature(AsyncAgent.countersign)
+    assert "signature_id" in sig.parameters
+
+
+@patch("asqav.client._post")
+def test_sign_forwards_co_signers_in_body(mock_post: object) -> None:
+    mock_post.return_value = {  # type: ignore[attr-defined]
+        "signature": "sig_bytes",
+        "signature_id": "sig_01",
+        "action_id": "act_01",
+        "timestamp": "2026-04-28T10:00:00Z",
+        "verification_url": "https://api.asqav.com/api/v1/verify/sig_01",
+        "required_co_signers": ["agent_bob", "agent_carol"],
+        "co_signatures": [],
+        "countersign_url": "/api/v1/agents/{agent_id}/countersign/sig_01",
+    }
+    agent = _make_agent()
+    resp = agent.sign(
+        action_type="verify:peer-output",
+        context={"task": "review"},
+        co_signers=["agent_bob", "agent_carol"],
+    )
+
+    sent_body = mock_post.call_args[0][1]  # type: ignore[attr-defined]
+    assert sent_body["co_signers"] == ["agent_bob", "agent_carol"]
+    assert resp.required_co_signers == ["agent_bob", "agent_carol"]
+    assert resp.co_signatures == []
+    assert resp.countersign_url is not None
+
+
+@patch("asqav.client._post")
+def test_sign_without_co_signers_omits_field(mock_post: object) -> None:
+    mock_post.return_value = {  # type: ignore[attr-defined]
+        "signature": "sig_bytes",
+        "signature_id": "sig_02",
+        "action_id": "act_02",
+        "timestamp": "2026-04-28T10:00:00Z",
+        "verification_url": "https://api.asqav.com/api/v1/verify/sig_02",
+    }
+    agent = _make_agent()
+    resp = agent.sign(action_type="api:call", context={})
+
+    sent_body = mock_post.call_args[0][1]  # type: ignore[attr-defined]
+    assert "co_signers" not in sent_body
+    assert resp.required_co_signers is None
+    assert resp.co_signatures is None
+
+
+@patch("asqav.client._post")
+def test_countersign_posts_to_correct_path(mock_post: object) -> None:
+    mock_post.return_value = {  # type: ignore[attr-defined]
+        "signature": "sig_bytes",
+        "signature_id": "sig_01",
+        "action_id": "act_01",
+        "timestamp": "2026-04-28T10:00:00Z",
+        "verification_url": "https://api.asqav.com/api/v1/verify/sig_01",
+        "required_co_signers": ["agent_alice"],
+        "co_signatures": [
+            {"agent_id": "agent_alice", "signature": "co_sig_bytes", "signed_at": "2026-04-28T10:00:01Z"}
+        ],
+    }
+    agent = _make_agent()
+    resp = agent.countersign("sig_01")
+
+    path = mock_post.call_args[0][0]  # type: ignore[attr-defined]
+    body = mock_post.call_args[0][1]  # type: ignore[attr-defined]
+    assert path == "/agents/agent_alice/countersign/sig_01"
+    assert body == {}
+    assert resp.co_signatures is not None
+    assert len(resp.co_signatures) == 1
+    assert resp.co_signatures[0]["agent_id"] == "agent_alice"
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_post", new_callable=AsyncMock)
+async def test_async_sign_forwards_co_signers(mock_post: AsyncMock) -> None:
+    mock_post.return_value = {
+        "signature": "sig_bytes",
+        "signature_id": "sig_async",
+        "action_id": "act_async",
+        "timestamp": "2026-04-28T10:00:00Z",
+        "verification_url": "https://api.asqav.com/api/v1/verify/sig_async",
+        "required_co_signers": ["agent_alice"],
+        "co_signatures": [],
+    }
+    agent = _make_async_agent()
+    resp = await agent.sign(
+        action_type="verify:peer-output",
+        context={},
+        co_signers=["agent_alice"],
+    )
+    sent_body = mock_post.call_args[0][1]
+    assert sent_body["co_signers"] == ["agent_alice"]
+    assert resp.required_co_signers == ["agent_alice"]
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_post", new_callable=AsyncMock)
+async def test_async_countersign_posts_to_correct_path(mock_post: AsyncMock) -> None:
+    mock_post.return_value = {
+        "signature": "sig_bytes",
+        "signature_id": "sig_async",
+        "action_id": "act_async",
+        "timestamp": "2026-04-28T10:00:00Z",
+        "verification_url": "https://api.asqav.com/api/v1/verify/sig_async",
+        "required_co_signers": ["agent_bob"],
+        "co_signatures": [
+            {"agent_id": "agent_bob", "signature": "co_sig", "signed_at": "2026-04-28T10:00:01Z"}
+        ],
+    }
+    agent = _make_async_agent()
+    resp = await agent.countersign("sig_async")
+    path = mock_post.call_args[0][0]
+    assert path == "/agents/agent_bob/countersign/sig_async"
+    assert resp.co_signatures is not None
+    assert resp.co_signatures[0]["agent_id"] == "agent_bob"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -119,6 +119,16 @@ export interface SignOptions {
   /** Optional parent action ID for linking child actions to their parent
    * in a workflow. Powers the agent graph view. */
   parentId?: string;
+  /** Optional list of agent_ids in the same org expected to countersign
+   * this record. Each peer fetches the record and calls
+   * ``agent.countersign(signatureId)``. */
+  coSigners?: string[];
+}
+
+export interface CoSignature {
+  agentId: string;
+  signature: string;
+  signedAt: string;
 }
 
 export interface SignatureResponse {
@@ -129,6 +139,12 @@ export interface SignatureResponse {
   verificationUrl: string;
   algorithm?: string;
   chainHash?: string;
+  /** Agents the original signer expects to countersign this record. */
+  requiredCoSigners?: string[];
+  /** Signatures appended by countersigning peers, in arrival order. */
+  coSignatures?: CoSignature[];
+  /** URL pattern (relative) for peers to POST their countersignature to. */
+  countersignUrl?: string;
 }
 
 export interface SessionResponse {
@@ -404,6 +420,9 @@ export class Agent {
       sessionId: this.sessionId,
       agentId: this.agentId,
     });
+    if (options.coSigners && options.coSigners.length > 0) {
+      body.co_signers = [...options.coSigners];
+    }
 
     const data = await request<{
       signature: string;
@@ -414,6 +433,9 @@ export class Agent {
       algorithm?: string;
       chain_hash?: string;
       record_hash?: string;
+      required_co_signers?: string[];
+      co_signatures?: Array<{ agent_id: string; signature: string; signed_at: string }>;
+      countersign_url?: string;
     }>("POST", `/agents/${this.agentId}/sign`, body);
 
     const response: SignatureResponse = {
@@ -424,10 +446,50 @@ export class Agent {
       verificationUrl: data.verification_url,
       algorithm: data.algorithm,
       chainHash: data.chain_hash ?? data.record_hash,
+      requiredCoSigners: data.required_co_signers,
+      coSignatures: data.co_signatures?.map((s) => ({
+        agentId: s.agent_id,
+        signature: s.signature,
+        signedAt: s.signed_at,
+      })),
+      countersignUrl: data.countersign_url,
     };
 
     _dispatchAfter(options.actionType, response);
     return response;
+  }
+
+  async countersign(signatureId: string): Promise<SignatureResponse> {
+    const data = await request<{
+      signature: string;
+      signature_id: string;
+      action_id: string;
+      timestamp: string;
+      verification_url: string;
+      algorithm?: string;
+      chain_hash?: string;
+      record_hash?: string;
+      required_co_signers?: string[];
+      co_signatures?: Array<{ agent_id: string; signature: string; signed_at: string }>;
+      countersign_url?: string;
+    }>("POST", `/agents/${this.agentId}/countersign/${signatureId}`, {});
+
+    return {
+      signature: data.signature,
+      signatureId: data.signature_id,
+      actionId: data.action_id,
+      timestamp: data.timestamp,
+      verificationUrl: data.verification_url,
+      algorithm: data.algorithm,
+      chainHash: data.chain_hash ?? data.record_hash,
+      requiredCoSigners: data.required_co_signers,
+      coSignatures: data.co_signatures?.map((s) => ({
+        agentId: s.agent_id,
+        signature: s.signature,
+        signedAt: s.signed_at,
+      })),
+      countersignUrl: data.countersign_url,
+    };
   }
 
   async startSession(): Promise<SessionResponse> {

--- a/typescript/tests/coSigners.test.ts
+++ b/typescript/tests/coSigners.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Agent, _resetForTests, init } from "../src/index.js";
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const AGENT_PAYLOAD = {
+  agent_id: "agt_alice",
+  name: "alice",
+  public_key: "pk",
+  key_id: "kid",
+  algorithm: "ml-dsa-65",
+  capabilities: [],
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+describe("agent.sign with co_signers", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("forwards coSigners as co_signers in request body", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(AGENT_PAYLOAD))
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          signature: "sig-bytes",
+          signature_id: "sig_1",
+          action_id: "act_1",
+          timestamp: "2026-01-01T00:00:00Z",
+          verification_url: "https://asqav.com/verify/sig_1",
+          required_co_signers: ["agt_bob", "agt_carol"],
+          co_signatures: [],
+          countersign_url: "/api/v1/agents/{agent_id}/countersign/sig_1",
+        }),
+      );
+
+    const agent = await Agent.create({ name: "alice" });
+    const sig = await agent.sign({
+      actionType: "verify:peer-output",
+      context: { task: "review" },
+      coSigners: ["agt_bob", "agt_carol"],
+    });
+
+    const signInit = fetchSpy.mock.calls[1]![1] as RequestInit;
+    const sentBody = JSON.parse(signInit.body as string);
+    expect(sentBody.co_signers).toEqual(["agt_bob", "agt_carol"]);
+    expect(sig.requiredCoSigners).toEqual(["agt_bob", "agt_carol"]);
+    expect(sig.coSignatures).toEqual([]);
+    expect(sig.countersignUrl).toBe("/api/v1/agents/{agent_id}/countersign/sig_1");
+  });
+
+  it("omits co_signers field when not provided", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(AGENT_PAYLOAD))
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          signature: "sig-bytes",
+          signature_id: "sig_2",
+          action_id: "act_2",
+          timestamp: "2026-01-01T00:00:00Z",
+          verification_url: "https://asqav.com/verify/sig_2",
+        }),
+      );
+
+    const agent = await Agent.create({ name: "alice" });
+    await agent.sign({ actionType: "api:call", context: {} });
+
+    const signInit = fetchSpy.mock.calls[1]![1] as RequestInit;
+    const sentBody = JSON.parse(signInit.body as string);
+    expect(sentBody.co_signers).toBeUndefined();
+  });
+});
+
+describe("agent.countersign", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts to /agents/{id}/countersign/{signature_id} with empty body", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(AGENT_PAYLOAD))
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          signature: "sig-bytes",
+          signature_id: "sig_1",
+          action_id: "act_1",
+          timestamp: "2026-01-01T00:00:00Z",
+          verification_url: "https://asqav.com/verify/sig_1",
+          required_co_signers: ["agt_alice"],
+          co_signatures: [
+            { agent_id: "agt_alice", signature: "co_sig", signed_at: "2026-01-01T00:00:01Z" },
+          ],
+        }),
+      );
+
+    const agent = await Agent.create({ name: "alice" });
+    const result = await agent.countersign("sig_1");
+
+    const [url, callInit] = fetchSpy.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe("https://api.example.test/api/v1/agents/agt_alice/countersign/sig_1");
+    expect(callInit.method).toBe("POST");
+    expect(JSON.parse(callInit.body as string)).toEqual({});
+    expect(result.coSignatures).toEqual([
+      { agentId: "agt_alice", signature: "co_sig", signedAt: "2026-01-01T00:00:01Z" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds multi-party countersigning to the Python and TypeScript SDKs.

- Python `agent.sign(..., co_signers=[...])` (sync + async): records the list of peer agent_ids the original signer expects to countersign. Response carries `required_co_signers`, `co_signatures`, `countersign_url`.
- Python `agent.countersign(signature_id)` (sync + async): peer signs the SAME canonical bytes the original signer signed. POSTs to `/agents/{agent_id}/countersign/{signature_id}` with empty body.
- TypeScript mirrors the API: `agent.sign({coSigners: [...]})` and `agent.countersign(signatureId)`.

## Why

A receipt signed only by the acting agent proves one side's view. When one agent verifies another's work, both parties need to sign independently. This SDK change exposes the new countersign endpoint so peers can append signatures to the same record.

## Versions

- Python: 0.3.2 -> 0.3.3
- TypeScript: 0.2.2 -> 0.2.3

## Hash-only safety

Countersign signs the same canonical bytes the original signer signed. No new prompts, tool args, or context travel during countersign. Only signatures are added.

## Cross-repo

Depends on backend PR #66 (https://github.com/jagmarques/asqav/pull/66) which ships the endpoints + DB columns.

## Test plan
- [x] Python: 9 new tests in `python/tests/test_co_signers.py` (sync + async). All pass.
- [x] Python full suite: 351 passing (excluding optional integration extras and one unrelated pre-existing haystack stub failure).
- [x] TypeScript: 4 new tests in `typescript/tests/coSigners.test.ts`. Full TS suite: 77/77 passing.
- [x] CHANGELOG entry added.
- [ ] Smoke test against backend PR before lockstep merge.

## Pre-flight
- 0 em dashes in new prose.
- 0 SOC2/ISO/certified claims.
- 0 stray exclamation marks in markdown/HTML.
- "Asqav" capital A in prose.

## Do not merge

Merge after (or in lockstep with) backend PR #66.