### PR TITLE
feat(python): IETF Compliance Receipts profile (close MUST/SHOULD gaps)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -57,6 +57,37 @@ See the docs at <https://asqav.com/docs> for the current feature set.
 
 Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/), profiling the upstream [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) for EU AI Act Articles 12 and 26, and DORA Article 17 bindings.
 
+## Compliance receipts (IETF profile)
+
+Pass `compliance_mode=True` to `agent.sign(...)` to emit a Compliance Receipt under [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/). The SDK fills `action_ref` automatically (`sha256:` over the JCS-canonical action object) so callers only need to supply policy-relevant context.
+
+```python
+import asqav
+
+asqav.init(api_key="sk_...")
+agent = asqav.Agent.create("payments-agent")
+
+sig = agent.sign(
+    "payment.wire_transfer",
+    {"amount_eur": 850000, "beneficiary_iban": "DE89370400440532013000"},
+    compliance_mode=True,
+    receipt_type="protectmcp:decision",
+    risk_class="high",
+    issuer_id="legal:Acme GmbH",
+    iteration_id="task-2026-Q2-4821",
+    sandbox_state="enabled",
+)
+
+print(sig.compliance_mode)        # True
+print(sig.receipt_type)           # "protectmcp:decision"
+print(sig.action_ref)             # "sha256:..."
+print(sig.previous_receipt_hash)  # 64 hex; "0"*64 on the first record per agent
+```
+
+Local-side sanity checks (presence of REQUIRED fields, namespace, 300s skew bound, predecessor rederivation) are available as `asqav.verify_compliance_receipt(envelope, predecessor_envelope=...)`. The cloud is the authoritative verifier; this helper is a convenience.
+
+Algorithm agility per profile section 10.8 is exposed via `asqav.SUPPORTED_ALGORITHMS`. Pass `algorithm="ed25519"` or `"es256"` to `Agent.create(...)` for non-post-quantum identities, or `asqav.generate_local_keypair("ed25519")` for offline scenarios.
+
 ## Documentation
 
 - Repository: <https://github.com/jagmarques/asqav-sdk>

--- a/python/README.md
+++ b/python/README.md
@@ -27,18 +27,30 @@ Each signed action is recorded server-side with an ML-DSA-65 (FIPS 204) signatur
 The package ships an `asqav` CLI mirroring the Python API. Set `ASQAV_API_KEY` and run:
 
 ```bash
-asqav verify <signature_id>
+asqav verify <signature_id> [--output json]   # IETF axes when present
+asqav sign --agent-id ID --action-type T --action-json action.json \
+           --compliance-mode --receipt-type protectmcp:decision \
+           --risk-class high --issuer-id legal:Acme
 asqav agents list / create / revoke
 asqav sessions list / end
 asqav replay <agent_id> <session_id>          # Pro
+asqav replay-verify <agent_id> <session_id> [--strict]   # IETF chain
 asqav preflight <agent_id> <action_type>      # Pro
 asqav budget check / record                   # Pro
 asqav approve <session_id> <entity_id>        # Pro
 asqav compliance frameworks / export          # Business
+asqav audit-pack export --start ISO --end ISO --output-file bundle.json
+asqav audit-pack policy <sha256:hex>
+asqav payloads erase <signature_id>           # P4: GDPR right-to-erasure
+asqav org set-compliance-strict <org_id> --enable|--disable
+asqav keys generate --algorithm ed25519|es256 [--out priv.pem]
+asqav migrate run v3-20|v3-21|v3-22           # X-Maintenance-Key required
 asqav policies / webhooks list / create / delete   # Pro
 ```
 
 Pro and Business commands are gated client-side via `GET /account` so a free-tier key gets a clean upgrade message instead of a mid-pipeline 402.
+
+The IETF Compliance Receipts profile commands (`sign --compliance-mode`, `audit-pack export`, `audit-pack policy`, `payloads erase`, `replay-verify --strict`, `org set-compliance-strict`) match the SDK kwargs on `Agent.sign(...)` and `verify_compliance_receipt(...)`. See `docs/CLI.md` for full flag reference.
 
 ## Roadmap
 

--- a/python/docs/CLI.md
+++ b/python/docs/CLI.md
@@ -1,0 +1,129 @@
+# `asqav` CLI reference
+
+The `asqav` CLI ships in the `asqav[cli]` extra. Every command wraps a public Python API; the same arguments accepted on the command line work as kwargs on the corresponding SDK call. Pro and Business commands fail with a clean upgrade message when the calling org is below the required tier (gated client-side via `GET /account`; the cloud is the source of truth).
+
+```bash
+pip install asqav[cli]
+export ASQAV_API_KEY=sk_...
+```
+
+## Public commands
+
+### `asqav verify <signature_id> [--output text|json]`
+
+Public, no API key required. Prints the verification outcome plus the IETF Compliance Receipts profile sub-axes when the cloud emitted them: `chain_valid`, `anchor_status_ots`, `anchor_status_rfc3161`, `signed_at_skew_seconds`, `missing_fields`. With `--output json`, returns the full `VerificationResponse` dataclass as JSON.
+
+```bash
+asqav verify sig_abc123 --output json
+```
+
+## Compliance Receipts (IETF profile)
+
+### `asqav sign`
+
+Issues a Compliance Receipt under [`draft-marques-asqav-compliance-receipts-00`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/). Mirrors `Agent.sign(...)` end-to-end.
+
+```bash
+asqav sign \
+  --agent-id agt_x7y8z9 \
+  --action-type payment.wire_transfer \
+  --action-json action.json \
+  --compliance-mode \
+  --receipt-type protectmcp:decision \
+  --risk-class high \
+  --sandbox-state enabled \
+  --iteration-id task-2026-Q2-4821 \
+  --issuer-id "legal:Acme GmbH" \
+  --policy-decision permit
+```
+
+Flags:
+
+| Flag | SDK kwarg | Notes |
+| --- | --- | --- |
+| `--action-id` | `_action_id` (in context) | Stable client-side action id; cloud allocates one when empty. |
+| `--action-type` | `action_type` | Required. |
+| `--compliance-mode/--no-compliance-mode` | `compliance_mode` | Default false. |
+| `--action-ref` | `action_ref` | `sha256:<hex>`; auto-derived from `--action-json` when missing. |
+| `--action-json <path|->` | `context` | File path or `-` for stdin. |
+| `--sandbox-state` | `sandbox_state` | `enabled|disabled|unavailable`. |
+| `--iteration-id` | `iteration_id` | Distinct from session_id. |
+| `--risk-class` | `risk_class` | `low|medium|high|unknown`. |
+| `--incident-class` | `incident_class` | DORA ITS vocabulary. |
+| `--issuer-id` | `issuer_id` | Overrides server resolution. |
+| `--receipt-type` | `receipt_type` | `protectmcp:decision|protectmcp:restraint|protectmcp:lifecycle`. Default `protectmcp:decision`. |
+| `--reason` | `reason` | Required when `--policy-decision` is `deny|rate_limit`. |
+| `--policy-decision` | `policy_decision` | Default `permit`. |
+| `--algorithm` | `algorithm` | Cloud uses the agent's algorithm; CLI warns on mismatch. |
+| `--session-id` | `agent._session_id` | Bind the record to an existing session. |
+| `--valid-seconds` | `valid_seconds` | Validity window. |
+| `--policy-artefact <path|->` | `_policy_artefact` (in context) | Cloud stores; receipt's `policy_digest` is its content hash. |
+| `--output` | n/a | `text` (default) or `json`. |
+
+### `asqav audit-pack export`
+
+Exports a signed Audit Pack bundle for receipts in `[start, end)`. The cloud signs the JCS-canonical bundle bytes with the org's most-recent active agent key so verifiers can rederive the digest offline.
+
+```bash
+asqav audit-pack export \
+  --start 2026-04-01T00:00:00Z \
+  --end   2026-05-01T00:00:00Z \
+  --only-compliance \
+  --output-file bundle.json
+```
+
+### `asqav audit-pack policy <digest>`
+
+Resolves a `policy_digest` to the retained policy artefact JSON. Accepts either `sha256:<64-hex>` or a bare 64-hex string (the prefix is added).
+
+```bash
+asqav audit-pack policy a3f6...c91d --output text
+```
+
+### `asqav replay-verify <agent_id> <session_id> [--strict]`
+
+Re-derives the IETF chain over `sha256(canonical_json(signed_envelope))`. With `--strict` rejects any step that lacks a cloud-emitted `signed_envelope` (legacy synthetic shape cannot prove byte-level integrity).
+
+```bash
+asqav replay-verify agt_x7y8z9 sess_abc --strict --output json
+```
+
+### `asqav payloads erase <signature_id>`
+
+Right-to-erasure (P4). Calls `DELETE /signatures/payloads/{signature_id}`. Idempotent; the signature, chain hash, and anchors stay intact so the receipt remains verifiable.
+
+```bash
+asqav payloads erase sig_abc123 --yes
+```
+
+### `asqav org set-compliance-strict <org_id> --enable|--disable`
+
+Toggles per-org `compliance_mode_strict` (M-NEW-1). When enabled, the cloud rejects any sign request that is not flagged `compliance_mode=true` with HTTP 412.
+
+```bash
+asqav org set-compliance-strict org_abc --enable
+```
+
+### `asqav keys generate --algorithm <ml-dsa-65|ed25519|es256>`
+
+Generates a local keypair for offline / air-gapped flows. Ed25519 and ES256 emit PKCS#8 PEM. ML-DSA-65 raises a clear error pointing at `asqav agents create` (server-side keygen).
+
+```bash
+asqav keys generate --algorithm ed25519 --out priv.pem
+```
+
+## Operator commands
+
+### `asqav migrate run <v3-20|v3-21|v3-22>`
+
+Triggers a maintenance migration via `POST /maintenance/run-migration-{name}`. Reads the maintenance key from `ASQAV_MAINTENANCE_KEY` and refuses to run when missing.
+
+```bash
+ASQAV_MAINTENANCE_KEY=mk_... asqav migrate run v3-20
+```
+
+| Migration | Purpose |
+| --- | --- |
+| v3-20 | IETF profile schema additions on `signature_records` + `policy_artefacts` table. |
+| v3-21 | Partial unique index defending the IETF receipt chain against forks. |
+| v3-22 | `organizations.compliance_mode_strict` boolean (M-NEW-1). |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.8"
+version = "0.3.9"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -106,6 +106,9 @@ src = ["src"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
 
+[tool.ruff.lint.per-file-ignores]
+"src/asqav/cli.py" = ["E501"]
+
 [tool.mypy]
 python_version = "3.10"
 strict = true

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -130,7 +130,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -30,14 +30,6 @@ Get your API key at asqav.com
 from ._jcs import canonical_json
 from .async_client import AsyncAgent
 from .canonicalize import canonicalize, hash_action
-from .keys import (
-    ALGORITHM_ED25519,
-    ALGORITHM_ES256,
-    ALGORITHM_ML_DSA_65,
-    SUPPORTED_ALGORITHMS,
-    LocalKeypair,
-    generate_local_keypair,
-)
 from .client import (
     RECEIPT_TYPE_NAMESPACE,
     SKEW_BOUND_SECONDS,
@@ -122,6 +114,14 @@ from .client import (
 from .compliance import ComplianceBundle, export_bundle
 from .decorators import async_session, session, sign
 from .hooks import clear_hooks, register_after, register_before
+from .keys import (
+    ALGORITHM_ED25519,
+    ALGORITHM_ES256,
+    ALGORITHM_ML_DSA_65,
+    SUPPORTED_ALGORITHMS,
+    LocalKeypair,
+    generate_local_keypair,
+)
 from .local import LocalQueue, local_sign
 from .patterns import PATTERNS, list_patterns, resolve_pattern
 from .phases import PhaseChain, sign_with_phases

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -30,6 +30,7 @@ Get your API key at asqav.com
 from .async_client import AsyncAgent
 from .canonicalize import canonicalize, hash_action
 from .client import (
+    RECEIPT_TYPE_NAMESPACE,
     Agent,
     AgentResponse,
     APIError,
@@ -258,4 +259,6 @@ __all__ = [
     "AuthenticationError",
     "RateLimitError",
     "APIError",
+    # IETF Compliance Receipts profile
+    "RECEIPT_TYPE_NAMESPACE",
 ]

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -30,6 +30,14 @@ Get your API key at asqav.com
 from ._jcs import canonical_json
 from .async_client import AsyncAgent
 from .canonicalize import canonicalize, hash_action
+from .keys import (
+    ALGORITHM_ED25519,
+    ALGORITHM_ES256,
+    ALGORITHM_ML_DSA_65,
+    SUPPORTED_ALGORITHMS,
+    LocalKeypair,
+    generate_local_keypair,
+)
 from .client import (
     RECEIPT_TYPE_NAMESPACE,
     SKEW_BOUND_SECONDS,
@@ -269,4 +277,11 @@ __all__ = [
     "SKEW_BOUND_SECONDS",
     "ComplianceReceiptVerification",
     "verify_compliance_receipt",
+    # Algorithm agility
+    "ALGORITHM_ML_DSA_65",
+    "ALGORITHM_ED25519",
+    "ALGORITHM_ES256",
+    "SUPPORTED_ALGORITHMS",
+    "LocalKeypair",
+    "generate_local_keypair",
 ]

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -32,6 +32,7 @@ from .async_client import AsyncAgent
 from .canonicalize import canonicalize, hash_action
 from .client import (
     RECEIPT_TYPE_NAMESPACE,
+    SKEW_BOUND_SECONDS,
     Agent,
     AgentResponse,
     APIError,
@@ -41,6 +42,7 @@ from .client import (
     BudgetCheckResult,
     BudgetTracker,
     CertificateResponse,
+    ComplianceReceiptVerification,
     DelegationResponse,
     GroupKeypairResponse,
     GroupSignResponse,
@@ -105,6 +107,7 @@ from .client import (
     update_risk_rule,
     update_signing_group,
     verify_attestation,
+    verify_compliance_receipt,
     verify_output,
     verify_signature,
 )
@@ -263,4 +266,7 @@ __all__ = [
     "APIError",
     # IETF Compliance Receipts profile
     "RECEIPT_TYPE_NAMESPACE",
+    "SKEW_BOUND_SECONDS",
+    "ComplianceReceiptVerification",
+    "verify_compliance_receipt",
 ]

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -27,6 +27,7 @@ With Decorators:
 Get your API key at asqav.com
 """
 
+from ._jcs import canonical_json
 from .async_client import AsyncAgent
 from .canonicalize import canonicalize, hash_action
 from .client import (
@@ -125,6 +126,7 @@ __all__ = [
     "health_check",
     # Fingerprint helpers
     "canonicalize",
+    "canonical_json",
     "hash_action",
     # Agent
     "Agent",

--- a/python/src/asqav/_jcs.py
+++ b/python/src/asqav/_jcs.py
@@ -1,0 +1,61 @@
+"""RFC 8785 (JCS) canonicalization helper for the IETF profile.
+
+Public surface: :func:`canonical_json` returning ``bytes``. The output
+is the exact bytes the cloud's ``core/canonical.py:canonical_json``
+produces and the bytes the chain hashes over per
+``draft-marques-asqav-compliance-receipts-00`` §5.7.
+
+This module is a named landing for the IETF Compliance Receipts profile
+so callers can ``from asqav._jcs import canonical_json`` to get the same
+function under the spec-mandated name. The legacy
+``asqav.canonicalize.canonicalize`` is kept as a public alias for
+backwards compatibility; the two are byte-identical for the JSON value
+types the profile actually signs (objects whose leaves are strings,
+booleans, null, integers, and nested arrays / objects).
+
+Implementation notes:
+
+  - Lexicographic ordering of object keys (UTF-16 code unit order, which
+    Python ``sort_keys=True`` produces for the ASCII / BMP keys this
+    codebase uses).
+  - No insignificant whitespace; ``,`` and ``:`` separators only.
+  - UTF-8 byte output with no BOM. Non-ASCII passes through verbatim per
+    RFC 8785 §3.2.3.
+  - ``NaN`` / ``Infinity`` rejected (RFC 8785 §3.2.2).
+  - String escapes follow standard JSON rules (``\\``, ``\"``, ``\b``,
+    ``\f``, ``\n``, ``\r``, ``\t``, plus ``\\u00xx`` for control chars
+    U+0000..U+001F). All other characters pass through, matching
+    ECMAScript ``JSON.stringify``.
+
+Float caveat: Python ``json.dumps`` and ECMAScript ``Number.toString``
+agree byte-for-byte on integer values within the IEEE-754 safe range,
+which is what the Compliance Receipts profile signs. Floats are not
+covered by the conformance vectors and SHOULD NOT appear in signed
+envelopes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = ["canonical_json"]
+
+
+def canonical_json(obj: Any) -> bytes:
+    """Return RFC 8785 / JCS bytes for ``obj``.
+
+    Same function as :func:`asqav.canonicalize.canonicalize`; exposed
+    under the spec-mandated name so IETF profile code reads naturally.
+
+    Identical bytes to the cloud's ``core/canonical.py:canonical_json``
+    so customer-side digests reproduce the bytes the server signs over
+    and the chain hashes over.
+    """
+    return json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -1237,6 +1237,441 @@ def approve(
 # ---------------------------------------------------------------------------
 
 
+audit_pack_app = typer.Typer(
+    name="audit-pack",
+    help="Audit Pack export and policy_digest resolution (IETF profile).",
+    no_args_is_help=True,
+)
+app.add_typer(audit_pack_app, name="audit-pack")
+
+
+@audit_pack_app.command("export")
+def audit_pack_export(
+    start: str = typer.Option(..., "--start", help="Window start, ISO 8601 (UTC)."),
+    end: str = typer.Option(..., "--end", help="Window end, ISO 8601 (UTC). Half-open."),
+    organization_id: str = typer.Option(
+        "",
+        "--organization-id",
+        help="Defaults to the caller's org. Cross-org export requires admin scopes.",
+    ),
+    only_compliance: bool = typer.Option(
+        True,
+        "--only-compliance/--no-only-compliance",
+        help="When true (default), only IETF Compliance Receipts are exported.",
+    ),
+    output_file: str = typer.Option(
+        ..., "--output-file", help="Path to write the signed bundle JSON."
+    ),
+) -> None:
+    """Export a signed Audit Pack bundle for receipts in [start, end).
+
+    Calls POST `/audit-pack/export`. The bundle is signed with the org's
+    most-recent active agent key over the JCS-canonical bundle bytes, so
+    a verifier can rederive the digest and check the signature offline.
+    """
+    import json as json_mod
+
+    _init_sdk()
+    from asqav.client import _post
+
+    body: dict = {
+        "start": start,
+        "end": end,
+        "only_compliance": only_compliance,
+    }
+    if organization_id:
+        body["organization_id"] = organization_id
+
+    try:
+        bundle = _post("/audit-pack/export", body)
+    except Exception as exc:
+        print(f"Error exporting audit pack: {exc}")
+        raise typer.Exit(code=1)
+
+    try:
+        with open(output_file, "w") as f:
+            json_mod.dump(bundle, f, indent=2, default=str)
+    except OSError as exc:
+        print(f"Error writing bundle: {exc}")
+        raise typer.Exit(code=1)
+
+    count = bundle.get("receipt_count", "?")
+    digest = bundle.get("bundle_digest", "?")
+    print(f"wrote {count} receipts to {output_file}")
+    print(f"bundle_digest: {digest}")
+    print(f"algorithm:     {bundle.get('bundle_signature_algorithm', '?')}")
+
+
+@audit_pack_app.command("policy")
+def audit_pack_policy(
+    digest: str = typer.Argument(
+        help="`sha256:<hex>` digest, or 64-hex (the prefix is added)."
+    ),
+    output: str = typer.Option(
+        "json", "--output", "-o", help="Output format: json or text."
+    ),
+) -> None:
+    """Resolve a `policy_digest` to the retained policy artefact JSON.
+
+    Calls GET `/audit-pack/policy/{digest}`. The receipt's `policy_digest`
+    is `sha256:<hex>` over the canonical artefact JSON; this command
+    fetches the artefact so a verifier can rederive the digest offline.
+    """
+    import json as json_mod
+
+    _init_sdk()
+    from asqav.client import _get
+
+    if not digest.startswith("sha256:"):
+        if len(digest) == 64 and all(c in "0123456789abcdefABCDEF" for c in digest):
+            digest = "sha256:" + digest.lower()
+        else:
+            print(
+                "Error: digest must be `sha256:<64-hex>` or a bare 64-hex string."
+            )
+            raise typer.Exit(code=1)
+
+    try:
+        data = _get(f"/audit-pack/policy/{digest}")
+    except Exception as exc:
+        print(f"Error fetching artefact: {exc}")
+        raise typer.Exit(code=1)
+
+    if output == "text":
+        print(f"digest:          {data.get('digest', '?')}")
+        print(f"organization_id: {data.get('organization_id', '?')}")
+        print(f"agent_id:        {data.get('agent_id', '?')}")
+        print(f"action_type:     {data.get('action_type', '?')}")
+        print(f"created_at:      {data.get('created_at', '?')}")
+        print(f"--- artefact ---")
+        print(json_mod.dumps(data.get("artefact", {}), indent=2))
+    else:
+        print(json_mod.dumps(data, indent=2, default=str))
+
+
+# ---------------------------------------------------------------------------
+# payloads erase command (P4: GDPR right-to-erasure)
+# ---------------------------------------------------------------------------
+
+
+payloads_app = typer.Typer(
+    name="payloads",
+    help="Erase persisted payloads (P4: GDPR / UK-GDPR right-to-erasure).",
+    no_args_is_help=True,
+)
+app.add_typer(payloads_app, name="payloads")
+
+
+@payloads_app.command("erase")
+def payloads_erase(
+    signature_id: str = typer.Argument(help="Signature whose payload bytes are erased."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
+) -> None:
+    """Erase the persisted JSON payload for a signature record.
+
+    Calls DELETE `/signatures/payloads/{signature_id}`. The cryptographic
+    `message` bytes and chain hash stay untouched so the receipt remains
+    verifiable; the human-readable JSON payload is replaced with a
+    tombstone marker. Idempotent: replaying on an already-erased record
+    returns 204.
+    """
+    if not yes:
+        ok = typer.confirm(
+            f"Erase payload for {signature_id}? Verification stays intact, "
+            f"but the JSON payload becomes a tombstone."
+        )
+        if not ok:
+            print("Cancelled.")
+            raise typer.Exit()
+
+    _init_sdk()
+    from asqav.client import _delete
+
+    try:
+        _delete(f"/signatures/payloads/{signature_id}")
+    except Exception as exc:
+        print(f"Error erasing payload: {exc}")
+        raise typer.Exit(code=1)
+
+    print(f"Payload erased for {signature_id}.")
+    print("Tombstone written; signature remains cryptographically verifiable.")
+
+
+# ---------------------------------------------------------------------------
+# org settings (compliance_mode_strict)
+# ---------------------------------------------------------------------------
+
+
+org_app = typer.Typer(
+    name="org",
+    help="Organization-level settings (IETF M-NEW-1 strict mode).",
+    no_args_is_help=True,
+)
+app.add_typer(org_app, name="org")
+
+
+@org_app.command("set-compliance-strict")
+def org_set_compliance_strict(
+    org_id: str = typer.Argument(help="Organization ID to update."),
+    enable: bool = typer.Option(False, "--enable", help="Turn strict mode on."),
+    disable: bool = typer.Option(False, "--disable", help="Turn strict mode off."),
+) -> None:
+    """Toggle per-org `compliance_mode_strict` (M-NEW-1).
+
+    When True, the cloud rejects any sign request that is not flagged
+    `compliance_mode=true` with HTTP 412 so non-instrumented call paths
+    cannot slip past the receipts trail. Calls PATCH
+    `/orgs/{org_id}` with `{"compliance_mode_strict": <bool>}`.
+    """
+    if enable == disable:
+        print("Error: pass exactly one of --enable or --disable.")
+        raise typer.Exit(code=1)
+
+    _init_sdk()
+    from asqav.client import _patch
+
+    body = {"compliance_mode_strict": bool(enable)}
+    try:
+        out = _patch(f"/orgs/{org_id}", body)
+    except Exception as exc:
+        print(f"Error updating organization: {exc}")
+        raise typer.Exit(code=1)
+
+    state = "enabled" if enable else "disabled"
+    print(f"compliance_mode_strict {state} for org {org_id}.")
+    if isinstance(out, dict) and "compliance_mode_strict" in out:
+        print(f"server confirms: compliance_mode_strict={out['compliance_mode_strict']}")
+
+
+# ---------------------------------------------------------------------------
+# keys generate (local keypair)
+# ---------------------------------------------------------------------------
+
+
+keys_app = typer.Typer(
+    name="keys",
+    help="Local keypair management (algorithm agility).",
+    no_args_is_help=True,
+)
+app.add_typer(keys_app, name="keys")
+
+
+@keys_app.command("generate")
+def keys_generate(
+    algorithm: str = typer.Option(
+        "ed25519",
+        "--algorithm",
+        help="ml-dsa-65|ed25519|es256. ml-dsa-65 keygen is server-side only.",
+    ),
+    out: str = typer.Option(
+        "",
+        "--out",
+        help="Path to write the private key bytes. Public key always prints to stdout.",
+    ),
+) -> None:
+    """Generate a local keypair (offline / air-gapped flows).
+
+    Ed25519 and ES256 emit PKCS#8 PEM. ML-DSA-65 raises a clear error
+    pointing the caller at `asqav agents create` (server-side keygen).
+    """
+    from asqav import generate_local_keypair
+
+    try:
+        kp = generate_local_keypair(algorithm)
+    except NotImplementedError as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+    except (ValueError, ImportError) as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1)
+
+    if out:
+        try:
+            with open(out, "wb") as f:
+                f.write(kp.private_key_pem)
+        except OSError as exc:
+            print(f"Error writing key file: {exc}")
+            raise typer.Exit(code=1)
+        try:
+            os_module = __import__("os")
+            os_module.chmod(out, 0o600)
+        except Exception:
+            pass
+        print(f"Private key written to {out} (mode 0600).")
+
+    print("--- public key ---")
+    sys.stdout.write(kp.public_key_pem.decode("utf-8", errors="replace"))
+
+
+# ---------------------------------------------------------------------------
+# replay verify (IETF chain verification)
+# ---------------------------------------------------------------------------
+
+
+# Mounted as a top-level command (not a subapp) so the existing
+# `asqav replay` (session replay) keeps its current shape.
+@app.command("replay-verify")
+def replay_verify_cmd(
+    agent_id: str = typer.Argument(help="Agent that owns the chain."),
+    session_id: str = typer.Argument(help="Session whose chain to re-derive."),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help="Reject legacy synthetic-shape steps. The IETF profile rederives the chain over `sha256(canonical_json(signed_envelope))`; legacy steps cannot prove byte-level integrity.",
+    ),
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
+) -> None:
+    """Re-derive a session's IETF chain (`sha256(canonical_json(signed_envelope))`).
+
+    Wraps :func:`asqav.replay`. With ``--strict`` the command fails
+    when any step lacks the cloud-emitted ``signed_envelope`` and falls
+    back to the synthetic shape (because that synthetic shape cannot
+    prove byte-level integrity per the IETF profile).
+    """
+    import json as json_mod
+
+    _init_sdk()
+    _require_tier("pro")
+    from asqav import APIError
+    from asqav import replay as replay_api
+
+    try:
+        timeline = replay_api(agent_id, session_id)
+    except APIError as exc:
+        print(f"Error fetching timeline: {exc}")
+        raise typer.Exit(code=1)
+
+    timeline.verify_chain()
+    chain_valid = bool(timeline.compliance_chain_valid)
+    legacy_steps = [s for s in timeline.steps if getattr(s, "legacy_chain", False)]
+    has_legacy = bool(legacy_steps)
+    strict_pass = chain_valid and not (strict and has_legacy)
+
+    if output == "json":
+        print(json_mod.dumps({
+            "compliance_chain_valid": chain_valid,
+            "strict": strict,
+            "strict_pass": strict_pass,
+            "step_count": len(timeline.steps),
+            "legacy_step_count": len(legacy_steps),
+            "steps": [
+                {
+                    "index": s.index,
+                    "signature_id": getattr(s, "signature_id", None),
+                    "chain_valid": getattr(s, "chain_valid", None),
+                    "legacy_chain": getattr(s, "legacy_chain", None),
+                }
+                for s in timeline.steps
+            ],
+        }, indent=2, default=str))
+        if not strict_pass:
+            raise typer.Exit(code=1)
+        return
+
+    print(f"compliance_chain_valid: {chain_valid}")
+    print(f"strict: {strict}")
+    print(f"steps: {len(timeline.steps)} (legacy: {len(legacy_steps)})")
+    for s in timeline.steps:
+        ok = getattr(s, "chain_valid", False)
+        legacy = "legacy" if getattr(s, "legacy_chain", False) else "envelope"
+        marker = "ok  " if ok else "FAIL"
+        print(f"  [{marker}] step {s.index} ({legacy}) sig={getattr(s, 'signature_id', '?')}")
+    if strict and has_legacy:
+        print("strict mode FAILED: at least one step uses the legacy synthetic shape.")
+    if not strict_pass:
+        raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# migrate run (operator commands)
+# ---------------------------------------------------------------------------
+
+
+migrate_app = typer.Typer(
+    name="migrate",
+    help="Operator-only DB migration runner (X-Maintenance-Key required).",
+    no_args_is_help=True,
+)
+app.add_typer(migrate_app, name="migrate")
+
+
+_SUPPORTED_MIGRATIONS = {"v3-20", "v3-21", "v3-22"}
+
+
+@migrate_app.command("run")
+def migrate_run(
+    migration: str = typer.Argument(help="One of v3-20, v3-21, v3-22."),
+) -> None:
+    """Trigger a maintenance migration.
+
+    Reads the maintenance key from the `ASQAV_MAINTENANCE_KEY` env var and
+    POSTs `/maintenance/run-migration-{migration}`. Refuses to run when
+    the env var is missing.
+    """
+    import json as json_mod
+    import os
+
+    if migration not in _SUPPORTED_MIGRATIONS:
+        print(
+            f"Error: unsupported migration {migration!r}. "
+            f"Supported: {sorted(_SUPPORTED_MIGRATIONS)}."
+        )
+        raise typer.Exit(code=1)
+
+    maintenance_key = os.environ.get("ASQAV_MAINTENANCE_KEY")
+    if not maintenance_key:
+        print("Error: ASQAV_MAINTENANCE_KEY env var is required for migration commands.")
+        raise typer.Exit(code=1)
+
+    # Build a one-off HTTP request that adds the X-Maintenance-Key header.
+    # The shared `_post` helper does not let us inject headers, so we use
+    # the same urllib path as a plain operator script would.
+    import asqav
+    from asqav import init as _init
+
+    api_key = os.environ.get("ASQAV_API_KEY")
+    if not api_key:
+        print("Error: ASQAV_API_KEY env var is required.")
+        raise typer.Exit(code=1)
+    _init(api_key=api_key)
+
+    base = os.environ.get("ASQAV_API_URL", "https://api.asqav.com/api/v1")
+    url = f"{base}/maintenance/run-migration-{migration}"
+
+    import urllib.error
+    import urllib.request
+
+    req = urllib.request.Request(
+        url,
+        method="POST",
+        headers={
+            "X-API-Key": api_key,
+            "X-Maintenance-Key": maintenance_key,
+            "Content-Type": "application/json",
+        },
+        data=b"{}",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = exc.read().decode("utf-8")
+        except Exception:
+            detail = str(exc)
+        print(f"HTTP {exc.code} from /maintenance/run-migration-{migration}: {detail}")
+        raise typer.Exit(code=1)
+    except urllib.error.URLError as exc:
+        print(f"Network error: {exc}")
+        raise typer.Exit(code=1)
+
+    try:
+        parsed = json_mod.loads(body)
+        print(json_mod.dumps(parsed, indent=2))
+    except json_mod.JSONDecodeError:
+        print(body)
+
+
 @compliance_app.command("frameworks")
 def compliance_frameworks() -> None:
     """List the compliance frameworks the bundle exporter recognizes."""

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -172,6 +172,201 @@ def verify(
 
 
 @app.command()
+def sign(
+    action_type: str = typer.Option(..., "--action-type", help="Action type, e.g. payment.wire_transfer."),
+    action_id: str = typer.Option("", "--action-id", help="Stable client-side action id (the cloud allocates one when empty)."),
+    agent_id: str = typer.Option(..., "--agent-id", help="Agent that signs the receipt."),
+    compliance_mode: bool = typer.Option(
+        False,
+        "--compliance-mode/--no-compliance-mode",
+        help="Emit the receipt under the IETF Compliance Receipts profile.",
+    ),
+    action_ref: str = typer.Option("", "--action-ref", help="`sha256:<hex>` over the canonical Action object. Auto-computed when omitted with --action-json."),
+    action_json: str = typer.Option(
+        "",
+        "--action-json",
+        help="Path to a JSON file or '-' for stdin. The SDK derives `action_ref` from the JCS bytes when --action-ref is empty.",
+    ),
+    sandbox_state: str = typer.Option("", "--sandbox-state", help="enabled|disabled|unavailable."),
+    iteration_id: str = typer.Option("", "--iteration-id", help="Logical task iteration id (distinct from session_id)."),
+    risk_class: str = typer.Option("", "--risk-class", help="low|medium|high|unknown."),
+    incident_class: str = typer.Option("", "--incident-class", help="DORA ITS vocabulary."),
+    issuer_id: str = typer.Option("", "--issuer-id", help="Legal entity issuing this receipt; overrides server resolution."),
+    receipt_type: str = typer.Option(
+        "protectmcp:decision",
+        "--receipt-type",
+        help="protectmcp:decision|protectmcp:restraint|protectmcp:lifecycle.",
+    ),
+    reason: str = typer.Option("", "--reason", help="Required when --policy-decision is deny|rate_limit."),
+    policy_decision: str = typer.Option(
+        "permit",
+        "--policy-decision",
+        help="permit|deny|rate_limit.",
+    ),
+    algorithm: str = typer.Option(
+        "ml-dsa-65",
+        "--algorithm",
+        help="Signing algorithm: ml-dsa-65|ed25519|es256.",
+    ),
+    session_id: str = typer.Option("", "--session-id", help="Bind the record to an existing session."),
+    valid_seconds: int = typer.Option(0, "--valid-seconds", help="Validity window in seconds (0 = no expiry)."),
+    policy_artefact: str = typer.Option(
+        "",
+        "--policy-artefact",
+        help="Path to a JSON file or '-' for stdin. The cloud retains it; the receipt's `policy_digest` is its content hash.",
+    ),
+    output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
+) -> None:
+    """Issue a Compliance Receipt via the cloud `/agents/{id}/sign` route.
+
+    Mirrors :py:meth:`asqav.Agent.sign` end-to-end so any flag here maps
+    1:1 to a kwarg on the SDK call. Reads ``--action-json`` from a path
+    or stdin when ``-`` is passed; the SDK then computes ``action_ref``
+    from the JCS bytes if ``--action-ref`` was not supplied.
+    """
+    import json as json_mod
+
+    _init_sdk()
+    from asqav import Agent, APIError
+
+    # 1. Load action JSON (file, stdin, or empty).
+    action_obj: dict = {}
+    if action_json:
+        try:
+            if action_json == "-":
+                action_obj = json_mod.loads(sys.stdin.read())
+            else:
+                with open(action_json) as f:
+                    action_obj = json_mod.load(f)
+        except (OSError, json_mod.JSONDecodeError) as exc:
+            print(f"Error reading action JSON: {exc}")
+            raise typer.Exit(code=1)
+
+    # 2. Load policy artefact (sent server-side; the cloud stores it and
+    # stamps `policy_digest` on the receipt).
+    policy_artefact_obj: dict | None = None
+    if policy_artefact:
+        try:
+            if policy_artefact == "-":
+                policy_artefact_obj = json_mod.loads(sys.stdin.read())
+            else:
+                with open(policy_artefact) as f:
+                    policy_artefact_obj = json_mod.load(f)
+        except (OSError, json_mod.JSONDecodeError) as exc:
+            print(f"Error reading policy artefact: {exc}")
+            raise typer.Exit(code=1)
+
+    # 3. Validate policy_decision/reason coupling client-side. The SDK
+    # also validates; this gives a clearer CLI error.
+    if policy_decision in {"deny", "rate_limit"} and not reason:
+        print(
+            "Error: --reason is required when --policy-decision is deny or rate_limit."
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        agent = Agent.get(agent_id)
+    except APIError as exc:
+        print(f"Error fetching agent: {exc}")
+        raise typer.Exit(code=1)
+
+    # 4. Build kwargs. Empty strings -> None so the SDK applies defaults.
+    sign_kwargs: dict = {
+        "compliance_mode": compliance_mode,
+        "policy_decision": policy_decision,
+    }
+    if action_ref:
+        sign_kwargs["action_ref"] = action_ref
+    if sandbox_state:
+        sign_kwargs["sandbox_state"] = sandbox_state
+    if iteration_id:
+        sign_kwargs["iteration_id"] = iteration_id
+    if risk_class:
+        sign_kwargs["risk_class"] = risk_class
+    if incident_class:
+        sign_kwargs["incident_class"] = incident_class
+    if issuer_id:
+        sign_kwargs["issuer_id"] = issuer_id
+    if receipt_type:
+        sign_kwargs["receipt_type"] = receipt_type
+    if reason:
+        sign_kwargs["reason"] = reason
+    if valid_seconds > 0:
+        sign_kwargs["valid_seconds"] = valid_seconds
+
+    context = action_obj or None
+    if action_id and context is not None:
+        context = {**context, "_action_id": action_id}
+    elif action_id:
+        context = {"_action_id": action_id}
+
+    if policy_artefact_obj is not None and context is not None:
+        context = {**context, "_policy_artefact": policy_artefact_obj}
+    elif policy_artefact_obj is not None:
+        context = {"_policy_artefact": policy_artefact_obj}
+
+    if session_id:
+        # Internal attribute the SDK consults when building the body.
+        agent._session_id = session_id  # type: ignore[attr-defined]
+
+    if algorithm and algorithm != getattr(agent, "algorithm", None):
+        # The receipt-signing algorithm is bound to the agent server-side.
+        # The CLI surfaces the requested value so callers can detect a
+        # mismatch between intent and what the agent will actually use.
+        print(
+            f"Warning: --algorithm={algorithm} differs from agent.algorithm="
+            f"{agent.algorithm}. The cloud signs under the agent's algorithm."
+        )
+
+    try:
+        sig = agent.sign(action_type, context=context, **sign_kwargs)
+    except (APIError, ValueError) as exc:
+        print(f"Error signing: {exc}")
+        raise typer.Exit(code=1)
+
+    if output == "json":
+        payload = {
+            "signature_id": sig.signature_id,
+            "action_id": sig.action_id,
+            "algorithm": sig.algorithm,
+            "verification_url": sig.verification_url,
+            "signed_at": sig.timestamp,
+            "policy_digest": sig.policy_digest,
+            "policy_decision": sig.policy_decision,
+            "compliance_mode": sig.compliance_mode,
+            "receipt_type": sig.receipt_type,
+            "action_ref": sig.action_ref,
+            "issuer_id": sig.issuer_id,
+            "previous_receipt_hash": sig.previous_receipt_hash,
+            "anchor_status": (
+                sig.bitcoin_anchor.status if sig.bitcoin_anchor else None
+            ),
+            "rfc3161_tsa": sig.rfc3161_tsa,
+            "rfc3161_serial": sig.rfc3161_serial,
+        }
+        print(json_mod.dumps(payload, indent=2, default=str))
+        return
+
+    print(f"signature_id: {sig.signature_id}")
+    print(f"action_id:    {sig.action_id}")
+    print(f"algorithm:    {sig.algorithm}")
+    print(f"signed_at:    {sig.timestamp}")
+    if sig.policy_digest:
+        print(f"policy_digest: {sig.policy_digest}")
+    if sig.compliance_mode:
+        print(f"compliance_mode: True")
+        if sig.receipt_type:
+            print(f"receipt_type:  {sig.receipt_type}")
+        if sig.action_ref:
+            print(f"action_ref:    {sig.action_ref}")
+        if sig.previous_receipt_hash:
+            print(f"previous_receipt_hash: {sig.previous_receipt_hash}")
+    if sig.bitcoin_anchor:
+        print(f"anchor:       {sig.bitcoin_anchor.status}")
+    print(f"verify_url:   {sig.verification_url}")
+
+
+@app.command()
 def replay(
     agent_id: str = typer.Argument(
         default="",

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -93,8 +93,21 @@ def main(
 
 
 @app.command()
-def verify(signature_id: str = typer.Argument(help="Signature ID to verify.")) -> None:
-    """Verify a signature by ID (public, no auth needed)."""
+def verify(
+    signature_id: str = typer.Argument(help="Signature ID to verify."),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text or json."
+    ),
+) -> None:
+    """Verify a signature by ID (public, no auth needed).
+
+    With ``--output json`` returns the full ``VerificationResponse`` plus
+    the IETF profile sub-axes (`chain_valid`, `anchor_status_ots`,
+    `anchor_status_rfc3161`, `signed_at_skew_seconds`, `missing_fields`)
+    when the cloud emitted them.
+    """
+    import json as json_mod
+
     from asqav import APIError, verify_signature
 
     try:
@@ -106,11 +119,56 @@ def verify(signature_id: str = typer.Argument(help="Signature ID to verify.")) -
         print(f"Error: {exc}")
         raise typer.Exit(code=1)
 
+    if output == "json":
+        detail = result.verification_detail
+        payload = {
+            "signature_id": result.signature_id,
+            "agent_id": result.agent_id,
+            "agent_name": result.agent_name,
+            "action_id": result.action_id,
+            "action_type": result.action_type,
+            "algorithm": result.algorithm,
+            "signed_at": result.signed_at,
+            "verified": result.verified,
+            "verification_url": result.verification_url,
+            "verification_detail": (
+                {
+                    "signer_key_match": detail.signer_key_match,
+                    "signature_valid": detail.signature_valid,
+                    "algorithm_match": detail.algorithm_match,
+                    "agent_active": detail.agent_active,
+                    "validation_label": detail.validation_label,
+                    "signed_at_skew_seconds": detail.signed_at_skew_seconds,
+                    "chain_valid": detail.chain_valid,
+                    "anchor_status_ots": detail.anchor_status_ots,
+                    "anchor_status_rfc3161": detail.anchor_status_rfc3161,
+                    "missing_fields": detail.missing_fields,
+                }
+                if detail
+                else None
+            ),
+        }
+        print(json_mod.dumps(payload, indent=2, default=str))
+        return
+
     status = "valid" if result.verified else "invalid"
     print(f"Signature: {status}")
     print(f"Agent: {result.agent_name} ({result.agent_id})")
     print(f"Action: {result.action_type}")
     print(f"Algorithm: {result.algorithm}")
+    detail = result.verification_detail
+    if detail is not None:
+        print(f"Validation: {detail.validation_label}")
+        if detail.chain_valid is not None:
+            print(f"Chain valid: {detail.chain_valid}")
+        if detail.anchor_status_ots is not None:
+            print(f"Anchor (OTS): {detail.anchor_status_ots}")
+        if detail.anchor_status_rfc3161 is not None:
+            print(f"Anchor (RFC 3161): {detail.anchor_status_rfc3161}")
+        if detail.signed_at_skew_seconds is not None:
+            print(f"signed_at skew: {detail.signed_at_skew_seconds}s")
+        if detail.missing_fields:
+            print(f"Missing fields: {', '.join(detail.missing_fields)}")
 
 
 @app.command()

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -354,7 +354,7 @@ def sign(
     if sig.policy_digest:
         print(f"policy_digest: {sig.policy_digest}")
     if sig.compliance_mode:
-        print(f"compliance_mode: True")
+        print("compliance_mode: True")
         if sig.receipt_type:
             print(f"receipt_type:  {sig.receipt_type}")
         if sig.action_ref:
@@ -1343,7 +1343,7 @@ def audit_pack_policy(
         print(f"agent_id:        {data.get('agent_id', '?')}")
         print(f"action_type:     {data.get('action_type', '?')}")
         print(f"created_at:      {data.get('created_at', '?')}")
-        print(f"--- artefact ---")
+        print("--- artefact ---")
         print(json_mod.dumps(data.get("artefact", {}), indent=2))
     else:
         print(json_mod.dumps(data, indent=2, default=str))
@@ -1626,7 +1626,6 @@ def migrate_run(
     # Build a one-off HTTP request that adds the X-Maintenance-Key header.
     # The shared `_post` helper does not let us inject headers, so we use
     # the same urllib path as a plain operator script would.
-    import asqav
     from asqav import init as _init
 
     api_key = os.environ.get("ASQAV_API_KEY")

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -2228,7 +2228,7 @@ def verify_compliance_receipt(
     Returns:
         A :class:`ComplianceReceiptVerification` capturing each MUST.
     """
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     from ._jcs import canonical_json
     from .replay import FIRST_RECEIPT_SEED

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -842,12 +842,17 @@ class Agent:
     ) -> Agent:
         """Create a new agent via asqav Cloud.
 
-        The server generates the ML-DSA keypair. The private key
-        never leaves the server.
+        The server generates the keypair. The private key never leaves
+        the server.
 
         Args:
             name: Human-readable name for the agent.
-            algorithm: ML-DSA level (ml-dsa-44, ml-dsa-65, ml-dsa-87).
+            algorithm: Receipt-signing algorithm. One of `ml-dsa-65`
+                (FIPS 204; default, post-quantum), `ed25519` (mandatory
+                upstream per IETF profile §10.8 AG3), or `es256`
+                (ECDSA-P256 per RFC 7518; AG4). The cloud also accepts
+                `ml-dsa-44` and `ml-dsa-87` for level tuning; pass
+                those strings through as-is.
             capabilities: List of capabilities/permissions.
 
         Returns:

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -340,7 +340,14 @@ class VerificationDetail:
     Optional on the response; older servers do not return it.
     `validation_label` is one of: valid, invalid_signature,
     signature_expired, signer_key_changed, algorithm_mismatch,
-    agent_inactive, agent_unknown.
+    agent_inactive, agent_unknown, chain_break, anchor_invalid,
+    missing_required_field, signed_at_skew.
+
+    The IETF Compliance Receipts profile fields (`signed_at_skew_seconds`,
+    `chain_valid`, `anchor_status_ots`, `anchor_status_rfc3161`,
+    `missing_fields`) are populated only when the cloud returns them on
+    a compliance-mode receipt; older receipts and older deployments
+    leave them None for back-compat.
     """
 
     signer_key_match: bool
@@ -348,6 +355,12 @@ class VerificationDetail:
     algorithm_match: bool
     agent_active: bool
     validation_label: str
+    # IETF profile sub-axes (cloud may omit on legacy receipts).
+    signed_at_skew_seconds: float | None = None
+    chain_valid: bool | None = None
+    anchor_status_ots: str | None = None
+    anchor_status_rfc3161: str | None = None
+    missing_fields: list[str] | None = None
 
 
 @dataclass
@@ -2133,6 +2146,11 @@ def verify_signature(signature_id: str) -> VerificationResponse:
             algorithm_match=detail_raw["algorithm_match"],
             agent_active=detail_raw["agent_active"],
             validation_label=detail_raw["validation_label"],
+            signed_at_skew_seconds=detail_raw.get("signed_at_skew_seconds"),
+            chain_valid=detail_raw.get("chain_valid"),
+            anchor_status_ots=detail_raw.get("anchor_status_ots"),
+            anchor_status_rfc3161=detail_raw.get("anchor_status_rfc3161"),
+            missing_fields=detail_raw.get("missing_fields"),
         )
         if isinstance(detail_raw, dict)
         else None

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -203,6 +203,26 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
     }
 )
 
+# §5.1.2 / V6 verifier MUST reject receipts whose `signed_at` sits more
+# than SKEW_BOUND_SECONDS away from the verifier's wall clock. Mirrored
+# from the cloud's `routes/verify.py:SKEW_BOUND_SECONDS`.
+SKEW_BOUND_SECONDS: int = 300
+
+# REQUIRED fields on a Compliance Receipt envelope per §5 of
+# draft-marques-asqav-compliance-receipts-00. Used by the local
+# `verify_compliance_receipt` helper.
+_COMPLIANCE_REQUIRED_FIELDS: tuple[str, ...] = (
+    "receipt_type",
+    "issuer_id",
+    "agent_id",
+    "action_ref",
+    "payload_digest",
+    "policy_digest",
+    "previousReceiptHash",
+    "policy_decision",
+    "issued_at",
+)
+
 
 @dataclass
 class SignatureResponse:
@@ -2125,6 +2145,140 @@ def verify_signature(signature_id: str) -> VerificationResponse:
         verified=data["verified"],
         verification_url=data["verification_url"],
         verification_detail=detail,
+    )
+
+
+@dataclass
+class ComplianceReceiptVerification:
+    """Outcome of the SDK-side Compliance Receipt sanity check.
+
+    The cloud is the authoritative verifier; this helper is a
+    convenience for callers who want to reject obviously bad receipts
+    before involving the network. Each boolean reflects one MUST clause
+    on draft-marques-asqav-compliance-receipts-00 §5.
+
+    `errors` carries a per-clause failure code so a CLI / dashboard can
+    show the user which clause failed. Codes mirror the cloud's
+    `validation_label` vocabulary in `routes/verify.py`.
+    """
+
+    valid: bool
+    fields_present: bool
+    receipt_type_in_namespace: bool
+    skew_within_bound: bool
+    chain_link_rederives: bool
+    errors: list[str]
+
+
+def verify_compliance_receipt(
+    envelope: dict[str, Any],
+    *,
+    predecessor_envelope: dict[str, Any] | None = None,
+    now: float | None = None,
+) -> ComplianceReceiptVerification:
+    """Local-side sanity-check on a Compliance Receipt envelope.
+
+    Validates the four MUSTs the SDK can check without round-tripping
+    to the cloud:
+
+    1. All REQUIRED fields are present (§5).
+    2. ``receipt_type`` is in the `protectmcp:*` namespace (F1).
+    3. ``signed_at`` (or ``issued_at``) is within
+       ``SKEW_BOUND_SECONDS`` of ``now`` (V6 / §5.1.2).
+    4. ``previousReceiptHash`` rederives over the predecessor envelope
+       under JCS, when one is supplied (§5.7). When the receipt is the
+       first on its chain (`previousReceiptHash == "0" * 64`) the
+       rederivation step is skipped.
+
+    The cloud is authoritative for cryptographic signature checks,
+    policy_digest resolution against the Audit Pack, and anchor
+    verification. This helper is a convenience.
+
+    Args:
+        envelope: The signed receipt envelope, as a dict.
+        predecessor_envelope: Optional predecessor envelope. When
+            provided, the chain-link is rederived and compared to
+            ``envelope["previousReceiptHash"]``.
+        now: Optional override for the verifier wall clock (UNIX
+            seconds). Defaults to ``time.time()``.
+
+    Returns:
+        A :class:`ComplianceReceiptVerification` capturing each MUST.
+    """
+    from datetime import datetime, timezone
+
+    from ._jcs import canonical_json
+    from .replay import FIRST_RECEIPT_SEED
+
+    errors: list[str] = []
+
+    # 1. REQUIRED fields present.
+    missing = [
+        f for f in _COMPLIANCE_REQUIRED_FIELDS if f not in envelope
+    ]
+    fields_present = not missing
+    if missing:
+        errors.append(f"missing_fields:{','.join(missing)}")
+
+    # 2. receipt_type namespace.
+    rt = envelope.get("receipt_type") or envelope.get("type")
+    receipt_type_in_namespace = rt in RECEIPT_TYPE_NAMESPACE
+    if not receipt_type_in_namespace:
+        errors.append("invalid_receipt_type")
+
+    # 3. 300-second skew bound (V6).
+    issued_at = envelope.get("issued_at") or envelope.get("signed_at")
+    skew_within_bound = False
+    if issued_at is None:
+        errors.append("missing_issued_at")
+    else:
+        try:
+            if isinstance(issued_at, (int, float)):
+                ts = float(issued_at)
+            else:
+                # ISO 8601; tolerate trailing "Z".
+                s = str(issued_at).replace("Z", "+00:00")
+                ts = datetime.fromisoformat(s).timestamp()
+            wall = now if now is not None else time.time()
+            skew = abs(ts - wall)
+            skew_within_bound = skew <= SKEW_BOUND_SECONDS
+            if not skew_within_bound:
+                errors.append("signed_at_skew")
+        except (ValueError, TypeError):
+            errors.append("invalid_issued_at")
+
+    # 4. Chain link rederives. Only checked when caller supplies the
+    # predecessor envelope; first-record seeds skip this.
+    chain_link_rederives = True
+    expected_prev = envelope.get("previousReceiptHash")
+    if expected_prev == FIRST_RECEIPT_SEED:
+        # First record on the chain; nothing to rederive.
+        pass
+    elif predecessor_envelope is not None:
+        actual_prev = hashlib.sha256(
+            canonical_json(predecessor_envelope)
+        ).hexdigest()
+        if actual_prev != expected_prev:
+            chain_link_rederives = False
+            errors.append("chain_link_mismatch")
+    # else: caller did not pass a predecessor; cannot rederive. We
+    # leave `chain_link_rederives=True` since "did not check" is not the
+    # same as "failed to check". Callers needing strictness pass the
+    # predecessor.
+
+    valid = (
+        fields_present
+        and receipt_type_in_namespace
+        and skew_within_bound
+        and chain_link_rederives
+    )
+    return ComplianceReceiptVerification(
+        valid=valid,
+        fields_present=fields_present,
+        receipt_type_in_namespace=receipt_type_in_namespace,
+        skew_within_bound=skew_within_bound,
+        chain_link_rederives=chain_link_rederives,
+        errors=errors,
     )
 
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -191,6 +191,19 @@ class BitcoinAnchor:
     bitcoin_block: int | None = None
 
 
+# IETF Compliance Receipts profile (draft-marques-asqav-compliance-receipts-00 §5).
+# Receipt type namespace mirrored from the cloud's SignRequest validator
+# (`src/asqav_cloud/api/routes/agents.py`). Kept here so the SDK can reject
+# bad inputs before a network roundtrip.
+RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
+    {
+        "protectmcp:decision",
+        "protectmcp:restraint",
+        "protectmcp:lifecycle",
+    }
+)
+
+
 @dataclass
 class SignatureResponse:
     """Response from signing operation.
@@ -222,6 +235,20 @@ class SignatureResponse:
     countersign_url: str | None = None
     # True when the server validated a user_intent envelope on this record.
     user_intent_verified: bool | None = None
+    # IETF Compliance Receipts profile fields. Populated by the cloud only
+    # when `compliance_mode=True` was passed on the sign call. None on
+    # legacy receipts so callers can branch cleanly.
+    compliance_mode: bool = False
+    receipt_type: str | None = None
+    action_ref: str | None = None
+    payload_digest: str | None = None
+    issuer_id: str | None = None
+    iteration_id: str | None = None
+    sandbox_state: str | None = None
+    risk_class: str | None = None
+    incident_class: str | None = None
+    reason: str | None = None
+    previous_receipt_hash: str | None = None
 
 
 @dataclass
@@ -678,6 +705,22 @@ def flush_spans() -> None:
         pass  # Don't fail on export errors
 
 
+def _compute_action_ref(
+    action_type: str, context: dict[str, Any] | None
+) -> str:
+    """Client-side ``sha256:<hex>`` of the canonical Action object.
+
+    The Action shape mirrors `core/canonical.py:hash_action` on the cloud
+    so the SDK and cloud agree byte-for-byte under JCS encoding.
+    """
+    from .canonicalize import canonicalize
+
+    canonical = canonicalize(
+        {"action_type": action_type, "context": context or {}}
+    )
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
 def _build_sign_body(
     *,
     action_type: str,
@@ -685,12 +728,16 @@ def _build_sign_body(
     session_id: str | None,
     agent_id: str,
     user_intent: dict[str, Any] | None = None,
+    compliance_fields: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the JSON body for a ``POST /agents/{id}/sign`` request.
 
     Branches on the SDK-level ``_mode``: full-payload sends ``context``
     as before; hash-only sends a ``hash`` field plus a whitelisted
-    ``metadata`` bag.
+    ``metadata`` bag. ``compliance_fields`` carries the IETF Compliance
+    Receipts profile kwargs (``compliance_mode``, ``action_ref`` etc).
+    They are added at the top level of the request body so the cloud's
+    Pydantic ``SignRequest`` model can validate them.
     """
     if _mode == "hash-only":
         from .canonicalize import hash_action
@@ -728,6 +775,10 @@ def _build_sign_body(
         }
         if user_intent is not None:
             body["user_intent"] = user_intent
+        if compliance_fields:
+            for key, value in compliance_fields.items():
+                if value is not None:
+                    body[key] = value
         return body
 
     # full-payload (default for self-hosted)
@@ -738,6 +789,10 @@ def _build_sign_body(
     }
     if user_intent is not None:
         body["user_intent"] = user_intent
+    if compliance_fields:
+        for key, value in compliance_fields.items():
+            if value is not None:
+                body[key] = value
     return body
 
 
@@ -915,6 +970,17 @@ class Agent:
         nonce: str | None = None,
         valid_seconds: int | None = None,
         expected_executor_pubkey_b64: str | None = None,
+        compliance_mode: bool = False,
+        receipt_type: str | None = None,
+        action_ref: str | None = None,
+        payload_digest: str | None = None,
+        issuer_id: str | None = None,
+        iteration_id: str | None = None,
+        sandbox_state: str | None = None,
+        risk_class: str | None = None,
+        incident_class: str | None = None,
+        reason: str | None = None,
+        policy_decision: str = "permit",
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -994,12 +1060,52 @@ class Agent:
         except Exception:
             logger.warning("asqav before-hook dispatch failed (fail-open)", exc_info=True)
 
+        # IETF Compliance Receipts profile (F1, F5, F9): validate caller
+        # input client-side so we surface bad arguments as ValueError before
+        # a network roundtrip. The cloud re-validates authoritatively.
+        if receipt_type is not None and receipt_type not in RECEIPT_TYPE_NAMESPACE:
+            raise ValueError(
+                "invalid_receipt_type: must be one of "
+                f"{sorted(RECEIPT_TYPE_NAMESPACE)}"
+            )
+        if policy_decision in {"deny", "rate_limit"} and not reason:
+            raise ValueError(
+                "missing_reason: policy_decision=deny|rate_limit "
+                "requires a `reason` code."
+            )
+        # F5: SDK helpfully computes action_ref under compliance_mode when
+        # the caller did not pre-compute one. Same canonical form the cloud
+        # expects (sha256 over JCS bytes of {action_type, context}).
+        if compliance_mode and action_ref is None:
+            action_ref = _compute_action_ref(action_type, context)
+
+        compliance_fields: dict[str, Any] = {}
+        if compliance_mode:
+            compliance_fields["compliance_mode"] = True
+            compliance_fields["receipt_type"] = (
+                receipt_type or "protectmcp:decision"
+            )
+            compliance_fields["policy_decision"] = policy_decision
+            compliance_fields["action_ref"] = action_ref
+            for k, v in (
+                ("payload_digest", payload_digest),
+                ("issuer_id", issuer_id),
+                ("iteration_id", iteration_id),
+                ("sandbox_state", sandbox_state),
+                ("risk_class", risk_class),
+                ("incident_class", incident_class),
+                ("reason", reason),
+            ):
+                if v is not None:
+                    compliance_fields[k] = v
+
         body = _build_sign_body(
             action_type=action_type,
             context=context,
             session_id=self._session_id,
             agent_id=self.agent_id,
             user_intent=user_intent,
+            compliance_fields=compliance_fields or None,
         )
         if co_signers:
             body["co_signers"] = list(co_signers)
@@ -1032,6 +1138,23 @@ class Agent:
             co_signatures=data.get("co_signatures"),
             countersign_url=data.get("countersign_url"),
             user_intent_verified=data.get("user_intent_verified"),
+            # IETF profile fields. Cloud emits both `previousReceiptHash`
+            # (camelCase per spec) and `previous_receipt_hash` (snake_case
+            # alias). Accept either so the SDK works against both shapes.
+            compliance_mode=bool(data.get("compliance_mode", False)),
+            receipt_type=data.get("receipt_type"),
+            action_ref=data.get("action_ref"),
+            payload_digest=data.get("payload_digest"),
+            issuer_id=data.get("issuer_id"),
+            iteration_id=data.get("iteration_id"),
+            sandbox_state=data.get("sandbox_state"),
+            risk_class=data.get("risk_class"),
+            incident_class=data.get("incident_class"),
+            reason=data.get("reason"),
+            previous_receipt_hash=(
+                data.get("previousReceiptHash")
+                or data.get("previous_receipt_hash")
+            ),
         )
 
         # Dispatch after-hooks (fail-open).

--- a/python/src/asqav/demo.py
+++ b/python/src/asqav/demo.py
@@ -399,11 +399,22 @@ class DemoHandler(http.server.BaseHTTPRequestHandler):
             if scenario is None:
                 self._json(404, {"error": "unknown scenario"})
                 return
+            # IETF Compliance Receipts profile (§5): populate `risk_class`
+            # from the scenario's existing `risk_classification` field so the
+            # demo receipt carries the same controlled-vocabulary value the
+            # cloud emits on a real Compliance Receipt envelope. Same for
+            # `receipt_type` (decision namespace per F1) and `reason` /
+            # `policy_decision` per F9.
             receipt = _sign(self.state, {
                 "scenario_id": sid,
                 "action_type": scenario["action_type"],
                 "decision": decision,
                 "reason": reason,
+                "risk_class": scenario.get("risk_classification", "unknown"),
+                "receipt_type": "protectmcp:decision",
+                "policy_decision": (
+                    "permit" if decision == "approved" else "deny"
+                ),
                 "timestamp": int(time.time()),
             })
             self.state.approvals[sid] = {"decision": decision, "reason": reason, "receipt": receipt}

--- a/python/src/asqav/extras/_base.py
+++ b/python/src/asqav/extras/_base.py
@@ -77,6 +77,7 @@ class AsqavAdapter:
         self,
         action_type: str,
         context: dict | None = None,
+        **compliance_kwargs,
     ) -> SignatureResponse | None:
         """Sign an action via the agent. Returns None on failure (fail-open).
 
@@ -85,6 +86,14 @@ class AsqavAdapter:
 
         When observe mode is enabled, logs the action that would be signed
         without making any API calls and returns None.
+
+        IETF Compliance Receipts profile: subclasses MAY pass any of
+        ``compliance_mode``, ``receipt_type``, ``action_ref``,
+        ``payload_digest``, ``issuer_id``, ``iteration_id``,
+        ``sandbox_state``, ``risk_class``, ``incident_class``, ``reason``,
+        ``policy_decision`` via ``**compliance_kwargs``. They forward
+        verbatim to ``Agent.sign``. Unknown kwargs raise TypeError on
+        ``Agent.sign`` and surface as a fail-open warning here.
         """
         if self._observe:
             logger.info(
@@ -92,7 +101,7 @@ class AsqavAdapter:
             )
             return None
         try:
-            sig = self._agent.sign(action_type, context)
+            sig = self._agent.sign(action_type, context, **compliance_kwargs)
             self._signatures.append(sig)
             return sig
         except AsqavError as exc:

--- a/python/src/asqav/extras/litellm.py
+++ b/python/src/asqav/extras/litellm.py
@@ -87,13 +87,21 @@ class AsqavGuardrail(AsqavAdapter):
         original_exception: Exception,
         user_api_key_dict: dict,
     ) -> None:
-        """Sign after a failed LLM call."""
+        """Sign after a failed LLM call.
+
+        Surfaces error events under `risk_class="medium"` so the IETF
+        Compliance Receipts profile sees a controlled-vocabulary risk
+        signal even when callers do not configure compliance_mode. The
+        cloud only emits risk_class on the signed envelope under
+        compliance_mode; outside it the value is dropped.
+        """
         self._sign_action(
             "llm:error",
             {
                 "error_type": type(original_exception).__name__,
                 "error_message": str(original_exception),
             },
+            risk_class="medium",
         )
 
     async def async_moderation_hook(

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -1,0 +1,169 @@
+"""Algorithm-agility helpers for the IETF Compliance Receipts profile.
+
+The Asqav cloud signs receipts server-side; client-side keypair
+generation is only useful for offline scenarios (LocalQueue, air-gapped
+demos, conformance vectors). This module exposes a tiny stable API so
+callers can opt into Ed25519 or ES256 (in addition to the default
+ML-DSA-65) without depending on `cryptography` / `pynacl` directly.
+
+Spec references:
+  * draft-marques-asqav-compliance-receipts-00 §10.8 (algorithm
+    registry).
+  * IETF audit cycle (`~/.company/cycles/ietf-impl-status-2026-05-04.md`)
+    AG3 (Ed25519) and AG4 (ES256) on the receipt-signing path.
+
+The module is import-safe even when `cryptography` is not installed:
+the import is deferred to call sites so legacy users (cloud-only,
+ML-DSA-65) never see a hard dependency. Callers that ask for Ed25519
+or ES256 without the optional dep get a clear ImportError pointing
+them at the install command.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+# Public identifiers the Compliance Receipts profile recognises. Mirrors
+# the cloud's SignatureRecord.algorithm column under §10.8 so cloud and
+# SDK never disagree on what a receipt advertises.
+ALGORITHM_ML_DSA_65 = "ml-dsa-65"
+ALGORITHM_ED25519 = "ed25519"
+ALGORITHM_ES256 = "es256"
+
+SUPPORTED_ALGORITHMS: frozenset[str] = frozenset(
+    {ALGORITHM_ML_DSA_65, ALGORITHM_ED25519, ALGORITHM_ES256}
+)
+
+Algorithm = Literal["ml-dsa-65", "ed25519", "es256"]
+
+
+@dataclass
+class LocalKeypair:
+    """A locally-generated keypair for offline / air-gapped flows.
+
+    `private_key_pem` is PKCS#8 (Ed25519, ES256) or a raw 32-byte secret
+    for ML-DSA-65. `public_key_pem` is SubjectPublicKeyInfo (Ed25519,
+    ES256) or raw 32-byte public for ML-DSA-65. The SDK intentionally
+    does not retain the private key after the dataclass is returned;
+    storage is the caller's problem.
+    """
+
+    algorithm: str
+    private_key_pem: bytes
+    public_key_pem: bytes
+
+
+def _check_algorithm(algorithm: str) -> str:
+    """Normalise + validate the requested algorithm string."""
+    norm = algorithm.lower()
+    if norm not in SUPPORTED_ALGORITHMS:
+        raise ValueError(
+            "unsupported_algorithm: "
+            f"{algorithm!r} is not in {sorted(SUPPORTED_ALGORITHMS)}"
+        )
+    return norm
+
+
+def generate_local_keypair(algorithm: Algorithm = "ml-dsa-65") -> LocalKeypair:
+    """Generate a keypair locally for the requested algorithm.
+
+    For cloud-signed receipts the cloud generates the keypair; this
+    helper is for offline scenarios (LocalQueue, conformance vector
+    fixtures, air-gapped operator tooling).
+
+    Args:
+        algorithm: One of `ml-dsa-65`, `ed25519`, `es256`. Default is
+            `ml-dsa-65` to match the cloud's default.
+
+    Returns:
+        A :class:`LocalKeypair` with PEM-encoded keys (or raw bytes for
+        ML-DSA-65; PEM is not standardised for that algorithm yet).
+
+    Raises:
+        ValueError: If `algorithm` is not in `SUPPORTED_ALGORITHMS`.
+        ImportError: If the optional `cryptography` package is needed
+            but not installed.
+    """
+    alg = _check_algorithm(algorithm)
+    if alg == ALGORITHM_ED25519:
+        return _generate_ed25519()
+    if alg == ALGORITHM_ES256:
+        return _generate_es256()
+    return _generate_ml_dsa_65()
+
+
+# ---------------------------------------------------------------------------
+# Per-algorithm implementations.
+# ---------------------------------------------------------------------------
+
+
+def _generate_ed25519() -> LocalKeypair:
+    try:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+    except ImportError as e:
+        raise ImportError(
+            "ed25519 keypair generation requires the `cryptography` "
+            "package. Install with `pip install asqav[crypto]` or "
+            "`pip install cryptography`."
+        ) from e
+
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return LocalKeypair(
+        algorithm=ALGORITHM_ED25519,
+        private_key_pem=private_pem,
+        public_key_pem=public_pem,
+    )
+
+
+def _generate_es256() -> LocalKeypair:
+    """Generate an ECDSA P-256 keypair (alg=ES256 in JOSE / RFC 7518)."""
+    try:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+    except ImportError as e:
+        raise ImportError(
+            "es256 keypair generation requires the `cryptography` "
+            "package. Install with `pip install asqav[crypto]` or "
+            "`pip install cryptography`."
+        ) from e
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return LocalKeypair(
+        algorithm=ALGORITHM_ES256,
+        private_key_pem=private_pem,
+        public_key_pem=public_pem,
+    )
+
+
+def _generate_ml_dsa_65() -> LocalKeypair:
+    """Stub for ML-DSA-65; the cloud is authoritative for this algorithm.
+
+    A pure-Python or Rust ML-DSA library is not yet in our optional deps.
+    Calling this raises NotImplementedError with a pointer to the cloud
+    `Agent.create()` flow which the SDK already supports.
+    """
+    raise NotImplementedError(
+        "ml-dsa-65 keypair generation runs server-side; call "
+        "`asqav.Agent.create(name, algorithm='ml-dsa-65')` to have the "
+        "cloud generate the keypair."
+    )

--- a/python/src/asqav/replay.py
+++ b/python/src/asqav/replay.py
@@ -1,4 +1,16 @@
-"""Audit trail replay - reconstruct and verify what any agent did, step by step."""
+"""Audit trail replay - reconstruct and verify what any agent did, step by step.
+
+Two chain shapes are supported:
+
+  * **IETF v2** (default): ``previousReceiptHash = sha256(JCS(predecessor
+    signed envelope))`` per draft-marques-asqav-compliance-receipts-00
+    §5.7. First record's predecessor seed is ``"0" * 64``
+    (``FIRST_RECEIPT_SEED``).
+  * **Legacy**: hash over ``{signature_id, action_type, timestamp,
+    prev_hash}`` with empty-string seed. Kept behind ``legacy_chain=True``
+    so historical receipts (issued before the IETF profile landed) keep
+    verifying.
+"""
 
 from __future__ import annotations
 
@@ -8,8 +20,14 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from ._jcs import canonical_json
 from .client import SignedActionResponse, get_session_signatures
 from .compliance import ComplianceBundle, _normalize_signature
+
+# Per-IETF-profile seed for the first record on every chain. Distinguishes
+# "no predecessor" from "predecessor not yet linked". Mirrors
+# `core/integrity.py:FIRST_RECEIPT_SEED` on the cloud.
+FIRST_RECEIPT_SEED: str = "0" * 64
 
 
 @dataclass
@@ -103,19 +121,31 @@ class ReplayTimeline:
 
         return "\n".join(lines)
 
-    def verify_chain(self) -> bool:
+    def verify_chain(self, *, legacy_chain: bool = False) -> bool:
         """Recompute each step's predecessor hash, compare to stored
         ``prev_chain_hash``. Mismatch = tampering. Steps lacking a stored
-        hash are marked invalid rather than passing silently."""
+        hash are marked invalid rather than passing silently.
+
+        Args:
+            legacy_chain: When True, recomputes using the pre-IETF
+                envelope shape (``{signature_id, action_type, timestamp,
+                prev_hash}``) so receipts issued before the profile
+                landed keep verifying. Default False uses the IETF v2
+                shape per §5.7.
+        """
         if not self.steps:
             self.chain_integrity = True
             return True
 
-        prev_hash = ""
+        seed = "" if legacy_chain else FIRST_RECEIPT_SEED
+        prev_hash = seed
         all_valid = True
 
         for step in self.steps:
             if step.index == 0:
+                # First-record seed: stored prev_chain_hash should match the
+                # spec seed under v2. Legacy chains used None so we accept
+                # both for compatibility with bundles produced pre-v2.
                 step.chain_valid = True
             else:
                 stored = getattr(step, "prev_chain_hash", None)
@@ -127,46 +157,92 @@ class ReplayTimeline:
                     if not step.chain_valid:
                         all_valid = False
 
-            entry = json.dumps(
-                {
-                    "signature_id": step.signature_id,
-                    "action_type": step.action_type,
-                    "timestamp": step.timestamp,
-                    "prev_hash": prev_hash,
-                },
-                sort_keys=True,
-                separators=(",", ":"),
+            prev_hash = _step_chain_hash(
+                step, prev_hash, legacy_chain=legacy_chain
             )
-            prev_hash = hashlib.sha256(entry.encode()).hexdigest()
 
         self.chain_integrity = all_valid
         return all_valid
 
 
-def _verify_hash_chain(signatures: list[dict]) -> list[bool]:
-    """Check each signature chains to the previous via SHA-256.
+def _step_chain_hash(
+    step: ReplayStep, prev_hash: str, *, legacy_chain: bool
+) -> str:
+    """Compute the chain hash a step contributes to the next link.
 
-    Returns a list of booleans, one per signature, indicating whether
-    the chain link from the previous entry is valid.
+    Under the IETF v2 shape (``draft-marques-asqav-compliance-receipts-00``
+    §5.7) this is ``sha256(JCS(predecessor_signed_envelope))``. The
+    "envelope" reconstructed here is the minimum the SDK can rebuild from
+    a ReplayStep: the signature_id, action_type, payload context, and
+    server timestamp, plus the previous-receipt-hash link. This is the
+    same shape the cloud serializes when it computes the chain link, so
+    SDK and cloud agree byte-for-byte for receipts the SDK observed.
+
+    Under ``legacy_chain=True`` the historic shape is used so bundles
+    exported before the profile landed still verify.
     """
-    if not signatures:
-        return []
-
-    results: list[bool] = []
-    prev_hash = ""
-
-    for i, sig in enumerate(signatures):
+    if legacy_chain:
         entry = json.dumps(
             {
-                "signature_id": sig.get("signature_id", ""),
-                "action_type": sig.get("action_type", ""),
-                "timestamp": sig.get("signed_at", sig.get("timestamp", 0)),
+                "signature_id": step.signature_id,
+                "action_type": step.action_type,
+                "timestamp": step.timestamp,
                 "prev_hash": prev_hash,
             },
             sort_keys=True,
             separators=(",", ":"),
         )
-        current_hash = hashlib.sha256(entry.encode()).hexdigest()
+        return hashlib.sha256(entry.encode()).hexdigest()
+
+    envelope = {
+        "signature_id": step.signature_id,
+        "action_type": step.action_type,
+        "context": step.context,
+        "timestamp": step.timestamp,
+        "previousReceiptHash": prev_hash,
+    }
+    return hashlib.sha256(canonical_json(envelope)).hexdigest()
+
+
+def _verify_hash_chain(
+    signatures: list[dict], *, legacy_chain: bool = False
+) -> list[bool]:
+    """Check each signature chains to the previous via SHA-256.
+
+    Returns a list of booleans, one per signature, indicating whether
+    the chain link from the previous entry is valid.
+
+    `legacy_chain` selects the pre-IETF envelope shape so old receipts
+    (recorded before the profile landed) keep verifying.
+    """
+    if not signatures:
+        return []
+
+    results: list[bool] = []
+    prev_hash = "" if legacy_chain else FIRST_RECEIPT_SEED
+
+    for i, sig in enumerate(signatures):
+        if legacy_chain:
+            entry = json.dumps(
+                {
+                    "signature_id": sig.get("signature_id", ""),
+                    "action_type": sig.get("action_type", ""),
+                    "timestamp": sig.get("signed_at", sig.get("timestamp", 0)),
+                    "prev_hash": prev_hash,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            current_hash = hashlib.sha256(entry.encode()).hexdigest()
+        else:
+            envelope = {
+                "signature_id": sig.get("signature_id", ""),
+                "action_type": sig.get("action_type", ""),
+                "context": sig.get("payload"),
+                "timestamp": sig.get("signed_at", sig.get("timestamp", 0)),
+                "previousReceiptHash": prev_hash,
+            }
+            current_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
         results.append(True)  # Valid link in a freshly-built chain
         prev_hash = current_hash
 
@@ -204,25 +280,35 @@ def _build_explanation(action_type: str, context: dict[str, Any] | None) -> str:
     return base
 
 
-def replay(agent_id: str, session_id: str) -> ReplayTimeline:
+def replay(
+    agent_id: str, session_id: str, *, legacy_chain: bool = False
+) -> ReplayTimeline:
     """Fetch signatures for a session and reconstruct the audit trail.
 
     Args:
         agent_id: The agent that owns the session.
         session_id: The session to replay.
+        legacy_chain: When True, derive chain links via the pre-IETF
+            envelope shape so historical receipts verify. Default False
+            uses the IETF v2 shape per §5.7.
 
     Returns:
         A ReplayTimeline with ordered steps and chain verification.
     """
     raw_sigs = get_session_signatures(session_id)
-    return _build_timeline(agent_id, session_id, raw_sigs)
+    return _build_timeline(
+        agent_id, session_id, raw_sigs, legacy_chain=legacy_chain
+    )
 
 
-def replay_from_bundle(bundle: ComplianceBundle) -> ReplayTimeline:
+def replay_from_bundle(
+    bundle: ComplianceBundle, *, legacy_chain: bool = False
+) -> ReplayTimeline:
     """Reconstruct a timeline from a ComplianceBundle offline.
 
     Args:
         bundle: A previously exported ComplianceBundle.
+        legacy_chain: Use the pre-IETF chain shape; see :func:`replay`.
 
     Returns:
         A ReplayTimeline built from the bundle receipts.
@@ -255,13 +341,17 @@ def replay_from_bundle(bundle: ComplianceBundle) -> ReplayTimeline:
             )
         )
 
-    return _build_timeline(agent_id, session_id, fake_sigs)
+    return _build_timeline(
+        agent_id, session_id, fake_sigs, legacy_chain=legacy_chain
+    )
 
 
 def _build_timeline(
     agent_id: str,
     session_id: str,
     signatures: list[SignedActionResponse],
+    *,
+    legacy_chain: bool = False,
 ) -> ReplayTimeline:
     """Shared logic to build a ReplayTimeline from a list of signatures."""
     # Sort by timestamp
@@ -269,23 +359,36 @@ def _build_timeline(
 
     # Build normalized dicts for chain verification
     sig_dicts = [_normalize_signature(s) for s in sorted_sigs]
-    chain_results = _verify_hash_chain(sig_dicts)
+    chain_results = _verify_hash_chain(sig_dicts, legacy_chain=legacy_chain)
 
     # Rolling chain hash; each step records its predecessor's value.
+    # Under the IETF v2 profile (§5.7) the seed is the all-zero SHA-256
+    # value so verifiers can distinguish "no predecessor" from "predecessor
+    # not yet linked". Legacy chains used the empty string.
     chain_hashes: list[str] = []
-    prev_hash = ""
+    prev_hash = "" if legacy_chain else FIRST_RECEIPT_SEED
     for sig in sorted_sigs:
-        entry = json.dumps(
-            {
+        if legacy_chain:
+            entry = json.dumps(
+                {
+                    "signature_id": sig.signature_id,
+                    "action_type": sig.action_type,
+                    "timestamp": sig.signed_at,
+                    "prev_hash": prev_hash,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            prev_hash = hashlib.sha256(entry.encode()).hexdigest()
+        else:
+            envelope = {
                 "signature_id": sig.signature_id,
                 "action_type": sig.action_type,
+                "context": sig.payload,
                 "timestamp": sig.signed_at,
-                "prev_hash": prev_hash,
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-        prev_hash = hashlib.sha256(entry.encode()).hexdigest()
+                "previousReceiptHash": prev_hash,
+            }
+            prev_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
         chain_hashes.append(prev_hash)
 
     steps: list[ReplayStep] = []

--- a/python/src/asqav/replay.py
+++ b/python/src/asqav/replay.py
@@ -44,6 +44,19 @@ class ReplayStep:
     explanation: str
     # Predecessor's chain hash; verify_chain recomputes and compares.
     prev_chain_hash: str | None = None
+    # IETF Compliance Receipts profile: when the caller has the full
+    # signed envelope for this step (the exact bytes the cloud put under
+    # `compute_signature_record_hash_v2`), verify_chain hashes those
+    # bytes byte-for-byte and tampering of any field surfaces. Legacy
+    # bundles that pre-date the profile leave this None and fall back
+    # to the synthetic shape (internal-consistency only).
+    signed_envelope: dict[str, Any] | None = None
+    # Marks a step that fell back to the synthetic envelope shape
+    # because no `signed_envelope` was attached. A timeline whose
+    # compliance steps all carry envelopes has `legacy_chain=False`
+    # on every step; mixed timelines flag the legacy ones so callers
+    # know which steps lack byte-level chain proof.
+    legacy_chain: bool = False
 
 
 @dataclass
@@ -54,6 +67,13 @@ class ReplayTimeline:
     session_id: str
     steps: list[ReplayStep] = field(default_factory=list)
     chain_integrity: bool = True
+    # IETF Compliance Receipts profile: True only when EVERY step under
+    # compliance mode carried a `signed_envelope` and verified
+    # byte-for-byte against the cloud's `compute_signature_record_hash_v2`.
+    # Distinguishes "the chain links inside this bundle are
+    # self-consistent" (chain_integrity) from "this bundle survives
+    # the cloud-side byte-for-byte check" (compliance_chain_valid).
+    compliance_chain_valid: bool = True
     start_time: float | None = None
     end_time: float | None = None
     total_actions: int = 0
@@ -74,10 +94,13 @@ class ReplayTimeline:
                     "chain_valid": s.chain_valid,
                     "explanation": s.explanation,
                     "prev_chain_hash": s.prev_chain_hash,
+                    "signed_envelope": s.signed_envelope,
+                    "legacy_chain": s.legacy_chain,
                 }
                 for s in self.steps
             ],
             "chain_integrity": self.chain_integrity,
+            "compliance_chain_valid": self.compliance_chain_valid,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "total_actions": self.total_actions,
@@ -126,6 +149,14 @@ class ReplayTimeline:
         ``prev_chain_hash``. Mismatch = tampering. Steps lacking a stored
         hash are marked invalid rather than passing silently.
 
+        When a step carries `signed_envelope`, the chain hash is computed
+        as ``sha256(JCS(signed_envelope))`` so the result matches the
+        cloud's ``compute_signature_record_hash_v2`` byte-for-byte; any
+        tampering of any signed field is caught. When `signed_envelope`
+        is None, the step falls back to the synthetic shape (legacy
+        path); `legacy_chain=True` is set on the step and the top-level
+        ``compliance_chain_valid`` becomes False.
+
         Args:
             legacy_chain: When True, recomputes using the pre-IETF
                 envelope shape (``{signature_id, action_type, timestamp,
@@ -135,11 +166,17 @@ class ReplayTimeline:
         """
         if not self.steps:
             self.chain_integrity = True
+            self.compliance_chain_valid = True
             return True
 
         seed = "" if legacy_chain else FIRST_RECEIPT_SEED
         prev_hash = seed
         all_valid = True
+        # `compliance_chain_valid` requires every step to carry a
+        # signed_envelope AND verify against it. Legacy verify_chain
+        # callers (legacy_chain=True) intentionally degrade this to
+        # False: the synthetic shape cannot prove byte-level integrity.
+        compliance_valid = not legacy_chain
 
         for step in self.steps:
             if step.index == 0:
@@ -157,11 +194,29 @@ class ReplayTimeline:
                     if not step.chain_valid:
                         all_valid = False
 
-            prev_hash = _step_chain_hash(
-                step, prev_hash, legacy_chain=legacy_chain
-            )
+            # Chain-link contribution. Prefer the cloud byte-for-byte
+            # shape when the envelope is present; flag the synthetic
+            # path as legacy so callers can spot which steps are
+            # internal-consistency only.
+            envelope = getattr(step, "signed_envelope", None)
+            if envelope is not None and not legacy_chain:
+                step.legacy_chain = False
+                prev_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
+            else:
+                step.legacy_chain = True
+                if not legacy_chain:
+                    # Compliance mode requested but no envelope attached:
+                    # cloud byte-for-byte check is not possible.
+                    compliance_valid = False
+                prev_hash = _step_chain_hash(
+                    step, prev_hash, legacy_chain=legacy_chain
+                )
 
         self.chain_integrity = all_valid
+        # compliance_chain_valid is True only when every step verified
+        # under the cloud envelope shape. A single legacy fallback or a
+        # broken link drops it.
+        self.compliance_chain_valid = bool(compliance_valid and all_valid)
         return all_valid
 
 
@@ -170,16 +225,17 @@ def _step_chain_hash(
 ) -> str:
     """Compute the chain hash a step contributes to the next link.
 
-    Under the IETF v2 shape (``draft-marques-asqav-compliance-receipts-00``
-    §5.7) this is ``sha256(JCS(predecessor_signed_envelope))``. The
-    "envelope" reconstructed here is the minimum the SDK can rebuild from
-    a ReplayStep: the signature_id, action_type, payload context, and
-    server timestamp, plus the previous-receipt-hash link. This is the
-    same shape the cloud serializes when it computes the chain link, so
-    SDK and cloud agree byte-for-byte for receipts the SDK observed.
+    When a `signed_envelope` is provided, the chain hash matches the
+    cloud byte-for-byte (``sha256(JCS(signed_envelope))`` per
+    ``compute_signature_record_hash_v2``). When not, a legacy synthetic
+    shape is used and `chain_valid` is internal-consistency only:
+    tampering of fields not in the synthetic envelope (`policy_digest`,
+    `policy_decision`, `issuer_id`, `payload_digest`, etc) will NOT be
+    caught. Callers that need byte-level integrity MUST attach
+    `signed_envelope` to the ReplayStep.
 
-    Under ``legacy_chain=True`` the historic shape is used so bundles
-    exported before the profile landed still verify.
+    Under ``legacy_chain=True`` the historic pre-IETF hash shape is
+    used so bundles exported before the profile landed still verify.
     """
     if legacy_chain:
         entry = json.dumps(
@@ -324,8 +380,12 @@ def replay_from_bundle(
     if not session_id:
         session_id = "bundle"
 
-    # Convert receipts to SignedActionResponse-like objects for processing
+    # Convert receipts to SignedActionResponse-like objects for processing.
+    # Receipts that carry `signed_envelope` (the IETF profile bytes the
+    # cloud anchored) keep it as a sidecar so verify_chain can reproduce
+    # the cloud hash byte-for-byte.
     fake_sigs = []
+    envelopes: list[dict[str, Any] | None] = []
     for r in bundle.receipts:
         fake_sigs.append(
             SignedActionResponse(
@@ -340,9 +400,11 @@ def replay_from_bundle(
                 verification_url=r.get("verification_url", ""),
             )
         )
+        envelopes.append(r.get("signed_envelope"))
 
     return _build_timeline(
-        agent_id, session_id, fake_sigs, legacy_chain=legacy_chain
+        agent_id, session_id, fake_sigs,
+        legacy_chain=legacy_chain, signed_envelopes=envelopes,
     )
 
 
@@ -352,10 +414,27 @@ def _build_timeline(
     signatures: list[SignedActionResponse],
     *,
     legacy_chain: bool = False,
+    signed_envelopes: list[dict[str, Any] | None] | None = None,
 ) -> ReplayTimeline:
-    """Shared logic to build a ReplayTimeline from a list of signatures."""
-    # Sort by timestamp
-    sorted_sigs = sorted(signatures, key=lambda s: s.signed_at)
+    """Shared logic to build a ReplayTimeline from a list of signatures.
+
+    `signed_envelopes` is an optional parallel list of cloud-issued
+    envelope dicts indexed against `signatures`. When supplied, each
+    step carries the full envelope so `verify_chain` reproduces the
+    cloud's `compute_signature_record_hash_v2` byte-for-byte.
+    """
+    # Sort by timestamp; carry envelope alongside.
+    indexed = list(enumerate(signatures))
+    indexed.sort(key=lambda pair: pair[1].signed_at)
+    sorted_sigs = [s for _, s in indexed]
+    sorted_envelopes: list[dict[str, Any] | None] = []
+    if signed_envelopes is not None:
+        sorted_envelopes = [
+            signed_envelopes[orig_idx] if orig_idx < len(signed_envelopes) else None
+            for orig_idx, _ in indexed
+        ]
+    else:
+        sorted_envelopes = [None] * len(sorted_sigs)
 
     # Build normalized dicts for chain verification
     sig_dicts = [_normalize_signature(s) for s in sorted_sigs]
@@ -367,7 +446,7 @@ def _build_timeline(
     # not yet linked". Legacy chains used the empty string.
     chain_hashes: list[str] = []
     prev_hash = "" if legacy_chain else FIRST_RECEIPT_SEED
-    for sig in sorted_sigs:
+    for sig, env in zip(sorted_sigs, sorted_envelopes):
         if legacy_chain:
             entry = json.dumps(
                 {
@@ -380,6 +459,9 @@ def _build_timeline(
                 separators=(",", ":"),
             )
             prev_hash = hashlib.sha256(entry.encode()).hexdigest()
+        elif env is not None:
+            # Compliance mode: byte-for-byte match with cloud's v2 hash.
+            prev_hash = hashlib.sha256(canonical_json(env)).hexdigest()
         else:
             envelope = {
                 "signature_id": sig.signature_id,
@@ -395,6 +477,7 @@ def _build_timeline(
     for i, sig in enumerate(sorted_sigs):
         explanation = _build_explanation(sig.action_type, sig.payload)
         prev_chain_hash = chain_hashes[i - 1] if i > 0 else None
+        env = sorted_envelopes[i]
         steps.append(
             ReplayStep(
                 index=i,
@@ -406,18 +489,29 @@ def _build_timeline(
                 chain_valid=chain_results[i] if i < len(chain_results) else False,
                 explanation=explanation,
                 prev_chain_hash=prev_chain_hash,
+                signed_envelope=env,
+                legacy_chain=(env is None and not legacy_chain) or legacy_chain,
             )
         )
 
     start_time = sorted_sigs[0].signed_at if sorted_sigs else None
     end_time = sorted_sigs[-1].signed_at if sorted_sigs else None
     chain_integrity = all(chain_results) if chain_results else True
+    # compliance_chain_valid is True only if every step has an envelope
+    # AND links verified. Mixed or legacy bundles drop it to False.
+    compliance_chain_valid = (
+        not legacy_chain
+        and chain_integrity
+        and all(env is not None for env in sorted_envelopes)
+        and len(sorted_envelopes) == len(sorted_sigs)
+    )
 
     return ReplayTimeline(
         agent_id=agent_id,
         session_id=session_id,
         steps=steps,
         chain_integrity=chain_integrity,
+        compliance_chain_valid=compliance_chain_valid,
         start_time=start_time,
         end_time=end_time,
         total_actions=len(steps),

--- a/python/tests/test_adapter_base.py
+++ b/python/tests/test_adapter_base.py
@@ -232,3 +232,59 @@ def test_end_session_skips_when_no_agent_session(mock_agent_cls):
 
     adapter._end_session()
     mock_agent.end_session.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# IETF Compliance Receipts profile pass-through
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.extras._base.Agent")
+def test_sign_action_forwards_compliance_kwargs(mock_agent_cls):
+    """_sign_action forwards IETF profile kwargs verbatim to Agent.sign.
+
+    Subclasses (LangChain callback, CrewAI hook, LiteLLM guardrail, etc)
+    rely on this to populate `risk_class`, `iteration_id`,
+    `compliance_mode` etc on the signed envelope without duplicating
+    the kwarg list per integration.
+    """
+    mock_agent = MagicMock()
+    mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
+    mock_agent.sign.return_value = mock_sig
+    mock_agent_cls.create.return_value = mock_agent
+
+    with patch("asqav.client._api_key", "sk_test"):
+        adapter = _TestAdapter(agent_name="test")
+
+    sig = adapter._sign_action(
+        "api:call",
+        {"k": "v"},
+        compliance_mode=True,
+        receipt_type="protectmcp:decision",
+        risk_class="high",
+        iteration_id="iter_42",
+    )
+    assert sig is mock_sig
+    mock_agent.sign.assert_called_once_with(
+        "api:call",
+        {"k": "v"},
+        compliance_mode=True,
+        receipt_type="protectmcp:decision",
+        risk_class="high",
+        iteration_id="iter_42",
+    )
+
+
+@patch("asqav.extras._base.Agent")
+def test_sign_action_no_compliance_kwargs_unchanged(mock_agent_cls):
+    """_sign_action without compliance kwargs calls Agent.sign as before."""
+    mock_agent = MagicMock()
+    mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
+    mock_agent.sign.return_value = mock_sig
+    mock_agent_cls.create.return_value = mock_agent
+
+    with patch("asqav.client._api_key", "sk_test"):
+        adapter = _TestAdapter(agent_name="test")
+
+    adapter._sign_action("api:call", {"k": "v"})
+    mock_agent.sign.assert_called_once_with("api:call", {"k": "v"})

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -80,6 +80,92 @@ def test_verify_not_found(mock_verify: MagicMock) -> None:
     assert "not found" in result.output.lower()
 
 
+# ---------------------------------------------------------------------------
+# sign command (IETF Compliance Receipts profile)
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.init")
+def test_sign_compliance_mode_calls_sdk(
+    mock_init: MagicMock, mock_get: MagicMock, tmp_path
+) -> None:
+    """sign --compliance-mode threads every IETF flag into Agent.sign()."""
+    fake_agent = MagicMock()
+    fake_agent.agent_id = "agent_x"
+    fake_agent.algorithm = "ml-dsa-65"
+    fake_agent.sign.return_value = MagicMock(
+        signature_id="sig_abc",
+        action_id="act_1",
+        algorithm="ml-dsa-65",
+        timestamp=1717.0,
+        verification_url="https://verify.example/sig_abc",
+        policy_digest="sha256:cafe",
+        policy_decision="permit",
+        compliance_mode=True,
+        receipt_type="protectmcp:decision",
+        action_ref="sha256:beef",
+        issuer_id="legal:Acme",
+        previous_receipt_hash="0" * 64,
+        bitcoin_anchor=None,
+        rfc3161_tsa=None,
+        rfc3161_serial=None,
+    )
+    mock_get.return_value = fake_agent
+
+    action_path = tmp_path / "action.json"
+    action_path.write_text('{"amount_eur": 850000}')
+
+    result = runner.invoke(
+        app,
+        [
+            "sign",
+            "--agent-id", "agent_x",
+            "--action-type", "payment.wire_transfer",
+            "--action-json", str(action_path),
+            "--compliance-mode",
+            "--receipt-type", "protectmcp:decision",
+            "--risk-class", "high",
+            "--issuer-id", "legal:Acme",
+            "--iteration-id", "task-2026-Q2",
+            "--sandbox-state", "enabled",
+        ],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "sig_abc" in result.output
+    assert "compliance_mode: True" in result.output
+    assert "receipt_type:  protectmcp:decision" in result.output
+    fake_agent.sign.assert_called_once()
+    call_kwargs = fake_agent.sign.call_args.kwargs
+    assert call_kwargs["compliance_mode"] is True
+    assert call_kwargs["receipt_type"] == "protectmcp:decision"
+    assert call_kwargs["risk_class"] == "high"
+    assert call_kwargs["issuer_id"] == "legal:Acme"
+    assert call_kwargs["iteration_id"] == "task-2026-Q2"
+    assert call_kwargs["sandbox_state"] == "enabled"
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.init")
+def test_sign_deny_without_reason_rejects(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    """sign --policy-decision deny without --reason exits non-zero."""
+    result = runner.invoke(
+        app,
+        [
+            "sign",
+            "--agent-id", "agent_x",
+            "--action-type", "x.y",
+            "--policy-decision", "deny",
+        ],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 1
+    assert "--reason is required" in result.output
+
+
 @patch("asqav.verify_signature")
 def test_verify_text_shows_ietf_axes(mock_verify: MagicMock) -> None:
     """verify --output text surfaces IETF profile sub-axes when present."""

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -816,3 +816,272 @@ def test_policies_blocked_on_free_tier(
     mock_get.return_value = {"tier": "free", "organization_id": "o", "organization_name": "n"}
     result = runner.invoke(app, ["policies", "list"], env={"ASQAV_API_KEY": "sk_test"})
     assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# audit-pack export / policy
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.client._post")
+@patch("asqav.init")
+def test_audit_pack_export_writes_bundle(
+    mock_init: MagicMock, mock_post: MagicMock, tmp_path
+) -> None:
+    """audit-pack export writes the cloud-signed bundle to disk."""
+    mock_post.return_value = {
+        "bundle_digest": "sha256:abc",
+        "bundle_signature": "BASE64SIG==",
+        "bundle_signature_algorithm": "ml-dsa-65",
+        "bundle_public_key": "BASE64PUB==",
+        "algorithm_registry_version": "2026-05-04.v1",
+        "receipt_count": 3,
+        "start": "2026-04-01T00:00:00Z",
+        "end": "2026-05-01T00:00:00Z",
+        "receipts": [{"signature_id": "sig_1"}],
+    }
+    out = tmp_path / "bundle.json"
+    result = runner.invoke(
+        app,
+        [
+            "audit-pack", "export",
+            "--start", "2026-04-01T00:00:00Z",
+            "--end", "2026-05-01T00:00:00Z",
+            "--output-file", str(out),
+        ],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    assert "wrote 3 receipts" in result.output
+    body = mock_post.call_args.args[1]
+    assert body["start"] == "2026-04-01T00:00:00Z"
+    assert body["only_compliance"] is True
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_audit_pack_policy_resolves_digest(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    """audit-pack policy returns the artefact JSON. 64-hex prefixes sha256:."""
+    mock_get.return_value = {
+        "digest": "sha256:" + "a" * 64,
+        "organization_id": "org_x",
+        "agent_id": "agent_x",
+        "action_type": "payment.wire_transfer",
+        "artefact": {"rule": "deny_over_500k"},
+        "created_at": "2026-04-01T00:00:00Z",
+    }
+    result = runner.invoke(
+        app,
+        ["audit-pack", "policy", "a" * 64, "--output", "json"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0
+    assert "deny_over_500k" in result.output
+    called_path = mock_get.call_args.args[0]
+    assert called_path == f"/audit-pack/policy/sha256:{'a' * 64}"
+
+
+# ---------------------------------------------------------------------------
+# payloads erase
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.client._delete")
+@patch("asqav.init")
+def test_payloads_erase_calls_delete(
+    mock_init: MagicMock, mock_delete: MagicMock
+) -> None:
+    """payloads erase --yes calls DELETE /signatures/payloads/{id}."""
+    mock_delete.return_value = {}
+    result = runner.invoke(
+        app,
+        ["payloads", "erase", "sig_abc", "--yes"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0
+    assert "Payload erased" in result.output
+    mock_delete.assert_called_once_with("/signatures/payloads/sig_abc")
+
+
+# ---------------------------------------------------------------------------
+# org set-compliance-strict
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.client._patch")
+@patch("asqav.init")
+def test_org_set_compliance_strict_enable(
+    mock_init: MagicMock, mock_patch: MagicMock
+) -> None:
+    mock_patch.return_value = {"id": "org_x", "compliance_mode_strict": True}
+    result = runner.invoke(
+        app,
+        ["org", "set-compliance-strict", "org_x", "--enable"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0
+    assert "compliance_mode_strict enabled" in result.output
+    body = mock_patch.call_args.args[1]
+    assert body == {"compliance_mode_strict": True}
+
+
+def test_org_set_compliance_strict_requires_one_flag() -> None:
+    result = runner.invoke(
+        app,
+        ["org", "set-compliance-strict", "org_x"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# keys generate
+# ---------------------------------------------------------------------------
+
+
+def test_keys_generate_ed25519(tmp_path) -> None:
+    """keys generate --algorithm ed25519 emits a PKCS#8 PEM private key."""
+    pytest_skipif_no_crypto = False
+    try:
+        from cryptography.hazmat.primitives.asymmetric import ed25519  # noqa: F401
+    except ImportError:
+        pytest_skipif_no_crypto = True
+    if pytest_skipif_no_crypto:
+        return
+    out = tmp_path / "ed25519.pem"
+    result = runner.invoke(
+        app,
+        ["keys", "generate", "--algorithm", "ed25519", "--out", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "BEGIN PUBLIC KEY" in result.output
+    assert out.exists()
+    assert b"BEGIN PRIVATE KEY" in out.read_bytes()
+
+
+def test_keys_generate_ml_dsa_errors() -> None:
+    """keys generate --algorithm ml-dsa-65 prints a server-side hint."""
+    result = runner.invoke(app, ["keys", "generate", "--algorithm", "ml-dsa-65"])
+    assert result.exit_code == 1
+    assert "server-side" in result.output.lower() or "agent.create" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# replay-verify
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.client._get")
+@patch("asqav.replay")
+@patch("asqav.init")
+def test_replay_verify_chain_valid(
+    mock_init: MagicMock, mock_replay: MagicMock, mock_account: MagicMock
+) -> None:
+    """replay-verify wraps replay() and prints the IETF outcome."""
+    mock_account.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    timeline = MagicMock()
+    timeline.compliance_chain_valid = True
+    step = MagicMock()
+    step.index = 0
+    step.signature_id = "sig_1"
+    step.chain_valid = True
+    step.legacy_chain = False
+    timeline.steps = [step]
+
+    def verify_chain_stub() -> bool:
+        return True
+
+    timeline.verify_chain = verify_chain_stub
+    mock_replay.return_value = timeline
+
+    result = runner.invoke(
+        app,
+        ["replay-verify", "agent_x", "sess_x"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "compliance_chain_valid: True" in result.output
+
+
+@patch("asqav.client._get")
+@patch("asqav.replay")
+@patch("asqav.init")
+def test_replay_verify_strict_rejects_legacy(
+    mock_init: MagicMock, mock_replay: MagicMock, mock_account: MagicMock
+) -> None:
+    """replay-verify --strict fails when any step is legacy."""
+    mock_account.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    timeline = MagicMock()
+    timeline.compliance_chain_valid = True
+    step = MagicMock()
+    step.index = 0
+    step.signature_id = "sig_1"
+    step.chain_valid = True
+    step.legacy_chain = True
+    timeline.steps = [step]
+    timeline.verify_chain = lambda: True
+    mock_replay.return_value = timeline
+
+    result = runner.invoke(
+        app,
+        ["replay-verify", "agent_x", "sess_x", "--strict"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 1
+    assert "strict mode FAILED" in result.output
+
+
+# ---------------------------------------------------------------------------
+# migrate run
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_run_requires_maintenance_key(monkeypatch) -> None:
+    """migrate run refuses without ASQAV_MAINTENANCE_KEY."""
+    monkeypatch.delenv("ASQAV_MAINTENANCE_KEY", raising=False)
+    result = runner.invoke(
+        app,
+        ["migrate", "run", "v3-20"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 1
+    assert "ASQAV_MAINTENANCE_KEY" in result.output
+
+
+def test_migrate_run_rejects_unknown(monkeypatch) -> None:
+    """migrate run rejects unsupported migration names."""
+    monkeypatch.setenv("ASQAV_MAINTENANCE_KEY", "mk")
+    result = runner.invoke(
+        app,
+        ["migrate", "run", "v9-99"],
+        env={"ASQAV_API_KEY": "sk_test", "ASQAV_MAINTENANCE_KEY": "mk"},
+    )
+    assert result.exit_code == 1
+    assert "unsupported migration" in result.output
+
+
+@patch("urllib.request.urlopen")
+@patch("asqav.init")
+def test_migrate_run_v3_22_calls_endpoint(
+    mock_init: MagicMock, mock_urlopen: MagicMock, monkeypatch
+) -> None:
+    """migrate run v3-22 POSTs to the correct path with X-Maintenance-Key."""
+    response = MagicMock()
+    response.read.return_value = b'{"status": "ok", "applied": 1, "migration": "v3-22"}'
+    response.__enter__ = lambda self: response
+    response.__exit__ = lambda *a: None
+    mock_urlopen.return_value = response
+
+    result = runner.invoke(
+        app,
+        ["migrate", "run", "v3-22"],
+        env={"ASQAV_API_KEY": "sk_test", "ASQAV_MAINTENANCE_KEY": "mk_test"},
+    )
+    assert result.exit_code == 0, result.output
+    req = mock_urlopen.call_args.args[0]
+    assert "/maintenance/run-migration-v3-22" in req.full_url
+    assert req.headers.get("X-maintenance-key") == "mk_test"
+    assert "v3-22" in result.output

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -80,6 +80,77 @@ def test_verify_not_found(mock_verify: MagicMock) -> None:
     assert "not found" in result.output.lower()
 
 
+@patch("asqav.verify_signature")
+def test_verify_text_shows_ietf_axes(mock_verify: MagicMock) -> None:
+    """verify --output text surfaces IETF profile sub-axes when present."""
+    from asqav import VerificationDetail
+
+    mock_verify.return_value = MagicMock(
+        verified=True,
+        agent_name="ietf-agent",
+        agent_id="agent_ietf",
+        action_type="payment.wire_transfer",
+        algorithm="ml-dsa-65",
+        verification_detail=VerificationDetail(
+            signer_key_match=True,
+            signature_valid=True,
+            algorithm_match=True,
+            agent_active=True,
+            validation_label="valid",
+            signed_at_skew_seconds=1.234,
+            chain_valid=True,
+            anchor_status_ots="pending",
+            anchor_status_rfc3161="valid",
+            missing_fields=None,
+        ),
+    )
+    result = runner.invoke(app, ["verify", "sig_ietf"])
+    assert result.exit_code == 0
+    assert "Chain valid: True" in result.output
+    assert "Anchor (OTS): pending" in result.output
+    assert "Anchor (RFC 3161): valid" in result.output
+    assert "skew: 1.234" in result.output
+
+
+@patch("asqav.verify_signature")
+def test_verify_json_emits_full_detail(mock_verify: MagicMock) -> None:
+    """verify --output json returns the full VerificationResponse."""
+    import json
+
+    from asqav import VerificationDetail
+
+    mock_verify.return_value = MagicMock(
+        signature_id="sig_xyz",
+        agent_id="agent_x",
+        agent_name="agent-x",
+        action_id="act_1",
+        action_type="api:call",
+        algorithm="ml-dsa-65",
+        signed_at=1717171717.0,
+        verified=True,
+        verification_url="https://verify.example/sig_xyz",
+        verification_detail=VerificationDetail(
+            signer_key_match=True,
+            signature_valid=True,
+            algorithm_match=True,
+            agent_active=True,
+            validation_label="valid",
+            signed_at_skew_seconds=0.5,
+            chain_valid=True,
+            anchor_status_ots="valid",
+            anchor_status_rfc3161="valid",
+            missing_fields=[],
+        ),
+    )
+    result = runner.invoke(app, ["verify", "sig_xyz", "--output", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["signature_id"] == "sig_xyz"
+    assert payload["verification_detail"]["chain_valid"] is True
+    assert payload["verification_detail"]["anchor_status_ots"] == "valid"
+    assert payload["verification_detail"]["signed_at_skew_seconds"] == 0.5
+
+
 # ---------------------------------------------------------------------------
 # agents list command
 # ---------------------------------------------------------------------------

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -1,0 +1,349 @@
+"""Tests for IETF Compliance Receipts profile sign-path fields.
+
+Spec: draft-marques-asqav-compliance-receipts-00 §5.
+
+Each test asserts one behaviour the SDK is responsible for:
+
+* the new kwargs travel to the cloud body,
+* `receipt_type` outside the `protectmcp:*` namespace is rejected
+  client-side before any HTTP call,
+* `compliance_mode=True` with no caller-supplied `action_ref` triggers
+  the SDK to compute it as `sha256:` + sha256 over canonical JSON of
+  ``{"action_type", "context"}``,
+* the response parser surfaces the new fields the cloud emits.
+
+These are the SDK side of the contract. The cloud's own pydantic
+validator is exercised in `tests/conformance/test_ietf_vectors.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav
+from asqav.canonicalize import canonicalize
+from asqav.client import (
+    RECEIPT_TYPE_NAMESPACE,
+    Agent,
+    SignatureResponse,
+    _build_sign_body,
+    _compute_action_ref,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_001",
+        name="test-agent",
+        public_key="pk_xxx",
+        key_id="key_001",
+        algorithm="ML-DSA-65",
+        capabilities=["api:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response(extra: dict | None = None) -> dict:
+    base = {
+        "signature": "sig_b64",
+        "signature_id": "sig_abc",
+        "action_id": "act_abc",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_abc",
+        "algorithm": "ML-DSA-65",
+        "chain_hash": "deadbeef",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Namespace + validation
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_type_namespace_constant() -> None:
+    """Namespace matches the cloud's pydantic validator exactly."""
+    assert RECEIPT_TYPE_NAMESPACE == frozenset(
+        {
+            "protectmcp:decision",
+            "protectmcp:restraint",
+            "protectmcp:lifecycle",
+        }
+    )
+
+
+def test_invalid_receipt_type_raises_before_http() -> None:
+    """SDK rejects bad receipt_type without making a network call."""
+    with patch("asqav.client._post") as p:
+        with pytest.raises(ValueError, match="invalid_receipt_type"):
+            _agent().sign(
+                "api:call",
+                {"k": "v"},
+                compliance_mode=True,
+                receipt_type="not:in:namespace",
+            )
+        p.assert_not_called()
+
+
+def test_deny_without_reason_raises_before_http() -> None:
+    """`policy_decision=deny` without `reason` is rejected client-side."""
+    with patch("asqav.client._post") as p:
+        with pytest.raises(ValueError, match="missing_reason"):
+            _agent().sign(
+                "api:call",
+                {"k": "v"},
+                compliance_mode=True,
+                policy_decision="deny",
+            )
+        p.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# action_ref auto-compute
+# ---------------------------------------------------------------------------
+
+
+def test_compute_action_ref_matches_canonical_sha256() -> None:
+    """Helper hash matches the JCS-canonical sha256 over the action object."""
+    action_type = "api:call"
+    context = {"model": "gpt-4", "params": {"temp": 0.0}}
+    expected = "sha256:" + hashlib.sha256(
+        canonicalize({"action_type": action_type, "context": context})
+    ).hexdigest()
+    assert _compute_action_ref(action_type, context) == expected
+
+
+def test_compliance_mode_auto_computes_action_ref() -> None:
+    """When the caller omits action_ref under compliance_mode, the SDK
+    computes it from canonical JSON of the action object so the cloud's
+    `action_ref` matches its own digest of the action."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"a": 1, "b": 2},
+            compliance_mode=True,
+            receipt_type="protectmcp:decision",
+        )
+
+    body = captured["body"]
+    assert body["compliance_mode"] is True
+    assert body["receipt_type"] == "protectmcp:decision"
+    expected = _compute_action_ref("api:call", {"a": 1, "b": 2})
+    assert body["action_ref"] == expected
+
+
+def test_compliance_mode_caller_supplied_action_ref_wins() -> None:
+    """A caller-supplied action_ref is forwarded verbatim, no recompute."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    forced = "sha256:" + "a" * 64
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"x": 1},
+            compliance_mode=True,
+            action_ref=forced,
+        )
+    assert captured["body"]["action_ref"] == forced
+
+
+def test_no_compliance_mode_means_no_extra_fields_on_body() -> None:
+    """Without compliance_mode the body shape is exactly the legacy shape."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("api:call", {"k": "v"})
+
+    body = captured["body"]
+    for k in (
+        "compliance_mode",
+        "receipt_type",
+        "action_ref",
+        "iteration_id",
+        "sandbox_state",
+        "risk_class",
+        "incident_class",
+        "reason",
+        "issuer_id",
+        "payload_digest",
+    ):
+        assert k not in body, f"unexpected legacy-mode field: {k}"
+
+
+# ---------------------------------------------------------------------------
+# Pass-through of all profile fields
+# ---------------------------------------------------------------------------
+
+
+def test_all_profile_fields_passthrough_in_body() -> None:
+    """Every profile field the caller sets reaches the cloud body verbatim."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            receipt_type="protectmcp:lifecycle",
+            iteration_id="iter_42",
+            sandbox_state="enabled",
+            risk_class="high",
+            incident_class="ICT-INC-001",
+            issuer_id="legal:Acme GmbH",
+            payload_digest="sha256:" + "b" * 64,
+        )
+
+    body = captured["body"]
+    assert body["compliance_mode"] is True
+    assert body["receipt_type"] == "protectmcp:lifecycle"
+    assert body["iteration_id"] == "iter_42"
+    assert body["sandbox_state"] == "enabled"
+    assert body["risk_class"] == "high"
+    assert body["incident_class"] == "ICT-INC-001"
+    assert body["issuer_id"] == "legal:Acme GmbH"
+    assert body["payload_digest"] == "sha256:" + "b" * 64
+
+
+def test_deny_with_reason_passes_through() -> None:
+    """`policy_decision=deny` plus `reason` reaches the body without raising."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            policy_decision="deny",
+            reason="policy_violation_outbound_url",
+        )
+    assert captured["body"]["policy_decision"] == "deny"
+    assert captured["body"]["reason"] == "policy_violation_outbound_url"
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+def test_signature_response_surfaces_new_fields() -> None:
+    """SignatureResponse exposes IETF fields when the cloud returns them."""
+    extra = {
+        "compliance_mode": True,
+        "receipt_type": "protectmcp:decision",
+        "action_ref": "sha256:" + "c" * 64,
+        "payload_digest": "sha256:" + "d" * 64,
+        "issuer_id": "legal:Acme GmbH",
+        "iteration_id": "iter_42",
+        "sandbox_state": "enabled",
+        "risk_class": "high",
+        "incident_class": "ICT-INC-001",
+        "reason": None,
+        "previousReceiptHash": "0" * 64,
+    }
+    with patch("asqav.client._post", return_value=_ok_response(extra)):
+        resp: SignatureResponse = _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+        )
+    assert resp.compliance_mode is True
+    assert resp.receipt_type == "protectmcp:decision"
+    assert resp.action_ref == "sha256:" + "c" * 64
+    assert resp.payload_digest == "sha256:" + "d" * 64
+    assert resp.issuer_id == "legal:Acme GmbH"
+    assert resp.iteration_id == "iter_42"
+    assert resp.sandbox_state == "enabled"
+    assert resp.risk_class == "high"
+    assert resp.incident_class == "ICT-INC-001"
+    assert resp.previous_receipt_hash == "0" * 64
+
+
+def test_response_accepts_snake_case_previous_receipt_hash() -> None:
+    """Older or self-hosted servers may emit `previous_receipt_hash`."""
+    extra = {
+        "compliance_mode": True,
+        "receipt_type": "protectmcp:decision",
+        "previous_receipt_hash": "f" * 64,
+    }
+    with patch("asqav.client._post", return_value=_ok_response(extra)):
+        resp = _agent().sign("api:call", {}, compliance_mode=True)
+    assert resp.previous_receipt_hash == "f" * 64
+
+
+# ---------------------------------------------------------------------------
+# Re-export
+# ---------------------------------------------------------------------------
+
+
+def test_constant_is_re_exported_at_top_level() -> None:
+    """`asqav.RECEIPT_TYPE_NAMESPACE` is part of the public surface."""
+    assert asqav.RECEIPT_TYPE_NAMESPACE == RECEIPT_TYPE_NAMESPACE
+
+
+# ---------------------------------------------------------------------------
+# _build_sign_body branches
+# ---------------------------------------------------------------------------
+
+
+def test_build_sign_body_full_payload_includes_compliance_fields() -> None:
+    body = _build_sign_body(
+        action_type="api:call",
+        context={"k": "v"},
+        session_id="sess_1",
+        agent_id="agent_001",
+        compliance_fields={
+            "compliance_mode": True,
+            "receipt_type": "protectmcp:decision",
+            "iteration_id": None,  # None entries dropped
+        },
+    )
+    assert body["compliance_mode"] is True
+    assert body["receipt_type"] == "protectmcp:decision"
+    assert "iteration_id" not in body
+
+
+def test_build_sign_body_omits_compliance_when_no_fields() -> None:
+    body = _build_sign_body(
+        action_type="api:call",
+        context={"k": "v"},
+        session_id=None,
+        agent_id="agent_001",
+    )
+    assert "compliance_mode" not in body

--- a/python/tests/test_jcs.py
+++ b/python/tests/test_jcs.py
@@ -1,0 +1,209 @@
+"""RFC 8785 (JCS) golden vector tests for `asqav._jcs.canonical_json`.
+
+Vectors mirror the appendix of RFC 8785 plus a few profile-shaped
+examples (signed envelopes from the IETF Compliance Receipts profile).
+Drift here means the SDK and the cloud disagree on the bytes that get
+signed, which silently breaks signature verification, so this file is a
+hard fail on byte mismatch.
+
+The companion module `asqav.canonicalize.canonicalize` is asserted to
+produce the same bytes so the two public entry points stay in lockstep.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav._jcs import canonical_json
+from asqav.canonicalize import canonicalize
+
+# ---------------------------------------------------------------------------
+# RFC 8785 §3.2 golden vectors
+# ---------------------------------------------------------------------------
+#
+# Each entry: (name, input, expected canonical UTF-8 string).
+#
+# Sources:
+#   * "rfc8785-empty-object" -> RFC 8785 §3.2 Example 1.
+#   * "rfc8785-key-ordering" -> RFC 8785 §3.2.3 (key sort by UTF-16 code units).
+#   * "rfc8785-string-escapes" -> RFC 8785 §3.2.3 / RFC 8259 §7.
+#   * "rfc8785-integers" -> RFC 8785 §3.2.2 (integers within safe range).
+#   * "rfc8785-nested" -> typical nested structure used in receipts.
+#   * "ietf-receipt-envelope" -> profile-shaped signed envelope.
+GOLDEN_VECTORS = [
+    (
+        "rfc8785-empty-object",
+        {},
+        "{}",
+    ),
+    (
+        "rfc8785-empty-array",
+        [],
+        "[]",
+    ),
+    (
+        "rfc8785-null",
+        None,
+        "null",
+    ),
+    (
+        "rfc8785-true",
+        True,
+        "true",
+    ),
+    (
+        "rfc8785-false",
+        False,
+        "false",
+    ),
+    (
+        "rfc8785-key-ordering",
+        # Insertion-ordered intentionally; canonical bytes MUST sort.
+        {"b": 1, "a": 2, "c": 3},
+        '{"a":2,"b":1,"c":3}',
+    ),
+    (
+        "rfc8785-key-ordering-utf16",
+        # Key "z" sorts after "a", and capital letters sort before lowercase.
+        {"z": 1, "A": 2, "a": 3},
+        '{"A":2,"a":3,"z":1}',
+    ),
+    (
+        "rfc8785-integers",
+        {"n": 0, "neg": -123, "pos": 123},
+        '{"n":0,"neg":-123,"pos":123}',
+    ),
+    (
+        "rfc8785-string-escapes",
+        # Standard JSON escapes for control chars and the two specials.
+        {"s": 'a"b\\c\nd\te'},
+        '{"s":"a\\"b\\\\c\\nd\\te"}',
+    ),
+    (
+        "rfc8785-string-non-ascii-passthrough",
+        # RFC 8785 §3.2.3: non-ASCII passes through as raw UTF-8.
+        {"x": "héllo"},
+        '{"x":"héllo"}',
+    ),
+    (
+        "rfc8785-nested",
+        {"outer": {"inner": [1, 2, 3], "k": "v"}, "a": [True, None]},
+        '{"a":[true,null],"outer":{"inner":[1,2,3],"k":"v"}}',
+    ),
+    (
+        "ietf-receipt-envelope",
+        # Profile-shaped envelope per
+        # draft-marques-asqav-compliance-receipts-00 §5.
+        {
+            "type": "protectmcp:decision",
+            "issued_at": "2026-05-04T12:00:00Z",
+            "issuer_id": "legal:Acme",
+            "agent_id": "agent_001",
+            "action_ref": "sha256:" + "a" * 64,
+            "payload_digest": "sha256:" + "b" * 64,
+            "policy_digest": "sha256:" + "c" * 64,
+            "previousReceiptHash": "0" * 64,
+            "policy_decision": "permit",
+        },
+        '{"action_ref":"sha256:' + "a" * 64
+        + '","agent_id":"agent_001","action_ref"'.replace(
+            ',"action_ref"', ""
+        )  # placeholder, real expected built below
+        ,
+    ),
+]
+
+
+def _expected_envelope() -> str:
+    """Sorted-keys serialization of the IETF envelope vector."""
+    import json
+
+    return json.dumps(
+        {
+            "type": "protectmcp:decision",
+            "issued_at": "2026-05-04T12:00:00Z",
+            "issuer_id": "legal:Acme",
+            "agent_id": "agent_001",
+            "action_ref": "sha256:" + "a" * 64,
+            "payload_digest": "sha256:" + "b" * 64,
+            "policy_digest": "sha256:" + "c" * 64,
+            "previousReceiptHash": "0" * 64,
+            "policy_decision": "permit",
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+# Replace the placeholder we used so the test data structure compiles even
+# without running the dynamic `_expected_envelope`.
+GOLDEN_VECTORS[-1] = (
+    GOLDEN_VECTORS[-1][0],
+    GOLDEN_VECTORS[-1][1],
+    _expected_envelope(),
+)
+
+
+@pytest.mark.parametrize(
+    "name,obj,expected",
+    GOLDEN_VECTORS,
+    ids=[name for name, _, _ in GOLDEN_VECTORS],
+)
+def test_golden_vector_matches(name: str, obj, expected: str) -> None:
+    """Each RFC 8785 vector serializes to its expected canonical string."""
+    actual = canonical_json(obj).decode("utf-8")
+    assert actual == expected, f"{name}: drift\n  expected: {expected!r}\n  actual:   {actual!r}"
+
+
+@pytest.mark.parametrize(
+    "name,obj,expected",
+    GOLDEN_VECTORS,
+    ids=[name for name, _, _ in GOLDEN_VECTORS],
+)
+def test_byte_equality_with_legacy_canonicalize(name: str, obj, expected: str) -> None:
+    """`_jcs.canonical_json` and `canonicalize.canonicalize` agree byte-for-byte."""
+    assert canonical_json(obj) == canonicalize(obj), f"{name}: drift"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases the spec explicitly calls out
+# ---------------------------------------------------------------------------
+
+
+def test_nan_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        canonical_json({"x": float("nan")})
+
+
+def test_infinity_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        canonical_json({"x": float("inf")})
+
+
+def test_negative_infinity_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        canonical_json({"x": float("-inf")})
+
+
+def test_insertion_order_does_not_change_bytes() -> None:
+    """Same logical object -> same bytes regardless of dict insertion order."""
+    a = {"z": 1, "y": 2, "x": 3}
+    b = {"x": 3, "y": 2, "z": 1}
+    assert canonical_json(a) == canonical_json(b)
+
+
+def test_no_insignificant_whitespace() -> None:
+    assert canonical_json({"a": 1, "b": [1, 2]}) == b'{"a":1,"b":[1,2]}'
+
+
+def test_re_export_at_package_root() -> None:
+    """`asqav.canonical_json` is part of the public surface."""
+    import asqav
+
+    assert asqav.canonical_json is canonical_json

--- a/python/tests/test_keys_alg_agility.py
+++ b/python/tests/test_keys_alg_agility.py
@@ -1,0 +1,192 @@
+"""Tests for algorithm agility on the SDK signing path.
+
+Covers AG3 (Ed25519) and AG4 (ES256) per IETF profile §10.8 plus the
+ML-DSA-65 default. The cloud is authoritative for cryptographic key
+generation when receipts are signed server-side; this module is the
+SDK's offline path (LocalQueue, conformance fixtures, air-gapped
+operator tooling).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav
+from asqav.keys import (
+    ALGORITHM_ED25519,
+    ALGORITHM_ES256,
+    ALGORITHM_ML_DSA_65,
+    SUPPORTED_ALGORITHMS,
+    LocalKeypair,
+    _check_algorithm,
+    generate_local_keypair,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants and namespace
+# ---------------------------------------------------------------------------
+
+
+def test_supported_algorithms_set() -> None:
+    assert SUPPORTED_ALGORITHMS == frozenset(
+        {ALGORITHM_ML_DSA_65, ALGORITHM_ED25519, ALGORITHM_ES256}
+    )
+
+
+def test_constants_match_spec_strings() -> None:
+    """Identifier strings match the cloud's SignatureRecord.algorithm column."""
+    assert ALGORITHM_ML_DSA_65 == "ml-dsa-65"
+    assert ALGORITHM_ED25519 == "ed25519"
+    assert ALGORITHM_ES256 == "es256"
+
+
+def test_re_exports_at_package_root() -> None:
+    assert asqav.ALGORITHM_ML_DSA_65 == ALGORITHM_ML_DSA_65
+    assert asqav.ALGORITHM_ED25519 == ALGORITHM_ED25519
+    assert asqav.ALGORITHM_ES256 == ALGORITHM_ES256
+    assert asqav.SUPPORTED_ALGORITHMS == SUPPORTED_ALGORITHMS
+    assert asqav.LocalKeypair is LocalKeypair
+    assert asqav.generate_local_keypair is generate_local_keypair
+
+
+# ---------------------------------------------------------------------------
+# _check_algorithm
+# ---------------------------------------------------------------------------
+
+
+def test_check_algorithm_normalises_case() -> None:
+    assert _check_algorithm("ED25519") == "ed25519"
+    assert _check_algorithm("ES256") == "es256"
+    assert _check_algorithm("ML-DSA-65") == "ml-dsa-65"
+
+
+def test_check_algorithm_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="unsupported_algorithm"):
+        _check_algorithm("rsa")
+
+
+# ---------------------------------------------------------------------------
+# Ed25519 (AG3)
+# ---------------------------------------------------------------------------
+
+
+def test_ed25519_keypair_generates_pem() -> None:
+    pytest.importorskip("cryptography")
+    kp = generate_local_keypair("ed25519")
+    assert kp.algorithm == "ed25519"
+    assert kp.private_key_pem.startswith(b"-----BEGIN PRIVATE KEY-----")
+    assert kp.public_key_pem.startswith(b"-----BEGIN PUBLIC KEY-----")
+
+
+def test_ed25519_public_key_round_trips() -> None:
+    """The PEM-encoded public key parses back to a valid Ed25519 key."""
+    pytest.importorskip("cryptography")
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    kp = generate_local_keypair("ed25519")
+    pub = serialization.load_pem_public_key(kp.public_key_pem)
+    assert isinstance(pub, ed25519.Ed25519PublicKey)
+
+
+def test_ed25519_signs_and_verifies() -> None:
+    """End-to-end: generate, sign with private, verify with public."""
+    pytest.importorskip("cryptography")
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    kp = generate_local_keypair("ed25519")
+    priv = serialization.load_pem_private_key(
+        kp.private_key_pem, password=None
+    )
+    assert isinstance(priv, ed25519.Ed25519PrivateKey)
+    msg = b"compliance receipt envelope bytes"
+    sig = priv.sign(msg)
+
+    pub = serialization.load_pem_public_key(kp.public_key_pem)
+    pub.verify(sig, msg)  # raises on failure
+
+
+# ---------------------------------------------------------------------------
+# ES256 (AG4)
+# ---------------------------------------------------------------------------
+
+
+def test_es256_keypair_generates_pem() -> None:
+    pytest.importorskip("cryptography")
+    kp = generate_local_keypair("es256")
+    assert kp.algorithm == "es256"
+    assert kp.private_key_pem.startswith(b"-----BEGIN PRIVATE KEY-----")
+    assert kp.public_key_pem.startswith(b"-----BEGIN PUBLIC KEY-----")
+
+
+def test_es256_curve_is_p256() -> None:
+    """ES256 means ECDSA over P-256 per RFC 7518."""
+    pytest.importorskip("cryptography")
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    kp = generate_local_keypair("es256")
+    pub = serialization.load_pem_public_key(kp.public_key_pem)
+    assert isinstance(pub, ec.EllipticCurvePublicKey)
+    assert isinstance(pub.curve, ec.SECP256R1)
+
+
+def test_es256_signs_and_verifies() -> None:
+    pytest.importorskip("cryptography")
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    kp = generate_local_keypair("es256")
+    priv = serialization.load_pem_private_key(
+        kp.private_key_pem, password=None
+    )
+    assert isinstance(priv, ec.EllipticCurvePrivateKey)
+    msg = b"compliance receipt envelope bytes"
+    sig = priv.sign(msg, ec.ECDSA(hashes.SHA256()))
+
+    pub = serialization.load_pem_public_key(kp.public_key_pem)
+    pub.verify(sig, msg, ec.ECDSA(hashes.SHA256()))
+
+
+# ---------------------------------------------------------------------------
+# ML-DSA-65 default
+# ---------------------------------------------------------------------------
+
+
+def test_ml_dsa_65_local_generation_routes_to_cloud() -> None:
+    """Local ML-DSA-65 generation is not implemented; SDK points the
+    caller to `Agent.create()` so the cloud generates the keypair."""
+    with pytest.raises(NotImplementedError, match="server-side"):
+        generate_local_keypair("ml-dsa-65")
+
+
+def test_default_algorithm_is_ml_dsa_65() -> None:
+    """`generate_local_keypair()` with no args defaults to ML-DSA-65."""
+    with pytest.raises(NotImplementedError):
+        generate_local_keypair()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_algorithm_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="unsupported_algorithm"):
+        generate_local_keypair("rsa")  # type: ignore[arg-type]
+
+
+def test_local_keypair_carries_only_pem_bytes() -> None:
+    """LocalKeypair is a plain dataclass; no extra state survives."""
+    pytest.importorskip("cryptography")
+    kp = generate_local_keypair("ed25519")
+    assert isinstance(kp.private_key_pem, bytes)
+    assert isinstance(kp.public_key_pem, bytes)
+    assert kp.algorithm in SUPPORTED_ALGORITHMS

--- a/python/tests/test_litellm_integration.py
+++ b/python/tests/test_litellm_integration.py
@@ -154,6 +154,7 @@ class TestPostCallFailureHook:
                 "error_type": "ValueError",
                 "error_message": "rate limit exceeded",
             },
+            risk_class="medium",
         )
 
 

--- a/python/tests/test_replay.py
+++ b/python/tests/test_replay.py
@@ -40,19 +40,29 @@ def _make_signed_action(**overrides) -> SignedActionResponse:
 
 
 def _make_timeline(n: int = 3) -> ReplayTimeline:
-    """Build a timeline with n steps; computes prev_chain_hash like _build_timeline."""
+    """Build a timeline with n steps under the IETF v2 chain shape.
+
+    Tracks the same envelope shape `_build_timeline` produces so
+    `verify_chain()` (default-mode v2) succeeds on a freshly built
+    timeline. Legacy-shape coverage lives in test_replay_ietf_chain.py.
+    """
     import hashlib
+
+    from asqav._jcs import canonical_json
+    from asqav.replay import FIRST_RECEIPT_SEED
+
     steps = []
-    prev_hash = ""
+    prev_hash = FIRST_RECEIPT_SEED
     for i in range(n):
         sig_id = f"sid_{i:03d}"
         action = f"api:call_{i}"
         ts = 1700000000.0 + i * 10
+        context = {"model": "gpt-4"}
         steps.append(
             ReplayStep(
                 index=i,
                 action_type=action,
-                context={"model": "gpt-4"},
+                context=context,
                 timestamp=ts,
                 signature_id=sig_id,
                 verification_url=f"https://asqav.com/verify/{sig_id}",
@@ -61,11 +71,14 @@ def _make_timeline(n: int = 3) -> ReplayTimeline:
                 prev_chain_hash=prev_hash if i > 0 else None,
             )
         )
-        entry = json.dumps(
-            {"signature_id": sig_id, "action_type": action, "timestamp": ts, "prev_hash": prev_hash},  # noqa: E501
-            sort_keys=True, separators=(",", ":"),
-        )
-        prev_hash = hashlib.sha256(entry.encode()).hexdigest()
+        envelope = {
+            "signature_id": sig_id,
+            "action_type": action,
+            "context": context,
+            "timestamp": ts,
+            "previousReceiptHash": prev_hash,
+        }
+        prev_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
     return ReplayTimeline(
         agent_id="agent_001",
         session_id="sess_001",

--- a/python/tests/test_replay_ietf_chain.py
+++ b/python/tests/test_replay_ietf_chain.py
@@ -1,0 +1,270 @@
+"""Tests for the IETF v2 chain shape in `asqav.replay`.
+
+Spec: draft-marques-asqav-compliance-receipts-00 §5.7.
+
+The chain link is ``sha256(JCS(predecessor_signed_envelope))``. The
+first record's ``previousReceiptHash`` is ``"0" * 64``
+(``FIRST_RECEIPT_SEED``). The legacy shape is kept available behind
+``legacy_chain=True`` so historic bundles still verify.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav._jcs import canonical_json
+from asqav.client import SignedActionResponse
+from asqav.replay import (
+    FIRST_RECEIPT_SEED,
+    ReplayStep,
+    ReplayTimeline,
+    _build_timeline,
+    _step_chain_hash,
+    _verify_hash_chain,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_signed_action(
+    *, idx: int = 0, action_type: str = "api:call", payload=None
+) -> SignedActionResponse:
+    return SignedActionResponse(
+        signature_id=f"sid_{idx:03d}",
+        agent_id="agent_001",
+        action_id=f"act_{idx:03d}",
+        action_type=action_type,
+        payload=payload or {"step": idx},
+        algorithm="ML-DSA-65",
+        signed_at=1700000000.0 + idx * 10,
+        signature_preview="sig_b64",
+        verification_url=f"https://asqav.com/verify/sid_{idx:03d}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# FIRST_RECEIPT_SEED matches the spec
+# ---------------------------------------------------------------------------
+
+
+def test_first_receipt_seed_is_64_zero_hex() -> None:
+    """`FIRST_RECEIPT_SEED == "0" * 64` per §5.7."""
+    assert FIRST_RECEIPT_SEED == "0" * 64
+    assert len(FIRST_RECEIPT_SEED) == 64
+    assert all(c == "0" for c in FIRST_RECEIPT_SEED)
+
+
+# ---------------------------------------------------------------------------
+# IETF v2 default behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_v2_chain_hash_matches_jcs_of_envelope() -> None:
+    """Each link is `sha256(JCS(envelope_with_prev_link))`."""
+    sigs = [_make_signed_action(idx=0), _make_signed_action(idx=1)]
+    sig_dicts = [
+        {
+            "signature_id": s.signature_id,
+            "action_type": s.action_type,
+            "payload": s.payload,
+            "signed_at": s.signed_at,
+        }
+        for s in sigs
+    ]
+    _verify_hash_chain(sig_dicts)  # smoke
+
+    # Recompute by hand and compare against the timeline's stored prev hashes.
+    timeline = _build_timeline("agent_001", "sess_1", sigs)
+    assert len(timeline.steps) == 2
+
+    expected_first_hash = hashlib.sha256(
+        canonical_json(
+            {
+                "signature_id": sigs[0].signature_id,
+                "action_type": sigs[0].action_type,
+                "context": sigs[0].payload,
+                "timestamp": sigs[0].signed_at,
+                "previousReceiptHash": FIRST_RECEIPT_SEED,
+            }
+        )
+    ).hexdigest()
+    assert timeline.steps[1].prev_chain_hash == expected_first_hash
+
+
+def test_v2_seed_is_used_under_default() -> None:
+    """The first envelope hashes against the all-zero seed, not empty."""
+    sigs = [_make_signed_action(idx=0)]
+    timeline = _build_timeline("agent_001", "sess_1", sigs)
+    # First step has no predecessor -> prev_chain_hash is None.
+    assert timeline.steps[0].prev_chain_hash is None
+
+    # But the implicit seed used in derivation IS the spec value:
+    expected_first_hash = hashlib.sha256(
+        canonical_json(
+            {
+                "signature_id": sigs[0].signature_id,
+                "action_type": sigs[0].action_type,
+                "context": sigs[0].payload,
+                "timestamp": sigs[0].signed_at,
+                "previousReceiptHash": FIRST_RECEIPT_SEED,
+            }
+        )
+    ).hexdigest()
+
+    # If we add a second sig and rebuild, its prev_chain_hash should be
+    # exactly that hash.
+    sigs.append(_make_signed_action(idx=1))
+    timeline = _build_timeline("agent_001", "sess_1", sigs)
+    assert timeline.steps[1].prev_chain_hash == expected_first_hash
+
+
+def test_v2_verify_chain_succeeds_on_freshly_built_timeline() -> None:
+    sigs = [_make_signed_action(idx=i) for i in range(4)]
+    timeline = _build_timeline("agent_001", "sess_1", sigs)
+    assert timeline.verify_chain() is True
+    assert timeline.chain_integrity is True
+    for step in timeline.steps:
+        assert step.chain_valid is True
+
+
+def test_v2_verify_chain_detects_tamper() -> None:
+    """If a step's stored prev_chain_hash is altered, verify_chain fails."""
+    sigs = [_make_signed_action(idx=i) for i in range(3)]
+    timeline = _build_timeline("agent_001", "sess_1", sigs)
+    # Tamper: corrupt the link on step 1.
+    timeline.steps[1].prev_chain_hash = "f" * 64
+    assert timeline.verify_chain() is False
+    assert timeline.steps[1].chain_valid is False
+
+
+def test_v2_chain_differs_from_legacy_for_same_signatures() -> None:
+    """The v2 envelope shape produces different bytes than the legacy
+    envelope so a forged legacy chain cannot pass v2 verification."""
+    sigs = [_make_signed_action(idx=i) for i in range(3)]
+    v2 = _build_timeline("agent_001", "sess_1", sigs, legacy_chain=False)
+    legacy = _build_timeline("agent_001", "sess_1", sigs, legacy_chain=True)
+    # First step has no predecessor in either (None), so compare step 1.
+    assert v2.steps[1].prev_chain_hash != legacy.steps[1].prev_chain_hash
+
+
+# ---------------------------------------------------------------------------
+# legacy_chain flag
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_chain_uses_old_envelope_shape() -> None:
+    """legacy_chain=True reproduces the pre-IETF chain hash byte-for-byte."""
+    sigs = [_make_signed_action(idx=0), _make_signed_action(idx=1)]
+    timeline = _build_timeline(
+        "agent_001", "sess_1", sigs, legacy_chain=True
+    )
+
+    expected = hashlib.sha256(
+        json.dumps(
+            {
+                "signature_id": sigs[0].signature_id,
+                "action_type": sigs[0].action_type,
+                "timestamp": sigs[0].signed_at,
+                "prev_hash": "",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    assert timeline.steps[1].prev_chain_hash == expected
+
+
+def test_legacy_chain_verify_succeeds() -> None:
+    sigs = [_make_signed_action(idx=i) for i in range(3)]
+    timeline = _build_timeline(
+        "agent_001", "sess_1", sigs, legacy_chain=True
+    )
+    assert timeline.verify_chain(legacy_chain=True) is True
+
+
+def test_legacy_chain_verify_fails_when_called_under_v2() -> None:
+    """A timeline built under legacy shape does not verify under v2."""
+    sigs = [_make_signed_action(idx=i) for i in range(3)]
+    timeline = _build_timeline(
+        "agent_001", "sess_1", sigs, legacy_chain=True
+    )
+    # Timeline stores legacy hashes. Verifying under v2 must reject.
+    assert timeline.verify_chain(legacy_chain=False) is False
+
+
+# ---------------------------------------------------------------------------
+# _step_chain_hash helper
+# ---------------------------------------------------------------------------
+
+
+def test_step_chain_hash_v2_matches_envelope() -> None:
+    step = ReplayStep(
+        index=0,
+        action_type="api:call",
+        context={"x": 1},
+        timestamp=1700000000.0,
+        signature_id="sid_001",
+        verification_url="https://asqav.com/verify/sid_001",
+        chain_valid=True,
+        explanation="x",
+    )
+    expected = hashlib.sha256(
+        canonical_json(
+            {
+                "signature_id": "sid_001",
+                "action_type": "api:call",
+                "context": {"x": 1},
+                "timestamp": 1700000000.0,
+                "previousReceiptHash": FIRST_RECEIPT_SEED,
+            }
+        )
+    ).hexdigest()
+    assert (
+        _step_chain_hash(step, FIRST_RECEIPT_SEED, legacy_chain=False)
+        == expected
+    )
+
+
+def test_step_chain_hash_legacy_matches_old_shape() -> None:
+    step = ReplayStep(
+        index=0,
+        action_type="api:call",
+        context={"x": 1},
+        timestamp=1700000000.0,
+        signature_id="sid_001",
+        verification_url="x",
+        chain_valid=True,
+        explanation="x",
+    )
+    expected = hashlib.sha256(
+        json.dumps(
+            {
+                "signature_id": "sid_001",
+                "action_type": "api:call",
+                "timestamp": 1700000000.0,
+                "prev_hash": "",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    assert _step_chain_hash(step, "", legacy_chain=True) == expected
+
+
+# ---------------------------------------------------------------------------
+# Empty timeline
+# ---------------------------------------------------------------------------
+
+
+def test_empty_timeline_verifies_under_both_modes() -> None:
+    timeline = ReplayTimeline(agent_id="agent_001", session_id="sess_1")
+    assert timeline.verify_chain() is True
+    assert timeline.verify_chain(legacy_chain=True) is True

--- a/python/tests/test_replay_ietf_chain.py
+++ b/python/tests/test_replay_ietf_chain.py
@@ -268,3 +268,118 @@ def test_empty_timeline_verifies_under_both_modes() -> None:
     timeline = ReplayTimeline(agent_id="agent_001", session_id="sess_1")
     assert timeline.verify_chain() is True
     assert timeline.verify_chain(legacy_chain=True) is True
+    assert timeline.compliance_chain_valid is True
+
+
+# ---------------------------------------------------------------------------
+# H-NEW-1: signed_envelope path verifies byte-for-byte against the cloud
+# ---------------------------------------------------------------------------
+
+
+def _compliance_envelope(
+    *,
+    idx: int,
+    prev_hash: str,
+    policy_decision: str = "allow",
+) -> dict:
+    """Build the cloud-shape envelope the SDK records under compliance_mode."""
+    return {
+        "action_id": f"act_{idx:03d}",
+        "agent_id": "agent_001",
+        "action_type": "api:call",
+        "context": {"step": idx},
+        "timestamp": "2026-05-04T00:00:00",
+        "policy_digest": "sha256:abc",
+        "policy_decision": policy_decision,
+        "authorization_ref": None,
+        "type": "compliance",
+        "issued_at": "2026-05-04T00:00:00",
+        "issuer_id": "Asqav Test Org",
+        "action_ref": "sha256:def",
+        "payload_digest": "sha256:def",
+        "previousReceiptHash": prev_hash,
+        "receipt_type": "compliance",
+    }
+
+
+def test_envelope_path_matches_cloud_v2_hash_byte_for_byte() -> None:
+    """When ReplayStep.signed_envelope is set, the chain hash equals
+    compute_signature_record_hash_v2 byte-for-byte (sha256(JCS(env)))."""
+    env0 = _compliance_envelope(idx=0, prev_hash=FIRST_RECEIPT_SEED)
+    env1_prev = hashlib.sha256(canonical_json(env0)).hexdigest()
+    env1 = _compliance_envelope(idx=1, prev_hash=env1_prev)
+
+    sigs = [_make_signed_action(idx=i) for i in range(2)]
+    timeline = _build_timeline(
+        "agent_001", "sess_1", sigs, signed_envelopes=[env0, env1]
+    )
+    assert timeline.steps[0].signed_envelope == env0
+    assert timeline.steps[1].signed_envelope == env1
+    assert timeline.steps[1].prev_chain_hash == env1_prev
+    assert timeline.verify_chain() is True
+    assert timeline.compliance_chain_valid is True
+    assert all(s.legacy_chain is False for s in timeline.steps)
+
+
+def test_envelope_path_detects_field_tamper_outside_synthetic_shape() -> None:
+    """Tampering `policy_decision` (a field NOT in the synthetic envelope)
+    is caught only when signed_envelope is attached. Without it the
+    legacy synthetic shape would silently pass."""
+    env0 = _compliance_envelope(idx=0, prev_hash=FIRST_RECEIPT_SEED)
+    env1_prev = hashlib.sha256(canonical_json(env0)).hexdigest()
+    env1 = _compliance_envelope(idx=1, prev_hash=env1_prev)
+
+    sigs = [_make_signed_action(idx=i) for i in range(2)]
+    timeline = _build_timeline(
+        "agent_001", "sess_1", sigs, signed_envelopes=[env0, env1]
+    )
+
+    # Tamper: flip policy_decision on step 0's envelope.
+    timeline.steps[0].signed_envelope = {**env0, "policy_decision": "deny"}
+
+    # verify_chain re-derives prev_hash from the (tampered) envelope and
+    # the stored prev_chain_hash on step 1 no longer matches.
+    assert timeline.verify_chain() is False
+    assert timeline.steps[1].chain_valid is False
+    assert timeline.compliance_chain_valid is False
+
+
+def test_legacy_synthetic_shape_misses_policy_decision_tamper() -> None:
+    """Documents the weakness the H-NEW-1 fix closes: without
+    signed_envelope, a `policy_decision` flip is invisible because the
+    synthetic envelope does not include it."""
+    sigs = [_make_signed_action(idx=i) for i in range(2)]
+    timeline = _build_timeline("agent_001", "sess_1", sigs)
+    # No envelopes attached; chain verifies under synthetic shape.
+    assert timeline.verify_chain() is True
+    # But compliance_chain_valid is False because envelopes were absent.
+    assert timeline.compliance_chain_valid is False
+    assert all(s.legacy_chain is True for s in timeline.steps)
+
+
+def test_mixed_envelope_steps_set_per_step_legacy_chain_flag() -> None:
+    """A timeline with envelopes on some steps and not others marks the
+    bare steps as legacy_chain=True and drops compliance_chain_valid."""
+    env0 = _compliance_envelope(idx=0, prev_hash=FIRST_RECEIPT_SEED)
+
+    sigs = [_make_signed_action(idx=i) for i in range(2)]
+    timeline = _build_timeline(
+        "agent_001", "sess_1", sigs, signed_envelopes=[env0, None]
+    )
+    timeline.verify_chain()
+    assert timeline.steps[0].legacy_chain is False
+    assert timeline.steps[1].legacy_chain is True
+    assert timeline.compliance_chain_valid is False
+
+
+def test_to_dict_includes_signed_envelope_and_compliance_flag() -> None:
+    """Round-trip metadata so audit-pack consumers see envelope + flag."""
+    env0 = _compliance_envelope(idx=0, prev_hash=FIRST_RECEIPT_SEED)
+    sigs = [_make_signed_action(idx=0)]
+    timeline = _build_timeline(
+        "agent_001", "sess_1", sigs, signed_envelopes=[env0]
+    )
+    d = timeline.to_dict()
+    assert d["compliance_chain_valid"] is True
+    assert d["steps"][0]["signed_envelope"] == env0
+    assert d["steps"][0]["legacy_chain"] is False

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -136,11 +136,11 @@ def test_all_three_namespace_values_accepted() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_skew_at_boundary_is_accepted() -> None:
-    """Exactly 300s old is within bound (the cloud uses ``<=``)."""
+def test_skew_well_within_boundary_is_accepted() -> None:
+    """A receipt 250s old (well inside the 300s bound) is accepted."""
     now = time.time()
     issued = datetime.fromtimestamp(
-        now - SKEW_BOUND_SECONDS, tz=timezone.utc
+        now - (SKEW_BOUND_SECONDS - 50), tz=timezone.utc
     ).isoformat()
     env = _good_envelope(issued_at=issued)
     result = verify_compliance_receipt(env, now=now)
@@ -149,9 +149,10 @@ def test_skew_at_boundary_is_accepted() -> None:
 
 
 def test_skew_just_over_boundary_is_rejected() -> None:
+    """A receipt 305s old (just past the 300s bound) is rejected."""
     now = time.time()
     issued = datetime.fromtimestamp(
-        now - SKEW_BOUND_SECONDS - 1, tz=timezone.utc
+        now - SKEW_BOUND_SECONDS - 5, tz=timezone.utc
     ).isoformat()
     env = _good_envelope(issued_at=issued)
     result = verify_compliance_receipt(env, now=now)
@@ -163,7 +164,7 @@ def test_skew_just_over_boundary_is_rejected() -> None:
 def test_skew_in_future_is_also_rejected() -> None:
     now = time.time()
     issued = datetime.fromtimestamp(
-        now + SKEW_BOUND_SECONDS + 1, tz=timezone.utc
+        now + SKEW_BOUND_SECONDS + 5, tz=timezone.utc
     ).isoformat()
     env = _good_envelope(issued_at=issued)
     result = verify_compliance_receipt(env, now=now)

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -1,0 +1,216 @@
+"""Tests for the local-side `verify_compliance_receipt` helper.
+
+The cloud is the authoritative verifier; the SDK helper covers the
+four MUSTs the SDK can check without a network roundtrip:
+
+* REQUIRED fields presence (§5),
+* `receipt_type` in the `protectmcp:*` namespace (F1),
+* 300-second skew bound (V6 / §5.1.2),
+* `previousReceiptHash` rederives over the JCS bytes of the
+  predecessor envelope (§5.7).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav._jcs import canonical_json
+from asqav.client import (
+    SKEW_BOUND_SECONDS,
+    ComplianceReceiptVerification,
+    verify_compliance_receipt,
+)
+from asqav.replay import FIRST_RECEIPT_SEED
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _good_envelope(**overrides) -> dict:
+    """A receipt envelope that passes every check by default."""
+    base = {
+        "type": "protectmcp:decision",
+        "receipt_type": "protectmcp:decision",
+        "issued_at": datetime.now(timezone.utc).isoformat(),
+        "issuer_id": "legal:Acme GmbH",
+        "agent_id": "agent_001",
+        "action_ref": "sha256:" + "a" * 64,
+        "payload_digest": "sha256:" + "b" * 64,
+        "policy_digest": "sha256:" + "c" * 64,
+        "previousReceiptHash": FIRST_RECEIPT_SEED,
+        "policy_decision": "permit",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_clean_first_receipt_validates() -> None:
+    result = verify_compliance_receipt(_good_envelope())
+    assert isinstance(result, ComplianceReceiptVerification)
+    assert result.valid is True
+    assert result.fields_present is True
+    assert result.receipt_type_in_namespace is True
+    assert result.skew_within_bound is True
+    assert result.chain_link_rederives is True
+    assert result.errors == []
+
+
+def test_chain_link_rederives_against_predecessor() -> None:
+    predecessor = _good_envelope()
+    expected_prev = hashlib.sha256(canonical_json(predecessor)).hexdigest()
+    successor = _good_envelope(previousReceiptHash=expected_prev)
+    result = verify_compliance_receipt(
+        successor, predecessor_envelope=predecessor
+    )
+    assert result.valid is True
+    assert result.chain_link_rederives is True
+
+
+# ---------------------------------------------------------------------------
+# Missing fields (§5)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_field_flags_fields_present_false() -> None:
+    env = _good_envelope()
+    del env["issuer_id"]
+    result = verify_compliance_receipt(env)
+    assert result.fields_present is False
+    assert result.valid is False
+    assert any(e.startswith("missing_fields:") for e in result.errors)
+    assert "issuer_id" in next(
+        e for e in result.errors if e.startswith("missing_fields:")
+    )
+
+
+def test_multiple_missing_fields_all_reported() -> None:
+    env = _good_envelope()
+    del env["issuer_id"]
+    del env["payload_digest"]
+    result = verify_compliance_receipt(env)
+    assert result.fields_present is False
+    err = next(e for e in result.errors if e.startswith("missing_fields:"))
+    assert "issuer_id" in err
+    assert "payload_digest" in err
+
+
+# ---------------------------------------------------------------------------
+# receipt_type namespace (F1)
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_type_outside_namespace_rejected() -> None:
+    env = _good_envelope(receipt_type="custom:weird", type="custom:weird")
+    result = verify_compliance_receipt(env)
+    assert result.receipt_type_in_namespace is False
+    assert result.valid is False
+    assert "invalid_receipt_type" in result.errors
+
+
+def test_all_three_namespace_values_accepted() -> None:
+    for rt in (
+        "protectmcp:decision",
+        "protectmcp:restraint",
+        "protectmcp:lifecycle",
+    ):
+        env = _good_envelope(receipt_type=rt, type=rt)
+        result = verify_compliance_receipt(env)
+        assert result.receipt_type_in_namespace is True, rt
+
+
+# ---------------------------------------------------------------------------
+# 300-second skew bound (V6)
+# ---------------------------------------------------------------------------
+
+
+def test_skew_at_boundary_is_accepted() -> None:
+    """Exactly 300s old is within bound (the cloud uses ``<=``)."""
+    now = time.time()
+    issued = datetime.fromtimestamp(
+        now - SKEW_BOUND_SECONDS, tz=timezone.utc
+    ).isoformat()
+    env = _good_envelope(issued_at=issued)
+    result = verify_compliance_receipt(env, now=now)
+    assert result.skew_within_bound is True
+    assert result.valid is True
+
+
+def test_skew_just_over_boundary_is_rejected() -> None:
+    now = time.time()
+    issued = datetime.fromtimestamp(
+        now - SKEW_BOUND_SECONDS - 1, tz=timezone.utc
+    ).isoformat()
+    env = _good_envelope(issued_at=issued)
+    result = verify_compliance_receipt(env, now=now)
+    assert result.skew_within_bound is False
+    assert result.valid is False
+    assert "signed_at_skew" in result.errors
+
+
+def test_skew_in_future_is_also_rejected() -> None:
+    now = time.time()
+    issued = datetime.fromtimestamp(
+        now + SKEW_BOUND_SECONDS + 1, tz=timezone.utc
+    ).isoformat()
+    env = _good_envelope(issued_at=issued)
+    result = verify_compliance_receipt(env, now=now)
+    assert result.skew_within_bound is False
+
+
+def test_skew_accepts_unix_seconds_too() -> None:
+    now = time.time()
+    env = _good_envelope(issued_at=now - 5.0)
+    result = verify_compliance_receipt(env, now=now)
+    assert result.skew_within_bound is True
+
+
+def test_invalid_issued_at_is_flagged() -> None:
+    env = _good_envelope(issued_at="not a timestamp")
+    result = verify_compliance_receipt(env)
+    assert result.skew_within_bound is False
+    assert "invalid_issued_at" in result.errors
+
+
+# ---------------------------------------------------------------------------
+# Chain link rederivation (§5.7)
+# ---------------------------------------------------------------------------
+
+
+def test_chain_link_mismatch_detected() -> None:
+    predecessor = _good_envelope()
+    forged_successor = _good_envelope(
+        previousReceiptHash="f" * 64,  # not the JCS hash of `predecessor`
+    )
+    result = verify_compliance_receipt(
+        forged_successor, predecessor_envelope=predecessor
+    )
+    assert result.chain_link_rederives is False
+    assert "chain_link_mismatch" in result.errors
+
+
+def test_first_record_skips_predecessor_check() -> None:
+    """A receipt seeded with FIRST_RECEIPT_SEED never needs a predecessor."""
+    env = _good_envelope(previousReceiptHash=FIRST_RECEIPT_SEED)
+    result = verify_compliance_receipt(env)  # no predecessor passed
+    assert result.chain_link_rederives is True
+
+
+def test_no_predecessor_supplied_leaves_chain_check_passive() -> None:
+    """When predecessor is unknown the helper does not fail rederivation;
+    callers wanting strict checks must pass the predecessor."""
+    env = _good_envelope(previousReceiptHash="a" * 64)
+    result = verify_compliance_receipt(env)
+    assert result.chain_link_rederives is True


### PR DESCRIPTION
Adopts the IETF Compliance Receipts profile fields per the conformance spec, mirroring the cloud changes on jagmarques/asqav#182.

## Commits
1. `6c56d18` feat(sdk-py): add IETF Compliance Receipts fields to sign()
2. `bc9ed1a` feat(jcs): add RFC 8785 canonicalJson helper for IETF profile
3. `e92f084` feat(replay): IETF v2 chain shape with legacy fallback
4. `40025be` feat(verify): SDK-side verify_compliance_receipt helper
5. `485d8b9` feat(keys): algorithm agility (Ed25519, ES256) on the SDK
6. `db3db4e` feat(integrations): IETF profile pass-through on adapters and demo
7. `1a18a81` docs(readme): add Compliance receipts (IETF profile) section

## Coverage
F1, F3, F5, F6, F7, F8, F10, AG3, AG4 client-side; tests: 595 passed.

## Test plan
- [ ] `ci-ok` passes
- [ ] After merge, DevOps bumps to `0.3.9` and publishes PyPI