### PR TITLE
feat(typescript): port BudgetTracker and Agent.preflight from Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [TypeScript 0.2.5] - 2026-05-02
+
+### Added
+- TypeScript `BudgetTracker` mirrors the Python primitive. `new BudgetTracker({ agent, limit, currency })` exposes `check(estimatedCost)` (fail-closed arithmetic) and `record(actionType, actualCost, context?)` which signs a `budget:*` action via the underlying agent. Re-exported from the package root.
+- TypeScript `Agent.preflight(actionType)` mirrors the Python sibling. Combines the `/agents/{id}/status` revoke/suspend check and the `/policies` block-rule check into a single fail-open `PreflightResult` with a human-readable explanation.
+
 ## [Python 0.3.4 / TypeScript 0.2.4] - 2026-05-01
 
 ### Added

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -85,6 +85,32 @@ Bracket related signings into a session for replay and compliance grouping.
 
 Revokes the agent's credentials globally. Irreversible.
 
+### `agent.preflight(actionType)`
+
+Pre-flight check combining revocation/suspension status and policy. Returns `{ cleared, agentActive, policyAllowed, reasons, explanation }`. Fail-open: a sub-check that errors records a warning in `reasons` but does not block.
+
+```ts
+const decision = await agent.preflight("data:read");
+if (!decision.cleared) {
+  throw new Error(decision.explanation);
+}
+```
+
+### `BudgetTracker`
+
+Client-side spend budget. Each recorded spend is signed via the agent so the budget trail is itself tamper-evident. `check()` is a fail-closed arithmetic check; the SDK does not block actions on its own.
+
+```ts
+import { BudgetTracker } from "@asqav/sdk";
+
+const budget = new BudgetTracker({ agent, limit: 10, currency: "USD" });
+
+const decision = budget.check(0.25);
+if (!decision.allowed) throw new Error(decision.reason);
+
+await budget.record("api:openai", 0.23, { model: "gpt-4" });
+```
+
 ### `verifySignature(signatureId)`
 
 Public verification endpoint. No auth required.

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.2.2",
+      "version": "0.2.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/budget.ts
+++ b/typescript/src/budget.ts
@@ -1,0 +1,121 @@
+/**
+ * Client-side spend budget tracking for AI agent actions.
+ *
+ * Mirrors the Python BudgetTracker. Each recorded spend is signed via
+ * the agent so the budget trail itself is tamper-evident. Enforcement
+ * is the caller's responsibility: `check()` is a fail-closed arithmetic
+ * check; the SDK does not block actions on its own.
+ */
+
+import type { Agent, SignatureResponse } from "./index.js";
+
+export interface BudgetCheckResult {
+  allowed: boolean;
+  currentSpend: number;
+  limit: number;
+  remaining: number;
+  reason?: "invalid_cost" | "budget_exhausted";
+}
+
+export interface BudgetTrackerOptions {
+  agent: Agent;
+  limit: number;
+  currency?: string;
+}
+
+export class BudgetTracker {
+  readonly agent: Agent;
+  readonly limit: number;
+  readonly currency: string;
+  private spend = 0;
+  private records: string[] = [];
+
+  constructor(options: BudgetTrackerOptions) {
+    if (!isFinite(options.limit) || options.limit < 0) {
+      throw new Error("budget limit must be a finite non-negative number");
+    }
+    this.agent = options.agent;
+    this.limit = options.limit;
+    this.currency = options.currency ?? "USD";
+  }
+
+  /**
+   * Decide whether a pending action with the given estimated cost is
+   * within budget. Fail-closed on negative, NaN, or infinite costs.
+   */
+  check(estimatedCost: number): BudgetCheckResult {
+    const remaining = this.limit - this.spend;
+    const cost = Number(estimatedCost);
+    if (!Number.isFinite(cost) || cost < 0) {
+      return {
+        allowed: false,
+        currentSpend: this.spend,
+        limit: this.limit,
+        remaining,
+        reason: "invalid_cost",
+      };
+    }
+    if (cost > remaining) {
+      return {
+        allowed: false,
+        currentSpend: this.spend,
+        limit: this.limit,
+        remaining,
+        reason: "budget_exhausted",
+      };
+    }
+    return {
+      allowed: true,
+      currentSpend: this.spend,
+      limit: this.limit,
+      remaining: remaining - cost,
+    };
+  }
+
+  /**
+   * Sign a spend record on the underlying agent. Updates cumulative
+   * spend after the signature is accepted by the server.
+   */
+  async record(
+    actionType: string,
+    actualCost: number,
+    context: Record<string, unknown> = {},
+  ): Promise<SignatureResponse> {
+    const cost = Number(actualCost);
+    if (!Number.isFinite(cost) || cost < 0) {
+      throw new Error("actualCost must be a finite non-negative number");
+    }
+    const next = this.spend + cost;
+    const sig = await this.agent.sign({
+      actionType: `budget:${actionType}`,
+      context: {
+        ...context,
+        cost,
+        currency: this.currency,
+        cumulative_spend: next,
+        limit: this.limit,
+      },
+    });
+    this.spend = next;
+    this.records.push(sig.signatureId);
+    return sig;
+  }
+
+  status(): {
+    limit: number;
+    currency: string;
+    spend: number;
+    remaining: number;
+    records: number;
+    signatureIds: string[];
+  } {
+    return {
+      limit: this.limit,
+      currency: this.currency,
+      spend: this.spend,
+      remaining: this.limit - this.spend,
+      records: this.records.length,
+      signatureIds: [...this.records],
+    };
+  }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -19,6 +19,7 @@ export { clearHooks, registerAfter, registerBefore } from "./hooks.js";
 export type { AfterHook, BeforeHook } from "./hooks.js";
 export { canonicalize, hashAction } from "./canonicalize.js";
 export { resolveMode, isAsqavCloudHost, type Mode } from "./mode.js";
+export { BudgetTracker, type BudgetCheckResult, type BudgetTrackerOptions } from "./budget.js";
 
 const DEFAULT_BASE_URL = "https://api.asqav.com/api/v1";
 /** Metadata keys allowed alongside a hash-only request. Mirrors the
@@ -193,6 +194,14 @@ export interface ExportAuditOptions {
   startDate?: string;
   endDate?: string;
   agentId?: string;
+}
+
+export interface PreflightResult {
+  cleared: boolean;
+  agentActive: boolean;
+  policyAllowed: boolean;
+  reasons: string[];
+  explanation: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -557,6 +566,75 @@ export class Agent {
     await request("POST", `/agents/${this.agentId}/revoke`, {
       reason: options.reason ?? "manual",
     });
+  }
+
+  /**
+   * Pre-flight check combining revocation/suspension status and policy.
+   * Fail-open: if a sub-check errors, it is recorded in `reasons` but
+   * does not block. Mirrors the Python `Agent.preflight`.
+   */
+  async preflight(actionType: string): Promise<PreflightResult> {
+    let agentActive = true;
+    let policyAllowed = true;
+    const reasons: string[] = [];
+
+    try {
+      const status = await request<{ revoked?: boolean; suspended?: boolean; suspended_reason?: string }>(
+        "GET",
+        `/agents/${this.agentId}/status`,
+      );
+      if (status.revoked) {
+        agentActive = false;
+        reasons.push("agent is revoked");
+      }
+      if (status.suspended) {
+        agentActive = false;
+        const suffix = status.suspended_reason ? ` (${status.suspended_reason})` : "";
+        reasons.push(`agent is suspended${suffix}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      reasons.push(`status check failed (${msg}) - skipped`);
+    }
+
+    try {
+      const policies = await request<Array<{
+        is_active?: boolean;
+        action_pattern?: string;
+        action?: string;
+        name?: string;
+      }>>("GET", "/policies");
+      const list = Array.isArray(policies) ? policies : [];
+      for (const p of list) {
+        if (!p.is_active) continue;
+        const pattern = p.action_pattern ?? "";
+        const matches = pattern === "*" || actionType.startsWith(pattern.replace(/\*+$/, ""));
+        if (matches && (p.action === "block" || p.action === "block_and_alert")) {
+          policyAllowed = false;
+          reasons.push(`blocked by policy: ${p.name ?? "unknown"}`);
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      reasons.push(`policy check failed (${msg}) - skipped`);
+    }
+
+    const cleared = agentActive && policyAllowed;
+    let explanation: string;
+    if (cleared) {
+      explanation = "Allowed: agent is active and action is permitted by policy";
+    } else if (!agentActive && reasons.includes("agent is revoked")) {
+      explanation = "Blocked: agent has been revoked";
+    } else if (!agentActive && reasons.some((r) => r.startsWith("agent is suspended"))) {
+      const suspendReason = reasons.find((r) => r.startsWith("agent is suspended")) ?? "";
+      explanation = `Blocked: ${suspendReason}`;
+    } else if (!policyAllowed) {
+      explanation = "Blocked: action not permitted by current policy rules";
+    } else {
+      explanation = reasons.length ? `Blocked: ${reasons.join("; ")}` : "Blocked";
+    }
+
+    return { cleared, agentActive, policyAllowed, reasons, explanation };
   }
 }
 

--- a/typescript/tests/budget.test.ts
+++ b/typescript/tests/budget.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  Agent,
+  BudgetTracker,
+  _resetForTests,
+  init,
+} from "../src/index.js";
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_1",
+    name: "test",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-01-01T00:00:00Z",
+  });
+}
+
+describe("BudgetTracker", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects negative or non-finite limit", () => {
+    expect(() => new BudgetTracker({ agent: makeAgent(), limit: -1 })).toThrow();
+    expect(() => new BudgetTracker({ agent: makeAgent(), limit: Number.POSITIVE_INFINITY })).toThrow();
+    expect(() => new BudgetTracker({ agent: makeAgent(), limit: Number.NaN })).toThrow();
+  });
+
+  it("check() allows costs within remaining budget", () => {
+    const b = new BudgetTracker({ agent: makeAgent(), limit: 10 });
+    const r = b.check(3);
+    expect(r.allowed).toBe(true);
+    expect(r.remaining).toBe(7);
+    expect(r.reason).toBeUndefined();
+  });
+
+  it("check() blocks costs that exceed remaining budget with reason budget_exhausted", () => {
+    const b = new BudgetTracker({ agent: makeAgent(), limit: 10 });
+    const r = b.check(11);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("budget_exhausted");
+  });
+
+  it("check() fail-closes on negative / NaN / infinite costs", () => {
+    const b = new BudgetTracker({ agent: makeAgent(), limit: 10 });
+    expect(b.check(-1).reason).toBe("invalid_cost");
+    expect(b.check(Number.NaN).reason).toBe("invalid_cost");
+    expect(b.check(Number.POSITIVE_INFINITY).reason).toBe("invalid_cost");
+  });
+
+  it("record() signs a budget:* action and updates cumulative spend", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockJsonResponse({
+        signature: "sig_data",
+        signature_id: "sig_1",
+        action_id: "act_1",
+        timestamp: "2026-05-01T00:00:00Z",
+        verification_url: "https://x/y",
+      }),
+    );
+    const b = new BudgetTracker({ agent: makeAgent(), limit: 10, currency: "USD" });
+
+    const sig = await b.record("api:openai", 0.42, { model: "gpt-4" });
+
+    expect(sig.signatureId).toBe("sig_1");
+    const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(calledInit.body as string);
+    expect(body.action_type).toBe("budget:api:openai");
+    expect(body.context.cost).toBe(0.42);
+    expect(body.context.currency).toBe("USD");
+    expect(body.context.cumulative_spend).toBe(0.42);
+    expect(body.context.limit).toBe(10);
+    expect(body.context.model).toBe("gpt-4");
+
+    expect(b.status().spend).toBeCloseTo(0.42);
+    expect(b.status().records).toBe(1);
+  });
+
+  it("record() refuses negative / non-finite costs", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockJsonResponse({}));
+    const b = new BudgetTracker({ agent: makeAgent(), limit: 10 });
+    await expect(b.record("api:openai", -1)).rejects.toThrow();
+    await expect(b.record("api:openai", Number.NaN)).rejects.toThrow();
+  });
+});

--- a/typescript/tests/preflight.test.ts
+++ b/typescript/tests/preflight.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Agent, _resetForTests, init } from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_1",
+    name: "test",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-01-01T00:00:00Z",
+  });
+}
+
+describe("Agent.preflight", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("clears active agent with no blocking policy", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ revoked: false, suspended: false }))
+      .mockResolvedValueOnce(jsonResponse([
+        { is_active: true, action_pattern: "data:*", action: "log", name: "audit" },
+      ]));
+
+    const r = await makeAgent().preflight("data:read");
+
+    expect(r.cleared).toBe(true);
+    expect(r.agentActive).toBe(true);
+    expect(r.policyAllowed).toBe(true);
+    expect(r.explanation).toMatch(/Allowed/);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("blocks when agent is revoked", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ revoked: true, suspended: false }))
+      .mockResolvedValueOnce(jsonResponse([]));
+
+    const r = await makeAgent().preflight("data:read");
+
+    expect(r.cleared).toBe(false);
+    expect(r.agentActive).toBe(false);
+    expect(r.reasons).toContain("agent is revoked");
+    expect(r.explanation).toMatch(/revoked/);
+  });
+
+  it("blocks when a matching policy has action=block", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ revoked: false, suspended: false }))
+      .mockResolvedValueOnce(jsonResponse([
+        { is_active: true, action_pattern: "data:*", action: "block", name: "no-data-access" },
+      ]));
+
+    const r = await makeAgent().preflight("data:read");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+    expect(r.reasons.some((s) => s.includes("no-data-access"))).toBe(true);
+    expect(r.explanation).toMatch(/policy/);
+  });
+
+  it("fail-open: status check error does not block on its own", async () => {
+    let call = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      call += 1;
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      if (url.includes("/status")) {
+        return jsonResponse({ detail: "boom" }, 400);
+      }
+      return jsonResponse([]);
+    });
+
+    const r = await makeAgent().preflight("data:read");
+
+    expect(r.cleared).toBe(true);
+    expect(r.reasons.some((s) => s.includes("status check failed"))).toBe(true);
+    expect(call).toBeGreaterThanOrEqual(2);
+  });
+
+  it("ignores inactive policies", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ revoked: false, suspended: false }))
+      .mockResolvedValueOnce(jsonResponse([
+        { is_active: false, action_pattern: "*", action: "block", name: "disabled-rule" },
+      ]));
+
+    const r = await makeAgent().preflight("data:read");
+    expect(r.cleared).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the TypeScript-vs-Python feature parity gap on two primitives:

- BudgetTracker (new typescript/src/budget.ts): same surface as the Python class. check(estimatedCost) is a fail-closed arithmetic check; record(actionType, actualCost, context?) signs a budget:* action via the underlying agent so the spend trail is itself tamper-evident.
- Agent.preflight(actionType): combines the /agents/{id}/status revoke/suspend check and the /policies block-rule check into a single fail-open PreflightResult with a human-readable explanation. Matches the Python Agent.preflight behavior including the fail-open semantics.

## Changes

- typescript/src/budget.ts - new file
- typescript/src/index.ts - re-export budget primitives, add PreflightResult, add Agent.preflight
- typescript/tests/budget.test.ts - 6 tests
- typescript/tests/preflight.test.ts - 5 tests
- typescript/README.md - API surface section now documents both primitives
- CHANGELOG.md - new TypeScript 0.2.5 entry
- typescript/package.json + lockfile - bump to 0.2.5

## Test plan

- [x] npm test - 103/103 pass (was 92, +11 new)
- [x] npm run lint - tsc --noEmit clean
- [ ] CI green