### PR TITLE
docs(readme): add Standards section linking the IETF profile draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ What ships on Asqav today. Each item is available on `main`.
 
 See the docs at <https://asqav.com/docs> for the current feature set.
 
+## Standards
+
+Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/), an Independent Submission that profiles [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) for EU AI Act Articles 12 and 26, and DORA Article 17 bindings.
+
 ## Why governance
 
 | Without governance | With Asqav |

--- a/python/README.md
+++ b/python/README.md
@@ -53,6 +53,10 @@ Six-line view of what is shipped on Asqav:
 
 See the docs at <https://asqav.com/docs> for the current feature set.
 
+## Standards
+
+Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/), profiling the upstream [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) for EU AI Act Articles 12 and 26, and DORA Article 17 bindings.
+
 ## Documentation
 
 - Repository: <https://github.com/jagmarques/asqav-sdk>

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -192,6 +192,10 @@ Six-line view of what is shipped on Asqav:
 
 See the docs at <https://asqav.com/docs> for the current feature set.
 
+## Standards
+
+Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/), profiling the upstream [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) for EU AI Act Articles 12 and 26, and DORA Article 17 bindings.
+
 ## License
 
 MIT. Get an API key at [asqav.com](https://asqav.com).


### PR DESCRIPTION
## Summary

Adds a Standards section to the three README files in this monorepo, linking to the live IETF Internet-Draft `draft-marques-asqav-compliance-receipts-00` (Datatracker submission today).

- `README.md` (root)
- `python/README.md`
- `typescript/README.md`

The draft profiles `draft-farley-acta-signed-receipts` for EU AI Act Articles 12 and 26, and DORA Article 17 bindings.

Datatracker: https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/

## Test plan
- [x] CI green (no code changes)