### PR TITLE
feat(extras): instructor integration via Hooks API

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -62,6 +62,7 @@ smolagents = ["smolagents>=1.0.0"]
 dspy = ["dspy>=2.5.0"]
 letta = ["letta-client>=1.10.0"]
 strands = ["strands-agents>=0.1.0"]
+instructor = ["instructor>=1.5.0"]
 all = [
     "httpx>=0.24.0",
     "typer>=0.12.0",
@@ -75,6 +76,7 @@ all = [
     "dspy>=2.5.0",
     "letta-client>=1.10.0",
     "strands-agents>=0.1.0",
+    "instructor>=1.5.0",
 ]
 dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0", "ruff>=0.5.0", "mypy>=1.10.0"]
 

--- a/python/src/asqav/extras/instructor.py
+++ b/python/src/asqav/extras/instructor.py
@@ -1,0 +1,165 @@
+"""instructor integration for asqav.
+
+Install: pip install asqav[instructor]
+
+Usage::
+
+    import asqav
+    import instructor
+    from asqav.extras.instructor import AsqavInstructorHook
+
+    asqav.init(api_key="...")
+    client = instructor.from_provider("openai/gpt-4o-mini")
+
+    hook = AsqavInstructorHook(agent_name="my-extractor")
+    hook.attach(client)
+
+    # Every client.chat.completions.create(...) call is now signed via asqav.
+
+instructor's hook system fires four events: ``completion:kwargs`` (request),
+``completion:response`` (success), ``completion:error`` (HTTP / provider
+error), ``parse:error`` (model output failed Pydantic validation). The
+adapter signs each event with a stable ``action_type`` so an auditor can
+distinguish requests, successes, and the two failure modes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from instructor.core.hooks import HookName
+except ImportError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "instructor integration requires instructor. "
+        "Install with: pip install asqav[instructor]"
+    ) from exc
+
+from ._base import AsqavAdapter
+
+
+def _model_name(kwargs: dict[str, Any]) -> str:
+    """Best-effort extraction of the model id from completion kwargs."""
+    model = kwargs.get("model")
+    if isinstance(model, str):
+        return model
+    return "unknown"
+
+
+def _response_model_name(kwargs: dict[str, Any]) -> str | None:
+    """Best-effort name of the Pydantic schema instructor is targeting."""
+    rm = kwargs.get("response_model")
+    if rm is None:
+        return None
+    try:
+        return rm.__name__  # type: ignore[no-any-return]
+    except AttributeError:
+        try:
+            return type(rm).__name__
+        except Exception:
+            return None
+
+
+def _exception_name(exc: BaseException | None) -> str | None:
+    if exc is None:
+        return None
+    try:
+        return type(exc).__name__
+    except Exception:
+        return "Exception"
+
+
+class AsqavInstructorHook(AsqavAdapter):
+    """asqav adapter for instructor clients.
+
+    Signs ``instructor.completion.start`` on every extraction request,
+    ``instructor.completion.complete`` on each successful response, and
+    ``instructor.completion.error`` / ``instructor.parse.error`` on the two
+    failure paths. Signing is fail-open: if asqav is unreachable the
+    extraction still runs.
+
+    Args:
+        api_key: Optional API key override (uses ``asqav.init()`` default).
+        agent_name: Name for a new asqav agent (calls ``Agent.create``).
+        agent_id: ID of an existing asqav agent (calls ``Agent.get``).
+
+    Example:
+        client = instructor.from_provider("openai/gpt-4o-mini")
+        hook = AsqavInstructorHook(agent_name="my-extractor")
+        hook.attach(client)
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        agent_name: str | None = None,
+        agent_id: str | None = None,
+    ) -> None:
+        super().__init__(api_key=api_key, agent_name=agent_name, agent_id=agent_id)
+
+    # ------------------------------------------------------------------
+    # Public attachment surface
+    # ------------------------------------------------------------------
+
+    def attach(self, client: Any) -> None:
+        """Register this hook on an instructor client.
+
+        Accepts both sync (``instructor.from_openai`` style) and async
+        (``instructor.from_openai(client, ...)`` with the async OpenAI client)
+        instructor clients. Both expose the same ``.on()`` interface.
+        """
+        if not hasattr(client, "on"):
+            raise TypeError(
+                "client does not look like an instructor client; "
+                "expected a .on(hook_name, handler) method"
+            )
+        client.on(HookName.COMPLETION_KWARGS, self._on_kwargs)
+        client.on(HookName.COMPLETION_RESPONSE, self._on_response)
+        client.on(HookName.COMPLETION_ERROR, self._on_error)
+        client.on(HookName.COMPLETION_LAST_ATTEMPT, self._on_last_attempt)
+        client.on(HookName.PARSE_ERROR, self._on_parse_error)
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _on_kwargs(self, *args: Any, **kwargs: Any) -> None:
+        """instructor emits the LLM kwargs right before the call."""
+        self._sign_action(
+            "instructor.completion.start",
+            {
+                "model": _model_name(kwargs),
+                "response_model": _response_model_name(kwargs),
+                "stream": bool(kwargs.get("stream", False)),
+            },
+        )
+
+    def _on_response(self, response: Any) -> None:
+        """Successful completion. We only persist hashable, low-PII fields."""
+        usage = getattr(response, "usage", None)
+        ctx: dict[str, Any] = {"id": getattr(response, "id", None)}
+        if usage is not None:
+            ctx["prompt_tokens"] = getattr(usage, "prompt_tokens", None)
+            ctx["completion_tokens"] = getattr(usage, "completion_tokens", None)
+            ctx["total_tokens"] = getattr(usage, "total_tokens", None)
+        self._sign_action("instructor.completion.complete", ctx)
+
+    def _on_error(self, error: Exception, **_kwargs: Any) -> None:
+        self._sign_action(
+            "instructor.completion.error",
+            {"error_type": _exception_name(error), "message": str(error)[:500]},
+        )
+
+    def _on_last_attempt(self, error: Exception, **_kwargs: Any) -> None:
+        self._sign_action(
+            "instructor.completion.last_attempt",
+            {"error_type": _exception_name(error), "message": str(error)[:500]},
+        )
+
+    def _on_parse_error(self, error: Exception) -> None:
+        """Pydantic validation failed against response_model."""
+        self._sign_action(
+            "instructor.parse.error",
+            {"error_type": _exception_name(error), "message": str(error)[:500]},
+        )

--- a/python/tests/test_instructor_integration.py
+++ b/python/tests/test_instructor_integration.py
@@ -1,0 +1,233 @@
+"""Tests for instructor AsqavInstructorHook integration.
+
+Uses a mock instructor.core.hooks module injected into sys.modules so tests
+run without instructor installed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from enum import Enum
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# ---------------------------------------------------------------------------
+# Inject fake instructor.core.hooks module before importing the integration
+# ---------------------------------------------------------------------------
+
+_MISSING = object()
+_original_modules: dict[str, ModuleType | object] = {}
+
+
+def _install_instructor_mocks() -> type:
+    for mod_name in ("instructor", "instructor.core", "instructor.core.hooks"):
+        _original_modules[mod_name] = sys.modules.get(mod_name, _MISSING)
+
+    class HookName(Enum):
+        COMPLETION_KWARGS = "completion:kwargs"
+        COMPLETION_RESPONSE = "completion:response"
+        COMPLETION_ERROR = "completion:error"
+        COMPLETION_LAST_ATTEMPT = "completion:last_attempt"
+        PARSE_ERROR = "parse:error"
+
+    instructor = ModuleType("instructor")
+    instructor_core = ModuleType("instructor.core")
+    instructor_core_hooks = ModuleType("instructor.core.hooks")
+
+    instructor_core_hooks.HookName = HookName  # type: ignore[attr-defined]
+    instructor_core.hooks = instructor_core_hooks  # type: ignore[attr-defined]
+    instructor.core = instructor_core  # type: ignore[attr-defined]
+
+    sys.modules["instructor"] = instructor
+    sys.modules["instructor.core"] = instructor_core
+    sys.modules["instructor.core.hooks"] = instructor_core_hooks
+
+    return HookName
+
+
+def _remove_instructor_mocks() -> None:
+    for mod_name, original in _original_modules.items():
+        if original is _MISSING:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = original  # type: ignore[assignment]
+    sys.modules.pop("asqav.extras.instructor", None)
+
+
+HookName = _install_instructor_mocks()
+
+from asqav.extras.instructor import AsqavInstructorHook  # noqa: E402
+
+
+@pytest.fixture
+def hook() -> AsqavInstructorHook:
+    """Build a hook with _sign_action mocked so we can assert calls."""
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        h = AsqavInstructorHook(agent_name="extractor")
+    h._sign_action = MagicMock()  # type: ignore[method-assign]
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+def test_no_init_raises_when_no_api_key() -> None:
+    from asqav.client import AsqavError
+
+    with patch("asqav.client._api_key", None):
+        with pytest.raises(AsqavError):
+            AsqavInstructorHook(agent_name="extractor")
+
+
+# ---------------------------------------------------------------------------
+# attach()
+# ---------------------------------------------------------------------------
+
+
+def test_attach_registers_all_five_hooks(hook: AsqavInstructorHook) -> None:
+    client = MagicMock()
+    hook.attach(client)
+
+    registered = {call.args[0] for call in client.on.call_args_list}
+    assert registered == {
+        HookName.COMPLETION_KWARGS,
+        HookName.COMPLETION_RESPONSE,
+        HookName.COMPLETION_ERROR,
+        HookName.COMPLETION_LAST_ATTEMPT,
+        HookName.PARSE_ERROR,
+    }
+
+
+def test_attach_rejects_non_instructor_client(hook: AsqavInstructorHook) -> None:
+    not_a_client = object()
+    with pytest.raises(TypeError):
+        hook.attach(not_a_client)
+
+
+# ---------------------------------------------------------------------------
+# completion:kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_on_kwargs_signs_start(hook: AsqavInstructorHook) -> None:
+    class User:
+        pass
+
+    hook._on_kwargs(model="gpt-4o-mini", response_model=User, stream=False)
+    hook._sign_action.assert_called_once_with(
+        "instructor.completion.start",
+        {"model": "gpt-4o-mini", "response_model": "User", "stream": False},
+    )
+
+
+def test_on_kwargs_handles_missing_fields(hook: AsqavInstructorHook) -> None:
+    """Missing model and response_model still produce a clean signed payload."""
+    hook._on_kwargs()
+    args, _ = hook._sign_action.call_args
+    assert args[0] == "instructor.completion.start"
+    assert args[1] == {"model": "unknown", "response_model": None, "stream": False}
+
+
+# ---------------------------------------------------------------------------
+# completion:response
+# ---------------------------------------------------------------------------
+
+
+def test_on_response_signs_complete_with_usage(hook: AsqavInstructorHook) -> None:
+    response = MagicMock(
+        id="cmpl_a1",
+        usage=MagicMock(prompt_tokens=12, completion_tokens=34, total_tokens=46),
+    )
+    hook._on_response(response)
+    hook._sign_action.assert_called_once_with(
+        "instructor.completion.complete",
+        {
+            "id": "cmpl_a1",
+            "prompt_tokens": 12,
+            "completion_tokens": 34,
+            "total_tokens": 46,
+        },
+    )
+
+
+def test_on_response_handles_missing_usage(hook: AsqavInstructorHook) -> None:
+    response = MagicMock(spec=["id"])
+    response.id = "cmpl_a2"
+    hook._on_response(response)
+    args, _ = hook._sign_action.call_args
+    assert args[1] == {"id": "cmpl_a2"}
+
+
+# ---------------------------------------------------------------------------
+# error events
+# ---------------------------------------------------------------------------
+
+
+def test_on_error_signs_completion_error(hook: AsqavInstructorHook) -> None:
+    hook._on_error(RuntimeError("provider down"), model="gpt-4o-mini")
+    args, _ = hook._sign_action.call_args
+    assert args[0] == "instructor.completion.error"
+    assert args[1]["error_type"] == "RuntimeError"
+    assert "provider down" in args[1]["message"]
+
+
+def test_on_last_attempt_signs_separate_action(hook: AsqavInstructorHook) -> None:
+    hook._on_last_attempt(TimeoutError("retry exhausted"))
+    args, _ = hook._sign_action.call_args
+    assert args[0] == "instructor.completion.last_attempt"
+    assert args[1]["error_type"] == "TimeoutError"
+
+
+def test_on_parse_error_signs_parse_error(hook: AsqavInstructorHook) -> None:
+    hook._on_parse_error(ValueError("schema mismatch"))
+    args, _ = hook._sign_action.call_args
+    assert args[0] == "instructor.parse.error"
+    assert args[1]["error_type"] == "ValueError"
+
+
+# ---------------------------------------------------------------------------
+# Fail-open: signing must never block instructor execution
+# ---------------------------------------------------------------------------
+
+
+def test_fail_open_on_asqav_error() -> None:
+    from asqav.client import AsqavError
+
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent = MagicMock()
+        mock_agent.sign.side_effect = AsqavError("network down")
+        mock_agent_cls.create.return_value = mock_agent
+        h = AsqavInstructorHook(agent_name="fail-open")
+
+    # None of these should raise even though sign() always errors.
+    h._on_kwargs(model="gpt-4o-mini")
+    h._on_response(MagicMock())
+    h._on_error(RuntimeError("x"))
+    h._on_last_attempt(RuntimeError("y"))
+    h._on_parse_error(ValueError("z"))
+
+    assert mock_agent.sign.call_count == 5
+    assert len(h._signatures) == 0
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+def teardown_module() -> None:
+    _remove_instructor_mocks()


### PR DESCRIPTION
## Summary

Closes #58.

`AsqavInstructorHook` attaches to an [instructor](https://pypi.org/project/instructor/) client and signs each of the five hook events:

- `completion:kwargs` -> `instructor.completion.start` (model, response_model, stream)
- `completion:response` -> `instructor.completion.complete` (id, prompt/completion/total tokens)
- `completion:error` -> `instructor.completion.error` (error_type, message)
- `completion:last_attempt` -> `instructor.completion.last_attempt` (after retries exhausted)
- `parse:error` -> `instructor.parse.error` (Pydantic validation failure)

Usage:

```python
import asqav, instructor
from asqav.extras.instructor import AsqavInstructorHook

asqav.init(api_key="...")
client = instructor.from_provider("openai/gpt-4o-mini")

hook = AsqavInstructorHook(agent_name="my-extractor")
hook.attach(client)
# Every client.chat.completions.create(...) call is now signed.
```

## Verification

The five hook event names were verified against the live instructor 1.15.1 source (`instructor.core.hooks.HookName`) before writing. Pattern mirrors `extras/dspy.py`: extends `AsqavAdapter`, fail-open on signing errors, accepts `agent_name` or `agent_id`.

## Test plan

- [x] 11 new tests cover: init guard, attach registers all five hooks, attach rejects non-instructor clients, kwargs/response/error/last_attempt/parse_error each sign the right action, response handler tolerates missing `usage`, fail-open swallows AsqavError without breaking the pipeline.
- [x] Tests use a mock `instructor.core.hooks` module so they run without instructor installed (mirrors `test_dspy_integration.py`).