### PR TITLE
docs: Streamlit dashboard cookbook

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ export ASQAV_API_KEY=sk_...
 | [`quarterly_audit.py`](quarterly_audit.py) | Export bundle, replay timeline offline, verify SHA-256 chain, summarize | #63 |
 | [`human_approval.py`](human_approval.py) | Request signing session for a high-risk action, wait for human approval, then sign | #64 |
 | [`dify_workflow.md`](dify_workflow.md) | Dify plugin: sign actions in a workflow, bundle the run for an auditor | #50 |
+| [`streamlit_dashboard.py`](streamlit_dashboard.py) | Streamlit dashboard: list agents, replay timelines, verify chain, export bundle | #56 |
 
 ## CLI parity
 

--- a/examples/streamlit_dashboard.py
+++ b/examples/streamlit_dashboard.py
@@ -1,0 +1,165 @@
+"""Streamlit dashboard for asqav audit trails.
+
+Visualizes signed agent activity, replay timelines, and chain verification
+in one page. Backed entirely by the asqav SDK and CLI; nothing custom on
+the server side.
+
+Run:
+    pip install asqav streamlit
+    export ASQAV_API_KEY=sk_...
+    streamlit run examples/streamlit_dashboard.py
+
+Same data is reachable from the CLI:
+    asqav agents list
+    asqav replay <agent_id> <session_id>
+    asqav compliance export --session <session_id> --output bundle.json
+    asqav replay --bundle bundle.json
+
+Closes #56.
+"""
+
+from __future__ import annotations
+
+import os
+
+import streamlit as st
+
+import asqav
+from asqav.client import _get, get_session_signatures
+from asqav.compliance import FRAMEWORKS, export_bundle
+from asqav.replay import replay
+
+
+def _ensure_init() -> None:
+    """Initialize asqav with the API key from the environment.
+
+    Streamlit re-runs the script top-to-bottom on every interaction, so guard
+    re-init with a session_state flag to avoid re-creating clients each time.
+    """
+    if st.session_state.get("_asqav_initialized"):
+        return
+    api_key = os.environ.get("ASQAV_API_KEY")
+    if not api_key:
+        st.error(
+            "ASQAV_API_KEY is not set. Get a key at https://cloud.asqav.com "
+            "and re-run with `ASQAV_API_KEY=sk_... streamlit run ...`."
+        )
+        st.stop()
+    asqav.init(api_key=api_key)
+    st.session_state["_asqav_initialized"] = True
+
+
+def _list_agents() -> list[dict]:
+    """Best-effort agent list. Falls back to an empty list on API errors."""
+    try:
+        data = _get("/agents")
+    except Exception as exc:
+        st.warning(f"Could not list agents: {exc}")
+        return []
+    return data if isinstance(data, list) else data.get("agents", [])
+
+
+def _agent_label(agent: dict) -> str:
+    return f"{agent.get('name', '?')} ({agent.get('agent_id', '?')})"
+
+
+def main() -> None:
+    st.set_page_config(page_title="asqav dashboard", layout="wide")
+    st.title("asqav governance dashboard")
+    st.caption(
+        "Live view of agents, signed actions, replay timelines, and "
+        "compliance bundles. Every panel below maps 1:1 to a public asqav "
+        "Python API and `asqav` CLI command."
+    )
+
+    _ensure_init()
+
+    agents = _list_agents()
+    if not agents:
+        st.info("No agents yet. Create one with `asqav agents create my-agent`.")
+        st.stop()
+
+    with st.sidebar:
+        st.subheader("Filters")
+        agent = st.selectbox(
+            "Agent",
+            agents,
+            format_func=_agent_label,
+            key="agent_select",
+        )
+        session_id = st.text_input(
+            "Session ID",
+            placeholder="sess_...",
+            help="The session whose signatures you want to inspect.",
+        )
+        framework = st.selectbox(
+            "Compliance framework",
+            sorted(FRAMEWORKS.keys()),
+            index=0,
+        )
+
+    if not session_id:
+        st.info("Enter a session ID in the sidebar to load its audit trail.")
+        st.stop()
+
+    sigs = get_session_signatures(session_id)
+    if not sigs:
+        st.warning(f"No signatures found for session `{session_id}`.")
+        st.stop()
+
+    st.subheader("Signed actions")
+    rows = [
+        {
+            "signature_id": s.signature_id,
+            "action_type": s.action_type,
+            "algorithm": s.algorithm,
+            "signed_at": s.signed_at,
+            "verify": s.verification_url,
+        }
+        for s in sigs
+    ]
+    st.dataframe(rows, use_container_width=True)
+
+    st.subheader("Replay timeline")
+    timeline = replay(agent["agent_id"], session_id)
+    chain_ok = timeline.verify_chain()
+
+    cols = st.columns(3)
+    cols[0].metric("Actions", timeline.total_actions or len(timeline.steps))
+    cols[1].metric(
+        "Chain integrity",
+        "OK" if chain_ok else "BROKEN",
+        delta=None if chain_ok else "tampered",
+    )
+    cols[2].metric("Steps", len(timeline.steps))
+
+    for step in timeline.steps:
+        mark = "OK" if step.chain_valid else "BROKEN"
+        st.write(
+            f"**[{step.index}] {step.action_type}** "
+            f"({mark}) - {step.explanation}"
+        )
+
+    st.subheader("Compliance bundle")
+    if st.button("Export bundle"):
+        bundle = export_bundle(sigs, framework=framework)
+        st.success(
+            f"Exported {bundle.receipt_count} receipts under {framework}. "
+            f"Merkle root: `{bundle.merkle_root}`"
+        )
+        st.download_button(
+            "Download bundle JSON",
+            bundle.to_json(),
+            file_name=f"bundle-{session_id}.json",
+            mime="application/json",
+        )
+
+    st.caption(
+        "Same flows from the terminal: "
+        "`asqav replay <agent_id> <session_id>`, "
+        "`asqav compliance export --session <id> --output bundle.json`."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #56.

Standalone Streamlit app at `examples/streamlit_dashboard.py` that visualizes the same data the SDK and CLI already expose:

- **Agents** - lists agents via `asqav.client._get('/agents')` (mirrors `asqav agents list`).
- **Signed actions** - `get_session_signatures(session_id)` rendered as a table.
- **Replay timeline** - `asqav.replay(agent_id, session_id)` with `verify_chain()` and per-step status.
- **Compliance bundle** - `asqav.compliance.export_bundle` plus a Streamlit download button. Framework selection drawn from `compliance.FRAMEWORKS`.

The caption explicitly names the matching CLI commands so users see the dashboard sits on the same APIs as `asqav replay` and `asqav compliance export`.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` clean.
- [x] All API/method names cross-checked against `client.py`, `compliance.py`, `replay.py`.
- [x] No hardcoded session IDs or framework keys; framework dropdown reads from `FRAMEWORKS` directly so it stays in sync.