### PR TITLE
feat: user-intent envelope on Agent.sign()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.3.3 / TypeScript 0.2.3] - 2026-04-28
+
+### Added
+- `user_intent` parameter on `Agent.sign()` (Python) and `agent.sign({userIntent: ...})` (TypeScript). Optional envelope containing a user-produced signature plus public key, algorithm, signed bytes, and signed-at timestamp. The SDK passes it through to the backend verbatim. The backend verifies and stores it alongside the agent signature so receipts prove "this user authorized this specific action right now". Supported algorithms: `ed25519`, `ecdsa-p256`, `webauthn` (store-only for now). See docs/user-intent.md for the recommended pattern.
+- `user_intent_verified` field on `SignatureResponse` reflecting backend verification result.
+
 ## [Python 0.3.2 / TypeScript 0.2.2] - 2026-04-30
 
 ### Added

--- a/docs/user-intent.md
+++ b/docs/user-intent.md
@@ -1,0 +1,112 @@
+# User-intent binding
+
+A receipt that says "agent X ran this action" answers half the question. The other half is "did the user actually authorize this specific action right now". User-intent binding is the primitive that answers it.
+
+## The shape
+
+When you call `agent.sign(...)`, you can attach an optional `user_intent` envelope. The user produces a signature over the bytes they're asserting (typically a digest of action_type plus context plus a fresh nonce). The SDK passes those bytes to the backend verbatim. The backend verifies the signature with the declared algorithm and stores both the agent signature and the user signature on the same record.
+
+The envelope:
+
+```json
+{
+  "signature": "<base64>",
+  "public_key": "<base64>",
+  "algorithm": "ed25519",
+  "key_id": "optional, useful for WebAuthn",
+  "signed_message": "<base64; what the user actually signed>",
+  "signed_at": "2026-04-28T12:00:00Z"
+}
+```
+
+Supported algorithms today:
+
+- `ed25519` - verified server-side via the cryptography library.
+- `ecdsa-p256` - verified server-side via the cryptography library.
+- `webauthn` - stored advisory only. Full WebAuthn assertion verification is on the roadmap. The signature bytes still travel and persist; `user_intent_verified` will be `false` until the WebAuthn worker ships.
+
+If verification fails, the backend returns 400 with `code: USER_INTENT_INVALID` and does not sign over a bogus envelope.
+
+## What goes in `signed_message`
+
+Whatever the customer chooses. The recommended pattern is a SHA-256 digest of:
+
+- the action_type
+- a stable serialization of the context
+- a nonce that's fresh per action
+
+Asqav stores the bytes; it does not interpret them. If you want the receipt to prove "this user authorized exactly this action", make sure your signed bytes commit to enough of the action context for that claim to hold.
+
+## Python example with Ed25519
+
+```python
+import base64, hashlib, time
+from nacl.signing import SigningKey
+from asqav import Agent
+
+# In production, this private key lives on the user's device or hardware.
+sk = SigningKey.generate()
+vk = sk.verify_key
+
+action_type = "transfer:funds"
+context = {"to": "acct_42", "amount_eur": 100}
+nonce = "9f3c..."  # fresh per action
+digest = hashlib.sha256(
+    f"{action_type}|{context}|{nonce}".encode()
+).digest()
+
+sig = sk.sign(digest).signature
+
+agent = Agent.get("agt_xxx")
+resp = agent.sign(
+    action_type,
+    context,
+    user_intent={
+        "signature": base64.b64encode(sig).decode(),
+        "public_key": base64.b64encode(bytes(vk)).decode(),
+        "algorithm": "ed25519",
+        "signed_message": base64.b64encode(digest).decode(),
+        "signed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    },
+)
+assert resp.user_intent_verified is True
+```
+
+## Browser example with WebAuthn (sketch)
+
+The actual WebAuthn flow is the customer's responsibility. The sketch below is a starting point:
+
+```js
+// 1. On enroll: navigator.credentials.create(...) -> store credential id
+// 2. On action: build a digest of action_type + context + nonce
+// 3. navigator.credentials.get({ publicKey: { challenge: digest, ... } })
+// 4. Pull authenticatorData + clientDataJSON + signature out of the assertion
+// 5. Send via the SDK:
+
+await agent.sign({
+  actionType: "transfer:funds",
+  context: { to: "acct_42", amount_eur: 100 },
+  userIntent: {
+    signature: b64(assertion.response.signature),
+    public_key: b64(storedPublicKey),
+    algorithm: "webauthn",
+    key_id: assertion.id,
+    signed_message: b64(digest),
+    signed_at: new Date().toISOString(),
+  },
+});
+```
+
+WebAuthn assertion verification is store-only today. The bytes are persisted on the receipt, but `user_intent_verified` will be `false` until the WebAuthn worker ships.
+
+## What this is not
+
+- It is not an identity primitive. The user public key only identifies "the same key that signed before", not "Jane Smith".
+- It is not a content disclosure. The signed bytes are whatever you put in them; in hash-only mode you typically sign a digest, not the raw context.
+- It is not a replacement for the agent signature. Both end up on the receipt; they answer different questions.
+
+## Roadmap
+
+- WebAuthn assertion verification (parse `authenticatorData` plus `clientDataJSON`, verify against the stored COSE key).
+- A `verifyUserIntent(signatureId)` helper on both SDKs that re-runs verification against the stored bytes.
+- Optional policy: require `user_intent_verified=true` for specific action_type patterns.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.2"
+version = "0.3.3"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.3"
+version = "0.3.4"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -235,6 +235,7 @@ class AsyncAgent:
         parent_id: str | None = None,
         *,
         co_signers: list[str] | None = None,
+        user_intent: dict[str, Any] | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically (async).
 
@@ -291,6 +292,7 @@ class AsyncAgent:
             required_co_signers=data.get("required_co_signers"),
             co_signatures=data.get("co_signatures"),
             countersign_url=data.get("countersign_url"),
+            user_intent_verified=data.get("user_intent_verified"),
         )
 
     async def countersign(self, signature_id: str) -> SignatureResponse:
@@ -325,6 +327,7 @@ class AsyncAgent:
             required_co_signers=data.get("required_co_signers"),
             co_signatures=data.get("co_signatures"),
             countersign_url=data.get("countersign_url"),
+            user_intent_verified=data.get("user_intent_verified"),
         )
 
     async def start_session(self) -> SessionResponse:

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -233,6 +233,7 @@ class AsyncAgent:
         tool_name: str | None = None,
         model_name: str | None = None,
         parent_id: str | None = None,
+        user_intent: dict[str, Any] | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically (async).
 
@@ -262,6 +263,7 @@ class AsyncAgent:
             context=context,
             session_id=self._session_id,
             agent_id=self.agent_id,
+            user_intent=user_intent,
         )
         data = await _async_post(f"/agents/{self.agent_id}/sign", body)
 
@@ -280,6 +282,7 @@ class AsyncAgent:
             policy_decision=data.get("policy_decision", "permit"),
             authorization_ref=data.get("authorization_ref"),
             bitcoin_anchor=_parse_bitcoin_anchor(data.get("bitcoin_anchor")),
+            user_intent_verified=data.get("user_intent_verified"),
         )
 
     async def start_session(self) -> SessionResponse:

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -214,6 +214,7 @@ class SignatureResponse:
     policy_decision: str = "permit"
     authorization_ref: str | None = None
     bitcoin_anchor: BitcoinAnchor | None = None
+    user_intent_verified: bool | None = None
 
 
 @dataclass
@@ -658,6 +659,7 @@ def _build_sign_body(
     context: dict[str, Any] | None,
     session_id: str | None,
     agent_id: str,
+    user_intent: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the JSON body for a ``POST /agents/{id}/sign`` request.
 
@@ -692,20 +694,26 @@ def _build_sign_body(
         # Defensive: only ship whitelisted keys even if a future caller
         # mutates `metadata` above.
         metadata = {k: v for k, v in metadata.items() if k in _HASH_ONLY_METADATA_WHITELIST}
-        return {
+        body: dict[str, Any] = {
             "action_type": action_type,
             "hash": digest,
             "hash_algo": "sha256",
             "metadata": metadata,
             "session_id": session_id,
         }
+        if user_intent is not None:
+            body["user_intent"] = user_intent
+        return body
 
     # full-payload (default for self-hosted)
-    return {
+    body = {
         "action_type": action_type,
         "context": context or {},
         "session_id": session_id,
     }
+    if user_intent is not None:
+        body["user_intent"] = user_intent
+    return body
 
 
 @dataclass
@@ -876,6 +884,7 @@ class Agent:
         counterparty: dict[str, Any] | None = None,
         tool_name: str | None = None,
         model_name: str | None = None,
+        user_intent: dict[str, Any] | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -960,6 +969,7 @@ class Agent:
             context=context,
             session_id=self._session_id,
             agent_id=self.agent_id,
+            user_intent=user_intent,
         )
         data = _post(f"/agents/{self.agent_id}/sign", body)
 
@@ -978,6 +988,7 @@ class Agent:
             policy_decision=data.get("policy_decision", "permit"),
             authorization_ref=data.get("authorization_ref"),
             bitcoin_anchor=_parse_bitcoin_anchor(data.get("bitcoin_anchor")),
+            user_intent_verified=data.get("user_intent_verified"),
         )
 
         # Dispatch after-hooks (fail-open).

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -220,6 +220,8 @@ class SignatureResponse:
     required_co_signers: list[str] | None = None
     co_signatures: list[dict[str, Any]] | None = None
     countersign_url: str | None = None
+    # True when the server validated a user_intent envelope on this record.
+    user_intent_verified: bool | None = None
 
 
 @dataclass
@@ -891,6 +893,7 @@ class Agent:
         model_name: str | None = None,
         *,
         co_signers: list[str] | None = None,
+        user_intent: dict[str, Any] | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -999,6 +1002,7 @@ class Agent:
             required_co_signers=data.get("required_co_signers"),
             co_signatures=data.get("co_signatures"),
             countersign_url=data.get("countersign_url"),
+            user_intent_verified=data.get("user_intent_verified"),
         )
 
         # Dispatch after-hooks (fail-open).
@@ -1049,6 +1053,7 @@ class Agent:
             required_co_signers=data.get("required_co_signers"),
             co_signatures=data.get("co_signatures"),
             countersign_url=data.get("countersign_url"),
+            user_intent_verified=data.get("user_intent_verified"),
         )
 
     def sign_batch(

--- a/python/tests/test_user_intent.py
+++ b/python/tests/test_user_intent.py
@@ -1,0 +1,105 @@
+"""Verify user_intent kwarg passes through to the wire body.
+
+The SDK does not interpret user_intent; it only serializes the dict as-is.
+Backend verification is covered by the asqav backend test suite.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav import client as client_mod  # noqa: E402
+from asqav.client import Agent  # noqa: E402
+
+MOCK_SIGN_RESPONSE: dict = {
+    "signature": "sig-bytes",
+    "signature_id": "sig_001",
+    "action_id": "act_001",
+    "timestamp": "2026-04-28T12:00:00Z",
+    "verification_url": "https://verify.asqav.com/sig_001",
+    "algorithm": "ml-dsa-65",
+    "chain_hash": "ch_abc",
+    "rfc3161_timestamp": None,
+    "scan_result": None,
+    "policy_digest": "pd",
+    "policy_decision": "permit",
+    "authorization_ref": None,
+    "bitcoin_anchor": None,
+    "user_intent_verified": True,
+}
+
+
+def _make_agent() -> Agent:
+    return Agent(
+        agent_id="agt_001",
+        name="t",
+        public_key="pk",
+        key_id="kid",
+        algorithm="ml-dsa-65",
+        capabilities=[],
+        created_at=0.0,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_state() -> None:
+    saved = (client_mod._mode, client_mod._org_salt, client_mod._api_key)
+    client_mod._api_key = "sk_test"
+    yield
+    client_mod._mode, client_mod._org_salt, client_mod._api_key = saved
+
+
+def _intent() -> dict:
+    return {
+        "signature": "AAAA",
+        "public_key": "BBBB",
+        "algorithm": "ed25519",
+        "signed_message": "CCCC",
+        "signed_at": "2026-04-28T12:00:00Z",
+    }
+
+
+def test_user_intent_passthrough_full_payload() -> None:
+    client_mod._mode = "full-payload"
+    client_mod._org_salt = None
+    agent = _make_agent()
+    intent = _intent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        resp = agent.sign("api:call", {"x": 1}, user_intent=intent)
+
+    _path, body = mock_post.call_args[0]
+    assert body["user_intent"] == intent
+    assert resp.user_intent_verified is True
+
+
+def test_user_intent_passthrough_hash_only() -> None:
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    agent = _make_agent()
+    intent = _intent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"x": 1}, user_intent=intent)
+
+    _path, body = mock_post.call_args[0]
+    assert body["user_intent"] == intent
+    assert "context" not in body  # hash-only invariant preserved
+
+
+def test_user_intent_omitted_when_not_set() -> None:
+    client_mod._mode = "full-payload"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", {"x": 1})
+
+    _path, body = mock_post.call_args[0]
+    assert "user_intent" not in body

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -145,6 +145,8 @@ export interface SignatureResponse {
   coSignatures?: CoSignature[];
   /** URL pattern (relative) for peers to POST their countersignature to. */
   countersignUrl?: string;
+  /** True when the server validated a user_intent envelope on this record. */
+  userIntentVerified?: boolean;
 }
 
 export interface SessionResponse {
@@ -442,6 +444,7 @@ export class Agent {
       required_co_signers?: string[];
       co_signatures?: Array<{ agent_id: string; signature: string; signed_at: string }>;
       countersign_url?: string;
+      user_intent_verified?: boolean;
     }>("POST", `/agents/${this.agentId}/sign`, body);
 
     const response: SignatureResponse = {
@@ -459,6 +462,7 @@ export class Agent {
         signedAt: s.signed_at,
       })),
       countersignUrl: data.countersign_url,
+      userIntentVerified: data.user_intent_verified,
     };
 
     _dispatchAfter(options.actionType, response);
@@ -478,6 +482,7 @@ export class Agent {
       required_co_signers?: string[];
       co_signatures?: Array<{ agent_id: string; signature: string; signed_at: string }>;
       countersign_url?: string;
+      user_intent_verified?: boolean;
     }>("POST", `/agents/${this.agentId}/countersign/${signatureId}`, {});
 
     return {
@@ -495,6 +500,7 @@ export class Agent {
         signedAt: s.signed_at,
       })),
       countersignUrl: data.countersign_url,
+      userIntentVerified: data.user_intent_verified,
     };
   }
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -107,6 +107,15 @@ export interface AgentCreateOptions {
   capabilities?: string[];
 }
 
+export interface UserIntent {
+  signature: string;
+  public_key: string;
+  algorithm: 'ed25519' | 'ecdsa-p256' | 'webauthn' | string;
+  key_id?: string;
+  signed_message: string;
+  signed_at: string;
+}
+
 export interface SignOptions {
   actionType: string;
   context?: Record<string, unknown>;
@@ -123,6 +132,9 @@ export interface SignOptions {
    * this record. Each peer fetches the record and calls
    * ``agent.countersign(signatureId)``. */
   coSigners?: string[];
+  /** Optional user-intent envelope. The end user signs a digest of the
+   * action and the SDK passes it through to the backend verbatim. */
+  userIntent?: UserIntent;
 }
 
 export interface CoSignature {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -119,6 +119,29 @@ export interface SignOptions {
   /** Optional parent action ID for linking child actions to their parent
    * in a workflow. Powers the agent graph view. */
   parentId?: string;
+  /** Optional user-intent envelope. The caller produces a signature over a
+   * digest of the action (e.g. via WebAuthn passkey, hardware key, or
+   * Ed25519). The SDK passes the bytes through verbatim. The backend
+   * verifies and stores them alongside the agent signature so the receipt
+   * proves "this user authorized this specific action". See
+   * docs/user-intent.md for the recommended pattern. */
+  userIntent?: UserIntent;
+}
+
+export interface UserIntent {
+  /** base64 signature bytes */
+  signature: string;
+  /** base64 public key bytes */
+  public_key: string;
+  /** "ed25519" | "ecdsa-p256" | "webauthn" */
+  algorithm: string;
+  /** optional credential id, useful for WebAuthn passkeys */
+  key_id?: string;
+  /** base64 of the bytes the user actually signed (typically a digest of
+   * action_type + context + nonce). The backend does not interpret this. */
+  signed_message: string;
+  /** ISO8601 timestamp of when the user signed */
+  signed_at: string;
 }
 
 export interface SignatureResponse {
@@ -129,6 +152,7 @@ export interface SignatureResponse {
   verificationUrl: string;
   algorithm?: string;
   chainHash?: string;
+  userIntentVerified?: boolean;
 }
 
 export interface SessionResponse {
@@ -287,6 +311,7 @@ interface BuildSignBodyArgs {
   context: Record<string, unknown>;
   sessionId: string | null;
   agentId: string;
+  userIntent?: UserIntent;
 }
 
 async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, unknown>> {
@@ -314,19 +339,23 @@ async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, un
     for (const k of Object.keys(metadata)) {
       if (!HASH_ONLY_METADATA_WHITELIST.has(k)) delete metadata[k];
     }
-    return {
+    const hashBody: Record<string, unknown> = {
       action_type: args.actionType,
       hash: digest,
       hash_algo: "sha256",
       metadata,
       session_id: args.sessionId,
     };
+    if (args.userIntent !== undefined) hashBody.user_intent = args.userIntent;
+    return hashBody;
   }
-  return {
+  const fullBody: Record<string, unknown> = {
     action_type: args.actionType,
     context: args.context,
     session_id: args.sessionId,
   };
+  if (args.userIntent !== undefined) fullBody.user_intent = args.userIntent;
+  return fullBody;
 }
 
 // ---------------------------------------------------------------------------
@@ -403,6 +432,7 @@ export class Agent {
       context: finalContext,
       sessionId: this.sessionId,
       agentId: this.agentId,
+      userIntent: options.userIntent,
     });
 
     const data = await request<{
@@ -414,6 +444,7 @@ export class Agent {
       algorithm?: string;
       chain_hash?: string;
       record_hash?: string;
+      user_intent_verified?: boolean;
     }>("POST", `/agents/${this.agentId}/sign`, body);
 
     const response: SignatureResponse = {
@@ -424,6 +455,7 @@ export class Agent {
       verificationUrl: data.verification_url,
       algorithm: data.algorithm,
       chainHash: data.chain_hash ?? data.record_hash,
+      userIntentVerified: data.user_intent_verified,
     };
 
     _dispatchAfter(options.actionType, response);

--- a/typescript/tests/userIntent.test.ts
+++ b/typescript/tests/userIntent.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  _resetForTests,
+  _setModeForTests,
+  init,
+} from "../src/index.js";
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const SIGN_RESPONSE = {
+  signature: "sig-bytes",
+  signature_id: "sig_001",
+  action_id: "act_001",
+  timestamp: "2026-04-28T12:00:00Z",
+  verification_url: "https://verify.asqav.com/sig_001",
+  algorithm: "ml-dsa-65",
+  user_intent_verified: true,
+};
+
+const AGENT_DATA = {
+  agent_id: "agt_001",
+  name: "test",
+  public_key: "pk",
+  key_id: "kid",
+  algorithm: "ml-dsa-65",
+  capabilities: [],
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const INTENT = {
+  signature: "AAAA",
+  public_key: "BBBB",
+  algorithm: "ed25519",
+  signed_message: "CCCC",
+  signed_at: "2026-04-28T12:00:00Z",
+};
+
+async function makeAgent(): Promise<Agent> {
+  const spy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(mockJsonResponse(AGENT_DATA));
+  const agent = await Agent.create({ name: "test" });
+  spy.mockRestore();
+  return agent;
+}
+
+describe("Agent.sign userIntent passthrough", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("forwards userIntent on the wire (full-payload)", async () => {
+    _setModeForTests("full-payload");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    const resp = await agent.sign({
+      actionType: "api:call",
+      context: { x: 1 },
+      userIntent: INTENT,
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.user_intent).toEqual(INTENT);
+    expect(resp.userIntentVerified).toBe(true);
+  });
+
+  it("forwards userIntent in hash-only mode and preserves invariants", async () => {
+    _setModeForTests("hash-only");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({
+      actionType: "api:call",
+      context: { x: 1 },
+      userIntent: INTENT,
+    });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.user_intent).toEqual(INTENT);
+    expect(body.context).toBeUndefined();
+    expect(body.hash).toBeDefined();
+  });
+
+  it("omits user_intent from the body when not passed", async () => {
+    _setModeForTests("full-payload");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    await agent.sign({ actionType: "api:call", context: { x: 1 } });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(body.user_intent).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- New optional `user_intent` parameter on Python `Agent.sign(action_type, context, *, user_intent=...)` and TypeScript `agent.sign({actionType, context, userIntent})`.
- SDK passes the dict through verbatim. Response surface adds `user_intent_verified` reflecting backend verification.
- New `docs/user-intent.md` covers the recommended pattern (Ed25519 example, WebAuthn sketch).
- Pre-release; backend companion PR opened in parallel. Do NOT merge until founder review.

## What this primitive does
A receipt that says "agent X ran this action" answers half the question. The other half is "did the user actually authorize this specific action right now". User-intent binding adds that. The user signs a digest, the SDK ships the bytes alongside the agent signature, the backend verifies and stores both.

## Wire shape
```json
{
  "action_type": "...",
  "context": {...},
  "user_intent": {
    "signature": "<base64>",
    "public_key": "<base64>",
    "algorithm": "ed25519" | "ecdsa-p256" | "webauthn",
    "key_id": "<optional>",
    "signed_message": "<base64>",
    "signed_at": "<ISO8601>"
  }
}
```

WebAuthn assertion verification is store-only today; documented in `docs/user-intent.md`.

## Versions
- python `asqav` 0.3.2 -> 0.3.3
- typescript `@asqav/sdk` 0.2.2 -> 0.2.3

## Test plan
- [x] Python: 14 tests pass (`tests/test_user_intent.py` + `tests/test_client_hash_mode.py`)
- [x] TypeScript: 77 tests pass (`npm test`)
- [ ] Manual smoke against the backend PR once both are reviewed
- [ ] Verify hash-only invariant preserved (no context leakage when user_intent is set)