### PR TITLE
feat(cli): tier gating for Pro/Business commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.3.5] - 2026-05-02
+
+### Added
+- Tier gating for the `asqav` CLI. The Pro-only commands (`replay`, `preflight`, `budget`, `approve`) and Business-only `compliance export` now check the calling org's subscription tier via the new `GET /api/v1/account` endpoint and exit with a clean message + upgrade URL when the tier is insufficient. The server is still the source of truth; this only adds a friendly client-side gate. Older self-hosted deployments without `/account` are unaffected (the gate skips when the endpoint is unreachable).
+- `__version__` in `asqav/__init__.py` realigned with the package version (was drifting at 0.3.1).
+
 ## [TypeScript 0.2.5] - 2026-05-02
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.4"
+version = "0.3.5"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -114,7 +114,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.1"
+__version__ = "0.3.5"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -180,6 +180,7 @@ def replay(
             raise typer.Exit(code=1)
 
         _init_sdk()
+        _require_tier("pro")
 
         from asqav import APIError
         from asqav import replay as replay_api
@@ -281,6 +282,54 @@ def _init_sdk() -> None:
         print("Error: ASQAV_API_KEY environment variable required.")
         raise typer.Exit(code=1)
     asqav.init(api_key=api_key)
+
+
+_TIER_RANK = {"free": 0, "pro": 1, "business": 2, "enterprise": 3}
+
+
+def _fetch_account_tier() -> str | None:
+    """Best-effort lookup of the calling org's subscription tier.
+
+    Returns the lowercase tier string, or None when the server does not
+    expose the endpoint (older deployments) or the call fails. Callers
+    treat None as "skip the gate" - the server still enforces.
+    """
+    try:
+        from asqav.client import _get
+    except Exception:
+        return None
+    try:
+        data = _get("/account")
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    tier = data.get("tier")
+    if not isinstance(tier, str) or not tier:
+        return None
+    return tier.lower()
+
+
+def _require_tier(min_tier: str) -> None:
+    """Block the command when the calling org is below ``min_tier``.
+
+    Skips the gate when the /account endpoint is unreachable so older
+    self-hosted deployments stay functional. The server is still the
+    source of truth - this only gives a clean client-side message.
+    """
+    tier = _fetch_account_tier()
+    if tier is None:
+        return
+    have = _TIER_RANK.get(tier, 0)
+    need = _TIER_RANK.get(min_tier.lower(), 0)
+    if have >= need:
+        return
+    print(
+        f"Error: this command requires the {min_tier.title()} tier "
+        f"(current: {tier}). Upgrade at https://asqav.com/pricing.",
+        file=sys.stderr,
+    )
+    raise typer.Exit(code=2)
 
 
 @app.command()
@@ -538,6 +587,7 @@ def preflight(
     import json as json_mod
 
     _init_sdk()
+    _require_tier("pro")
     from asqav import Agent, APIError
 
     try:
@@ -593,6 +643,7 @@ def budget_check(
     import json as json_mod
 
     _init_sdk()
+    _require_tier("pro")
     from asqav import Agent, BudgetTracker
 
     agent = Agent.get(agent_id)
@@ -639,6 +690,7 @@ def budget_record(
     cumulative spend after the record, and the configured limit.
     """
     _init_sdk()
+    _require_tier("pro")
     from asqav import Agent, APIError, BudgetTracker
 
     try:
@@ -670,6 +722,7 @@ def approve(
     import json as json_mod
 
     _init_sdk()
+    _require_tier("pro")
     from asqav import APIError, approve_action
 
     try:
@@ -725,6 +778,7 @@ def compliance_export(
     Run 'asqav compliance frameworks' to see valid framework keys.
     """
     _init_sdk()
+    _require_tier("business")
     from asqav import APIError
     from asqav.client import get_session_signatures
     from asqav.compliance import export_bundle

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -457,3 +457,85 @@ def test_compliance_export_unknown_framework(
     )
     assert result.exit_code == 1
     assert "nonexistent" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Tier gating
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_pro_command_blocked_on_free_tier(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    """A free-tier API key is blocked at the client when invoking a Pro command."""
+    mock_get.return_value = {"tier": "free", "organization_id": "o", "organization_name": "n"}
+    result = runner.invoke(
+        app,
+        ["preflight", "agt_x", "data:read"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 2
+    assert "Pro" in result.output or "Pro" in result.stderr_bytes.decode() if hasattr(result, "stderr_bytes") else True
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_pro_command_runs_on_pro_tier(
+    mock_init: MagicMock, mock_get_acc: MagicMock, mock_agent_get: MagicMock,
+) -> None:
+    """A pro-tier API key passes the gate."""
+    mock_get_acc.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    mock_agent = MagicMock()
+    mock_agent.preflight.return_value = MagicMock(
+        cleared=True, agent_active=True, policy_allowed=True,
+        reasons=[], explanation="ok",
+    )
+    mock_agent_get.return_value = mock_agent
+    result = runner.invoke(
+        app,
+        ["preflight", "agt_x", "data:read"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_business_command_blocked_on_pro_tier(
+    mock_init: MagicMock, mock_get_acc: MagicMock, mock_agent_get: MagicMock,
+) -> None:
+    """A pro-tier key is blocked from a business-only command."""
+    mock_get_acc.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    result = runner.invoke(
+        app,
+        ["compliance", "export",
+         "--session", "sess_a", "--output", "/tmp/x.json"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 2
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_unreachable_account_endpoint_does_not_block(
+    mock_init: MagicMock, mock_get_acc: MagicMock, mock_agent_get: MagicMock,
+) -> None:
+    """Older self-hosted deployments without /account stay functional."""
+    mock_get_acc.side_effect = Exception("404 Not Found")
+    mock_agent = MagicMock()
+    mock_agent.preflight.return_value = MagicMock(
+        cleared=True, agent_active=True, policy_allowed=True,
+        reasons=[], explanation="ok",
+    )
+    mock_agent_get.return_value = mock_agent
+    result = runner.invoke(
+        app,
+        ["preflight", "agt_x", "data:read"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary

The Python CLI's gated commands (replay, preflight, budget, approve, compliance export) had no client-side tier check. A free-tier user invoking 'asqav preflight' got an opaque 402/403 mid-pipeline. This PR adds a friendly gate that calls GET /api/v1/account once and exits 2 with an upgrade URL when the tier is insufficient. Backend endpoint is added in the asqav repo (companion PR).

## Behavior

- replay / preflight / budget check / budget record / approve - require Pro
- compliance export - requires Business
- /account unreachable (older self-hosted deployments) - gate skips; server remains source of truth

## Test plan

- [x] python/tests/test_cli.py - 31/31 pass (was 27, +4 new for the gate)
- [ ] CI green

Depends on the asqav-repo PR adding GET /api/v1/account.