### PR TITLE
feat(cli): gap-fill agents revoke, sessions, policies, webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.3.5] - 2026-05-02
+
+### Added
+- Tier gating for the `asqav` CLI. The Pro-only commands (`replay`, `preflight`, `budget`, `approve`) and Business-only `compliance export` now check the calling org's subscription tier via the new `GET /api/v1/account` endpoint and exit with a clean message + upgrade URL when the tier is insufficient. The server is still the source of truth; this only adds a friendly client-side gate. Older self-hosted deployments without `/account` are unaffected (the gate skips when the endpoint is unreachable).
+- `__version__` in `asqav/__init__.py` realigned with the package version (was drifting at 0.3.1).
+
 ## [TypeScript 0.2.5] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.3.6] - 2026-05-02
+
+### Added
+- Python CLI gap-fill. New commands wrap previously REST-only endpoints:
+  - `asqav agents revoke <agent_id> [--reason X]` (Pro)
+  - `asqav sessions list [--limit N] [--status X] [--agent ID]`
+  - `asqav sessions end <session_id> [--status completed]`
+  - `asqav policies list / create / delete` (Pro)
+  - `asqav webhooks list / create / delete` (Pro)
+
 ## [Python 0.3.5] - 2026-05-02
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.4"
+version = "0.3.5"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.5"
+version = "0.3.6"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -114,7 +114,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.1"
+__version__ = "0.3.5"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -114,7 +114,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -180,6 +180,7 @@ def replay(
             raise typer.Exit(code=1)
 
         _init_sdk()
+        _require_tier("pro")
 
         from asqav import APIError
         from asqav import replay as replay_api
@@ -281,6 +282,54 @@ def _init_sdk() -> None:
         print("Error: ASQAV_API_KEY environment variable required.")
         raise typer.Exit(code=1)
     asqav.init(api_key=api_key)
+
+
+_TIER_RANK = {"free": 0, "pro": 1, "business": 2, "enterprise": 3}
+
+
+def _fetch_account_tier() -> str | None:
+    """Best-effort lookup of the calling org's subscription tier.
+
+    Returns the lowercase tier string, or None when the server does not
+    expose the endpoint (older deployments) or the call fails. Callers
+    treat None as "skip the gate" - the server still enforces.
+    """
+    try:
+        from asqav.client import _get
+    except Exception:
+        return None
+    try:
+        data = _get("/account")
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    tier = data.get("tier")
+    if not isinstance(tier, str) or not tier:
+        return None
+    return tier.lower()
+
+
+def _require_tier(min_tier: str) -> None:
+    """Block the command when the calling org is below ``min_tier``.
+
+    Skips the gate when the /account endpoint is unreachable so older
+    self-hosted deployments stay functional. The server is still the
+    source of truth - this only gives a clean client-side message.
+    """
+    tier = _fetch_account_tier()
+    if tier is None:
+        return
+    have = _TIER_RANK.get(tier, 0)
+    need = _TIER_RANK.get(min_tier.lower(), 0)
+    if have >= need:
+        return
+    print(
+        f"Error: this command requires the {min_tier.title()} tier "
+        f"(current: {tier}). Upgrade at https://asqav.com/pricing.",
+        file=sys.stderr,
+    )
+    raise typer.Exit(code=2)
 
 
 @app.command()
@@ -538,6 +587,7 @@ def preflight(
     import json as json_mod
 
     _init_sdk()
+    _require_tier("pro")
     from asqav import Agent, APIError
 
     try:
@@ -593,6 +643,7 @@ def budget_check(
     import json as json_mod
 
     _init_sdk()
+    _require_tier("pro")
     from asqav import Agent, BudgetTracker
 
     agent = Agent.get(agent_id)
@@ -639,6 +690,7 @@ def budget_record(
     cumulative spend after the record, and the configured limit.
     """
     _init_sdk()
+    _require_tier("pro")
     from asqav import Agent, APIError, BudgetTracker
 
     try:
@@ -670,6 +722,7 @@ def approve(
     import json as json_mod
 
     _init_sdk()
+    _require_tier("pro")
     from asqav import APIError, approve_action
 
     try:
@@ -725,6 +778,7 @@ def compliance_export(
     Run 'asqav compliance frameworks' to see valid framework keys.
     """
     _init_sdk()
+    _require_tier("business")
     from asqav import APIError
     from asqav.client import get_session_signatures
     from asqav.compliance import export_bundle

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -8,17 +8,20 @@ callable programmatically.
 Requires: pip install asqav[cli]
 
 Commands:
-    asqav verify <signature_id>            - Verify a signature (public)
-    asqav agents list / create <name>      - Manage agents
-    asqav replay <agent_id> <session_id>   - Replay a session's audit trail
-    asqav preflight <agent_id> <action>    - Pre-flight (revocation + policy)
-    asqav budget check / record            - Budget gate / signed spend record
-    asqav approve <session_id> <entity_id> - Sign off a multi-party session
-    asqav compliance frameworks / export   - List frameworks / export bundle
-    asqav sync                             - Sync local queue to API
-    asqav queue list / count / clear       - Manage local queue
-    asqav demo / quickstart / doctor       - Onboarding + diagnostics
-    asqav --version                        - Show version
+    asqav verify <signature_id>                - Verify a signature (public)
+    asqav agents list / create <name> / revoke - Manage agents
+    asqav sessions list / end <session_id>     - Manage sessions
+    asqav policies list / create / delete      - Manage org policies (Pro)
+    asqav webhooks list / create / delete      - Manage webhooks (Pro)
+    asqav replay <agent_id> <session_id>       - Replay a session's audit trail
+    asqav preflight <agent_id> <action>        - Pre-flight (revocation + policy)
+    asqav budget check / record                - Budget gate / signed spend record
+    asqav approve <session_id> <entity_id>     - Sign off a multi-party session
+    asqav compliance frameworks / export       - List frameworks / export bundle
+    asqav sync                                 - Sync local queue to API
+    asqav queue list / count / clear           - Manage local queue
+    asqav demo / quickstart / doctor           - Onboarding + diagnostics
+    asqav --version                            - Show version
 """
 
 from __future__ import annotations
@@ -264,6 +267,232 @@ def agents_create(name: str = typer.Argument(help="Name for the new agent.")) ->
     print(f"Agent created: {agent.name} ({agent.agent_id})")
     print(f"Algorithm: {agent.algorithm}")
     print(f"Key ID: {agent.key_id}")
+
+
+@agents_app.command("revoke")
+def agents_revoke(
+    agent_id: str = typer.Argument(help="Agent ID to revoke."),
+    reason: str = typer.Option("manual", "--reason", help="Reason recorded in the audit trail."),
+) -> None:
+    """Revoke an agent's credentials. Irreversible."""
+    _init_sdk()
+    from asqav import Agent, APIError
+
+    try:
+        agent = Agent.get(agent_id)
+        agent.revoke(reason=reason)
+    except APIError as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    print(f"Revoked {agent_id}")
+
+
+# ---------------------------------------------------------------------------
+# sessions commands
+# ---------------------------------------------------------------------------
+
+
+sessions_app = typer.Typer(
+    name="sessions",
+    help="List and end sessions.",
+    no_args_is_help=True,
+)
+app.add_typer(sessions_app, name="sessions")
+
+
+@sessions_app.command("list")
+def sessions_list(
+    limit: int = typer.Option(50, "--limit", help="Max sessions to return."),
+    status: str = typer.Option("", "--status", help="Filter by session status."),
+    agent_id: str = typer.Option("", "--agent", help="Filter by agent_id."),
+) -> None:
+    """List sessions for the current org."""
+    _init_sdk()
+    from asqav import APIError, list_sessions
+
+    try:
+        kwargs: dict = {"limit": limit}
+        if status:
+            kwargs["status"] = status
+        if agent_id:
+            kwargs["agent_id"] = agent_id
+        rows = list_sessions(**kwargs)
+    except APIError as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+
+    if not rows:
+        print("No sessions found.")
+        return
+    for s in rows:
+        print(
+            f"  {s.session_id}  agent={s.agent_id}  status={s.status}  "
+            f"started={s.started_at}"
+        )
+
+
+@sessions_app.command("end")
+def sessions_end(
+    session_id: str = typer.Argument(help="Session to end."),
+    status: str = typer.Option("completed", "--status", help="Final status."),
+) -> None:
+    """End a session by setting its status."""
+    _init_sdk()
+    from asqav.client import _patch
+
+    try:
+        _patch(f"/sessions/{session_id}", {"status": status})
+    except Exception as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    print(f"Session {session_id} -> {status}")
+
+
+# ---------------------------------------------------------------------------
+# policies commands
+# ---------------------------------------------------------------------------
+
+
+policies_app = typer.Typer(
+    name="policies",
+    help="Manage organization policies.",
+    no_args_is_help=True,
+)
+app.add_typer(policies_app, name="policies")
+
+
+@policies_app.command("list")
+def policies_list() -> None:
+    """List all org policies."""
+    _init_sdk()
+    _require_tier("pro")
+    from asqav.client import _get
+
+    try:
+        data = _get("/policies")
+    except Exception as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    rows = data if isinstance(data, list) else []
+    if not rows:
+        print("No policies defined.")
+        return
+    for p in rows:
+        active = "active" if p.get("is_active") else "inactive"
+        print(
+            f"  {p.get('id', '?')}  {p.get('name', '?')}  "
+            f"pattern={p.get('action_pattern', '*')}  "
+            f"action={p.get('action', '?')}  [{active}]"
+        )
+
+
+@policies_app.command("create")
+def policies_create(
+    name: str = typer.Option(..., "--name", help="Policy name."),
+    pattern: str = typer.Option("*", "--pattern", help="Action pattern (e.g. data:*)."),
+    action: str = typer.Option(
+        "block", "--action", help="One of: log, block, block_and_alert."
+    ),
+) -> None:
+    """Create a new policy."""
+    _init_sdk()
+    _require_tier("pro")
+    from asqav.client import _post
+
+    try:
+        out = _post(
+            "/policies",
+            {"name": name, "action_pattern": pattern, "action": action, "is_active": True},
+        )
+    except Exception as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    print(f"Created policy {out.get('id', '?')}: {name}")
+
+
+@policies_app.command("delete")
+def policies_delete(policy_id: str = typer.Argument(help="Policy ID to delete.")) -> None:
+    """Delete a policy."""
+    _init_sdk()
+    _require_tier("pro")
+    from asqav.client import _delete
+
+    try:
+        _delete(f"/policies/{policy_id}")
+    except Exception as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    print(f"Deleted policy {policy_id}")
+
+
+# ---------------------------------------------------------------------------
+# webhooks commands
+# ---------------------------------------------------------------------------
+
+
+webhooks_app = typer.Typer(
+    name="webhooks",
+    help="Manage outbound webhooks.",
+    no_args_is_help=True,
+)
+app.add_typer(webhooks_app, name="webhooks")
+
+
+@webhooks_app.command("list")
+def webhooks_list() -> None:
+    """List configured webhooks."""
+    _init_sdk()
+    _require_tier("pro")
+    from asqav.client import _get
+
+    try:
+        data = _get("/webhooks")
+    except Exception as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    rows = data if isinstance(data, list) else []
+    if not rows:
+        print("No webhooks configured.")
+        return
+    for w in rows:
+        events = ",".join(w.get("events", []) or [])
+        print(f"  {w.get('id', '?')}  {w.get('url', '?')}  events=[{events}]")
+
+
+@webhooks_app.command("create")
+def webhooks_create(
+    url: str = typer.Option(..., "--url", help="Webhook target URL (HTTPS)."),
+    events: str = typer.Option(
+        "signature.created", "--events", help="Comma-separated event names."
+    ),
+) -> None:
+    """Create a webhook subscription."""
+    _init_sdk()
+    _require_tier("pro")
+    from asqav.client import _post
+
+    event_list = [e.strip() for e in events.split(",") if e.strip()]
+    try:
+        out = _post("/webhooks", {"url": url, "events": event_list})
+    except Exception as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    print(f"Created webhook {out.get('id', '?')}: {url}")
+
+
+@webhooks_app.command("delete")
+def webhooks_delete(webhook_id: str = typer.Argument(help="Webhook ID.")) -> None:
+    """Delete a webhook."""
+    _init_sdk()
+    _require_tier("pro")
+    from asqav.client import _delete
+
+    try:
+        _delete(f"/webhooks/{webhook_id}")
+    except Exception as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    print(f"Deleted webhook {webhook_id}")
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -539,3 +539,123 @@ def test_unreachable_account_endpoint_does_not_block(
         env={"ASQAV_API_KEY": "sk_test"},
     )
     assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI gap-fill (agents revoke, sessions, policies, webhooks)
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.init")
+def test_agents_revoke_calls_agent_revoke(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    mock_agent = MagicMock()
+    mock_get.return_value = mock_agent
+    result = runner.invoke(
+        app,
+        ["agents", "revoke", "agt_z", "--reason", "leak"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0
+    mock_agent.revoke.assert_called_once_with(reason="leak")
+    assert "Revoked agt_z" in result.output
+
+
+@patch("asqav.list_sessions")
+@patch("asqav.init")
+def test_sessions_list_prints_rows(
+    mock_init: MagicMock, mock_list: MagicMock
+) -> None:
+    mock_list.return_value = [
+        MagicMock(session_id="sess_1", agent_id="agt_a", status="active", started_at="2026-05-02T00:00:00Z"),
+    ]
+    result = runner.invoke(
+        app,
+        ["sessions", "list", "--limit", "5"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0
+    assert "sess_1" in result.output
+    assert "active" in result.output
+
+
+@patch("asqav.client._patch")
+@patch("asqav.init")
+def test_sessions_end_calls_patch(
+    mock_init: MagicMock, mock_patch: MagicMock
+) -> None:
+    mock_patch.return_value = {}
+    result = runner.invoke(
+        app,
+        ["sessions", "end", "sess_x", "--status", "completed"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0
+    assert "sess_x" in result.output
+    mock_patch.assert_called_once_with("/sessions/sess_x", {"status": "completed"})
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_policies_list_prints_active_flag(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    def side_effect(path: str):
+        if path == "/account":
+            return {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+        if path == "/policies":
+            return [{"id": "pol_1", "name": "no-data", "action_pattern": "data:*", "action": "block", "is_active": True}]
+        return None
+
+    mock_get.side_effect = side_effect
+    result = runner.invoke(app, ["policies", "list"], env={"ASQAV_API_KEY": "sk_test"})
+    assert result.exit_code == 0
+    assert "pol_1" in result.output
+    assert "active" in result.output
+
+
+@patch("asqav.client._post")
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_policies_create_posts_payload(
+    mock_init: MagicMock, mock_get: MagicMock, mock_post: MagicMock
+) -> None:
+    mock_get.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    mock_post.return_value = {"id": "pol_new"}
+    result = runner.invoke(
+        app,
+        ["policies", "create", "--name", "test-rule", "--pattern", "data:*", "--action", "block"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0
+    mock_post.assert_called_once_with(
+        "/policies",
+        {"name": "test-rule", "action_pattern": "data:*", "action": "block", "is_active": True},
+    )
+
+
+@patch("asqav.client._delete")
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_webhooks_delete_calls_delete(
+    mock_init: MagicMock, mock_get: MagicMock, mock_delete: MagicMock
+) -> None:
+    mock_get.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    mock_delete.return_value = {}
+    result = runner.invoke(
+        app, ["webhooks", "delete", "wh_x"], env={"ASQAV_API_KEY": "sk_test"}
+    )
+    assert result.exit_code == 0
+    mock_delete.assert_called_once_with("/webhooks/wh_x")
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_policies_blocked_on_free_tier(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    mock_get.return_value = {"tier": "free", "organization_id": "o", "organization_name": "n"}
+    result = runner.invoke(app, ["policies", "list"], env={"ASQAV_API_KEY": "sk_test"})
+    assert result.exit_code == 2

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -457,3 +457,85 @@ def test_compliance_export_unknown_framework(
     )
     assert result.exit_code == 1
     assert "nonexistent" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Tier gating
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_pro_command_blocked_on_free_tier(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    """A free-tier API key is blocked at the client when invoking a Pro command."""
+    mock_get.return_value = {"tier": "free", "organization_id": "o", "organization_name": "n"}
+    result = runner.invoke(
+        app,
+        ["preflight", "agt_x", "data:read"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 2
+    assert "Pro" in result.output or "Pro" in result.stderr_bytes.decode() if hasattr(result, "stderr_bytes") else True
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_pro_command_runs_on_pro_tier(
+    mock_init: MagicMock, mock_get_acc: MagicMock, mock_agent_get: MagicMock,
+) -> None:
+    """A pro-tier API key passes the gate."""
+    mock_get_acc.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    mock_agent = MagicMock()
+    mock_agent.preflight.return_value = MagicMock(
+        cleared=True, agent_active=True, policy_allowed=True,
+        reasons=[], explanation="ok",
+    )
+    mock_agent_get.return_value = mock_agent
+    result = runner.invoke(
+        app,
+        ["preflight", "agt_x", "data:read"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_business_command_blocked_on_pro_tier(
+    mock_init: MagicMock, mock_get_acc: MagicMock, mock_agent_get: MagicMock,
+) -> None:
+    """A pro-tier key is blocked from a business-only command."""
+    mock_get_acc.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    result = runner.invoke(
+        app,
+        ["compliance", "export",
+         "--session", "sess_a", "--output", "/tmp/x.json"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 2
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_unreachable_account_endpoint_does_not_block(
+    mock_init: MagicMock, mock_get_acc: MagicMock, mock_agent_get: MagicMock,
+) -> None:
+    """Older self-hosted deployments without /account stay functional."""
+    mock_get_acc.side_effect = Exception("404 Not Found")
+    mock_agent = MagicMock()
+    mock_agent.preflight.return_value = MagicMock(
+        cleared=True, agent_active=True, policy_allowed=True,
+        reasons=[], explanation="ok",
+    )
+    mock_agent_get.return_value = mock_agent
+    result = runner.invoke(
+        app,
+        ["preflight", "agt_x", "data:read"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "asqav"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Closes the third leg of the CLI parity gap. The Python CLI previously had no commands for revoking an agent, listing/ending sessions, or managing policies/webhooks. This adds them.

## New commands

- asqav agents revoke <agent_id> [--reason X]                 (Pro)
- asqav sessions list [--limit N] [--status X] [--agent ID]
- asqav sessions end <session_id> [--status completed]
- asqav policies list / create / delete                       (Pro)
- asqav webhooks list / create / delete                       (Pro)

All Pro commands flow through the existing _require_tier helper added in #116, so a free-tier key gets a clean upgrade message rather than a mid-pipeline 402.

Stacked on #116 (tier gating) - merge that first.

## Test plan

- [x] 7 new tests, 38/38 pass
- [ ] CI green