### PR TITLE
chore(release): bump @asqav/sdk to 0.2.7

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -32,7 +32,7 @@ import {
   type LocalSigningAlgorithm,
 } from "./index.js";
 
-const CLI_VERSION = "0.2.5";
+const CLI_VERSION = "0.2.7";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,


### PR DESCRIPTION
Patch release: IETF Compliance Receipts profile fields + JCS canonicalization + Ed25519/ES256 algorithm agility + CLI commands.

Bumps:
- typescript/package.json: 0.2.6 → 0.2.7
- typescript/src/cli.ts CLI_VERSION: 0.2.5 → 0.2.7 (was stale)