### PR TITLE
docs: publish public roadmap (Today vs Coming)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ What ships next on Asqav. "Today" means available on `main`. "Coming" means on t
 
 **3. Bring-your-own KMS (AWS KMS / GCP KMS)** - Enterprise tier
 - WHAT: Bring-your-own KMS. Provision your agents' ML-DSA-65 keys in your own AWS KMS or GCP KMS so signing material lives in your HSM, not ours.
-- WHY NOW: AWS KMS uses the `ML_DSA_65` key spec on FIPS 140-3 Level 3 HSMs; GCP KMS uses `PQ_SIGN_ML_DSA_65` (PQC preview). Toggle with `KMS_PROVIDER=aws|gcp`.
+- WHY NOW: AWS KMS uses the `ML_DSA_65` key spec on FIPS 140-3 Level 3 HSMs; GCP KMS uses `PQ_SIGN_ML_DSA_65` (currently in software preview, HSM coming). Toggle with `KMS_PROVIDER=aws|gcp`.
 
 **4. Customer-owned storage**
 - WHAT: Customer-owned storage on self-hosted. Postgres, Redis, raw payloads, and ML-DSA private keys all sit in your container. Optional upstream relay only ever sees `{hash, signature, timestamp, algorithm, agent_id, signature_id}`.
@@ -137,7 +137,7 @@ What ships next on Asqav. "Today" means available on `main`. "Coming" means on t
 ### Coming
 
 **5. SCITT / COSE receipt export**
-- WHAT: Same ML-DSA-65 signature you get today, wrapped in a COSE_Sign1 structure so it can be ingested by IETF SCITT transparency services.
+- WHAT: A SCITT-compatible receipt format alongside the current JCS receipt. The same ML-DSA-65 key signs both; the COSE_Sign1 variant signs the CBOR Sig_structure so SCITT transparency services can ingest it.
 - WHY NOW: Receipt format and canonical record are already deterministic. The remaining work is a CBOR encoder and a SCITT registration policy. Tracking the IETF SCITT-Architecture and COSE Receipts drafts.
 
 **6. Air-gapped / on-prem mode**

--- a/README.md
+++ b/README.md
@@ -112,6 +112,40 @@ await init({ apiKey: "...", baseUrl: "https://api.asqav.com", mode: "hash-only" 
 
 The fingerprint format is RFC 8785-style sorted JSON with no whitespace, hashed with SHA-256. See `docs/fingerprint-spec.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
 
+## Roadmap
+
+What ships next on Asqav. "Today" means available on `main`. "Coming" means on the roadmap, not yet shipped.
+
+### Today
+
+**1. Hash-only mode for cloud**
+- WHAT: Hash-only mode on cloud. The SDK hashes `{action_type, context}` locally with RFC 8785 + SHA-256 and sends only the hash plus a small whitelisted metadata bag.
+- WHY NOW: Default for any client pointed at api.asqav.com. Raw prompts and tool arguments never leave your process. Spec is open in `docs/fingerprint-spec.md` and cross-language vectors ship in `conformance/vectors.json`.
+
+**2. Self-hosted signer (split-trust)**
+- WHAT: Self-hosted signer container. Run the Asqav signing path inside your VPC; ML-DSA-65 private keys, raw prompts, and reasoning traces never cross the container boundary.
+- WHY NOW: Compose file and env contract documented in the Asqav backend repo at `docker-compose.signer.yml` and `docs/self-hosted-signer.md`. Optional digest-only relay back to `api.asqav.com` is gated by a fixed allowlist enforced in code.
+
+**3. Bring-your-own KMS (AWS KMS / GCP KMS)** - Enterprise tier
+- WHAT: Bring-your-own KMS. Provision your agents' ML-DSA-65 keys in your own AWS KMS or GCP KMS so signing material lives in your HSM, not ours.
+- WHY NOW: AWS KMS uses the `ML_DSA_65` key spec on FIPS 140-3 Level 3 HSMs; GCP KMS uses `PQ_SIGN_ML_DSA_65` (PQC preview). Toggle with `KMS_PROVIDER=aws|gcp`.
+
+**4. Customer-owned storage**
+- WHAT: Customer-owned storage on self-hosted. Postgres, Redis, raw payloads, and ML-DSA private keys all sit in your container. Optional upstream relay only ever sees `{hash, signature, timestamp, algorithm, agent_id, signature_id}`.
+- WHY NOW: The allowlist is enforced in code at `src/asqav_cloud/core/signer_relay.py` (Asqav backend repo) and asserted by `tests/test_self_hosted_signer.py`. Auditors can read the forbidden-keys frozenset and confirm what cannot leak.
+
+### Coming
+
+**5. SCITT / COSE receipt export**
+- WHAT: Same ML-DSA-65 signature you get today, wrapped in a COSE_Sign1 structure so it can be ingested by IETF SCITT transparency services.
+- WHY NOW: Receipt format and canonical record are already deterministic. The remaining work is a CBOR encoder and a SCITT registration policy. Tracking the IETF SCITT-Architecture and COSE Receipts drafts.
+
+**6. Air-gapped / on-prem mode**
+- WHAT: Self-hosted signer with offline license validation, zero outbound HTTP, and a packaged update channel.
+- WHY NOW: The signer container already runs without AWS, GCP, or Bitcoin dependencies. Remaining gap is offline license validation and a fully-vendored timestamping path. Targeted at regulated EU institutions with no-egress requirements.
+
+Full roadmap page: <https://asqav.com/roadmap>.
+
 ## Why governance
 
 | Without governance | With Asqav |

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,64 @@
+# asqav
+
+Python SDK for [asqav.com](https://asqav.com). All ML-DSA cryptography runs server-side. Drop-in for AI agent governance: audit trails, policy enforcement, compliance.
+
+## Install
+
+```bash
+pip install asqav
+```
+
+## Quick start
+
+```python
+import asqav
+
+asqav.init(api_key="sk_...")
+agent = asqav.Agent.create("my-agent")
+sig = agent.sign("api:call", {"model": "gpt-4"})
+
+print(sig.verification_url)
+```
+
+Each signed action is recorded server-side with an ML-DSA-65 (FIPS 204) signature, a chain hash, and a public verification URL.
+
+## CLI
+
+The package ships an `asqav` CLI mirroring the Python API. Set `ASQAV_API_KEY` and run:
+
+```bash
+asqav verify <signature_id>
+asqav agents list / create / revoke
+asqav sessions list / end
+asqav replay <agent_id> <session_id>          # Pro
+asqav preflight <agent_id> <action_type>      # Pro
+asqav budget check / record                   # Pro
+asqav approve <session_id> <entity_id>        # Pro
+asqav compliance frameworks / export          # Business
+asqav policies / webhooks list / create / delete   # Pro
+```
+
+Pro and Business commands are gated client-side via `GET /account` so a free-tier key gets a clean upgrade message instead of a mid-pipeline 402.
+
+## Roadmap
+
+Six-line view of what is shipped and what is next on Asqav:
+
+- Hash-only mode for cloud - Today (default for `*.asqav.com`).
+- Self-hosted signer (split-trust) - Today.
+- Bring-your-own KMS (AWS KMS / GCP KMS) - Today, Enterprise tier.
+- Customer-owned storage - Today (self-hosted; relay payload allowlist enforced in code).
+- SCITT / COSE receipt export - Coming.
+- Air-gapped / on-prem mode - Coming.
+
+Full detail with file citations is in the [root README](https://github.com/jagmarques/asqav-sdk#roadmap) and at <https://asqav.com/roadmap>.
+
+## Documentation
+
+- Repository: <https://github.com/jagmarques/asqav-sdk>
+- Full docs: <https://asqav.com/docs>
+- Roadmap: <https://asqav.com/roadmap>
+
+## License
+
+MIT. Get an API key at [asqav.com](https://asqav.com).

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "asqav"
 version = "0.3.6"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
-readme = { text = "AI agent governance SDK. See https://github.com/jagmarques/asqav-sdk for full documentation.", content-type = "text/markdown" }
+readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -179,6 +179,19 @@ All thrown errors extend `AsqavError`. `AuthenticationError`, `RateLimitError`, 
 
 Node 18 or newer. Uses the built-in `fetch`. No transitive runtime dependencies.
 
+## Roadmap
+
+Six-line view of what is shipped and what is next on Asqav:
+
+- Hash-only mode for cloud - Today (default for `*.asqav.com`).
+- Self-hosted signer (split-trust) - Today (compose file in the Asqav backend repo).
+- Bring-your-own KMS (AWS KMS / GCP KMS) - Today, Enterprise tier.
+- Customer-owned storage - Today (self-hosted; relay payload allowlist enforced in code).
+- SCITT / COSE receipt export - Coming.
+- Air-gapped / on-prem mode - Coming.
+
+Full detail with file citations lives in the [root README roadmap section](../README.md#roadmap) and at <https://asqav.com/roadmap>.
+
 ## License
 
 MIT. Get an API key at [asqav.com](https://asqav.com).


### PR DESCRIPTION
## Summary

Mirrors the asqav repo roadmap so npm and PyPI viewers see the same picture.

## Files

- README.md: new ## Roadmap section after ## Data handling modes
- typescript/README.md: short mini-roadmap above License with a link to the root README

## Items (canonical names, identical across both repos)

**Today (shipped on main):**
- Hash-only mode for cloud
- Self-hosted signer (split-trust)
- Bring-your-own KMS, AWS KMS / GCP KMS, Enterprise tier
- Customer-owned storage

**Coming:**
- SCITT / COSE receipt export
- Air-gapped / on-prem mode

Companion PR: jagmarques/asqav#99 (website + repo README + docs cross-refs)