### PR TITLE
docs: governance examples (budget, scope, audit, approval)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,44 @@
+# Examples
+
+Self-contained scripts that exercise the asqav governance flows end-to-end.
+Every example uses both surfaces of the SDK:
+
+- the Python API directly, for programmatic use inside an application
+- the equivalent CLI commands in the docstring, for shell scripts and CI
+
+Pick whichever surface fits your runtime; they accept the same arguments and
+return the same data.
+
+## Setup
+
+```bash
+pip install asqav
+export ASQAV_API_KEY=sk_...
+```
+
+## Examples
+
+| File | What it shows | Closes |
+|------|---------------|--------|
+| [`budget_tracking.py`](budget_tracking.py) | Multi-provider budget ceiling, per-call check, signed spend records | #61 |
+| [`scope_enforcement.py`](scope_enforcement.py) | Preflight catches out-of-scope actions, violation gets its own signed audit entry | #62 |
+| [`quarterly_audit.py`](quarterly_audit.py) | Export bundle, replay timeline offline, verify SHA-256 chain, summarize | #63 |
+| [`human_approval.py`](human_approval.py) | Request signing session for a high-risk action, wait for human approval, then sign | #64 |
+
+## CLI parity
+
+Every flow above has a matching CLI command. Run any of these from a shell:
+
+```bash
+asqav preflight <agent_id> data:read           # scope check
+asqav budget check --agent-id <id> --limit 10 --estimated-cost 0.25
+asqav budget record --agent-id <id> --action api:openai --actual-cost 0.23 --limit 10
+asqav approve <session_id> <entity_id>         # human approval
+asqav compliance frameworks                    # list known frameworks
+asqav compliance export --session <sid> --output bundle.json
+asqav replay <agent_id> <session_id>           # online replay
+asqav replay --bundle bundle.json              # offline replay
+```
+
+See `python/src/asqav/cli.py` for the full command surface; every command
+wraps a public function from the same package.

--- a/examples/budget_tracking.py
+++ b/examples/budget_tracking.py
@@ -1,0 +1,73 @@
+"""Multi-provider budget enforcement with signed spend records.
+
+A pipeline that calls GPT-4 for reasoning and Claude for code generation
+shares a single ceiling. Every spend is signed via agent.sign() so the
+budget trail is independently verifiable.
+
+Run:
+    export ASQAV_API_KEY=sk_...
+    python examples/budget_tracking.py
+
+Or do the same thing from the shell:
+    asqav budget check --agent-id <id> --limit 10 --estimated-cost 0.25 --current-spend 4.20
+    asqav budget record --agent-id <id> --action api:openai --actual-cost 0.23 --limit 10 --current-spend 4.20
+
+Closes #61.
+"""
+
+from __future__ import annotations
+
+import asqav
+
+# Per-call cost lookups for the example. Real pipelines pull these from the
+# provider response (e.g. response.usage.total_tokens * price_per_token).
+PRICE_PER_CALL = {
+    "openai/gpt-4-reason": 0.30,
+    "anthropic/claude-codegen": 0.18,
+    "google/gemini-fastpath": 0.04,
+}
+
+
+def main() -> None:
+    asqav.init()
+
+    agent = asqav.Agent.create("multi-provider-pipeline")
+    budget = asqav.BudgetTracker(agent, limit=10.00, currency="USD")
+
+    plan = [
+        ("openai/gpt-4-reason", "draft a strategy"),
+        ("anthropic/claude-codegen", "implement step 1"),
+        ("anthropic/claude-codegen", "implement step 2"),
+        ("google/gemini-fastpath", "summarize the run"),
+    ]
+
+    for action_type, description in plan:
+        estimated = PRICE_PER_CALL[action_type]
+        decision = budget.check(estimated)
+        if not decision.allowed:
+            print(f"DENIED {action_type}: {decision.reason}")
+            print(
+                f"  current_spend={decision.current_spend:.2f} "
+                f"limit={decision.limit:.2f}"
+            )
+            break
+
+        # ... actually execute the call here ...
+        actual = estimated  # for the example, assume estimate matches reality
+
+        sig = budget.record(
+            action_type,
+            actual_cost=actual,
+            context={"description": description},
+        )
+        print(
+            f"OK    {action_type:32s} ${actual:.2f}  "
+            f"spend=${budget._spend:.2f}/{budget.limit:.2f}  sig={sig.signature_id}"
+        )
+
+    print(f"\nFinal spend: ${budget._spend:.2f} of ${budget.limit:.2f}")
+    print("Every entry is a signed record on asqav, replay-verifiable from the audit trail.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/human_approval.py
+++ b/examples/human_approval.py
@@ -1,0 +1,91 @@
+"""Pause high-risk agent actions for human review and approval.
+
+Some calls are too risky to execute automatically: data deletion, customer
+emails, payment processing. The pattern: request a signing session, wait for
+human approval, then proceed only when the session is fully signed.
+
+Run:
+    export ASQAV_API_KEY=sk_...
+    python examples/human_approval.py
+
+Same flow at the terminal:
+    asqav approve <session_id> <entity_id>     # human signs off
+
+Closes #64.
+"""
+
+from __future__ import annotations
+
+import time
+
+import asqav
+from asqav.client import get_action_status, request_action
+
+HIGH_RISK_PATTERNS = {
+    "sql-destructive",
+    "payment:process",
+    "email:send-customer",
+}
+
+
+def needs_approval(action_type: str) -> bool:
+    """Trivial classifier. Real systems read this from a policy table."""
+    return action_type in HIGH_RISK_PATTERNS
+
+
+def wait_for_approval(session_id: str, timeout_s: int = 300) -> bool:
+    """Poll the session until approved or timed out. Approval happens out-of-band
+    (a reviewer calls asqav.approve_action(session_id, entity_id) or runs
+    `asqav approve <session_id> <entity_id>`)."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        session = get_action_status(session_id)
+        if session.status == "approved":
+            return True
+        if session.status in {"denied", "expired"}:
+            return False
+        time.sleep(2)
+    return False
+
+
+def main() -> None:
+    asqav.init()
+
+    agent = asqav.Agent.create("review-required-agent")
+    action_type = "payment:process"
+    params = {"amount_usd": 4500, "vendor": "vendor_42", "reference": "PO-7711"}
+
+    if needs_approval(action_type):
+        print(f"{action_type} is high-risk, requesting human approval")
+        session = request_action(
+            agent_id=agent.agent_id,
+            action_type=action_type,
+            params=params,
+        )
+        print(f"  session_id: {session.session_id}")
+        print(f"  needs {session.approvals_required} approvals")
+        print(
+            f"  share the session id with the reviewer; they sign with:\n"
+            f"    asqav approve {session.session_id} <entity_id>"
+        )
+
+        if not wait_for_approval(session.session_id):
+            print("approval not granted, aborting")
+            return
+
+        print("approved, proceeding")
+        sig = agent.sign(
+            action_type,
+            params,
+            counterparty={"endpoint": "vendor_42.example.com"},
+        )
+        # The signing session id ties the executed signature back to the
+        # human approval, which is what an auditor reads later.
+        print(f"signed {sig.signature_id} (authorization_ref={sig.authorization_ref})")
+    else:
+        sig = agent.sign(action_type, params)
+        print(f"low-risk, signed inline as {sig.signature_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quarterly_audit.py
+++ b/examples/quarterly_audit.py
@@ -1,0 +1,69 @@
+"""End-to-end quarterly audit: bundle, replay, verify, summarize.
+
+Auditors get a self-contained file (no API access required) that contains
+every signed action over the period plus a Merkle root. Replay reconstructs
+the timeline; chain verification proves the records were not tampered with
+after the fact.
+
+Run:
+    export ASQAV_API_KEY=sk_...
+    python examples/quarterly_audit.py
+
+Same flow at the terminal:
+    asqav compliance export --session sess_q3 --framework eu_ai_act_art12 --output q3-bundle.json
+    asqav replay --bundle q3-bundle.json
+
+Closes #63.
+"""
+
+from __future__ import annotations
+
+from asqav.client import get_session_signatures
+from asqav.compliance import export_bundle
+from asqav.replay import replay_from_bundle
+
+
+def main() -> None:
+    import asqav
+    asqav.init()
+
+    # Replace these with the actual identifiers for the audit period.
+    session_id = "sess_q3_2026"
+    framework = "eu_ai_act_art12"
+    bundle_path = "q3-bundle.json"
+
+    print(f"Step 1. Fetch signatures for {session_id}")
+    sigs = get_session_signatures(session_id)
+    print(f"        pulled {len(sigs)} signed actions")
+
+    print(f"\nStep 2. Export {framework} bundle to {bundle_path}")
+    bundle = export_bundle(sigs, framework=framework)
+    bundle.to_file(bundle_path)
+    print(f"        receipts={bundle.receipt_count}")
+    print(f"        merkle_root={bundle.merkle_root}")
+
+    print("\nStep 3. Replay the timeline from the bundle (offline, no API)")
+    timeline = replay_from_bundle(bundle)
+    print(timeline.summary())
+
+    print("\nStep 4. Re-verify the SHA-256 chain")
+    chain_ok = timeline.verify_chain()
+    if chain_ok:
+        print("        chain verified, the audit trail has not been tampered with")
+    else:
+        print("        chain BROKEN, this bundle cannot be trusted")
+        for step in timeline.steps:
+            if not step.chain_valid:
+                print(f"        - step {step.index} ({step.signature_id}) failed")
+
+    print("\nStep 5. Summary line for the audit report")
+    print(
+        f"  Period: {session_id} | Framework: {framework} | "
+        f"Actions: {bundle.receipt_count} | "
+        f"Chain integrity: {'OK' if chain_ok else 'BROKEN'} | "
+        f"Merkle root: {bundle.merkle_root}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/scope_enforcement.py
+++ b/examples/scope_enforcement.py
@@ -1,0 +1,64 @@
+"""Catch out-of-scope agent actions before they execute.
+
+Define an agent's allowed actions, then run a preflight check against each
+action it's about to perform. If the policy blocks the call, the example
+records the violation as a signed audit entry so the attempt is permanent.
+
+Run:
+    export ASQAV_API_KEY=sk_...
+    python examples/scope_enforcement.py
+
+Same flow at the terminal:
+    asqav preflight <agent_id> data:read       # exits 0 if cleared
+    asqav preflight <agent_id> sql-destructive # exits 1 with reasons listed
+
+Closes #62.
+"""
+
+from __future__ import annotations
+
+import asqav
+
+# Pretend an external orchestrator just told the agent to do these.
+ATTEMPTED_ACTIONS = [
+    "data:read",
+    "api:call",
+    "sql-destructive",     # likely blocked by the org's destructive-sql policy
+    "filesystem:write:*",  # likely outside the agent's scope
+]
+
+
+def main() -> None:
+    asqav.init()
+
+    agent = asqav.Agent.create("scope-demo-agent")
+
+    for action_type in ATTEMPTED_ACTIONS:
+        result = agent.preflight(action_type)
+        if result.cleared:
+            print(f"CLEARED  {action_type:24s}  {result.explanation}")
+            sig = agent.sign(action_type, {"source": "scope-demo"})
+            print(f"         executed and signed as {sig.signature_id}")
+            continue
+
+        print(f"BLOCKED  {action_type:24s}")
+        for reason in result.reasons:
+            print(f"           - {reason}")
+
+        # Sign the violation itself so the attempt is permanent. The
+        # action_type is namespaced under 'audit:' so the org's policy
+        # engine doesn't conflate it with the original blocked call.
+        violation_sig = agent.sign(
+            "audit:scope_violation",
+            {
+                "attempted": action_type,
+                "reasons": result.reasons,
+                "policy_allowed": result.policy_allowed,
+                "agent_active": result.agent_active,
+            },
+        )
+        print(f"           audit record signed as {violation_sig.signature_id}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Four runnable examples plus an `examples/README.md` index. Each example uses both the Python API directly (in code) and the equivalent CLI command (in the docstring), so readers can pick the surface that fits their runtime.

- `budget_tracking.py` — multi-provider ceiling with signed spend records on every call. Closes #61.
- `scope_enforcement.py` — preflight blocks out-of-scope action types, the violation itself is signed as an audit entry. Closes #62.
- `quarterly_audit.py` — export bundle, replay timeline offline (no API access), verify the SHA-256 chain, print summary. Closes #63.
- `human_approval.py` — request a multi-party signing session for a high-risk action, wait for `approve_action`, then sign. Closes #64.

## Test plan

- [x] Each file syntax-checked with `ast.parse`.
- [x] All API/method calls cross-referenced against `python/src/asqav/{client.py, compliance.py, replay.py, __init__.py}` — Agent.create, preflight, sign; BudgetTracker.check + record; get_session_signatures, export_bundle, replay_from_bundle, ReplayTimeline.summary/verify_chain; request_action, get_action_status, approve_action.
- [x] Each docstring shows the matching CLI commands so the parity rule is visible from the example.

Pairs with PR #104 (CLI parity) — that one adds the CLI commands, this one shows them in use.