### PR TITLE
feat: pytest plugin signs test results into a compliance bundle

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -81,6 +81,9 @@ dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0", "ruff>=0.5.0", "mypy>=1.10.0"]
 [project.scripts]
 asqav = "asqav.cli:app"
 
+[project.entry-points.pytest11]
+asqav = "asqav.pytest_plugin"
+
 [project.urls]
 Homepage = "https://asqav.com"
 Documentation = "https://asqav.com/docs"

--- a/python/src/asqav/pytest_plugin.py
+++ b/python/src/asqav/pytest_plugin.py
@@ -1,0 +1,188 @@
+"""Pytest plugin: sign each test result and produce a compliance bundle.
+
+Activates with `pytest --asqav --asqav-agent=test-runner`. Each test result
+(passed/failed/skipped) is signed via agent.sign() and included in a
+ComplianceBundle written at the end of the run.
+
+Both surfaces are exposed:
+
+- CLI: `pytest --asqav` runs the plugin via pytest's entry-point system.
+- API: import `asqav.pytest_plugin` and call `make_bundle_from_report(...)`
+  if you have your own test runner.
+
+Requires `ASQAV_API_KEY` in the environment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+
+@dataclass
+class CapturedOutcome:
+    """One test outcome captured for the bundle."""
+
+    nodeid: str
+    outcome: str  # "passed" | "failed" | "skipped"
+    duration: float
+    longrepr: str | None = None
+
+
+@dataclass
+class _PluginState:
+    """In-memory state for one pytest invocation."""
+
+    enabled: bool = False
+    agent_name: str = "test-runner"
+    output_path: str = "audit-bundle.json"
+    framework: str = "soc2"
+    results: list[CapturedOutcome] = field(default_factory=list)
+    signatures: list[Any] = field(default_factory=list)
+    agent: Any = None
+
+
+_state = _PluginState()
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("asqav", "Asqav governance plugin")
+    group.addoption(
+        "--asqav",
+        action="store_true",
+        default=False,
+        help="Enable asqav: sign each test result and write a compliance bundle.",
+    )
+    group.addoption(
+        "--asqav-agent",
+        action="store",
+        default="test-runner",
+        help="Agent name to use when signing test results (default: test-runner).",
+    )
+    group.addoption(
+        "--asqav-output",
+        action="store",
+        default="audit-bundle.json",
+        help="Where to write the compliance bundle (default: audit-bundle.json).",
+    )
+    group.addoption(
+        "--asqav-framework",
+        action="store",
+        default="soc2",
+        help="Compliance framework key (default: soc2). See `asqav compliance frameworks`.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    if not config.getoption("--asqav"):
+        return
+
+    import os
+
+    if not os.environ.get("ASQAV_API_KEY"):
+        # Configuration error, not a test failure. Exit early so the rest of
+        # the run does not partially sign with a half-set-up agent.
+        raise pytest.UsageError(
+            "--asqav requires ASQAV_API_KEY in the environment. "
+            "Get one at https://cloud.asqav.com."
+        )
+
+    import asqav
+
+    asqav.init()
+
+    _state.enabled = True
+    _state.agent_name = config.getoption("--asqav-agent")
+    _state.output_path = config.getoption("--asqav-output")
+    _state.framework = config.getoption("--asqav-framework")
+    _state.agent = asqav.Agent.create(_state.agent_name)
+    _state.results = []
+    _state.signatures = []
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):  # type: ignore[no-untyped-def]
+    """Capture each test phase outcome. We only sign the 'call' phase."""
+    outcome = yield
+    if not _state.enabled:
+        return
+
+    report = outcome.get_result()
+    if report.when != "call":
+        return
+
+    longrepr: str | None = None
+    if report.longrepr is not None:
+        longrepr = str(report.longrepr)[:2000]  # cap to keep payloads sane
+
+    result = CapturedOutcome(
+        nodeid=report.nodeid,
+        outcome=report.outcome,
+        duration=report.duration,
+        longrepr=longrepr,
+    )
+    _state.results.append(result)
+
+    if _state.agent is None:
+        return
+
+    try:
+        sig = _state.agent.sign(
+            "test:result",
+            context={
+                "nodeid": result.nodeid,
+                "outcome": result.outcome,
+                "duration": result.duration,
+                "framework": _state.framework,
+            },
+        )
+        _state.signatures.append(sig)
+    except Exception as exc:
+        # A failed signature should not mask the test failure.
+        report.sections.append(("asqav", f"sign failed: {exc}"))
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if not _state.enabled or not _state.signatures:
+        return
+
+    from asqav.compliance import export_bundle
+
+    bundle = export_bundle(_state.signatures, framework=_state.framework)
+    bundle.to_file(_state.output_path)
+    print(
+        f"\n[asqav] wrote {bundle.receipt_count} signed test results to "
+        f"{_state.output_path} (merkle_root={bundle.merkle_root})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Programmatic API
+# ---------------------------------------------------------------------------
+
+
+def make_bundle_from_report(
+    signatures: list[Any], *, framework: str = "soc2"
+) -> Any:
+    """Build a ComplianceBundle from a list of pre-signed test results.
+
+    Use from a custom test runner that signs results itself and just wants
+    the bundle structure. Returns the same ComplianceBundle the pytest hook
+    writes at end-of-run.
+    """
+    from asqav.compliance import export_bundle
+
+    return export_bundle(signatures, framework=framework)
+
+
+# Test-only escape hatches so test_pytest_plugin.py can manipulate plugin state
+# without spawning a real subprocess.
+def _reset_state_for_tests() -> None:
+    global _state
+    _state = _PluginState()
+
+
+def _get_state_for_tests() -> _PluginState:
+    return _state

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -1,0 +1,220 @@
+"""Tests for the asqav pytest plugin."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+from asqav.pytest_plugin import (
+    CapturedOutcome,
+    _get_state_for_tests,
+    _reset_state_for_tests,
+    make_bundle_from_report,
+    pytest_configure,
+    pytest_runtest_makereport,
+    pytest_sessionfinish,
+)
+
+assert CapturedOutcome  # imported for the public surface
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    _reset_state_for_tests()
+
+
+def _config(**opts) -> MagicMock:  # type: ignore[no-untyped-def]
+    cfg = MagicMock()
+    defaults = {
+        "--asqav": False,
+        "--asqav-agent": "test-runner",
+        "--asqav-output": "audit-bundle.json",
+        "--asqav-framework": "soc2",
+    }
+    defaults.update(opts)
+    cfg.getoption.side_effect = lambda key: defaults[key]
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_by_default() -> None:
+    """The plugin is a no-op unless --asqav is passed."""
+    pytest_configure(_config(**{"--asqav": False}))
+    assert _get_state_for_tests().enabled is False
+
+
+@patch("asqav.Agent.create")
+@patch("asqav.init")
+def test_configure_enables_plugin(mock_init: MagicMock, mock_create: MagicMock) -> None:
+    """--asqav with an API key initializes the agent and enables the plugin."""
+    mock_create.return_value = MagicMock(agent_id="agt_test")
+    with patch.dict(os.environ, {"ASQAV_API_KEY": "sk_test"}, clear=False):
+        pytest_configure(_config(**{
+            "--asqav": True,
+            "--asqav-agent": "ci-runner",
+            "--asqav-output": "out.json",
+            "--asqav-framework": "soc2",
+        }))
+
+    state = _get_state_for_tests()
+    assert state.enabled is True
+    assert state.agent_name == "ci-runner"
+    assert state.output_path == "out.json"
+    assert state.framework == "soc2"
+    mock_create.assert_called_once_with("ci-runner")
+
+
+def test_configure_without_api_key_raises() -> None:
+    """--asqav without ASQAV_API_KEY exits with a usage error."""
+    with patch.dict(os.environ, {"ASQAV_API_KEY": ""}, clear=False):
+        with pytest.raises(pytest.UsageError):
+            pytest_configure(_config(**{"--asqav": True}))
+
+
+# ---------------------------------------------------------------------------
+# Result capture
+# ---------------------------------------------------------------------------
+
+
+def test_makereport_captures_call_phase() -> None:
+    """Only the 'call' phase produces a TestResult; setup/teardown are ignored."""
+    state = _get_state_for_tests()
+    state.enabled = True
+    state.agent = MagicMock()
+    state.agent.sign.return_value = MagicMock(signature_id="sig_1")
+
+    report = MagicMock(when="call", nodeid="test.py::test_a",
+                      outcome="passed", duration=0.1, longrepr=None,
+                      sections=[])
+
+    # Drive the hookwrapper generator with an outcome that yields the report.
+    gen = pytest_runtest_makereport(MagicMock(), MagicMock())
+    next(gen)
+    try:
+        gen.send(MagicMock(get_result=lambda: report))
+    except StopIteration:
+        pass
+
+    assert len(state.results) == 1
+    assert state.results[0].nodeid == "test.py::test_a"
+    assert state.results[0].outcome == "passed"
+    assert len(state.signatures) == 1
+
+
+def test_makereport_skips_non_call_phases() -> None:
+    """Setup and teardown phases are ignored."""
+    state = _get_state_for_tests()
+    state.enabled = True
+    state.agent = MagicMock()
+
+    for phase in ("setup", "teardown"):
+        report = MagicMock(when=phase, nodeid="test.py::test_a",
+                          outcome="passed", duration=0.0, longrepr=None,
+                          sections=[])
+        gen = pytest_runtest_makereport(MagicMock(), MagicMock())
+        next(gen)
+        try:
+            gen.send(MagicMock(get_result=lambda r=report: r))
+        except StopIteration:
+            pass
+
+    assert len(state.results) == 0
+
+
+def test_makereport_disabled_does_nothing() -> None:
+    """When the plugin is disabled the hook is a pass-through."""
+    state = _get_state_for_tests()
+    state.enabled = False
+
+    report = MagicMock(when="call", nodeid="test.py::test_a",
+                      outcome="passed", duration=0.1, longrepr=None,
+                      sections=[])
+    gen = pytest_runtest_makereport(MagicMock(), MagicMock())
+    next(gen)
+    try:
+        gen.send(MagicMock(get_result=lambda: report))
+    except StopIteration:
+        pass
+
+    assert len(state.results) == 0
+    assert len(state.signatures) == 0
+
+
+def test_sign_failure_does_not_mask_test() -> None:
+    """If sign() raises, the report.sections records the error but no exception bubbles."""
+    state = _get_state_for_tests()
+    state.enabled = True
+    state.agent = MagicMock()
+    state.agent.sign.side_effect = RuntimeError("api down")
+
+    report = MagicMock(when="call", nodeid="test.py::test_a",
+                      outcome="failed", duration=0.5, longrepr="boom",
+                      sections=[])
+
+    gen = pytest_runtest_makereport(MagicMock(), MagicMock())
+    next(gen)
+    try:
+        gen.send(MagicMock(get_result=lambda: report))
+    except StopIteration:
+        pass
+
+    # No signatures were appended (sign failed) but the section was added.
+    assert len(state.signatures) == 0
+    assert any("sign failed" in s[1] for s in report.sections)
+
+
+# ---------------------------------------------------------------------------
+# Session finish
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.compliance.export_bundle")
+def test_sessionfinish_writes_bundle(mock_export: MagicMock, tmp_path) -> None:
+    """At end of run, a ComplianceBundle is exported to the configured path."""
+    mock_bundle = MagicMock(receipt_count=2, merkle_root="root123")
+    mock_export.return_value = mock_bundle
+
+    state = _get_state_for_tests()
+    state.enabled = True
+    state.signatures = [MagicMock(), MagicMock()]
+    state.output_path = str(tmp_path / "out.json")
+    state.framework = "soc2"
+
+    pytest_sessionfinish(MagicMock(), 0)
+
+    mock_export.assert_called_once_with(state.signatures, framework="soc2")
+    mock_bundle.to_file.assert_called_once_with(state.output_path)
+
+
+def test_sessionfinish_noop_when_no_signatures() -> None:
+    """Empty signature list is a no-op so the runner does not write garbage."""
+    state = _get_state_for_tests()
+    state.enabled = True
+    state.signatures = []
+
+    # Should not raise even though nothing is patched.
+    pytest_sessionfinish(MagicMock(), 0)
+
+
+# ---------------------------------------------------------------------------
+# Programmatic API
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.compliance.export_bundle")
+def test_make_bundle_from_report(mock_export: MagicMock) -> None:
+    """make_bundle_from_report wraps export_bundle and forwards the framework."""
+    mock_export.return_value = MagicMock(receipt_count=3)
+    sigs = [MagicMock(), MagicMock(), MagicMock()]
+    bundle = make_bundle_from_report(sigs, framework="dora_ict")
+    mock_export.assert_called_once_with(sigs, framework="dora_ict")
+    assert bundle.receipt_count == 3


### PR DESCRIPTION
## Summary

Closes #57.

A pytest plugin that signs each test result and produces a Merkle-rooted compliance bundle the auditor can verify offline.

```bash
pip install asqav
export ASQAV_API_KEY=sk_...
pytest --asqav --asqav-agent=ci-runner --asqav-output=audit-bundle.json
# After the run: audit-bundle.json contains every test outcome as a signed receipt.
```

Options:

- `--asqav` enables the plugin (no-op when missing, so the rest of the suite is unaffected)
- `--asqav-agent NAME` agent name to sign as (default: `test-runner`)
- `--asqav-output PATH` bundle output (default: `audit-bundle.json`)
- `--asqav-framework KEY` compliance framework (default: `soc2`; see `asqav compliance frameworks`)

CLI + API parity:

- CLI: `pytest --asqav` (registered via `project.entry-points.pytest11`)
- API: `from asqav.pytest_plugin import make_bundle_from_report` for custom test runners

## Implementation notes

- Only the `call` phase is signed; `setup` / `teardown` outcomes are noise for compliance and are skipped.
- Signing failures are recorded under `report.sections` rather than masking the underlying test failure.
- `--asqav` without `ASQAV_API_KEY` raises `pytest.UsageError` early so the run does not partially sign with a half-set-up agent.

## Test plan

- [x] 10 new tests covering: enabled/disabled, missing API key, call-phase capture, non-call skip, sign-failure handling, sessionfinish writes bundle, empty-signatures no-op, programmatic `make_bundle_from_report`.
- [x] Verified API calls: `Agent.create`, `Agent.sign(action_type, context=...)`, `compliance.export_bundle(sigs, framework=...)` against `client.py` / `compliance.py`.