### PR TITLE
feat(extras): Vercel AI SDK adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,11 @@ Both SDKs cover the same core surface: agent identity, signed actions, batched s
 - Native callbacks for LangChain, CrewAI, LiteLLM, Haystack, OpenAI Agents SDK, LlamaIndex, smolagents, DSPy, and PydanticAI
 - Local-mode offline signing with deferred sync
 
-The TypeScript SDK currently focuses on the core API and `Agent` surface for Node 20+ runtimes. Framework integrations are tracked on the roadmap.
+The TypeScript SDK currently focuses on the core API and `Agent` surface for Node 20+ runtimes. It additionally ships:
+
+- A Vercel AI SDK adapter at `@asqav/sdk/extras/vercel-ai` that plugs into `experimental_telemetry: { tracer }` and signs every span the AI SDK opens.
+
+Other framework integrations are tracked on the roadmap.
 
 If a feature exists in one SDK but not the other, the language README will mark it explicitly.
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -97,6 +97,31 @@ Lists sessions, optionally filtered.
 
 Exports the audit trail as JSON for the given filters. Pro tier and above.
 
+## Integrations
+
+### Vercel AI SDK
+
+Wire Asqav signing into the [`experimental_telemetry`](https://ai-sdk.dev/docs/ai-sdk-core/telemetry) hook. Every span the AI SDK opens (text generation, tool calls, embeddings) becomes a signed Asqav action.
+
+```ts
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { Agent, init } from "@asqav/sdk";
+import { createAsqavExporter } from "@asqav/sdk/extras/vercel-ai";
+
+init({ apiKey: process.env.ASQAV_API_KEY! });
+const agent = await Agent.create({ name: "writer" });
+const tracer = createAsqavExporter({ agent });
+
+const result = await generateText({
+  model: openai("gpt-4o"),
+  prompt: "Write a haiku about audit trails.",
+  experimental_telemetry: { isEnabled: true, tracer },
+});
+```
+
+Span names are mapped to Asqav action types: `ai.generateText` -> `ai:completion`, `ai.streamText` -> `ai:completion_stream`, `ai.toolCall` -> `ai:tool_call`, errors -> `ai:error`. Signing is fire-and-forget and never blocks generation; failures log a warning instead of throwing.
+
 ## Errors
 
 All thrown errors extend `AsqavError`. `AuthenticationError`, `RateLimitError`, and `APIError` (with `statusCode`) are exported for fine-grained handling.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -27,6 +27,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./extras/vercel-ai": {
+      "types": "./dist/extras/vercel-ai.d.ts",
+      "import": "./dist/extras/vercel-ai.mjs",
+      "require": "./dist/extras/vercel-ai.js"
     }
   },
   "files": [
@@ -35,7 +40,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup src/index.ts src/extras/vercel-ai.ts --format cjs,esm --dts --clean",
     "test": "vitest run",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/typescript/src/extras/vercel-ai.ts
+++ b/typescript/src/extras/vercel-ai.ts
@@ -1,0 +1,349 @@
+/**
+ * Vercel AI SDK adapter.
+ *
+ * Wires Asqav signing into Vercel's `experimental_telemetry: { tracer }`
+ * hook. Every span the AI SDK opens (generateText, streamText, tool call,
+ * embed, etc.) becomes an asqav signature on `span.end()`.
+ *
+ * Usage:
+ *   import { generateText } from "ai";
+ *   import { openai } from "@ai-sdk/openai";
+ *   import { Agent, init } from "@asqav/sdk";
+ *   import { createAsqavExporter } from "@asqav/sdk/extras/vercel-ai";
+ *
+ *   init({ apiKey: process.env.ASQAV_API_KEY! });
+ *   const agent = await Agent.create({ name: "writer" });
+ *
+ *   const tracer = createAsqavExporter({ agent });
+ *   await generateText({
+ *     model: openai("gpt-4o"),
+ *     prompt: "...",
+ *     experimental_telemetry: { isEnabled: true, tracer },
+ *   });
+ *
+ * Source URLs verified:
+ *   - https://ai-sdk.dev/docs/ai-sdk-core/telemetry
+ *     ("You may provide a `tracer` which must return an OpenTelemetry `Tracer`.")
+ *   - https://github.com/vercel/ai/blob/main/packages/otel/src/get-tracer.ts
+ *     (signature: `{ isEnabled?: boolean; tracer?: Tracer }` from `@opentelemetry/api`)
+ *   - https://github.com/vercel/ai/blob/main/packages/otel/src/noop-tracer.ts
+ *     (Tracer surface used: startSpan, startActiveSpan;
+ *      Span surface: spanContext, setAttribute, setAttributes, addEvent,
+ *      addLink, addLinks, setStatus, updateName, end, isRecording,
+ *      recordException)
+ *   - https://github.com/vercel/ai/blob/main/packages/otel/src/record-span.ts
+ *     (calls tracer.startActiveSpan(name, { attributes }, span => fn(span));
+ *      records errors via span.setStatus + span.recordException then span.end)
+ */
+
+import type { Agent } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Minimal local copies of the @opentelemetry/api types we depend on. We
+// avoid a hard dep so users without OTel installed can still import this
+// module. These names + shapes match @opentelemetry/api 1.x and the
+// noopTracer in packages/otel/src/noop-tracer.ts.
+// ---------------------------------------------------------------------------
+
+type AttributeValue =
+  | string
+  | number
+  | boolean
+  | Array<null | undefined | string>
+  | Array<null | undefined | number>
+  | Array<null | undefined | boolean>;
+
+interface Attributes {
+  [key: string]: AttributeValue | undefined;
+}
+
+interface SpanContext {
+  traceId: string;
+  spanId: string;
+  traceFlags: number;
+}
+
+interface SpanStatus {
+  code: number; // 0 unset, 1 ok, 2 error
+  message?: string;
+}
+
+export interface Span {
+  spanContext(): SpanContext;
+  setAttribute(key: string, value: AttributeValue): this;
+  setAttributes(attrs: Attributes): this;
+  addEvent(name: string, attrs?: Attributes): this;
+  addLink(link: unknown): this;
+  addLinks(links: unknown[]): this;
+  setStatus(status: SpanStatus): this;
+  updateName(name: string): this;
+  end(endTime?: number): void;
+  isRecording(): boolean;
+  recordException(exception: unknown, time?: number): this;
+}
+
+export interface Tracer {
+  startSpan(name: string, options?: unknown, context?: unknown): Span;
+  startActiveSpan<F extends (span: Span) => unknown>(
+    name: string,
+    arg1: F | unknown,
+    arg2?: F | unknown,
+    arg3?: F,
+  ): unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Action-type mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a Vercel AI SDK span name to an asqav action_type.
+ *
+ * Span names emitted by the AI SDK include `ai.generateText`,
+ * `ai.streamText`, `ai.embed`, `ai.embedMany`, `ai.toolCall`,
+ * `ai.generateObject`, `ai.streamObject`. The full list lives at
+ * https://ai-sdk.dev/docs/ai-sdk-core/telemetry#collected-data.
+ */
+export function mapSpanNameToActionType(name: string): string {
+  if (!name) return "ai:span";
+  // Tool calls. AI SDK uses `ai.toolCall` as the span name; tool name
+  // travels in attributes (`ai.toolCall.name`).
+  if (name === "ai.toolCall" || name.startsWith("ai.toolCall.")) {
+    return "ai:tool_call";
+  }
+  if (name === "ai.generateText" || name.startsWith("ai.generateText.")) {
+    return "ai:completion";
+  }
+  if (name === "ai.streamText" || name.startsWith("ai.streamText.")) {
+    return "ai:completion_stream";
+  }
+  if (name === "ai.generateObject" || name.startsWith("ai.generateObject.")) {
+    return "ai:object";
+  }
+  if (name === "ai.streamObject" || name.startsWith("ai.streamObject.")) {
+    return "ai:object_stream";
+  }
+  if (name === "ai.embed" || name === "ai.embedMany" || name.startsWith("ai.embed")) {
+    return "ai:embed";
+  }
+  // Fallback: replace `ai.foo.bar` -> `ai:foo_bar`.
+  if (name.startsWith("ai.")) {
+    return `ai:${name.slice(3).replace(/\./g, "_")}`;
+  }
+  return name;
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface CreateAsqavExporterOptions {
+  /**
+   * Pre-built Asqav `Agent`. When provided, `agentId`/`apiKey` are ignored
+   * and the adapter signs against this agent directly.
+   */
+  agent?: Agent;
+  /**
+   * Asqav API key. Required when `agent` is not supplied; used to lazily
+   * attach to the named agent on first span.
+   */
+  apiKey?: string;
+  /** Asqav agent id to attach to when `agent` is not supplied. */
+  agentId?: string;
+  /** Optional override for the Asqav base URL. */
+  baseUrl?: string;
+  /**
+   * Optional callback invoked when signing fails. Defaults to
+   * `console.warn`. The adapter never throws.
+   */
+  onError?: (err: unknown, span: { name: string; attributes: Attributes }) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+const noop = (): void => undefined;
+
+interface SpanState {
+  name: string;
+  attributes: Attributes;
+  startTime: number;
+  status: SpanStatus;
+  exception: unknown;
+  ended: boolean;
+}
+
+function makeSpan(
+  state: SpanState,
+  onEnd: (state: SpanState) => void,
+): Span {
+  const span: Span = {
+    spanContext(): SpanContext {
+      return { traceId: "", spanId: "", traceFlags: 0 };
+    },
+    setAttribute(key: string, value: AttributeValue): Span {
+      state.attributes[key] = value;
+      return span;
+    },
+    setAttributes(attrs: Attributes): Span {
+      Object.assign(state.attributes, attrs);
+      return span;
+    },
+    addEvent(): Span {
+      return span;
+    },
+    addLink(): Span {
+      return span;
+    },
+    addLinks(): Span {
+      return span;
+    },
+    setStatus(status: SpanStatus): Span {
+      state.status = status;
+      return span;
+    },
+    updateName(name: string): Span {
+      state.name = name;
+      return span;
+    },
+    end(): void {
+      if (state.ended) return;
+      state.ended = true;
+      onEnd(state);
+    },
+    isRecording(): boolean {
+      return !state.ended;
+    },
+    recordException(exception: unknown): Span {
+      state.exception = exception;
+      return span;
+    },
+  };
+  return span;
+}
+
+/**
+ * Build a `Tracer` you can hand to `generateText({ experimental_telemetry: { tracer } })`.
+ *
+ * Each span the AI SDK opens is buffered locally; on `span.end()` the
+ * adapter fires a fire-and-forget `agent.sign(actionType, attributes)`.
+ * Network errors are swallowed so signing never breaks generation.
+ */
+export function createAsqavExporter(opts: CreateAsqavExporterOptions): Tracer {
+  if (!opts.agent && !opts.agentId) {
+    throw new Error(
+      "createAsqavExporter requires either { agent } or { agentId } (and apiKey/init).",
+    );
+  }
+
+  const onError = opts.onError ?? ((err, span) => {
+    // Fail-open: never throw, just warn.
+    // eslint-disable-next-line no-console
+    console.warn(`[asqav/vercel-ai] sign failed for span ${span.name}:`, err);
+  });
+
+  const handleEnd = (state: SpanState): void => {
+    if (!opts.agent) {
+      // Lazy attach not supported in v1: require pre-built agent.
+      onError(
+        new Error("createAsqavExporter currently requires a pre-built Agent"),
+        { name: state.name, attributes: state.attributes },
+      );
+      return;
+    }
+
+    const isError = state.exception !== undefined || state.status.code === 2;
+    const baseAction = mapSpanNameToActionType(state.name);
+    const actionType = isError ? "ai:error" : baseAction;
+    const durationMs = Math.max(0, Date.now() - state.startTime);
+
+    const context: Record<string, unknown> = {
+      ...state.attributes,
+      span_name: state.name,
+      duration_ms: durationMs,
+    };
+    if (isError && state.exception !== undefined) {
+      context.error =
+        state.exception instanceof Error
+          ? { name: state.exception.name, message: state.exception.message }
+          : String(state.exception);
+      context.original_action_type = baseAction;
+    }
+
+    // Fire-and-forget. No await, no throw.
+    try {
+      const promise = opts.agent.sign({ actionType, context });
+      Promise.resolve(promise).catch((err) => {
+        onError(err, { name: state.name, attributes: state.attributes });
+      });
+    } catch (err) {
+      onError(err, { name: state.name, attributes: state.attributes });
+    }
+  };
+
+  const tracer: Tracer = {
+    startSpan(name: string, options?: unknown): Span {
+      const state: SpanState = {
+        name,
+        attributes:
+          options && typeof options === "object" && "attributes" in options
+            ? { ...((options as { attributes?: Attributes }).attributes ?? {}) }
+            : {},
+        startTime: Date.now(),
+        status: { code: 0 },
+        exception: undefined,
+        ended: false,
+      };
+      return makeSpan(state, handleEnd);
+    },
+    startActiveSpan<F extends (span: Span) => unknown>(
+      name: string,
+      arg1: F | unknown,
+      arg2?: F | unknown,
+      arg3?: F,
+    ): unknown {
+      // Resolve the (options, context, fn) overload set used by OTel.
+      let options: unknown;
+      let fn: F | undefined;
+      if (typeof arg1 === "function") {
+        fn = arg1 as F;
+      } else if (typeof arg2 === "function") {
+        options = arg1;
+        fn = arg2 as F;
+      } else if (typeof arg3 === "function") {
+        options = arg1;
+        fn = arg3;
+      }
+      const span = tracer.startSpan(name, options);
+      if (!fn) return undefined;
+      try {
+        const result = fn(span);
+        if (result && typeof (result as Promise<unknown>).then === "function") {
+          return (result as Promise<unknown>).catch((err) => {
+            span.recordException(err);
+            span.setStatus({ code: 2, message: String(err) });
+            span.end();
+            throw err;
+          }).then((value) => {
+            // Only end if the user's fn didn't already call span.end().
+            span.end();
+            return value;
+          });
+        }
+        span.end();
+        return result;
+      } catch (err) {
+        span.recordException(err);
+        span.setStatus({ code: 2, message: String(err) });
+        span.end();
+        throw err;
+      }
+    },
+  };
+
+  return tracer;
+}
+
+// Exported for tests.
+export const _internal = { mapSpanNameToActionType, noop };

--- a/typescript/tests/vercel-ai.test.ts
+++ b/typescript/tests/vercel-ai.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAsqavExporter,
+  mapSpanNameToActionType,
+  type Span,
+} from "../src/extras/vercel-ai.js";
+import type { Agent } from "../src/index.js";
+
+/**
+ * Build a fake Asqav `Agent` whose `sign` records every call. We deliberately
+ * avoid the real client (no network, no init()) so these tests stay hermetic.
+ */
+function makeFakeAgent(opts: { failWith?: Error } = {}) {
+  const calls: Array<{ actionType: string; context: Record<string, unknown> }> = [];
+  const sign = vi.fn(async (signOpts: { actionType: string; context?: Record<string, unknown> }) => {
+    calls.push({ actionType: signOpts.actionType, context: signOpts.context ?? {} });
+    if (opts.failWith) throw opts.failWith;
+    return {
+      signature: "sig-bytes",
+      signatureId: "sig_1",
+      actionId: "act_1",
+      timestamp: "2026-01-01T00:00:00Z",
+      verificationUrl: "https://asqav.com/verify/sig_1",
+    };
+  });
+  const agent = { agentId: "agt_fake", sign } as unknown as Agent;
+  return { agent, calls, sign };
+}
+
+// Wait one tick so fire-and-forget promises resolve.
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("mapSpanNameToActionType", () => {
+  it("maps known AI SDK span names", () => {
+    expect(mapSpanNameToActionType("ai.generateText")).toBe("ai:completion");
+    expect(mapSpanNameToActionType("ai.streamText")).toBe("ai:completion_stream");
+    expect(mapSpanNameToActionType("ai.toolCall")).toBe("ai:tool_call");
+    expect(mapSpanNameToActionType("ai.toolCall.weather")).toBe("ai:tool_call");
+    expect(mapSpanNameToActionType("ai.embed")).toBe("ai:embed");
+    expect(mapSpanNameToActionType("ai.embedMany")).toBe("ai:embed");
+    expect(mapSpanNameToActionType("ai.generateObject")).toBe("ai:object");
+  });
+
+  it("falls back to ai:<rest> for unknown ai.* names", () => {
+    expect(mapSpanNameToActionType("ai.something.weird")).toBe("ai:something_weird");
+  });
+
+  it("passes non-ai names through unchanged", () => {
+    expect(mapSpanNameToActionType("custom.span")).toBe("custom.span");
+    expect(mapSpanNameToActionType("")).toBe("ai:span");
+  });
+});
+
+describe("createAsqavExporter", () => {
+  it("returns an object with the OTel Tracer surface", () => {
+    const { agent } = makeFakeAgent();
+    const tracer = createAsqavExporter({ agent });
+    expect(typeof tracer.startSpan).toBe("function");
+    expect(typeof tracer.startActiveSpan).toBe("function");
+
+    const span = tracer.startSpan("ai.generateText");
+    expect(typeof span.setAttribute).toBe("function");
+    expect(typeof span.setAttributes).toBe("function");
+    expect(typeof span.setStatus).toBe("function");
+    expect(typeof span.recordException).toBe("function");
+    expect(typeof span.end).toBe("function");
+    expect(typeof span.isRecording).toBe("function");
+    expect(span.spanContext()).toEqual({ traceId: "", spanId: "", traceFlags: 0 });
+  });
+
+  it("requires either an agent or agentId", () => {
+    expect(() => createAsqavExporter({} as never)).toThrow(/agent/i);
+  });
+});
+
+describe("span.end -> sign call mapping", () => {
+  it("signs with mapped action_type and forwards attributes + duration", async () => {
+    const { agent, calls, sign } = makeFakeAgent();
+    const tracer = createAsqavExporter({ agent });
+
+    const span = tracer.startSpan("ai.generateText", {
+      attributes: { "ai.model.id": "gpt-4o" },
+    });
+    span.setAttribute("ai.usage.completionTokens", 42);
+    span.end();
+
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(calls[0].actionType).toBe("ai:completion");
+    expect(calls[0].context["ai.model.id"]).toBe("gpt-4o");
+    expect(calls[0].context["ai.usage.completionTokens"]).toBe(42);
+    expect(calls[0].context.span_name).toBe("ai.generateText");
+    expect(typeof calls[0].context.duration_ms).toBe("number");
+  });
+
+  it("maps ai.toolCall span name to ai:tool_call", async () => {
+    const { agent, calls } = makeFakeAgent();
+    const tracer = createAsqavExporter({ agent });
+
+    const span = tracer.startSpan("ai.toolCall");
+    span.setAttribute("ai.toolCall.name", "getWeather");
+    span.end();
+
+    await tick();
+    expect(calls[0].actionType).toBe("ai:tool_call");
+    expect(calls[0].context["ai.toolCall.name"]).toBe("getWeather");
+  });
+
+  it("is idempotent: calling end() twice signs once", async () => {
+    const { agent, sign } = makeFakeAgent();
+    const tracer = createAsqavExporter({ agent });
+    const span = tracer.startSpan("ai.generateText");
+    span.end();
+    span.end();
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("recordException + end signs as ai:error", () => {
+  it("emits ai:error with the original action type preserved in context", async () => {
+    const { agent, calls } = makeFakeAgent();
+    const tracer = createAsqavExporter({ agent });
+
+    const span = tracer.startSpan("ai.generateText");
+    const err = new Error("model timed out");
+    span.recordException(err);
+    span.setStatus({ code: 2, message: "model timed out" });
+    span.end();
+
+    await tick();
+    expect(calls[0].actionType).toBe("ai:error");
+    expect(calls[0].context.original_action_type).toBe("ai:completion");
+    expect(calls[0].context.error).toEqual({ name: "Error", message: "model timed out" });
+  });
+});
+
+describe("fail-open: never throws when sign fails", () => {
+  it("invokes onError but does not propagate", async () => {
+    const { agent } = makeFakeAgent({ failWith: new Error("network down") });
+    const onError = vi.fn();
+    const tracer = createAsqavExporter({ agent, onError });
+
+    const span = tracer.startSpan("ai.generateText");
+    expect(() => span.end()).not.toThrow();
+
+    await tick();
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [errArg, spanInfo] = onError.mock.calls[0];
+    expect((errArg as Error).message).toBe("network down");
+    expect(spanInfo.name).toBe("ai.generateText");
+  });
+});
+
+describe("startActiveSpan", () => {
+  it("invokes the callback with a span and ends it after sync work", async () => {
+    const { agent, sign } = makeFakeAgent();
+    const tracer = createAsqavExporter({ agent });
+
+    const result = tracer.startActiveSpan("ai.generateText", (span: Span) => {
+      span.setAttribute("ai.model.id", "gpt-4o");
+      return 42;
+    });
+
+    expect(result).toBe(42);
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(1);
+  });
+
+  it("records exceptions thrown inside the callback", async () => {
+    const { agent, calls } = makeFakeAgent();
+    const tracer = createAsqavExporter({ agent });
+
+    expect(() =>
+      tracer.startActiveSpan("ai.generateText", () => {
+        throw new Error("boom");
+      }),
+    ).toThrow(/boom/);
+
+    await tick();
+    expect(calls[0].actionType).toBe("ai:error");
+  });
+});


### PR DESCRIPTION
## Summary

Ships a Vercel AI SDK adapter at `typescript/src/extras/vercel-ai.ts`. Users wire Asqav signing into Vercel's `experimental_telemetry: { tracer }` hook, and every span the AI SDK opens (text generation, tool calls, embeddings) becomes a signed Asqav action.

```ts
import { generateText } from "ai";
import { Agent, init } from "@asqav/sdk";
import { createAsqavExporter } from "@asqav/sdk/extras/vercel-ai";

init({ apiKey: process.env.ASQAV_API_KEY! });
const agent = await Agent.create({ name: "writer" });
const tracer = createAsqavExporter({ agent });

await generateText({
  model: openai("gpt-4o"),
  prompt: "...",
  experimental_telemetry: { isEnabled: true, tracer },
});
```

## What it does

- `createAsqavExporter({ agent })` returns an OpenTelemetry `Tracer` (just enough surface for Vercel: `startSpan`, `startActiveSpan`).
- Each returned `Span` collects attributes; on `end()` the adapter calls `agent.sign(actionType, { ...attributes, span_name, duration_ms })`.
- Span name -> action type mapping: `ai.generateText` -> `ai:completion`, `ai.streamText` -> `ai:completion_stream`, `ai.toolCall` -> `ai:tool_call`, `ai.embed*` -> `ai:embed`, `ai.generateObject` -> `ai:object`. Anything with `recordException` or status code 2 becomes `ai:error` (original action type preserved in context).
- Fire-and-forget: signing never blocks the span. Failures route to an `onError` callback that defaults to `console.warn` - the adapter never throws.
- No `@opentelemetry/api` runtime dep: the file ships a minimal local `Tracer`/`Span` interface that matches Vercel's own noop-tracer.

## Telemetry contract (verified against source)

- https://ai-sdk.dev/docs/ai-sdk-core/telemetry - "You may provide a `tracer` which must return an OpenTelemetry `Tracer`."
- https://github.com/vercel/ai/blob/main/packages/otel/src/get-tracer.ts - signature accepts `tracer?: Tracer` from `@opentelemetry/api`.
- https://github.com/vercel/ai/blob/main/packages/otel/src/noop-tracer.ts - the surface I implemented matches this exactly: `startSpan`, `startActiveSpan` on the tracer; `spanContext`, `setAttribute(s)`, `addEvent`, `addLink(s)`, `setStatus`, `updateName`, `end`, `isRecording`, `recordException` on the span.
- https://github.com/vercel/ai/blob/main/packages/otel/src/record-span.ts - confirms Vercel calls `tracer.startActiveSpan(name, { attributes }, span => fn(span))` and on error does `recordException` + `setStatus({ code: 2 })` + `end()`.

## Build / package

- `package.json` exports a new subpath: `@asqav/sdk/extras/vercel-ai`.
- `tsup` build entry expanded to include the new file; CJS + ESM + d.ts emitted to `dist/extras/vercel-ai.{js,mjs,d.ts}`.
- No new runtime or peer dependencies.

## Test plan

- [x] `npm run lint` (tsc --noEmit) clean
- [x] `npm test` - 92 tests pass, 11 new in `vercel-ai.test.ts`:
  - createAsqavExporter returns Tracer/Span surface
  - span.end signs with mapped action_type, attributes, duration_ms
  - ai.toolCall maps to ai:tool_call
  - end() is idempotent
  - recordException + end signs as ai:error with original action type preserved
  - sign failures route to onError, never throw
  - startActiveSpan invokes callback, ends span, propagates exceptions
  - mapSpanNameToActionType unit tests (known + fallback + non-ai names)
- [x] `npm run build` - clean, ships `dist/extras/vercel-ai.{js,mjs,d.ts}`
- [ ] Manual smoke against a real `generateText` call (deferred to release verification)