### PR TITLE
feat(typescript): IETF Compliance Receipts profile (close MUST/SHOULD gaps)

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -171,6 +171,82 @@ const result = await generateText({
 
 Span names are mapped to Asqav action types: `ai.generateText` -> `ai:completion`, `ai.streamText` -> `ai:completion_stream`, `ai.toolCall` -> `ai:tool_call`, errors -> `ai:error`. Signing is fire-and-forget and never blocks generation; failures log a warning instead of throwing.
 
+## Compliance receipts (IETF profile)
+
+Set `complianceMode: true` on `agent.sign(...)` to opt the receipt into the IETF Compliance Receipts profile (`draft-marques-asqav-compliance-receipts-00`). The cloud then emits a §5.7-conformant chain link, content-addressed `policy_digest`, fail-closed anchoring, and the raised retention floor.
+
+```ts
+const sig = await agent.sign({
+  actionType: "stripe:refund",
+  context: { chargeId: "ch_abc", amountCents: 1299, reason: "broken" },
+  complianceMode: true,
+  receiptType: "protectmcp:decision",
+  riskClass: "high",
+  sandboxState: "disabled",
+  iterationId: "refund-ch_abc",
+  policyDecision: "permit",
+});
+
+console.log(sig.previousReceiptHash); // 64 lowercase hex; "0".repeat(64) on first record
+console.log(sig.actionRef);            // sha256:<hex> of the canonical action
+```
+
+Field reference (camelCase on the SDK, snake_case on the JSON wire):
+
+- `complianceMode` -> `compliance_mode`. Default `false`.
+- `receiptType` -> `receipt_type`. One of `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`. Validated client-side.
+- `actionRef` -> `action_ref`. `sha256:<hex>` of the canonical action. SDK derives it under `complianceMode` when omitted.
+- `payloadDigest` -> `payload_digest`. `sha256:<hex>` of the request payload.
+- `issuerId` -> `issuer_id`. Legal entity. Resolved server-side when omitted.
+- `iterationId` -> `iteration_id`. Required for multi-step receipts.
+- `sandboxState` -> `sandbox_state`. One of `enabled`, `disabled`, `unavailable`. Required for High-Risk.
+- `riskClass` -> `risk_class`. One of `low`, `medium`, `high`, `unknown`.
+- `incidentClass` -> `incident_class`. DORA ITS code; empty when not applicable.
+- `policyDecision` -> `policy_decision`. One of `permit`, `deny`, `rate_limit`.
+- `reason` -> `reason`. Required when `policyDecision` is `deny` or `rate_limit`.
+
+### RFC 8785 canonicalization
+
+The exact bytes the cloud signs (and the chain hashes over) are JCS-canonicalized JSON. The SDK exposes the canonicalizer so callers can reproduce them offline:
+
+```ts
+import { canonicalJson } from "@asqav/sdk";
+
+const bytes = canonicalJson({ b: 2, a: 1 }); // -> Uint8Array of `{"a":1,"b":2}`
+```
+
+### Offline chain verification
+
+`verifyChain(records)` walks an ordered list of signed envelopes for one agent and re-derives each `previousReceiptHash` per §5.7. The first record's seed is `"0".repeat(64)`.
+
+```ts
+import { verifyChain } from "@asqav/sdk";
+
+const result = verifyChain(records);
+if (!result.chainIntegrity) {
+  for (const step of result.steps.filter((s) => !s.chainValid)) {
+    console.error(`step ${step.index}: expected ${step.expectedPreviousReceiptHash}, got ${step.actualPreviousReceiptHash}`);
+  }
+}
+```
+
+Pass `{ legacy: true }` to use the v1 chain shape during the one-release backward-compat window.
+
+### Algorithm agility
+
+`Agent.create({ algorithm })` accepts `ml-dsa-65` (default), `ml-dsa-44`, `ml-dsa-87`, `ed25519`, and `es256`. ML-DSA is server-side only. For Ed25519 / ES256 the SDK ships keypair, sign, and verify helpers via `node:crypto`:
+
+```ts
+import { generateKeypair, signMessage, verifyMessage, canonicalJson } from "@asqav/sdk";
+
+const kp = generateKeypair("ed25519");
+const message = canonicalJson({ intent: "approve refund ch_abc" });
+const sig = signMessage("ed25519", kp.privateKeyPkcs8B64, message);
+const ok = verifyMessage("ed25519", kp.publicKeySpkiB64, message, sig);
+```
+
+ES256 signatures are emitted in IEEE-P1363 (raw r||s) form so they match the cloud verifier byte-for-byte.
+
 ## Errors
 
 All thrown errors extend `AsqavError`. `AuthenticationError`, `RateLimitError`, and `APIError` (with `statusCode`) are exported for fine-grained handling.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -14,22 +14,30 @@ The package ships an `asqav` binary mirroring the Python CLI surface. Set `ASQAV
 
 ```bash
 asqav --version
-asqav verify <signature_id>
-asqav agents list
-asqav agents create my-agent
-asqav agents revoke <agent_id>
-asqav sessions list [--limit N] [--status X] [--agent ID]
-asqav sessions end <session_id>
+asqav verify <signature_id> [--output text|json]           # IETF axes when present
+asqav sign --agent-id ID --action-type T --action-json action.json \
+           --compliance-mode --receipt-type protectmcp:decision \
+           --risk-class high --issuer-id legal:Acme
+asqav agents list / create / revoke
+asqav sessions list / end <session_id>
 asqav replay <agent_id> <session_id> [--json]              # Pro
+asqav replay-verify <agent_id> <session_id> [--strict]     # Pro: IETF chain
 asqav preflight <agent_id> <action_type> [--json]          # Pro
 asqav budget check --agent-id ID --limit 10 --estimated-cost 0.25     # Pro
 asqav budget record --agent-id ID --action api:openai --actual-cost 0.23 --limit 10  # Pro
 asqav approve <session_id> <entity_id>                     # Pro
-asqav compliance frameworks
-asqav compliance export --session ID --output bundle.json  # Business
+asqav compliance frameworks / export                       # Business
+asqav audit-pack export --start ISO --end ISO --output-file bundle.json
+asqav audit-pack policy <sha256:hex>
+asqav payloads erase <signature_id> --yes                  # P4 right-to-erasure
+asqav org set-compliance-strict <org_id> --enable|--disable
+asqav keys generate --algorithm ed25519|es256 [--out priv.bin]
+asqav migrate run v3-20|v3-21|v3-22                        # X-Maintenance-Key required
 ```
 
 Pro/Business commands are gated client-side via `GET /account` so a free-tier key gets a clean upgrade message instead of a mid-pipeline 402. The server is the source of truth; older self-hosted deployments without `/account` skip the gate.
+
+The IETF Compliance Receipts profile commands (`sign --compliance-mode`, `audit-pack export`, `audit-pack policy`, `payloads erase`, `replay-verify --strict`, `org set-compliance-strict`) match the SDK options on `agent.sign(...)`. Wire keys are snake_case (`compliance_mode`, `policy_decision`, `action_ref`) per `draft-marques-asqav-compliance-receipts-00`; the CLI accepts the kebab-case equivalents.
 
 ## Quick start
 

--- a/typescript/examples/langchain-js.ts
+++ b/typescript/examples/langchain-js.ts
@@ -53,6 +53,11 @@ async function main(): Promise<void> {
     async (args: z.infer<typeof refundSchema>) => {
       // Sign the intent FIRST. If the side effect throws, the audit
       // record still proves what the agent decided to do.
+      //
+      // We opt into the IETF Compliance Receipts profile here because
+      // refunds are High-Risk and we want fail-closed anchoring +
+      // raised retention. The cloud derives `previousReceiptHash`,
+      // `policy_digest`, and `issuer_id`; the SDK fills in the rest.
       const sig = await agent.sign({
         actionType: "stripe:refund",
         context: {
@@ -61,6 +66,12 @@ async function main(): Promise<void> {
           reason: args.reason,
           model: "gpt-4o",
         },
+        complianceMode: true,
+        receiptType: "protectmcp:decision",
+        riskClass: "high",
+        sandboxState: "disabled",
+        iterationId: `refund-${args.chargeId}`,
+        policyDecision: "permit",
       });
 
       const result = await stripeRefundStub(args);

--- a/typescript/examples/vercel-ai-sdk.ts
+++ b/typescript/examples/vercel-ai-sdk.ts
@@ -54,9 +54,20 @@ async function main(): Promise<void> {
     execute: async ({ chargeId, amountCents, reason }) => {
       // Sign the intent FIRST. If the side effect throws, the audit
       // record still proves what the agent decided to do.
+      //
+      // Opt into the IETF Compliance Receipts profile so the cloud
+      // emits a §5.7-conformant chain link, content-addressed
+      // policy_digest, and applies fail-closed anchoring under the
+      // raised retention floor.
       const sig = await agent.sign({
         actionType: "stripe:refund",
         context: { chargeId, amountCents, reason, model: "gpt-4o" },
+        complianceMode: true,
+        receiptType: "protectmcp:decision",
+        riskClass: "high",
+        sandboxState: "disabled",
+        iterationId: `refund-${chargeId}`,
+        policyDecision: "permit",
       });
 
       const result = await stripeRefundStub({ chargeId, amountCents, reason });

--- a/typescript/src/algorithms.ts
+++ b/typescript/src/algorithms.ts
@@ -1,0 +1,154 @@
+/**
+ * Algorithm agility for the IETF Compliance Receipts profile (AG3, AG4).
+ *
+ * The cloud accepts `ml-dsa-65` (default), `ed25519`, and `es256` on the
+ * receipt-signing path. ML-DSA always runs server-side because it is not
+ * available in Node's standard `crypto` module. Ed25519 and ES256 are
+ * available locally via `node:crypto`, so the SDK can generate keypairs
+ * and produce signatures off-cloud (handy for `user_intent` envelopes
+ * and offline test fixtures).
+ *
+ * Public surface:
+ *   SUPPORTED_ALGORITHMS   - the set the SDK accepts on `Agent.create`.
+ *   isSupportedAlgorithm   - tiny type-guard.
+ *   generateKeypair        - Ed25519 / ES256 keypair (raw bytes + b64).
+ *   signMessage            - sign canonical bytes with the local key.
+ *   verifyMessage          - verify a local signature.
+ */
+
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign,
+  verify,
+} from "node:crypto";
+
+export const SUPPORTED_ALGORITHMS = [
+  "ml-dsa-65",
+  "ml-dsa-44",
+  "ml-dsa-87",
+  "ed25519",
+  "es256",
+] as const;
+
+export type SupportedAlgorithm = (typeof SUPPORTED_ALGORITHMS)[number];
+
+/** Algorithms the SDK can keypair-generate and sign with locally. */
+export const LOCAL_SIGNING_ALGORITHMS = ["ed25519", "es256"] as const;
+
+export type LocalSigningAlgorithm = (typeof LOCAL_SIGNING_ALGORITHMS)[number];
+
+export function isSupportedAlgorithm(value: string): value is SupportedAlgorithm {
+  return (SUPPORTED_ALGORITHMS as readonly string[]).includes(value);
+}
+
+export function isLocalSigningAlgorithm(
+  value: string,
+): value is LocalSigningAlgorithm {
+  return (LOCAL_SIGNING_ALGORITHMS as readonly string[]).includes(value);
+}
+
+/** Public + private bytes for a locally-generated keypair. */
+export interface LocalKeypair {
+  algorithm: LocalSigningAlgorithm;
+  /** PKCS8 DER private key (base64). */
+  privateKeyPkcs8B64: string;
+  /** SPKI DER public key (base64). */
+  publicKeySpkiB64: string;
+}
+
+/**
+ * Generate a fresh keypair for a local-signing algorithm. ML-DSA is
+ * intentionally rejected here because it is server-side only.
+ */
+export function generateKeypair(algorithm: LocalSigningAlgorithm): LocalKeypair {
+  if (algorithm === "ed25519") {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    return {
+      algorithm,
+      privateKeyPkcs8B64: privateKey
+        .export({ type: "pkcs8", format: "der" })
+        .toString("base64"),
+      publicKeySpkiB64: publicKey
+        .export({ type: "spki", format: "der" })
+        .toString("base64"),
+    };
+  }
+  if (algorithm === "es256") {
+    const { publicKey, privateKey } = generateKeyPairSync("ec", {
+      namedCurve: "P-256",
+    });
+    return {
+      algorithm,
+      privateKeyPkcs8B64: privateKey
+        .export({ type: "pkcs8", format: "der" })
+        .toString("base64"),
+      publicKeySpkiB64: publicKey
+        .export({ type: "spki", format: "der" })
+        .toString("base64"),
+    };
+  }
+  // Exhaustiveness guard.
+  const exhaustive: never = algorithm;
+  throw new Error(`Unsupported local algorithm: ${exhaustive as string}`);
+}
+
+/**
+ * Sign canonical bytes with a locally-generated keypair.
+ *
+ * Returns the raw signature as base64. For `es256`, the output is the
+ * IEEE P1363 (raw r||s) form the cloud's `_verify_signature` expects;
+ * Node's default for ECDSA is DER, so we convert.
+ */
+export function signMessage(
+  algorithm: LocalSigningAlgorithm,
+  privateKeyPkcs8B64: string,
+  message: Uint8Array,
+): string {
+  const key = createPrivateKey({
+    key: Buffer.from(privateKeyPkcs8B64, "base64"),
+    format: "der",
+    type: "pkcs8",
+  });
+  if (algorithm === "ed25519") {
+    return sign(null, Buffer.from(message), key).toString("base64");
+  }
+  if (algorithm === "es256") {
+    const der = sign("sha256", Buffer.from(message), {
+      key,
+      dsaEncoding: "ieee-p1363",
+    });
+    return der.toString("base64");
+  }
+  const exhaustive: never = algorithm;
+  throw new Error(`Unsupported local algorithm: ${exhaustive as string}`);
+}
+
+/** Verify a base64 signature against a base64 SPKI public key. */
+export function verifyMessage(
+  algorithm: LocalSigningAlgorithm,
+  publicKeySpkiB64: string,
+  message: Uint8Array,
+  signatureB64: string,
+): boolean {
+  const key = createPublicKey({
+    key: Buffer.from(publicKeySpkiB64, "base64"),
+    format: "der",
+    type: "spki",
+  });
+  const sig = Buffer.from(signatureB64, "base64");
+  if (algorithm === "ed25519") {
+    return verify(null, Buffer.from(message), key, sig);
+  }
+  if (algorithm === "es256") {
+    return verify(
+      "sha256",
+      Buffer.from(message),
+      { key, dsaEncoding: "ieee-p1363" },
+      sig,
+    );
+  }
+  const exhaustive: never = algorithm;
+  throw new Error(`Unsupported local algorithm: ${exhaustive as string}`);
+}

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -23,10 +23,13 @@ import {
   Agent,
   APIError,
   BudgetTracker,
+  generateKeypair,
   init,
   listSessions,
   request,
+  verifyChain,
   verifySignature,
+  type LocalSigningAlgorithm,
 } from "./index.js";
 
 const CLI_VERSION = "0.2.5";
@@ -385,6 +388,360 @@ async function cmdComplianceExport(args: string[]): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// IETF Compliance Receipts profile commands
+// ---------------------------------------------------------------------------
+
+async function readJsonInput(value: string): Promise<unknown> {
+  if (value === "-") {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : (chunk as Buffer));
+    }
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  }
+  const fs = await import("node:fs/promises");
+  const text = await fs.readFile(value, "utf8");
+  return JSON.parse(text);
+}
+
+async function cmdSign(args: string[]): Promise<void> {
+  const agentId = parseFlag(args, "agent-id");
+  const actionType = parseFlag(args, "action-type");
+  if (!agentId || !actionType) {
+    die("Usage: asqav sign --agent-id ID --action-type T [--compliance-mode] [--action-json PATH]");
+  }
+  const complianceMode = hasFlag(args, "compliance-mode");
+  const actionRef = parseFlag(args, "action-ref");
+  const actionJson = parseFlag(args, "action-json");
+  const sandboxState = parseFlag(args, "sandbox-state");
+  const iterationId = parseFlag(args, "iteration-id");
+  const riskClass = parseFlag(args, "risk-class");
+  const incidentClass = parseFlag(args, "incident-class");
+  const issuerId = parseFlag(args, "issuer-id");
+  const receiptType = parseFlag(args, "receipt-type") ?? "protectmcp:decision";
+  const reason = parseFlag(args, "reason");
+  const policyDecision = parseFlag(args, "policy-decision") ?? "permit";
+  const sessionId = parseFlag(args, "session-id");
+  const validSecondsStr = parseFlag(args, "valid-seconds");
+  const policyArtefactPath = parseFlag(args, "policy-artefact");
+  const output = parseFlag(args, "output") ?? "text";
+
+  if ((policyDecision === "deny" || policyDecision === "rate_limit") && !reason) {
+    die("Error: --reason is required when --policy-decision is deny or rate_limit.");
+  }
+
+  ensureApiKey();
+  let context: Record<string, unknown> | undefined;
+  if (actionJson) {
+    try {
+      context = (await readJsonInput(actionJson)) as Record<string, unknown>;
+    } catch (err) {
+      die(`Error reading action JSON: ${(err as Error).message}`);
+    }
+  }
+  if (policyArtefactPath) {
+    try {
+      const artefact = await readJsonInput(policyArtefactPath);
+      context = { ...(context ?? {}), _policy_artefact: artefact };
+    } catch (err) {
+      die(`Error reading policy artefact: ${(err as Error).message}`);
+    }
+  }
+  const actionId = parseFlag(args, "action-id");
+  if (actionId) {
+    context = { ...(context ?? {}), _action_id: actionId };
+  }
+
+  try {
+    const agent = await Agent.get(agentId);
+    if (sessionId) {
+      // Internal field used by buildSignBody when the session is bound.
+      (agent as unknown as { sessionId: string }).sessionId = sessionId;
+    }
+    const sig = await agent.sign({
+      actionType: actionType,
+      context,
+      complianceMode,
+      actionRef,
+      sandboxState: sandboxState as "enabled" | "disabled" | "unavailable" | undefined,
+      iterationId,
+      riskClass: riskClass as "low" | "medium" | "high" | "unknown" | undefined,
+      incidentClass,
+      issuerId,
+      receiptType: receiptType as
+        | "protectmcp:decision"
+        | "protectmcp:restraint"
+        | "protectmcp:lifecycle",
+      reason,
+      policyDecision: policyDecision as "permit" | "deny" | "rate_limit",
+      validSeconds: validSecondsStr ? Number(validSecondsStr) : undefined,
+    });
+    if (output === "json") {
+      process.stdout.write(`${JSON.stringify(sig, null, 2)}\n`);
+      return;
+    }
+    process.stdout.write(`signature_id: ${sig.signatureId}\n`);
+    process.stdout.write(`action_id:    ${sig.actionId}\n`);
+    process.stdout.write(`algorithm:    ${sig.algorithm ?? "?"}\n`);
+    process.stdout.write(`signed_at:    ${sig.timestamp}\n`);
+    if (sig.policyDigest) process.stdout.write(`policy_digest: ${sig.policyDigest}\n`);
+    if (sig.complianceMode) {
+      process.stdout.write(`compliance_mode: true\n`);
+      if (sig.receiptType) process.stdout.write(`receipt_type:  ${sig.receiptType}\n`);
+      if (sig.actionRef) process.stdout.write(`action_ref:    ${sig.actionRef}\n`);
+      if (sig.previousReceiptHash) {
+        process.stdout.write(`previous_receipt_hash: ${sig.previousReceiptHash}\n`);
+      }
+    }
+    process.stdout.write(`verify_url:   ${sig.verificationUrl}\n`);
+  } catch (err) {
+    die(`Error signing: ${(err as Error).message}`);
+  }
+}
+
+async function cmdAuditPackExport(args: string[]): Promise<void> {
+  const start = parseFlag(args, "start");
+  const end = parseFlag(args, "end");
+  const outputFile = parseFlag(args, "output-file");
+  const organizationId = parseFlag(args, "organization-id");
+  const onlyCompliance = !hasFlag(args, "no-only-compliance");
+  if (!start || !end || !outputFile) {
+    die("Usage: asqav audit-pack export --start ISO --end ISO --output-file PATH [--organization-id ID] [--no-only-compliance]");
+  }
+  ensureApiKey();
+  try {
+    const body: Record<string, unknown> = { start, end, only_compliance: onlyCompliance };
+    if (organizationId) body.organization_id = organizationId;
+    const bundle = await request<{
+      receipt_count?: number;
+      bundle_digest?: string;
+      bundle_signature_algorithm?: string;
+    }>("POST", "/audit-pack/export", body);
+    const fs = await import("node:fs/promises");
+    await fs.writeFile(outputFile, `${JSON.stringify(bundle, null, 2)}\n`, "utf8");
+    process.stdout.write(`wrote ${bundle.receipt_count ?? "?"} receipts to ${outputFile}\n`);
+    if (bundle.bundle_digest) process.stdout.write(`bundle_digest: ${bundle.bundle_digest}\n`);
+    if (bundle.bundle_signature_algorithm) {
+      process.stdout.write(`algorithm:     ${bundle.bundle_signature_algorithm}\n`);
+    }
+  } catch (err) {
+    die(`Error exporting audit pack: ${(err as Error).message}`);
+  }
+}
+
+async function cmdAuditPackPolicy(args: string[]): Promise<void> {
+  let [digest] = positional(args);
+  if (!digest) die("Usage: asqav audit-pack policy <sha256:hex>");
+  if (!digest.startsWith("sha256:")) {
+    if (/^[0-9a-fA-F]{64}$/.test(digest)) {
+      digest = `sha256:${digest.toLowerCase()}`;
+    } else {
+      die("Error: digest must be sha256:<64-hex> or a bare 64-hex string.");
+    }
+  }
+  const output = parseFlag(args, "output") ?? "json";
+  ensureApiKey();
+  try {
+    const data = await request<unknown>("GET", `/audit-pack/policy/${digest}`);
+    if (output === "text") {
+      const d = data as {
+        digest?: string;
+        organization_id?: string;
+        agent_id?: string;
+        action_type?: string;
+        created_at?: string;
+        artefact?: unknown;
+      };
+      process.stdout.write(`digest:          ${d.digest ?? "?"}\n`);
+      process.stdout.write(`organization_id: ${d.organization_id ?? "?"}\n`);
+      process.stdout.write(`agent_id:        ${d.agent_id ?? "?"}\n`);
+      process.stdout.write(`action_type:     ${d.action_type ?? "?"}\n`);
+      process.stdout.write(`created_at:      ${d.created_at ?? "?"}\n`);
+      process.stdout.write(`--- artefact ---\n${JSON.stringify(d.artefact ?? {}, null, 2)}\n`);
+    } else {
+      process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+    }
+  } catch (err) {
+    die(`Error fetching artefact: ${(err as Error).message}`);
+  }
+}
+
+async function cmdPayloadsErase(args: string[]): Promise<void> {
+  const [signatureId] = positional(args);
+  if (!signatureId) die("Usage: asqav payloads erase <signature_id> [--yes]");
+  if (!hasFlag(args, "yes") && !hasFlag(args, "y")) {
+    die("Refusing to erase without --yes. Erasure is idempotent but cannot be undone.");
+  }
+  ensureApiKey();
+  try {
+    await request("DELETE", `/signatures/payloads/${signatureId}`);
+    process.stdout.write(`Payload erased for ${signatureId}.\n`);
+    process.stdout.write(`Tombstone written; signature remains cryptographically verifiable.\n`);
+  } catch (err) {
+    die(`Error erasing payload: ${(err as Error).message}`);
+  }
+}
+
+async function cmdOrgSetComplianceStrict(args: string[]): Promise<void> {
+  const [orgId] = positional(args);
+  if (!orgId) die("Usage: asqav org set-compliance-strict <org_id> --enable|--disable");
+  const enable = hasFlag(args, "enable");
+  const disable = hasFlag(args, "disable");
+  if (enable === disable) {
+    die("Error: pass exactly one of --enable or --disable.");
+  }
+  ensureApiKey();
+  try {
+    const out = await request<{ compliance_mode_strict?: boolean }>(
+      "PATCH",
+      `/orgs/${orgId}`,
+      { compliance_mode_strict: enable },
+    );
+    const state = enable ? "enabled" : "disabled";
+    process.stdout.write(`compliance_mode_strict ${state} for org ${orgId}.\n`);
+    if (out && typeof out.compliance_mode_strict === "boolean") {
+      process.stdout.write(
+        `server confirms: compliance_mode_strict=${out.compliance_mode_strict}\n`,
+      );
+    }
+  } catch (err) {
+    die(`Error updating organization: ${(err as Error).message}`);
+  }
+}
+
+async function cmdKeysGenerate(args: string[]): Promise<void> {
+  const algorithm = parseFlag(args, "algorithm") ?? "ed25519";
+  const out = parseFlag(args, "out");
+  if (algorithm === "ml-dsa-65") {
+    die(
+      "ml-dsa-65 keypair generation runs server-side; call `asqav agents create --algorithm ml-dsa-65`.",
+    );
+  }
+  if (algorithm !== "ed25519" && algorithm !== "es256") {
+    die(`unsupported_algorithm: ${algorithm}. Supported: ed25519, es256.`);
+  }
+  try {
+    const kp = generateKeypair(algorithm as LocalSigningAlgorithm);
+    if (out) {
+      const fs = await import("node:fs/promises");
+      // Write the PKCS#8 DER bytes (base64-decoded) so the file is the
+      // raw key material the cloud signing path expects.
+      await fs.writeFile(out, Buffer.from(kp.privateKeyPkcs8B64, "base64"), { mode: 0o600 });
+      process.stdout.write(`Private key (PKCS#8 DER) written to ${out} (mode 0600).\n`);
+    }
+    process.stdout.write(`--- public key (SPKI DER, base64) ---\n${kp.publicKeySpkiB64}\n`);
+  } catch (err) {
+    die(`Error generating keypair: ${(err as Error).message}`);
+  }
+}
+
+async function cmdReplayVerify(args: string[]): Promise<void> {
+  const [agentId, sessionId] = positional(args);
+  if (!agentId || !sessionId) {
+    die("Usage: asqav replay-verify <agent_id> <session_id> [--strict] [--output text|json]");
+  }
+  const strict = hasFlag(args, "strict");
+  const output = parseFlag(args, "output") ?? "text";
+  ensureApiKey();
+  await requireTier("pro");
+  try {
+    const data = await request<{
+      steps?: Array<{
+        signature_id?: string;
+        signed_envelope?: Record<string, unknown>;
+        previous_receipt_hash?: string;
+        previousReceiptHash?: string;
+      }>;
+    }>("GET", `/agents/${agentId}/sessions/${sessionId}/replay`);
+    const steps = Array.isArray(data.steps) ? data.steps : [];
+    if (steps.length === 0) {
+      die("Error: no replay steps returned by the cloud.");
+    }
+    const legacySteps = steps.filter((s) => !s.signed_envelope);
+    const records = steps
+      .filter((s) => !!s.signed_envelope)
+      .map((s) => ({ signedEnvelope: s.signed_envelope as Record<string, unknown> }));
+    const result = verifyChain(records);
+    const chainValid = result.chainIntegrity && legacySteps.length === 0;
+    const strictPass = strict ? chainValid : result.chainIntegrity;
+    if (output === "json") {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            compliance_chain_valid: chainValid,
+            strict,
+            strict_pass: strictPass,
+            step_count: steps.length,
+            legacy_step_count: legacySteps.length,
+            steps: result.steps,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else {
+      process.stdout.write(`compliance_chain_valid: ${chainValid}\n`);
+      process.stdout.write(`strict: ${strict}\n`);
+      process.stdout.write(`steps: ${steps.length} (legacy: ${legacySteps.length})\n`);
+      for (const step of result.steps) {
+        const ok = step.chainValid ? "ok  " : "FAIL";
+        process.stdout.write(`  [${ok}] step ${step.index}\n`);
+      }
+      if (strict && legacySteps.length > 0) {
+        process.stdout.write(
+          `strict mode FAILED: ${legacySteps.length} step(s) lack signed_envelope.\n`,
+        );
+      }
+    }
+    if (!strictPass) process.exit(1);
+  } catch (err) {
+    die(`Error: ${(err as Error).message}`);
+  }
+}
+
+const SUPPORTED_MIGRATIONS = new Set(["v3-20", "v3-21", "v3-22"]);
+
+async function cmdMigrateRun(args: string[]): Promise<void> {
+  const [migration] = positional(args);
+  if (!migration) die("Usage: asqav migrate run v3-20|v3-21|v3-22");
+  if (!SUPPORTED_MIGRATIONS.has(migration)) {
+    die(`Error: unsupported migration ${migration}. Supported: ${[...SUPPORTED_MIGRATIONS].join(", ")}`);
+  }
+  const maintenanceKey = process.env.ASQAV_MAINTENANCE_KEY;
+  if (!maintenanceKey) {
+    die("Error: ASQAV_MAINTENANCE_KEY env var is required for migration commands.");
+  }
+  if (!process.env.ASQAV_API_KEY) {
+    die("Error: ASQAV_API_KEY env var is required.");
+  }
+  const baseUrl = process.env.ASQAV_API_URL ?? "https://api.asqav.com/api/v1";
+  const url = `${baseUrl.replace(/\/+$/, "")}/maintenance/run-migration-${migration}`;
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "X-API-Key": process.env.ASQAV_API_KEY,
+        "X-Maintenance-Key": maintenanceKey,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    const text = await response.text();
+    if (response.status >= 400) {
+      die(`HTTP ${response.status} from /maintenance/run-migration-${migration}: ${text}`);
+    }
+    try {
+      const parsed = JSON.parse(text);
+      process.stdout.write(`${JSON.stringify(parsed, null, 2)}\n`);
+    } catch {
+      process.stdout.write(`${text}\n`);
+    }
+  } catch (err) {
+    die(`Network error: ${(err as Error).message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Help / usage
 // ---------------------------------------------------------------------------
 
@@ -393,21 +750,28 @@ function printHelp(): void {
 
 Usage:
   asqav --version
-  asqav verify <signature_id>
-  asqav agents list
-  asqav agents create <name>
-  asqav agents revoke <agent_id> [--reason X]
-  asqav sessions list [--limit N] [--status X] [--agent ID]
-  asqav sessions end <session_id> [--status completed]
+  asqav verify <signature_id> [--output text|json]
+  asqav sign --agent-id ID --action-type T [--compliance-mode] [--action-json PATH|-]
+             [--receipt-type protectmcp:decision|...] [--risk-class low|medium|high|unknown]
+             [--sandbox-state enabled|disabled|unavailable] [--iteration-id ID]
+             [--issuer-id LEGAL] [--policy-decision permit|deny|rate_limit] [--reason CODE]
+             [--algorithm ml-dsa-65|ed25519|es256] [--policy-artefact PATH|-]
+             [--session-id ID] [--valid-seconds N] [--output text|json]
+  asqav agents list / create <name> / revoke <agent_id>
+  asqav sessions list / end <session_id>
   asqav replay <agent_id> <session_id> [--json]            (Pro)
+  asqav replay-verify <agent_id> <session_id> [--strict]   (Pro)  IETF chain
   asqav preflight <agent_id> <action_type> [--json]        (Pro)
-  asqav budget check --agent-id ID --limit N --estimated-cost N
-                     [--current-spend N] [--currency USD] [--json]   (Pro)
-  asqav budget record --agent-id ID --action TYPE --actual-cost N --limit N
-                      [--current-spend N] [--currency USD]           (Pro)
-  asqav approve <session_id> <entity_id> [--json]          (Pro)
-  asqav compliance frameworks
-  asqav compliance export --session ID --output PATH [--framework KEY]  (Business)
+  asqav budget check / record                              (Pro)
+  asqav approve <session_id> <entity_id>                   (Pro)
+  asqav compliance frameworks / export                     (Business)
+  asqav audit-pack export --start ISO --end ISO --output-file PATH
+                          [--organization-id ID] [--no-only-compliance]
+  asqav audit-pack policy <sha256:hex> [--output text|json]
+  asqav payloads erase <signature_id> --yes                P4 right-to-erasure
+  asqav org set-compliance-strict <org_id> --enable|--disable
+  asqav keys generate --algorithm ed25519|es256 [--out priv.pem]
+  asqav migrate run v3-20|v3-21|v3-22                      X-Maintenance-Key required
 
 Set ASQAV_API_KEY to authenticate. Get a key at https://asqav.com.
 `);
@@ -431,6 +795,8 @@ export async function runCli(argv: string[]): Promise<void> {
   switch (first) {
     case "verify":
       return cmdVerify(rest);
+    case "sign":
+      return cmdSign(rest);
     case "agents": {
       const [sub, ...rest2] = rest;
       if (sub === "list") return cmdAgentsList();
@@ -446,6 +812,8 @@ export async function runCli(argv: string[]): Promise<void> {
     }
     case "replay":
       return cmdReplay(rest);
+    case "replay-verify":
+      return cmdReplayVerify(rest);
     case "preflight":
       return cmdPreflight(rest);
     case "budget": {
@@ -461,6 +829,32 @@ export async function runCli(argv: string[]): Promise<void> {
       if (sub === "frameworks") return cmdComplianceFrameworks();
       if (sub === "export") return cmdComplianceExport(rest2);
       die("Usage: asqav compliance (frameworks | export)");
+    }
+    case "audit-pack": {
+      const [sub, ...rest2] = rest;
+      if (sub === "export") return cmdAuditPackExport(rest2);
+      if (sub === "policy") return cmdAuditPackPolicy(rest2);
+      die("Usage: asqav audit-pack (export | policy <digest>)");
+    }
+    case "payloads": {
+      const [sub, ...rest2] = rest;
+      if (sub === "erase") return cmdPayloadsErase(rest2);
+      die("Usage: asqav payloads erase <signature_id> --yes");
+    }
+    case "org": {
+      const [sub, ...rest2] = rest;
+      if (sub === "set-compliance-strict") return cmdOrgSetComplianceStrict(rest2);
+      die("Usage: asqav org set-compliance-strict <org_id> --enable|--disable");
+    }
+    case "keys": {
+      const [sub, ...rest2] = rest;
+      if (sub === "generate") return cmdKeysGenerate(rest2);
+      die("Usage: asqav keys generate --algorithm ed25519|es256 [--out PATH]");
+    }
+    case "migrate": {
+      const [sub, ...rest2] = rest;
+      if (sub === "run") return cmdMigrateRun(rest2);
+      die("Usage: asqav migrate run v3-20|v3-21|v3-22");
     }
     default:
       die(`Unknown command: ${first}\nRun 'asqav --help' for usage.`);

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -108,13 +108,41 @@ function positional(args: string[]): string[] {
 
 async function cmdVerify(args: string[]): Promise<void> {
   const [sigId] = positional(args);
-  if (!sigId) die("Usage: asqav verify <signature_id>");
+  if (!sigId) die("Usage: asqav verify <signature_id> [--output text|json]");
+  const output = parseFlag(args, "output") ?? "text";
+  // Verify is public (no auth required) but the underlying request
+  // helper short-circuits on missing config; init with whatever key is
+  // available so the public endpoint still works.
+  init({ apiKey: process.env.ASQAV_API_KEY ?? "anon" });
   try {
     const r = await verifySignature(sigId);
+    if (output === "json") {
+      process.stdout.write(`${JSON.stringify(r, null, 2)}\n`);
+      return;
+    }
     process.stdout.write(`Signature: ${r.verified ? "valid" : "invalid"}\n`);
     if (r.agentId) process.stdout.write(`Agent: ${r.agentName ?? "?"} (${r.agentId})\n`);
     if (r.actionType) process.stdout.write(`Action: ${r.actionType}\n`);
     process.stdout.write(`Algorithm: ${r.algorithm}\n`);
+    const d = r.verificationDetail;
+    if (d) {
+      process.stdout.write(`Validation: ${d.validationLabel}\n`);
+      if (d.chainValid !== undefined) {
+        process.stdout.write(`Chain valid: ${d.chainValid}\n`);
+      }
+      if (d.anchorStatusOts !== undefined) {
+        process.stdout.write(`Anchor (OTS): ${d.anchorStatusOts}\n`);
+      }
+      if (d.anchorStatusRfc3161 !== undefined) {
+        process.stdout.write(`Anchor (RFC 3161): ${d.anchorStatusRfc3161}\n`);
+      }
+      if (d.signedAtSkewSeconds !== undefined) {
+        process.stdout.write(`signed_at skew: ${d.signedAtSkewSeconds}s\n`);
+      }
+      if (d.missingFields && d.missingFields.length > 0) {
+        process.stdout.write(`Missing fields: ${d.missingFields.join(", ")}\n`);
+      }
+    }
   } catch (err) {
     if (err instanceof APIError && err.statusCode === 404) {
       die(`Signature not found: ${sigId}`);

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -300,7 +300,13 @@ export interface SessionResponse {
 
 /** Granular sub-checks the cloud returns alongside `verified`. The
  * `validationLabel` string is the dominant failure reason when
- * `verified=false`, e.g. `signature_expired` or `signer_key_changed`. */
+ * `verified=false`, e.g. `signature_expired` or `signer_key_changed`.
+ *
+ * The IETF Compliance Receipts profile sub-axes (`chainValid`,
+ * `anchorStatusOts`, `anchorStatusRfc3161`, `signedAtSkewSeconds`,
+ * `missingFields`) are populated only when the cloud emits them on a
+ * compliance-mode receipt; older receipts and older deployments leave
+ * them undefined for back-compat. */
 export interface VerificationDetail {
   signerKeyMatch: boolean;
   signatureValid: boolean;
@@ -314,7 +320,31 @@ export interface VerificationDetail {
     | "algorithm_mismatch"
     | "agent_inactive"
     | "agent_unknown"
+    | "chain_break"
+    | "anchor_invalid"
+    | "missing_required_field"
+    | "signed_at_skew"
     | string;
+  /** Absolute skew between the receipt's `signed_at` and the verifier's
+   * wall clock, in seconds. Receipts beyond `SKEW_BOUND_SECONDS`
+   * (300s) are rejected per V6 / §5.1.2. */
+  signedAtSkewSeconds?: number;
+  /** True when the cloud could rederive the chain hash from the stored
+   * `signed_envelope` and the predecessor matches. None on legacy
+   * (pre-IETF) records. */
+  chainValid?: boolean;
+  /** Tri-state OTS status. `pending` means the proof is still inside
+   * the upgrade window; `invalid` means corruption or stale; `valid`
+   * mirrors the Bitcoin block-confirmed case. */
+  anchorStatusOts?: "valid" | "pending" | "invalid";
+  /** RFC 3161 anchor outcome. Deterministic at issuance; never
+   * `pending`. */
+  anchorStatusRfc3161?: "valid" | "pending" | "invalid";
+  /** REQUIRED-fields presence check. When the record is
+   * `compliance_mode=true` and any spec-mandated field has been NULLed
+   * post-issuance, surfaces the missing column names. Empty list /
+   * undefined means every required field is present. */
+  missingFields?: string[];
 }
 
 export interface VerificationResponse {
@@ -946,6 +976,11 @@ export async function verifySignature(signatureId: string): Promise<Verification
       algorithm_match: boolean;
       agent_active: boolean;
       validation_label: string;
+      signed_at_skew_seconds?: number;
+      chain_valid?: boolean;
+      anchor_status_ots?: "valid" | "pending" | "invalid";
+      anchor_status_rfc3161?: "valid" | "pending" | "invalid";
+      missing_fields?: string[];
     };
   }>("GET", `/verify/${signatureId}`);
 
@@ -968,6 +1003,11 @@ export async function verifySignature(signatureId: string): Promise<Verification
           algorithmMatch: data.verification_detail.algorithm_match,
           agentActive: data.verification_detail.agent_active,
           validationLabel: data.verification_detail.validation_label,
+          signedAtSkewSeconds: data.verification_detail.signed_at_skew_seconds,
+          chainValid: data.verification_detail.chain_valid,
+          anchorStatusOts: data.verification_detail.anchor_status_ots,
+          anchorStatusRfc3161: data.verification_detail.anchor_status_rfc3161,
+          missingFields: data.verification_detail.missing_fields,
         }
       : undefined,
   };

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -12,6 +12,11 @@
  */
 
 import { createHash } from "node:crypto";
+import {
+  SUPPORTED_ALGORITHMS,
+  isSupportedAlgorithm,
+  type SupportedAlgorithm,
+} from "./algorithms.js";
 import { canonicalize, hashAction } from "./canonicalize.js";
 import { _dispatchAfter, _dispatchBefore } from "./hooks.js";
 import { canonicalJson } from "./jcs.js";
@@ -47,6 +52,18 @@ export {
   type ChainVerificationResult,
   type VerifyChainOptions,
 } from "./replay.js";
+export {
+  SUPPORTED_ALGORITHMS,
+  LOCAL_SIGNING_ALGORITHMS,
+  isSupportedAlgorithm,
+  isLocalSigningAlgorithm,
+  generateKeypair,
+  signMessage,
+  verifyMessage,
+  type SupportedAlgorithm,
+  type LocalSigningAlgorithm,
+  type LocalKeypair,
+} from "./algorithms.js";
 export { resolveMode, isAsqavCloudHost, type Mode } from "./mode.js";
 export { BudgetTracker, type BudgetCheckResult, type BudgetTrackerOptions } from "./budget.js";
 
@@ -133,7 +150,11 @@ export interface InitOptions {
 
 export interface AgentCreateOptions {
   name: string;
-  algorithm?: string;
+  /** One of `ml-dsa-65` (default), `ml-dsa-44`, `ml-dsa-87`, `ed25519`,
+   * or `es256`. Validated client-side; the cloud is the source of
+   * truth on which algorithms are honored on the receipt-signing
+   * path. */
+  algorithm?: SupportedAlgorithm | string;
   capabilities?: string[];
 }
 
@@ -594,9 +615,18 @@ export class Agent {
   }
 
   static async create(options: AgentCreateOptions): Promise<Agent> {
+    const algorithm = options.algorithm ?? "ml-dsa-65";
+    // Algorithm agility (AG3, AG4): the cloud accepts ml-dsa-{44,65,87},
+    // ed25519, and es256. Validate client-side so callers get a clean
+    // error before a round-trip.
+    if (!isSupportedAlgorithm(algorithm)) {
+      throw new AsqavError(
+        `unsupported_algorithm: '${algorithm}'. Use one of: ${SUPPORTED_ALGORITHMS.join(", ")}`,
+      );
+    }
     const data = await request<AgentData>("POST", "/agents/create", {
       name: options.name,
-      algorithm: options.algorithm ?? "ml-dsa-65",
+      algorithm,
       capabilities: options.capabilities ?? [],
     });
     return new Agent(data);

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -18,6 +18,7 @@ import { type Mode, resolveMode } from "./mode.js";
 export { clearHooks, registerAfter, registerBefore } from "./hooks.js";
 export type { AfterHook, BeforeHook } from "./hooks.js";
 export { canonicalize, hashAction } from "./canonicalize.js";
+export { canonicalJson } from "./jcs.js";
 export { resolveMode, isAsqavCloudHost, type Mode } from "./mode.js";
 export { BudgetTracker, type BudgetCheckResult, type BudgetTrackerOptions } from "./budget.js";
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -11,9 +11,28 @@
  *   const sig = await agent.sign({ actionType: "api:call", context: { model: "gpt-4" } });
  */
 
+import { createHash } from "node:crypto";
 import { canonicalize, hashAction } from "./canonicalize.js";
 import { _dispatchAfter, _dispatchBefore } from "./hooks.js";
+import { canonicalJson } from "./jcs.js";
 import { type Mode, resolveMode } from "./mode.js";
+
+/** Allowed values for `receiptType` per the IETF Compliance Receipts profile. */
+export const RECEIPT_TYPE_NAMESPACE = [
+  "protectmcp:decision",
+  "protectmcp:restraint",
+  "protectmcp:lifecycle",
+] as const;
+export type ReceiptType = (typeof RECEIPT_TYPE_NAMESPACE)[number];
+
+/** Sandbox state vocabulary per the High-Risk gate. */
+export type SandboxState = "enabled" | "disabled" | "unavailable";
+
+/** Risk class controlled vocabulary. */
+export type RiskClass = "low" | "medium" | "high" | "unknown";
+
+/** Policy decision vocabulary; deny / rate_limit require `reason`. */
+export type PolicyDecision = "permit" | "deny" | "rate_limit";
 
 export { clearHooks, registerAfter, registerBefore } from "./hooks.js";
 export type { AfterHook, BeforeHook } from "./hooks.js";
@@ -147,6 +166,61 @@ export interface SignOptions {
    * original signer expects on the post-apply attestation. The cloud
    * rejects attestations from any other key with 403 `executor_key_mismatch`. */
   expectedExecutorPubkeyB64?: string;
+
+  // -------------------------------------------------------------------
+  // IETF Compliance Receipts profile fields
+  // (draft-marques-asqav-compliance-receipts-00). All optional client-
+  // side; the cloud applies the per-field MUST/REQUIRED rules when
+  // ``complianceMode=true``. Wire keys are snake_case per the IETF
+  // profile (e.g. ``action_ref``).
+  // -------------------------------------------------------------------
+
+  /** Emit the receipt under the IETF profile. When true, the cloud uses
+   * fail-closed anchoring, raises the retention floor, and writes the
+   * v3-20 envelope fields. Defaults to false. */
+  complianceMode?: boolean;
+
+  /** `sha256:<hex>` of the canonical Action object. When omitted under
+   * `complianceMode=true`, the SDK computes it client-side as
+   * `"sha256:" + sha256(canonicalJson(action))` where `action` is
+   * `{action_type, context}`. */
+  actionRef?: string;
+
+  /** High-Risk gate. Caller-supplied; defaults to `"unavailable"` when
+   * not provided and the receipt is High-Risk. */
+  sandboxState?: SandboxState;
+
+  /** Logical task iteration id, distinct from `session_id`. REQUIRED
+   * for multi-step receipts. */
+  iterationId?: string;
+
+  /** Risk classification controlled vocabulary. */
+  riskClass?: RiskClass;
+
+  /** DORA ITS incident class; empty string when not applicable. */
+  incidentClass?: string;
+
+  /** Names a legal entity. Resolved server-side from
+   * `Organization.legal_entity` when omitted. */
+  issuerId?: string;
+
+  /** `sha256:<hex>` of the request payload. Conceptually the same value
+   * as `context_hash`; emitted under both names for one release. */
+  payloadDigest?: string;
+
+  /** Receipt namespace. One of `protectmcp:decision` |
+   * `protectmcp:restraint` | `protectmcp:lifecycle`. Defaults to
+   * `protectmcp:decision`. Validated client-side. */
+  receiptType?: ReceiptType;
+
+  /** Machine-readable code for `policy_decision in {deny, rate_limit}`.
+   * Drawn from the IETF rejection-reason vocabulary; the cloud is the
+   * source of truth on which codes are accepted. */
+  reason?: string;
+
+  /** Policy decision. `permit` (default), `deny`, or `rate_limit`. When
+   * not `permit`, `reason` is required. */
+  policyDecision?: PolicyDecision;
 }
 
 export interface CoSignature {
@@ -171,6 +245,19 @@ export interface SignatureResponse {
   countersignUrl?: string;
   /** True when the server validated a user_intent envelope on this record. */
   userIntentVerified?: boolean;
+  /** True when the cloud emitted this receipt under the IETF profile. */
+  complianceMode?: boolean;
+  /** IETF §5.7 chain link: `sha256(canonicalJson(predecessor_envelope))`,
+   * lowercase 64-hex. First record per agent is `"0".repeat(64)`. */
+  previousReceiptHash?: string;
+  /** `sha256:<hex>` of the canonical Action object. */
+  actionRef?: string;
+  /** `sha256:<hex>` of the policy artefact retained for this receipt. */
+  policyDigest?: string;
+  /** Receipt namespace echoed from the request. */
+  receiptType?: string;
+  /** Resolved legal entity for this receipt. */
+  issuerId?: string;
 }
 
 export interface SessionResponse {
@@ -527,6 +614,39 @@ export class Agent {
     }
     const finalContext = _dispatchBefore(options.actionType, initialContext);
 
+    const complianceMode = options.complianceMode === true;
+
+    // Validate the IETF receipt namespace client-side so callers fail
+    // fast instead of waiting for the server's 422. The cloud is still
+    // the source of truth; we mirror the same vocabulary.
+    if (options.receiptType !== undefined
+      && !(RECEIPT_TYPE_NAMESPACE as readonly string[]).includes(options.receiptType)) {
+      throw new AsqavError(
+        `invalid_receipt_type: must be one of ${RECEIPT_TYPE_NAMESPACE.join(", ")}`,
+      );
+    }
+    if (options.policyDecision !== undefined
+      && options.policyDecision !== "permit"
+      && !options.reason) {
+      throw new AsqavError(
+        "missing_reason: policy_decision=deny|rate_limit requires a `reason` code",
+      );
+    }
+
+    // Compute action_ref client-side when the caller is in compliance
+    // mode and did not supply one. Per spec:
+    //   action_ref = "sha256:" + sha256(canonicalJson(action))
+    // where `action = {action_type, context}` matches the cloud-side
+    // shape used by `hash_action`.
+    let actionRef = options.actionRef;
+    if (complianceMode && actionRef === undefined) {
+      const action = { action_type: options.actionType, context: finalContext };
+      const hex = createHash("sha256")
+        .update(canonicalJson(action))
+        .digest("hex");
+      actionRef = `sha256:${hex}`;
+    }
+
     const body = await buildSignBody({
       actionType: options.actionType,
       context: finalContext,
@@ -547,6 +667,23 @@ export class Agent {
       body.expected_executor_pubkey_b64 = options.expectedExecutorPubkeyB64;
     }
 
+    // IETF Compliance Receipts profile fields. Wire-format names are
+    // snake_case per draft-marques-asqav-compliance-receipts-00.
+    // `compliance_mode` always travels (default false) so the cloud
+    // knows whether to apply the profile rules. The other fields ride
+    // along when present; the cloud applies the per-field MUST checks.
+    if (complianceMode) body.compliance_mode = true;
+    if (actionRef !== undefined) body.action_ref = actionRef;
+    if (options.sandboxState !== undefined) body.sandbox_state = options.sandboxState;
+    if (options.iterationId !== undefined) body.iteration_id = options.iterationId;
+    if (options.riskClass !== undefined) body.risk_class = options.riskClass;
+    if (options.incidentClass !== undefined) body.incident_class = options.incidentClass;
+    if (options.issuerId !== undefined) body.issuer_id = options.issuerId;
+    if (options.payloadDigest !== undefined) body.payload_digest = options.payloadDigest;
+    if (options.receiptType !== undefined) body.receipt_type = options.receiptType;
+    if (options.reason !== undefined) body.reason = options.reason;
+    if (options.policyDecision !== undefined) body.policy_decision = options.policyDecision;
+
     const data = await request<{
       signature: string;
       signature_id: string;
@@ -560,6 +697,13 @@ export class Agent {
       co_signatures?: Array<{ agent_id: string; signature: string; signed_at: string }>;
       countersign_url?: string;
       user_intent_verified?: boolean;
+      compliance_mode?: boolean;
+      previousReceiptHash?: string;
+      previous_receipt_hash?: string;
+      action_ref?: string;
+      policy_digest?: string;
+      receipt_type?: string;
+      issuer_id?: string;
     }>("POST", `/agents/${this.agentId}/sign`, body);
 
     const response: SignatureResponse = {
@@ -578,6 +722,14 @@ export class Agent {
       })),
       countersignUrl: data.countersign_url,
       userIntentVerified: data.user_intent_verified,
+      complianceMode: data.compliance_mode,
+      // Accept either camelCase (per the IETF profile JSON wire) or
+      // snake_case (legacy alias for one release).
+      previousReceiptHash: data.previousReceiptHash ?? data.previous_receipt_hash,
+      actionRef: data.action_ref,
+      policyDigest: data.policy_digest,
+      receiptType: data.receipt_type,
+      issuerId: data.issuer_id,
     };
 
     _dispatchAfter(options.actionType, response);

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -38,6 +38,15 @@ export { clearHooks, registerAfter, registerBefore } from "./hooks.js";
 export type { AfterHook, BeforeHook } from "./hooks.js";
 export { canonicalize, hashAction } from "./canonicalize.js";
 export { canonicalJson } from "./jcs.js";
+export {
+  verifyChain,
+  deriveChainHash,
+  FIRST_RECEIPT_SEED,
+  type ChainRecord,
+  type ChainStepResult,
+  type ChainVerificationResult,
+  type VerifyChainOptions,
+} from "./replay.js";
 export { resolveMode, isAsqavCloudHost, type Mode } from "./mode.js";
 export { BudgetTracker, type BudgetCheckResult, type BudgetTrackerOptions } from "./budget.js";
 

--- a/typescript/src/jcs.ts
+++ b/typescript/src/jcs.ts
@@ -1,0 +1,122 @@
+/**
+ * RFC 8785 (JCS) canonicalization helper for the IETF Compliance Receipts profile.
+ *
+ * Public surface: `canonicalJson(obj): Uint8Array`.
+ *
+ * The output bytes are the exact bytes the cloud (`core/canonical.py`)
+ * signs and the bytes the chain hashes over per
+ * `draft-marques-asqav-compliance-receipts-00 §5.7`.
+ *
+ * Subset implemented:
+ *   - Lexicographic (UTF-16 code unit) ordering of object keys.
+ *   - No insignificant whitespace.
+ *   - UTF-8 byte output, no BOM, non-ASCII passes through verbatim.
+ *   - String escapes per RFC 8259 §7 (backslash, quote, b, f, n, r, t,
+ *     and `\u00xx` for U+0000..U+001F).
+ *   - Numbers per RFC 8785 §3.2.2 / ECMA-262 7.1.12.1: integers within
+ *     IEEE-754 safe range serialize without trailing ".0"; finite floats
+ *     use the shortest round-trip form (V8's Number.toString already
+ *     produces this, matching ECMAScript).
+ *   - NaN / Infinity rejected (not representable in JSON / RFC 8785).
+ *
+ * Out of scope: JCS pre-2024 erratum normalization for non-finite numbers
+ * and explicit handling of negative zero (we map -0 to "0", as
+ * Python's json.dumps does, since the Compliance Receipts profile signs
+ * no floats).
+ *
+ * The companion module `canonicalize.ts` exposes the same function under
+ * the legacy name `canonicalize()`. They are kept byte-identical; this
+ * module is the named landing for the IETF profile callers.
+ */
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * Canonicalize a JSON-serializable value to RFC 8785 / JCS bytes.
+ *
+ * Throws TypeError for values not representable in JSON (functions,
+ * undefined, BigInt, Symbol) and for non-finite numbers (NaN, Infinity,
+ * -Infinity).
+ */
+export function canonicalJson(value: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalString(value));
+}
+
+function canonicalString(value: unknown): string {
+  if (value === null) return "null";
+  if (value === true) return "true";
+  if (value === false) return "false";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError("NaN / Infinity are not allowed in canonical JSON");
+    }
+    return numberToCanonical(value);
+  }
+  if (typeof value === "string") {
+    return jsonString(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(canonicalString).join(",") + "]";
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    // RFC 8785 §3.2.3: sort by UTF-16 code unit. JavaScript's default
+    // Array.prototype.sort on strings is exactly this ordering.
+    const keys = Object.keys(obj).sort();
+    const parts: string[] = [];
+    for (const k of keys) {
+      parts.push(jsonString(k) + ":" + canonicalString(obj[k]));
+    }
+    return "{" + parts.join(",") + "}";
+  }
+  throw new TypeError(`Not JSON-serializable: ${typeof value}`);
+}
+
+function numberToCanonical(n: number): string {
+  // Map -0 to 0 so equal mathematical values produce identical bytes.
+  if (n === 0) return "0";
+  // For safe integers, plain toString matches RFC 8785 byte-for-byte.
+  if (Number.isInteger(n) && Number.isSafeInteger(n)) {
+    return n.toString();
+  }
+  // For floats, V8's Number.toString already produces the shortest
+  // round-trip representation that ECMA-262 mandates and RFC 8785
+  // references. The Compliance Receipts profile signs no floats, so
+  // this branch is not exercised by spec vectors.
+  return n.toString();
+}
+
+function jsonString(s: string): string {
+  let out = '"';
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    const ch = s[i];
+    if (ch === '"') {
+      out += '\\"';
+    } else if (ch === "\\") {
+      out += "\\\\";
+    } else if (code === 0x08) {
+      out += "\\b";
+    } else if (code === 0x09) {
+      out += "\\t";
+    } else if (code === 0x0a) {
+      out += "\\n";
+    } else if (code === 0x0c) {
+      out += "\\f";
+    } else if (code === 0x0d) {
+      out += "\\r";
+    } else if (code < 0x20) {
+      out += "\\u" + code.toString(16).padStart(4, "0");
+    } else {
+      out += ch;
+    }
+  }
+  out += '"';
+  return out;
+}

--- a/typescript/src/replay.ts
+++ b/typescript/src/replay.ts
@@ -1,0 +1,181 @@
+/**
+ * Offline replay / chain verification for the IETF Compliance Receipts
+ * profile (draft-marques-asqav-compliance-receipts-00 §5.7).
+ *
+ * The verifier walks an ordered list of signed envelopes for one agent,
+ * re-derives each predecessor's `previousReceiptHash`, and reports any
+ * mismatch as a chain break. Equivalent to the Python SDK's
+ * `replay.ReplayTimeline.verify_chain` rewritten for the v2 chain shape.
+ *
+ * v2 (default) chain link:
+ *
+ *   previousReceiptHash[i+1] = sha256(canonicalJson(envelope[i]))   // 64 hex
+ *   previousReceiptHash[0]   = "0".repeat(64)
+ *
+ * Legacy chain link (kept under `legacy: true` for one release):
+ *
+ *   prev_hash[i+1] = sha256(json.dumps(
+ *     {signature_id, action_type, timestamp, prev_hash}, sort_keys=True
+ *   ))
+ *
+ * This module is import-free of any HTTP / network code so it can run
+ * over a downloaded ComplianceBundle.
+ */
+
+import { createHash } from "node:crypto";
+
+import { canonicalJson } from "./jcs.js";
+
+/** Seed value for the first record on every chain (§5.7). */
+export const FIRST_RECEIPT_SEED = "0".repeat(64);
+
+/** A single record in the chain to verify. */
+export interface ChainRecord {
+  /** The full signed envelope (the bytes the cloud signed, as a JSON
+   * object). Must include `previousReceiptHash`. Other fields are
+   * passed through as-is into the JCS canonical bytes. */
+  signedEnvelope: Record<string, unknown>;
+  /** Optional pre-computed chain hash for this record. When omitted,
+   * the verifier derives it from the envelope. */
+  chainHash?: string;
+}
+
+/** Per-record outcome. */
+export interface ChainStepResult {
+  index: number;
+  /** True iff `signedEnvelope.previousReceiptHash` matches the predecessor's
+   * derived hash (or the seed for index 0). */
+  chainValid: boolean;
+  /** What the predecessor's chain hash should have been. */
+  expectedPreviousReceiptHash: string;
+  /** What this record claims its predecessor was. */
+  actualPreviousReceiptHash: string;
+  /** This record's derived chain hash. */
+  derivedChainHash: string;
+  /** When `chainHash` was supplied on the input, true if it matches the
+   * derived value (catches storage-side mutation). Undefined when not
+   * supplied. */
+  storedChainHashMatches?: boolean;
+}
+
+/** Aggregate outcome. */
+export interface ChainVerificationResult {
+  chainIntegrity: boolean;
+  steps: ChainStepResult[];
+}
+
+export interface VerifyChainOptions {
+  /** Use the legacy v1 chain shape instead of the v2 / IETF shape.
+   * Kept for one release per the backward-compat window. */
+  legacy?: boolean;
+}
+
+/**
+ * Re-derive the chain over an ordered list of signed envelopes for one
+ * agent and return per-step + aggregate validity.
+ *
+ * The list MUST be in chain order (oldest first). Mixing agents yields
+ * `chainIntegrity=false` because the predecessor links won't match.
+ */
+export function verifyChain(
+  records: ChainRecord[],
+  options: VerifyChainOptions = {},
+): ChainVerificationResult {
+  if (options.legacy === true) {
+    return verifyChainLegacy(records);
+  }
+
+  const steps: ChainStepResult[] = [];
+  let allValid = true;
+  let expectedPrev = FIRST_RECEIPT_SEED;
+
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i];
+    const env = record.signedEnvelope;
+    const actualPrev = String(env.previousReceiptHash ?? env.previous_receipt_hash ?? "");
+    const derived = sha256Hex(canonicalJson(env));
+
+    const chainValid = actualPrev === expectedPrev;
+    if (!chainValid) allValid = false;
+
+    let storedChainHashMatches: boolean | undefined;
+    if (record.chainHash !== undefined) {
+      storedChainHashMatches = record.chainHash === derived;
+      if (!storedChainHashMatches) allValid = false;
+    }
+
+    steps.push({
+      index: i,
+      chainValid,
+      expectedPreviousReceiptHash: expectedPrev,
+      actualPreviousReceiptHash: actualPrev,
+      derivedChainHash: derived,
+      storedChainHashMatches,
+    });
+
+    expectedPrev = derived;
+  }
+
+  return { chainIntegrity: allValid, steps };
+}
+
+/**
+ * Convenience: derive the v2 chain hash for one signed envelope.
+ *
+ *   sha256(canonicalJson(envelope))
+ */
+export function deriveChainHash(envelope: Record<string, unknown>): string {
+  return sha256Hex(canonicalJson(envelope));
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Legacy v1 chain shape (kept for one release).
+// ---------------------------------------------------------------------------
+
+interface LegacyMinimalRecord {
+  signature_id?: string;
+  action_type?: string;
+  timestamp?: number | string;
+  signed_at?: number | string;
+}
+
+function verifyChainLegacy(records: ChainRecord[]): ChainVerificationResult {
+  const steps: ChainStepResult[] = [];
+  let allValid = true;
+  let prevHash = "";
+
+  for (let i = 0; i < records.length; i++) {
+    const env = records[i].signedEnvelope as LegacyMinimalRecord & Record<string, unknown>;
+    const actualPrev = String(env.previousReceiptHash ?? env.previous_hash ?? "");
+
+    const chainValid = i === 0 ? true : actualPrev === prevHash;
+    if (!chainValid) allValid = false;
+
+    const entry = JSON.stringify({
+      signature_id: env.signature_id ?? "",
+      action_type: env.action_type ?? "",
+      timestamp: env.signed_at ?? env.timestamp ?? 0,
+      prev_hash: prevHash,
+    });
+    // JSON.stringify in JS does not sort keys; the Python legacy form
+    // uses sort_keys=True. We match Python's output by sorting.
+    const sortedEntry = JSON.stringify(JSON.parse(entry), Object.keys(JSON.parse(entry)).sort());
+    const derived = sha256Hex(new TextEncoder().encode(sortedEntry));
+
+    steps.push({
+      index: i,
+      chainValid,
+      expectedPreviousReceiptHash: i === 0 ? "" : prevHash,
+      actualPreviousReceiptHash: actualPrev,
+      derivedChainHash: derived,
+    });
+
+    prevHash = derived;
+  }
+
+  return { chainIntegrity: allValid, steps };
+}

--- a/typescript/tests/algorithms.test.ts
+++ b/typescript/tests/algorithms.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Algorithm agility tests (AG3, AG4).
+ *
+ * The SDK validates algorithm names client-side and exposes Web Crypto
+ * (Node `crypto`) helpers for Ed25519 + ES256 keypair generation, sign,
+ * and verify.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  AsqavError,
+  LOCAL_SIGNING_ALGORITHMS,
+  SUPPORTED_ALGORITHMS,
+  _resetForTests,
+  generateKeypair,
+  init,
+  isLocalSigningAlgorithm,
+  isSupportedAlgorithm,
+  signMessage,
+  verifyMessage,
+} from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("algorithm registry", () => {
+  it("includes ML-DSA, Ed25519, and ES256", () => {
+    expect(SUPPORTED_ALGORITHMS).toContain("ml-dsa-65");
+    expect(SUPPORTED_ALGORITHMS).toContain("ed25519");
+    expect(SUPPORTED_ALGORITHMS).toContain("es256");
+  });
+
+  it("isSupportedAlgorithm matches the registry", () => {
+    for (const a of SUPPORTED_ALGORITHMS) {
+      expect(isSupportedAlgorithm(a)).toBe(true);
+    }
+    expect(isSupportedAlgorithm("rsa")).toBe(false);
+    expect(isSupportedAlgorithm("")).toBe(false);
+  });
+
+  it("isLocalSigningAlgorithm rejects ML-DSA (server-side only)", () => {
+    expect(isLocalSigningAlgorithm("ed25519")).toBe(true);
+    expect(isLocalSigningAlgorithm("es256")).toBe(true);
+    expect(isLocalSigningAlgorithm("ml-dsa-65")).toBe(false);
+  });
+});
+
+describe("Agent.create algorithm validation", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects unknown algorithm without making a request", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(
+      Agent.create({ name: "x", algorithm: "rsa-2048" }),
+    ).rejects.toThrow(AsqavError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("forwards ed25519 to the cloud", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        agent_id: "agt_1",
+        name: "x",
+        public_key: "pk",
+        key_id: "kid",
+        algorithm: "ed25519",
+        capabilities: [],
+        created_at: "t",
+      }),
+    );
+    await Agent.create({ name: "x", algorithm: "ed25519" });
+    const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(calledInit.body as string).algorithm).toBe("ed25519");
+  });
+
+  it("forwards es256 to the cloud", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        agent_id: "agt_1",
+        name: "x",
+        public_key: "pk",
+        key_id: "kid",
+        algorithm: "es256",
+        capabilities: [],
+        created_at: "t",
+      }),
+    );
+    await Agent.create({ name: "x", algorithm: "es256" });
+    const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(calledInit.body as string).algorithm).toBe("es256");
+  });
+});
+
+describe("local Ed25519 keypair + sign + verify round-trip", () => {
+  it("signs canonical bytes and verifies them", () => {
+    const kp = generateKeypair("ed25519");
+    expect(kp.algorithm).toBe("ed25519");
+    expect(kp.privateKeyPkcs8B64.length).toBeGreaterThan(0);
+    expect(kp.publicKeySpkiB64.length).toBeGreaterThan(0);
+
+    const message = new TextEncoder().encode("hello asqav");
+    const sig = signMessage("ed25519", kp.privateKeyPkcs8B64, message);
+    expect(typeof sig).toBe("string");
+
+    expect(verifyMessage("ed25519", kp.publicKeySpkiB64, message, sig)).toBe(true);
+    // Tamper detection.
+    const wrong = new TextEncoder().encode("hello asqav!");
+    expect(verifyMessage("ed25519", kp.publicKeySpkiB64, wrong, sig)).toBe(false);
+  });
+});
+
+describe("local ES256 keypair + sign + verify round-trip", () => {
+  it("signs canonical bytes and verifies them in IEEE-P1363 form", () => {
+    const kp = generateKeypair("es256");
+    expect(kp.algorithm).toBe("es256");
+
+    const message = new TextEncoder().encode("compliance receipt");
+    const sig = signMessage("es256", kp.privateKeyPkcs8B64, message);
+    // IEEE-P1363 / raw r||s for P-256 = 64 bytes = 88 base64 chars
+    // (with optional padding).
+    const decoded = Buffer.from(sig, "base64");
+    expect(decoded.length).toBe(64);
+
+    expect(verifyMessage("es256", kp.publicKeySpkiB64, message, sig)).toBe(true);
+    const wrong = new TextEncoder().encode("compliance receipt!");
+    expect(verifyMessage("es256", kp.publicKeySpkiB64, wrong, sig)).toBe(false);
+  });
+});
+
+describe("local signing rejects ML-DSA", () => {
+  it("generateKeypair only knows about local algorithms", () => {
+    for (const a of LOCAL_SIGNING_ALGORITHMS) {
+      expect(() => generateKeypair(a)).not.toThrow();
+    }
+  });
+});

--- a/typescript/tests/cli.test.ts
+++ b/typescript/tests/cli.test.ts
@@ -212,4 +212,147 @@ describe("asqav CLI (TypeScript)", () => {
     expect(parsed.verificationDetail.chainValid).toBe(true);
     expect(parsed.verificationDetail.anchorStatusOts).toBe("valid");
   });
+
+  it("sign rejects --policy-decision deny without --reason", async () => {
+    try {
+      await runCli([
+        "sign",
+        "--agent-id", "agt_x",
+        "--action-type", "x.y",
+        "--policy-decision", "deny",
+      ]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("--reason is required");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("audit-pack policy normalizes a bare 64-hex digest", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        digest: "sha256:" + "a".repeat(64),
+        organization_id: "org_x",
+        agent_id: "agt_x",
+        action_type: "payment.wire_transfer",
+        artefact: { rule: "deny_over_500k" },
+        created_at: "2026-04-01T00:00:00Z",
+      }),
+    );
+    await runCli(["audit-pack", "policy", "a".repeat(64), "--output", "text"]);
+    expect(fetchSpy.mock.calls[0]?.[0]).toContain(`/audit-pack/policy/sha256:${"a".repeat(64)}`);
+    expect(output()).toContain("deny_over_500k");
+  });
+
+  it("payloads erase requires --yes", async () => {
+    try {
+      await runCli(["payloads", "erase", "sig_abc"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("Refusing to erase without --yes");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("payloads erase --yes calls DELETE", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+    await runCli(["payloads", "erase", "sig_abc", "--yes"]);
+    expect(fetchSpy.mock.calls[0]?.[0]).toContain("/signatures/payloads/sig_abc");
+    expect((fetchSpy.mock.calls[0]?.[1] as RequestInit).method).toBe("DELETE");
+    expect(output()).toContain("Payload erased for sig_abc");
+  });
+
+  it("org set-compliance-strict requires exactly one of --enable / --disable", async () => {
+    try {
+      await runCli(["org", "set-compliance-strict", "org_x"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("exactly one of --enable or --disable");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("org set-compliance-strict --enable patches the org", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ id: "org_x", compliance_mode_strict: true }),
+    );
+    await runCli(["org", "set-compliance-strict", "org_x", "--enable"]);
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ compliance_mode_strict: true });
+    expect(output()).toContain("compliance_mode_strict enabled");
+  });
+
+  it("keys generate ed25519 emits an SPKI DER public key", async () => {
+    await runCli(["keys", "generate", "--algorithm", "ed25519"]);
+    expect(output()).toContain("public key (SPKI DER, base64)");
+  });
+
+  it("keys generate ml-dsa-65 errors with server-side hint", async () => {
+    try {
+      await runCli(["keys", "generate", "--algorithm", "ml-dsa-65"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("server-side");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("migrate run refuses without ASQAV_MAINTENANCE_KEY", async () => {
+    delete process.env.ASQAV_MAINTENANCE_KEY;
+    try {
+      await runCli(["migrate", "run", "v3-20"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("ASQAV_MAINTENANCE_KEY");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("migrate run rejects unsupported migrations", async () => {
+    process.env.ASQAV_MAINTENANCE_KEY = "mk_test";
+    try {
+      await runCli(["migrate", "run", "v9-99"]);
+    } catch {
+      // exit
+    }
+    delete process.env.ASQAV_MAINTENANCE_KEY;
+    expect(output()).toContain("unsupported migration");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("migrate run v3-22 POSTs with X-Maintenance-Key", async () => {
+    process.env.ASQAV_MAINTENANCE_KEY = "mk_test";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ status: "ok", applied: 1, migration: "v3-22" }),
+    );
+    await runCli(["migrate", "run", "v3-22"]);
+    delete process.env.ASQAV_MAINTENANCE_KEY;
+    const url = fetchSpy.mock.calls[0]?.[0] as string;
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(url).toContain("/maintenance/run-migration-v3-22");
+    expect((init.headers as Record<string, string>)["X-Maintenance-Key"]).toBe("mk_test");
+    expect(output()).toContain("v3-22");
+  });
+
+  it("replay-verify --strict rejects legacy steps", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ tier: "pro", organization_id: "o", organization_name: "n" }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          steps: [
+            { signature_id: "sig_1" /* no signed_envelope */ },
+          ],
+        }),
+      );
+    try {
+      await runCli(["replay-verify", "agt_x", "sess_x", "--strict"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("strict mode FAILED");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
 });

--- a/typescript/tests/cli.test.ts
+++ b/typescript/tests/cli.test.ts
@@ -150,4 +150,66 @@ describe("asqav CLI (TypeScript)", () => {
     expect(output()).toMatch(/Unknown command/);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  it("verify --output text surfaces IETF VerificationDetail axes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        signature_id: "sig_1",
+        agent_id: "agt_1",
+        agent_name: "agt-1",
+        action_id: "act_1",
+        action_type: "x.y",
+        signature: "sig",
+        algorithm: "ml-dsa-65",
+        signed_at: "2026-05-04T00:00:00Z",
+        verified: true,
+        verification_url: "https://verify.example/sig_1",
+        verification_detail: {
+          signer_key_match: true,
+          signature_valid: true,
+          algorithm_match: true,
+          agent_active: true,
+          validation_label: "valid",
+          chain_valid: true,
+          anchor_status_ots: "pending",
+          anchor_status_rfc3161: "valid",
+          signed_at_skew_seconds: 0.5,
+        },
+      }),
+    );
+    await runCli(["verify", "sig_1"]);
+    const out = output();
+    expect(out).toContain("Chain valid: true");
+    expect(out).toContain("Anchor (OTS): pending");
+    expect(out).toContain("Anchor (RFC 3161): valid");
+    expect(out).toContain("signed_at skew: 0.5");
+  });
+
+  it("verify --output json emits the full detail", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        signature_id: "sig_2",
+        agent_id: "agt_2",
+        algorithm: "ed25519",
+        signed_at: "2026-05-04T00:00:00Z",
+        verified: true,
+        verification_detail: {
+          signer_key_match: true,
+          signature_valid: true,
+          algorithm_match: true,
+          agent_active: true,
+          validation_label: "valid",
+          chain_valid: true,
+          anchor_status_ots: "valid",
+          anchor_status_rfc3161: "valid",
+          signed_at_skew_seconds: 0,
+        },
+      }),
+    );
+    await runCli(["verify", "sig_2", "--output", "json"]);
+    const parsed = JSON.parse(output());
+    expect(parsed.signatureId).toBe("sig_2");
+    expect(parsed.verificationDetail.chainValid).toBe(true);
+    expect(parsed.verificationDetail.anchorStatusOts).toBe("valid");
+  });
 });

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -1,0 +1,191 @@
+/**
+ * IETF Compliance Receipts profile fields on agent.sign().
+ *
+ * Covers the wire-format mapping (camelCase TS -> snake_case JSON), the
+ * client-side `action_ref` derivation under `complianceMode`, and the
+ * receipt-namespace / reason validation that mirrors the cloud.
+ */
+
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  AsqavError,
+  RECEIPT_TYPE_NAMESPACE,
+  _resetForTests,
+  init,
+} from "../src/index.js";
+import { canonicalJson } from "../src/jcs.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_ietf",
+    name: "ietf",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-05-04T00:00:00Z",
+  });
+}
+
+describe("agent.sign IETF profile fields", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("forwards all new fields with snake_case wire keys", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "s",
+        signature_id: "sig_1",
+        action_id: "act_1",
+        timestamp: "2026-05-04T00:00:00Z",
+        verification_url: "https://example.test/v",
+        compliance_mode: true,
+        previousReceiptHash: "0".repeat(64),
+        action_ref: "sha256:" + "a".repeat(64),
+        receipt_type: "protectmcp:decision",
+      }),
+    );
+
+    const agent = fakeAgent();
+    const sig = await agent.sign({
+      actionType: "api:call",
+      context: { model: "gpt-4" },
+      complianceMode: true,
+      receiptType: "protectmcp:decision",
+      sandboxState: "enabled",
+      iterationId: "iter-7",
+      riskClass: "high",
+      incidentClass: "ICT-INC-001",
+      issuerId: "Acme Legal Entity Ltd",
+      payloadDigest: "sha256:" + "b".repeat(64),
+      actionRef: "sha256:" + "c".repeat(64),
+      reason: "permitted",
+      policyDecision: "permit",
+    });
+
+    const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(calledInit.body as string) as Record<string, unknown>;
+
+    expect(body.compliance_mode).toBe(true);
+    expect(body.action_ref).toBe("sha256:" + "c".repeat(64));
+    expect(body.sandbox_state).toBe("enabled");
+    expect(body.iteration_id).toBe("iter-7");
+    expect(body.risk_class).toBe("high");
+    expect(body.incident_class).toBe("ICT-INC-001");
+    expect(body.issuer_id).toBe("Acme Legal Entity Ltd");
+    expect(body.payload_digest).toBe("sha256:" + "b".repeat(64));
+    expect(body.receipt_type).toBe("protectmcp:decision");
+    expect(body.reason).toBe("permitted");
+    expect(body.policy_decision).toBe("permit");
+
+    expect(sig.complianceMode).toBe(true);
+    expect(sig.previousReceiptHash).toBe("0".repeat(64));
+    expect(sig.actionRef).toBe("sha256:" + "a".repeat(64));
+    expect(sig.receiptType).toBe("protectmcp:decision");
+  });
+
+  it("computes action_ref client-side when omitted under complianceMode", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "s",
+        signature_id: "sig_1",
+        action_id: "act_1",
+        timestamp: "t",
+        verification_url: "u",
+      }),
+    );
+
+    const agent = fakeAgent();
+    const ctx = { model: "gpt-4", k: 1 };
+    await agent.sign({
+      actionType: "api:call",
+      context: ctx,
+      complianceMode: true,
+    });
+
+    const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(calledInit.body as string) as Record<string, unknown>;
+
+    const expected = "sha256:" + createHash("sha256")
+      .update(canonicalJson({ action_type: "api:call", context: ctx }))
+      .digest("hex");
+    expect(body.action_ref).toBe(expected);
+  });
+
+  it("does not set compliance_mode when complianceMode is false", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "s",
+        signature_id: "sig_1",
+        action_id: "act_1",
+        timestamp: "t",
+        verification_url: "u",
+      }),
+    );
+
+    const agent = fakeAgent();
+    await agent.sign({ actionType: "api:call", context: {} });
+
+    const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(calledInit.body as string) as Record<string, unknown>;
+    expect(body.compliance_mode).toBeUndefined();
+    expect(body.action_ref).toBeUndefined();
+  });
+
+  it("rejects unknown receiptType client-side", async () => {
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "api:call",
+        context: {},
+        // @ts-expect-error: testing runtime guard
+        receiptType: "rogue:type",
+      }),
+    ).rejects.toThrow(AsqavError);
+  });
+
+  it("rejects deny without reason", async () => {
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "api:call",
+        context: {},
+        policyDecision: "deny",
+      }),
+    ).rejects.toThrow(/missing_reason/);
+  });
+
+  it("accepts each value in the receipt-type namespace", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      jsonResponse({
+        signature: "s",
+        signature_id: "sig_1",
+        action_id: "act_1",
+        timestamp: "t",
+        verification_url: "u",
+      }),
+    );
+    const agent = fakeAgent();
+    for (const t of RECEIPT_TYPE_NAMESPACE) {
+      await expect(
+        agent.sign({ actionType: "api:call", context: {}, receiptType: t }),
+      ).resolves.toBeDefined();
+    }
+  });
+});

--- a/typescript/tests/jcs.test.ts
+++ b/typescript/tests/jcs.test.ts
@@ -1,0 +1,120 @@
+/**
+ * RFC 8785 (JCS) golden-vector tests for `canonicalJson`.
+ *
+ * Vectors come from RFC 8785 §3 (the appendix of test data).
+ * https://datatracker.ietf.org/doc/html/rfc8785
+ */
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { canonicalJson } from "../src/jcs.js";
+import { canonicalize } from "../src/canonicalize.js";
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+describe("canonicalJson() RFC 8785 golden vectors", () => {
+  it("§3.2.3 sorts object keys lexicographically (UTF-16 code unit order)", () => {
+    const input = { peach: "This sorting order", péché: "is wrong according to French", pêche: "but ordains", sin: "ordering by code unit" };
+    const out = decode(canonicalJson(input));
+    // The keys end up sorted by JavaScript's default string sort, which is
+    // UTF-16 code unit order: ascii letters come before pre-composed Latin
+    // accented letters.
+    expect(out).toBe(
+      "{\"peach\":\"This sorting order\",\"péché\":\"is wrong according to French\",\"pêche\":\"but ordains\",\"sin\":\"ordering by code unit\"}"
+    );
+  });
+
+  it("emits no insignificant whitespace", () => {
+    const input = { a: 1, b: [1, 2, 3], c: { d: true } };
+    const out = decode(canonicalJson(input));
+    expect(out).toBe("{\"a\":1,\"b\":[1,2,3],\"c\":{\"d\":true}}");
+    expect(out).not.toMatch(/[\n\t ]/);
+  });
+
+  it("emits non-ASCII strings as raw UTF-8", () => {
+    const input = { name: "café" };
+    const bytes = canonicalJson(input);
+    const utf8 = new TextEncoder().encode("café");
+    const haystack = Buffer.from(bytes);
+    expect(haystack.includes(Buffer.from(utf8))).toBe(true);
+    // No \u escape for non-control non-ASCII characters.
+    expect(decode(bytes)).not.toContain("\\u");
+  });
+
+  it("§3.2.2 emits integers without trailing decimals", () => {
+    const input = { n: 42, big: 1000000 };
+    const out = decode(canonicalJson(input));
+    expect(out).toBe("{\"big\":1000000,\"n\":42}");
+  });
+
+  it("§3.2.2 maps -0 to 0", () => {
+    const out = decode(canonicalJson({ n: -0 }));
+    expect(out).toBe("{\"n\":0}");
+  });
+
+  it("§3.2.2 rejects NaN and Infinity", () => {
+    expect(() => canonicalJson({ x: Number.NaN })).toThrow(TypeError);
+    expect(() => canonicalJson({ x: Number.POSITIVE_INFINITY })).toThrow(TypeError);
+    expect(() => canonicalJson({ x: Number.NEGATIVE_INFINITY })).toThrow(TypeError);
+  });
+
+  it("escapes the JSON-mandated control characters", () => {
+    const input = { s: "a\b\t\n\f\r\"\\b" };
+    const out = decode(canonicalJson(input));
+    expect(out).toBe("{\"s\":\"a\\b\\t\\n\\f\\r\\\"\\\\b\"}");
+  });
+
+  it("escapes other U+0000..U+001F as \\u00xx", () => {
+    const input = { s: "" };
+    const out = decode(canonicalJson(input));
+    expect(out).toBe("{\"s\":\"\\u0001\\u001f\"}");
+  });
+
+  it("is byte-identical with canonicalize() (legacy alias)", () => {
+    const input = { z: 1, a: { c: [1, 2, 3], b: "x" } };
+    expect(canonicalJson(input)).toEqual(canonicalize(input));
+  });
+
+  it("nested ordering: keys recursively sorted at every level", () => {
+    const a = { z: { y: 1, a: 2 }, a: 1 };
+    const b = { a: 1, z: { a: 2, y: 1 } };
+    expect(canonicalJson(a)).toEqual(canonicalJson(b));
+  });
+
+  it("known SHA-256 digest for the §5.7 chain seed envelope", () => {
+    // First record's previousReceiptHash MUST equal "0"*64 per §5.7.
+    const envelope = {
+      type: "protectmcp:decision",
+      issued_at: "2026-05-04T00:00:00Z",
+      issuer_id: "issuer-test",
+      agent_id: "agt_test",
+      action_ref: "sha256:" + "a".repeat(64),
+      payload_digest: "sha256:" + "a".repeat(64),
+      policy_digest: "sha256:" + "b".repeat(64),
+      previousReceiptHash: "0".repeat(64),
+      receipt_type: "protectmcp:decision",
+      policy_decision: "permit",
+    };
+    const bytes = canonicalJson(envelope);
+    const hex = createHash("sha256").update(bytes).digest("hex");
+    expect(hex).toMatch(/^[0-9a-f]{64}$/);
+    // Reproducible across key insertion order.
+    const reordered = {
+      receipt_type: "protectmcp:decision",
+      previousReceiptHash: "0".repeat(64),
+      policy_decision: "permit",
+      policy_digest: "sha256:" + "b".repeat(64),
+      payload_digest: "sha256:" + "a".repeat(64),
+      action_ref: "sha256:" + "a".repeat(64),
+      agent_id: "agt_test",
+      issuer_id: "issuer-test",
+      issued_at: "2026-05-04T00:00:00Z",
+      type: "protectmcp:decision",
+    };
+    const hex2 = createHash("sha256").update(canonicalJson(reordered)).digest("hex");
+    expect(hex).toBe(hex2);
+  });
+});

--- a/typescript/tests/replay.test.ts
+++ b/typescript/tests/replay.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Offline chain verification under the IETF v2 chain shape.
+ *
+ * The v2 chain is `previousReceiptHash[i+1] = sha256(canonicalJson(env[i]))`
+ * with seed `"0".repeat(64)` on the first record. This test builds a
+ * synthetic chain, then mutates each link to confirm tamper detection.
+ */
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { canonicalJson } from "../src/jcs.js";
+import {
+  FIRST_RECEIPT_SEED,
+  deriveChainHash,
+  verifyChain,
+  type ChainRecord,
+} from "../src/replay.js";
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function makeEnvelope(seq: number, prev: string): Record<string, unknown> {
+  return {
+    type: "protectmcp:decision",
+    issued_at: `2026-05-04T00:00:0${seq}Z`,
+    issuer_id: "Acme Ltd",
+    agent_id: "agt_test",
+    action_ref: `sha256:${"a".repeat(64)}`,
+    payload_digest: `sha256:${"b".repeat(64)}`,
+    policy_digest: `sha256:${"c".repeat(64)}`,
+    previousReceiptHash: prev,
+    receipt_type: "protectmcp:decision",
+    policy_decision: "permit",
+  };
+}
+
+function buildChain(n: number): ChainRecord[] {
+  const records: ChainRecord[] = [];
+  let prev = FIRST_RECEIPT_SEED;
+  for (let i = 0; i < n; i++) {
+    const env = makeEnvelope(i, prev);
+    records.push({ signedEnvelope: env });
+    prev = sha256Hex(canonicalJson(env));
+  }
+  return records;
+}
+
+describe("verifyChain (v2, IETF profile)", () => {
+  it("seed is 64 zeros", () => {
+    expect(FIRST_RECEIPT_SEED).toBe("0".repeat(64));
+    expect(FIRST_RECEIPT_SEED.length).toBe(64);
+  });
+
+  it("verifies a freshly-built chain end-to-end", () => {
+    const records = buildChain(5);
+    const result = verifyChain(records);
+    expect(result.chainIntegrity).toBe(true);
+    expect(result.steps.length).toBe(5);
+    for (const s of result.steps) {
+      expect(s.chainValid).toBe(true);
+    }
+    expect(result.steps[0].expectedPreviousReceiptHash).toBe(FIRST_RECEIPT_SEED);
+    expect(result.steps[0].actualPreviousReceiptHash).toBe(FIRST_RECEIPT_SEED);
+  });
+
+  it("derives chain hash via sha256(canonicalJson(envelope))", () => {
+    const env = makeEnvelope(0, FIRST_RECEIPT_SEED);
+    const expected = sha256Hex(canonicalJson(env));
+    expect(deriveChainHash(env)).toBe(expected);
+  });
+
+  it("detects a tampered envelope mid-chain", () => {
+    const records = buildChain(3);
+    // Mutate the second record's payload_digest. The chain link from
+    // [1] to [2] no longer matches because the predecessor's bytes
+    // changed.
+    (records[1].signedEnvelope as Record<string, unknown>).payload_digest =
+      `sha256:${"f".repeat(64)}`;
+    const result = verifyChain(records);
+    expect(result.chainIntegrity).toBe(false);
+    expect(result.steps[0].chainValid).toBe(true);
+    expect(result.steps[1].chainValid).toBe(true); // own prev still seeds correctly
+    expect(result.steps[2].chainValid).toBe(false); // [1]'s hash changed
+  });
+
+  it("detects a forged previousReceiptHash on the first record", () => {
+    const records = buildChain(2);
+    (records[0].signedEnvelope as Record<string, unknown>).previousReceiptHash =
+      "1".repeat(64);
+    const result = verifyChain(records);
+    expect(result.chainIntegrity).toBe(false);
+    expect(result.steps[0].chainValid).toBe(false);
+  });
+
+  it("flags storedChainHashMatches when caller supplied a wrong chain hash", () => {
+    const records = buildChain(1);
+    records[0].chainHash = "0".repeat(64);
+    const result = verifyChain(records);
+    expect(result.steps[0].storedChainHashMatches).toBe(false);
+    expect(result.chainIntegrity).toBe(false);
+  });
+
+  it("accepts snake_case `previous_receipt_hash` for one release", () => {
+    const env: Record<string, unknown> = {
+      a: 1,
+      previous_receipt_hash: FIRST_RECEIPT_SEED,
+    };
+    const result = verifyChain([{ signedEnvelope: env }]);
+    expect(result.chainIntegrity).toBe(true);
+  });
+
+  it("legacy: true uses the v1 chain shape", () => {
+    const env = {
+      signature_id: "sig_1",
+      action_type: "api:call",
+      timestamp: 1,
+      previousReceiptHash: "",
+    };
+    const result = verifyChain([{ signedEnvelope: env }], { legacy: true });
+    expect(result.chainIntegrity).toBe(true);
+  });
+});


### PR DESCRIPTION
Adopts the IETF Compliance Receipts profile fields on the TypeScript SDK, mirroring the cloud + Python SDK changes.

## Commits
1. `799cff7` feat(jcs): add RFC 8785 canonicalJson helper for IETF profile
2. `15ee6ce` feat(sign): IETF Compliance Receipts profile fields on agent.sign
3. `0b7ee88` feat(replay): IETF v2 chain verification (sha256(canonicalJson(env)))
4. `4fae99d` feat(algorithms): Ed25519 + ES256 agility on the SDK signing path
5. `ce2991b` docs(examples): show IETF Compliance Receipts profile in cookbook
6. `be4944e` docs(readme): Compliance receipts (IETF profile) section

## Coverage
F1, F3, F5, F6, F7, F8, F10, AG3, AG4 client-side; tests: 145 passed; tsc clean.

## Test plan
- [ ] `ci-ok` passes
- [ ] After merge, DevOps bumps to `0.2.7` and publishes npm