### PR TITLE
fix(python): sync __version__ with pyproject.toml; 0.3.8 release

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.7"
+version = "0.3.8"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -117,7 +117,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.6"
+__version__ = "0.3.8"
 __all__ = [
     # Initialization
     "init",


### PR DESCRIPTION
## Summary
PyPI 0.3.7 ships with a stale `__version__ = "0.3.6"` baked in (pyproject.toml says 0.3.7, but `python/src/asqav/__init__.py` was never bumped). Caught by post-publish smoke test:

```
$ pip install asqav==0.3.7
$ python -c "import asqav; print(asqav.__version__)"
0.3.6
```

PyPI does not allow re-uploading a version, so this PR ships 0.3.8 with both the pyproject and the runtime constant in sync. PyPI 0.3.8 is already published.

## Test plan
- [x] `grep version python/pyproject.toml` -> 0.3.8
- [x] `grep __version__ python/src/asqav/__init__.py` -> 0.3.8
- [x] `pip install asqav==0.3.8 && python -c "import asqav; print(asqav.__version__)"` -> 0.3.8 (run after PR merge).