### PR TITLE
fix(sdk): IETF wire-shape alignment (decision, signatureObject, anchors[])

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -208,6 +208,28 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
 # from the cloud's `routes/verify.py:SKEW_BOUND_SECONDS`.
 SKEW_BOUND_SECONDS: int = 300
 
+# IETF -01 Section 4.2.1 / Devil's Advocate N3: spec-shape `decision`
+# vocabulary on the wire is {"allow", "deny", "rate_limit"}. Legacy
+# `policy_decision` uses {"permit", "deny", "rate_limit"}. Map client-
+# side so callers can read `.decision` without having to know the
+# legacy translation. Unknown tokens fall back to "deny" so a strict
+# verifier never sees an out-of-vocabulary value.
+DECISION_MAP: dict[str, str] = {
+    "permit": "allow",
+    "allow": "allow",
+    "deny": "deny",
+    "rate_limit": "rate_limit",
+}
+
+
+def _map_policy_decision_to_decision(policy_decision: str | None) -> str:
+    """Translate internal `policy_decision` to spec-shape `decision`.
+
+    Used when emitting compliance receipts. Falls back to "deny" so a
+    misconfigured caller never publishes an out-of-vocabulary token.
+    """
+    return DECISION_MAP.get((policy_decision or "").lower(), "deny")
+
 # REQUIRED fields on a Compliance Receipt envelope per §5 of
 # draft-marques-asqav-compliance-receipts-00. Used by the local
 # `verify_compliance_receipt` helper.
@@ -269,6 +291,13 @@ class SignatureResponse:
     incident_class: str | None = None
     reason: str | None = None
     previous_receipt_hash: str | None = None
+    # IETF -01 N3 / Section 4.2.1: spec-shape `decision` token mirrors
+    # `policy_decision` with the spec vocabulary {"allow", "deny",
+    # "rate_limit"}. Mapped client-side from `policy_decision` ("permit"
+    # -> "allow") so callers reading `.decision` get the spec value
+    # without having to know the legacy mapping. None on non-compliance
+    # receipts so legacy code paths stay byte-stable.
+    decision: str | None = None
 
 
 @dataclass
@@ -1193,6 +1222,20 @@ class Agent:
                 data.get("previousReceiptHash")
                 or data.get("previous_receipt_hash")
             ),
+            # IETF -01 N3: surface the spec-shape `decision` token. The
+            # cloud emits both `decision` (spec) and `policy_decision`
+            # (legacy) under compliance_mode; pick the cloud's value if
+            # present, otherwise translate locally so older clouds work.
+            decision=(
+                data.get("decision")
+                or (
+                    _map_policy_decision_to_decision(
+                        data.get("policy_decision")
+                    )
+                    if data.get("compliance_mode")
+                    else None
+                )
+            ),
         )
 
         # Dispatch after-hooks (fail-open).
@@ -1244,6 +1287,16 @@ class Agent:
             co_signatures=data.get("co_signatures"),
             countersign_url=data.get("countersign_url"),
             user_intent_verified=data.get("user_intent_verified"),
+            decision=(
+                data.get("decision")
+                or (
+                    _map_policy_decision_to_decision(
+                        data.get("policy_decision")
+                    )
+                    if data.get("compliance_mode")
+                    else None
+                )
+            ),
         )
 
     def sign_batch(
@@ -1310,6 +1363,16 @@ class Agent:
                         policy_decision=sig.get("policy_decision", "permit"),
                         authorization_ref=sig.get("authorization_ref"),
                         bitcoin_anchor=_parse_bitcoin_anchor(sig.get("bitcoin_anchor")),
+                        decision=(
+                            sig.get("decision")
+                            or (
+                                _map_policy_decision_to_decision(
+                                    sig.get("policy_decision")
+                                )
+                                if sig.get("compliance_mode")
+                                else None
+                            )
+                        ),
                     )
                 )
         return results

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -303,6 +303,10 @@ class SignatureResponse:
     # under compliance_mode; older clouds populate the flat fields and
     # the SDK projects via `signature_object()` below.
     signatureObject: dict[str, str] | None = None
+    # IETF -01 N7: spec-shape anchors array. Cloud emits it directly;
+    # older clouds populate the flat fields and the SDK projects via
+    # `anchors_array()` below.
+    anchors: list[dict[str, Any]] | None = None
 
     def signature_object(self) -> dict[str, str] | None:
         """Return the spec-shape signature envelope `{alg, kid, sig}`.
@@ -314,6 +318,18 @@ class SignatureResponse:
         from .ietf_projection import signature_object_from_response
 
         return signature_object_from_response(self)
+
+    def anchors_array(self) -> list[dict[str, Any]] | None:
+        """Return the spec-shape `anchors[]` array.
+
+        IETF -01 N7 / Section 4.4. Returns the cloud-supplied list when
+        available, else projects from the flat columns. None for
+        non-compliance receipts; [] when compliance_mode is on but no
+        anchor columns are populated.
+        """
+        from .ietf_projection import anchors_from_response
+
+        return anchors_from_response(self)
 
 
 @dataclass
@@ -1253,6 +1269,7 @@ class Agent:
                 )
             ),
             signatureObject=data.get("signatureObject"),
+            anchors=data.get("anchors"),
         )
 
         # Dispatch after-hooks (fail-open).

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -298,6 +298,22 @@ class SignatureResponse:
     # without having to know the legacy mapping. None on non-compliance
     # receipts so legacy code paths stay byte-stable.
     decision: str | None = None
+    # IETF -01 N6: spec-shape signature envelope object {alg, kid, sig}
+    # surfaced as `signatureObject` on the wire. Cloud emits it directly
+    # under compliance_mode; older clouds populate the flat fields and
+    # the SDK projects via `signature_object()` below.
+    signatureObject: dict[str, str] | None = None
+
+    def signature_object(self) -> dict[str, str] | None:
+        """Return the spec-shape signature envelope `{alg, kid, sig}`.
+
+        IETF -01 N6 / Section 4. Returns the cloud-supplied
+        `signatureObject` when available, else projects from the flat
+        fields. None for non-compliance receipts.
+        """
+        from .ietf_projection import signature_object_from_response
+
+        return signature_object_from_response(self)
 
 
 @dataclass
@@ -1236,6 +1252,7 @@ class Agent:
                     else None
                 )
             ),
+            signatureObject=data.get("signatureObject"),
         )
 
         # Dispatch after-hooks (fail-open).

--- a/python/src/asqav/demo.py
+++ b/python/src/asqav/demo.py
@@ -405,16 +405,23 @@ class DemoHandler(http.server.BaseHTTPRequestHandler):
             # cloud emits on a real Compliance Receipt envelope. Same for
             # `receipt_type` (decision namespace per F1) and `reason` /
             # `policy_decision` per F9.
+            # IETF -01 N3: spec-shape `decision` token alongside the
+            # legacy `policy_decision` so the demo receipt mirrors what
+            # the cloud now emits under compliance_mode.
+            policy_decision_value = (
+                "permit" if decision == "approved" else "deny"
+            )
             receipt = _sign(self.state, {
                 "scenario_id": sid,
                 "action_type": scenario["action_type"],
-                "decision": decision,
+                "decision": (
+                    "allow" if decision == "approved" else "deny"
+                ),
                 "reason": reason,
                 "risk_class": scenario.get("risk_classification", "unknown"),
                 "receipt_type": "protectmcp:decision",
-                "policy_decision": (
-                    "permit" if decision == "approved" else "deny"
-                ),
+                "policy_decision": policy_decision_value,
+                "scenario_decision": decision,  # demo UI keeps "approved"/"rejected"
                 "timestamp": int(time.time()),
             })
             self.state.approvals[sid] = {"decision": decision, "reason": reason, "receipt": receipt}

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -41,6 +41,62 @@ def signature_object_from_response(response: Any) -> dict[str, str] | None:
     return {"alg": alg, "kid": kid, "sig": sig}
 
 
+def anchors_from_response(response: Any) -> list[dict[str, Any]] | None:
+    """Project a SignatureResponse / verify dict into `anchors[]`.
+
+    IETF -01 N7 / Section 4.4. Returns the cloud-supplied list when
+    present (deep-copied so callers cannot mutate the response),
+    otherwise builds entries from the flat columns
+    (`rfc3161_serial`, `rfc3161_tsa`, `bitcoin_anchor.status`).
+    Returns None when the response is non-compliance so legacy
+    callers stay byte-stable; returns [] (not None) when
+    compliance_mode is on but no anchor columns are populated.
+    """
+    cloud_supplied = _get(response, "anchors")
+    if isinstance(cloud_supplied, list):
+        return [dict(e) for e in cloud_supplied]
+
+    if not _get(response, "compliance_mode"):
+        return None
+
+    anchors: list[dict[str, Any]] = []
+
+    rfc3161_serial = _get(response, "rfc3161_serial")
+    rfc3161_tsa = _get(response, "rfc3161_tsa")
+    if rfc3161_serial or rfc3161_tsa:
+        entry: dict[str, Any] = {"type": "rfc3161", "value": ""}
+        if rfc3161_serial:
+            entry["serial"] = rfc3161_serial
+        if rfc3161_tsa:
+            entry["tsa"] = rfc3161_tsa
+        anchors.append(entry)
+
+    bitcoin_anchor = _get(response, "bitcoin_anchor")
+    if bitcoin_anchor is not None:
+        # The SDK BitcoinAnchor dataclass exposes `status`; the OTS
+        # proof bytes are not in the SDK type, so we surface a
+        # presence-only entry. Strict verifiers ignore this projection
+        # unless the cloud has populated `anchors[]` directly.
+        status = _get(bitcoin_anchor, "status")
+        if status:
+            anchors.append(
+                {
+                    "type": "opentimestamps",
+                    "value": "",
+                    "status": status,
+                }
+            )
+
+    return anchors
+
+
+def encode_anchor_value(raw: bytes) -> str:
+    """Helper for callers that hold raw anchor bytes locally."""
+    import base64
+
+    return base64.b64encode(raw).decode()
+
+
 def _get(obj: Any, name: str) -> Any:
     """Read attribute or dict key, whichever exists. None when absent."""
     if obj is None:

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -1,0 +1,50 @@
+"""IETF Compliance Receipts -01 wire-shape projection helpers.
+
+Mirror of `asqav_cloud.core.ietf_projection`. Pure functions that
+re-shape the legacy flat fields (algorithm/key_id/signature_b64) into
+the spec-shape JSON structures the IETF profile defines (Section 4
+"JSON Receipt Structure").
+
+Callers use these helpers to produce a draft-conformant view of a
+receipt for offline verification or audit-pack export when working
+against an older cloud that does not yet emit `signatureObject`
+directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def signature_object_from_response(response: Any) -> dict[str, str] | None:
+    """Project a SignatureResponse / verify dict into `{alg, kid, sig}`.
+
+    Returns the cloud-supplied `signatureObject` when present so callers
+    do not double-project; otherwise builds the envelope from the flat
+    fields (`algorithm`, `key_id` if exposed, `signature`). Returns None
+    when the response is non-compliance (no `compliance_mode=True`) so
+    legacy receipts are not silently re-shaped.
+    """
+    cloud_supplied = _get(response, "signatureObject")
+    if isinstance(cloud_supplied, dict) and cloud_supplied:
+        return dict(cloud_supplied)
+
+    if not _get(response, "compliance_mode"):
+        return None
+
+    alg = _get(response, "algorithm") or ""
+    sig = _get(response, "signature") or ""
+    # `key_id` is not surfaced on the dataclass today; cloud will pass
+    # it via `signatureObject` once available. Fall back to the empty
+    # string so the envelope keeps the spec-shape three keys.
+    kid = _get(response, "key_id") or _get(response, "kid") or ""
+    return {"alg": alg, "kid": kid, "sig": sig}
+
+
+def _get(obj: Any, name: str) -> Any:
+    """Read attribute or dict key, whichever exists. None when absent."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)

--- a/python/tests/test_client_decision_alias.py
+++ b/python/tests/test_client_decision_alias.py
@@ -1,0 +1,74 @@
+"""IETF -01 N3 / Section 4.2.1: spec-shape `decision` field on the SDK.
+
+The legacy `policy_decision` vocabulary {"permit", "deny", "rate_limit"}
+diverges from the published spec text {"allow", "deny", "rate_limit"}.
+The SDK surfaces a `decision` attribute on SignatureResponse populated
+either from the cloud (newer servers) or by mapping `policy_decision`
+locally (older servers), so callers can read the spec value uniformly.
+"""
+
+from __future__ import annotations
+
+from asqav.client import (
+    DECISION_MAP,
+    SignatureResponse,
+    _map_policy_decision_to_decision,
+)
+
+
+def test_decision_map_covers_full_legacy_vocabulary():
+    """Every legacy `policy_decision` token resolves to a spec token."""
+    assert DECISION_MAP["permit"] == "allow"
+    assert DECISION_MAP["deny"] == "deny"
+    assert DECISION_MAP["rate_limit"] == "rate_limit"
+
+
+def test_decision_map_idempotent_for_already_normalised_input():
+    """Spec-shape `allow` round-trips."""
+    assert DECISION_MAP["allow"] == "allow"
+    assert _map_policy_decision_to_decision("allow") == "allow"
+
+
+def test_unknown_token_falls_back_to_deny():
+    """Closed-by-default keeps misconfigured callers safe."""
+    assert _map_policy_decision_to_decision("yolo") == "deny"
+    assert _map_policy_decision_to_decision(None) == "deny"
+    assert _map_policy_decision_to_decision("") == "deny"
+
+
+def test_signature_response_decision_default_none():
+    """Non-compliance receipts MUST NOT carry a `decision` token."""
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+    )
+    assert resp.decision is None
+    # Legacy field default preserved.
+    assert resp.policy_decision == "permit"
+
+
+def test_signature_response_decision_alongside_policy_decision():
+    """Compliance receipts surface BOTH fields."""
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+        policy_decision="permit",
+        decision="allow",
+        compliance_mode=True,
+    )
+    assert resp.policy_decision == "permit"
+    assert resp.decision == "allow"
+
+
+def test_signature_response_deny_round_trip():
+    assert _map_policy_decision_to_decision("deny") == "deny"
+
+
+def test_signature_response_rate_limit_round_trip():
+    assert _map_policy_decision_to_decision("rate_limit") == "rate_limit"

--- a/python/tests/test_client_ietf_anchors.py
+++ b/python/tests/test_client_ietf_anchors.py
@@ -1,0 +1,115 @@
+"""IETF -01 N7 / S3: SDK-side `anchors_array()` projection helper.
+
+`anchors_array()` returns the spec-shape anchors list with `type`
+discriminator per Section 4.4. Gated on `compliance_mode=True`; legacy
+receipts get None back.
+"""
+
+from __future__ import annotations
+
+from asqav.client import BitcoinAnchor, SignatureResponse
+from asqav.ietf_projection import (
+    anchors_from_response,
+    encode_anchor_value,
+)
+
+
+def test_anchors_array_none_for_non_compliance_response():
+    """Non-compliance receipts MUST get None back."""
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+    )
+    assert resp.anchors_array() is None
+
+
+def test_anchors_array_returns_cloud_supplied_when_present():
+    """When the cloud emits `anchors`, the SDK passes it through."""
+    cloud_anchors = [
+        {"type": "rfc3161", "value": "ZmFrZS1kZXI=", "tsa": "freetsa.org"},
+        {"type": "opentimestamps", "value": "ZmFrZS1vdHM=", "status": "pending"},
+    ]
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+        compliance_mode=True,
+        anchors=cloud_anchors,
+    )
+    out = resp.anchors_array()
+    assert out == cloud_anchors
+    # Returned list is a copy of each entry (mutations do not leak back).
+    out[0]["tsa"] = "MUTATED"
+    assert resp.anchors[0]["tsa"] == "freetsa.org"
+
+
+def test_anchors_array_projects_rfc3161_from_flat_fields():
+    """Older clouds without `anchors` get an RFC 3161 entry from the flats."""
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+        rfc3161_serial="0xabc123",
+        rfc3161_tsa="freetsa.org",
+        compliance_mode=True,
+    )
+    out = resp.anchors_array()
+    assert len(out) == 1
+    assert out[0]["type"] == "rfc3161"
+    assert out[0]["serial"] == "0xabc123"
+    assert out[0]["tsa"] == "freetsa.org"
+
+
+def test_anchors_array_projects_opentimestamps_from_bitcoin_anchor():
+    """Older clouds with a BitcoinAnchor object get an OTS presence entry."""
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+        bitcoin_anchor=BitcoinAnchor(status="pending"),
+        compliance_mode=True,
+    )
+    out = resp.anchors_array()
+    assert any(e["type"] == "opentimestamps" for e in out)
+
+
+def test_anchors_array_empty_list_when_compliance_but_no_anchors():
+    """compliance_mode=True with no anchors -> [] not None."""
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+        compliance_mode=True,
+    )
+    out = resp.anchors_array()
+    assert out == []
+
+
+def test_anchors_helper_works_on_dict_input():
+    """The free helper accepts both objects and dicts (verify response)."""
+    cloud_anchors = [{"type": "rfc3161", "value": "ZmFrZQ=="}]
+    out = anchors_from_response(
+        {"compliance_mode": True, "anchors": cloud_anchors}
+    )
+    assert out == cloud_anchors
+
+
+def test_anchors_helper_none_for_legacy_dict():
+    """Dict input without compliance_mode returns None."""
+    assert anchors_from_response({"rfc3161_serial": "0x1"}) is None
+
+
+def test_encode_anchor_value_is_base64():
+    """Helper for callers that hold raw anchor bytes locally."""
+    assert encode_anchor_value(b"hello") == "aGVsbG8="

--- a/python/tests/test_client_ietf_projection.py
+++ b/python/tests/test_client_ietf_projection.py
@@ -1,0 +1,75 @@
+"""IETF -01 N6 / S2: SDK-side `signature_object()` projection helper.
+
+`signature_object()` returns `{alg, kid, sig}` per Section 4
+"JSON Receipt Structure". Gated on `compliance_mode=True`; legacy
+receipts get None back so the additive overlay stays byte-stable.
+"""
+
+from __future__ import annotations
+
+from asqav.client import SignatureResponse
+from asqav.ietf_projection import signature_object_from_response
+
+
+def test_signature_object_none_for_non_compliance_response():
+    """Non-compliance receipts MUST get None back."""
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+    )
+    assert resp.signature_object() is None
+
+
+def test_signature_object_returns_cloud_supplied_when_present():
+    """When the cloud emits `signatureObject`, the SDK passes it through."""
+    envelope = {"alg": "ML-DSA-65", "kid": "key_abc", "sig": "ZmFrZQ=="}
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+        compliance_mode=True,
+        signatureObject=envelope,
+    )
+    out = resp.signature_object()
+    assert out == envelope
+    # Returned dict is a copy (callers cannot mutate the response).
+    out["sig"] = "MUTATED"
+    assert resp.signatureObject["sig"] == "ZmFrZQ=="
+
+
+def test_signature_object_projects_from_flat_fields_under_compliance():
+    """Older clouds without `signatureObject` get projected from flats."""
+    resp = SignatureResponse(
+        signature="ZmFrZQ==",
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+        algorithm="ML-DSA-65",
+        compliance_mode=True,
+    )
+    out = resp.signature_object()
+    assert set(out.keys()) == {"alg", "kid", "sig"}
+    assert out["alg"] == "ML-DSA-65"
+    # kid not exposed on the dataclass yet -> empty string.
+    assert out["kid"] == ""
+    assert out["sig"] == "ZmFrZQ=="
+
+
+def test_signature_object_helper_works_on_dict_input():
+    """The free helper accepts both objects and dicts (verify response)."""
+    envelope = {"alg": "ML-DSA-65", "kid": "key_abc", "sig": "ZmFrZQ=="}
+    out = signature_object_from_response(
+        {"compliance_mode": True, "signatureObject": envelope}
+    )
+    assert out == envelope
+
+
+def test_signature_object_helper_none_for_legacy_dict():
+    """Dict input without compliance_mode returns None."""
+    assert signature_object_from_response({"algorithm": "ML-DSA-65"}) is None

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "asqav"
-version = "0.3.6"
+version = "0.3.9"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -420,7 +420,19 @@ async function cmdSign(args: string[]): Promise<void> {
   const issuerId = parseFlag(args, "issuer-id");
   const receiptType = parseFlag(args, "receipt-type") ?? "protectmcp:decision";
   const reason = parseFlag(args, "reason");
-  const policyDecision = parseFlag(args, "policy-decision") ?? "permit";
+  // IETF -01 N3: --decision is the spec-shape flag (allow|deny|rate_limit).
+  // --policy-decision is the legacy flag (permit|deny|rate_limit). They
+  // are mutually convertible; --decision wins when both supplied.
+  const decisionFlag = parseFlag(args, "decision");
+  const decisionMap: Record<string, string> = {
+    allow: "permit",
+    deny: "deny",
+    rate_limit: "rate_limit",
+  };
+  const policyDecision =
+    (decisionFlag !== undefined ? decisionMap[decisionFlag] : undefined)
+    ?? parseFlag(args, "policy-decision")
+    ?? "permit";
   const sessionId = parseFlag(args, "session-id");
   const validSecondsStr = parseFlag(args, "valid-seconds");
   const policyArtefactPath = parseFlag(args, "policy-artefact");
@@ -491,6 +503,9 @@ async function cmdSign(args: string[]): Promise<void> {
       if (sig.actionRef) process.stdout.write(`action_ref:    ${sig.actionRef}\n`);
       if (sig.previousReceiptHash) {
         process.stdout.write(`previous_receipt_hash: ${sig.previousReceiptHash}\n`);
+      }
+      if (sig.decision) {
+        process.stdout.write(`decision:      ${sig.decision}\n`);
       }
     }
     process.stdout.write(`verify_url:   ${sig.verificationUrl}\n`);
@@ -754,7 +769,8 @@ Usage:
   asqav sign --agent-id ID --action-type T [--compliance-mode] [--action-json PATH|-]
              [--receipt-type protectmcp:decision|...] [--risk-class low|medium|high|unknown]
              [--sandbox-state enabled|disabled|unavailable] [--iteration-id ID]
-             [--issuer-id LEGAL] [--policy-decision permit|deny|rate_limit] [--reason CODE]
+             [--issuer-id LEGAL] [--policy-decision permit|deny|rate_limit]
+             [--decision allow|deny|rate_limit] [--reason CODE]
              [--algorithm ml-dsa-65|ed25519|es256] [--policy-artefact PATH|-]
              [--session-id ID] [--valid-seconds N] [--output text|json]
   asqav agents list / create <name> / revoke <agent_id>

--- a/typescript/src/ietfProjection.ts
+++ b/typescript/src/ietfProjection.ts
@@ -1,0 +1,134 @@
+/**
+ * IETF Compliance Receipts -01 wire-shape projection helpers.
+ *
+ * Mirror of `asqav.ietf_projection` (Python) and
+ * `asqav_cloud.core.ietf_projection`. Pure functions that re-shape the
+ * legacy flat fields into the spec-shape JSON structures the IETF
+ * profile defines (Section 4 "JSON Receipt Structure" + Section 4.4
+ * "Anchors").
+ *
+ * Callers use these helpers to produce a draft-conformant view of a
+ * receipt for offline verification or audit-pack export when working
+ * against an older cloud that does not yet emit `signatureObject` /
+ * `anchors` directly.
+ */
+
+/** Spec-shape signature envelope per Section 4. */
+export interface SignatureEnvelope {
+  alg: string;
+  kid: string;
+  sig: string;
+}
+
+/** Spec-shape anchor entry per Section 4.4. */
+export interface AnchorEntry {
+  type: "rfc3161" | "opentimestamps" | string;
+  value: string;
+  serial?: string;
+  tsa?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+/** Minimal duck-typed slice of a SignatureResponse / verify dict the
+ * projection helpers read. */
+export interface ProjectableResponse {
+  algorithm?: string;
+  signature?: string;
+  key_id?: string;
+  kid?: string;
+  complianceMode?: boolean;
+  compliance_mode?: boolean;
+  signatureObject?: SignatureEnvelope | null;
+  anchors?: AnchorEntry[] | null;
+  rfc3161_serial?: string;
+  rfc3161_tsa?: string;
+  rfc3161Serial?: string;
+  rfc3161Tsa?: string;
+  bitcoinAnchor?: { status?: string } | null;
+  bitcoin_anchor?: { status?: string } | null;
+  [key: string]: unknown;
+}
+
+function pick<T>(obj: ProjectableResponse, ...names: string[]): T | undefined {
+  for (const n of names) {
+    const v = (obj as Record<string, unknown>)[n];
+    if (v !== undefined && v !== null) return v as T;
+  }
+  return undefined;
+}
+
+function isComplianceMode(obj: ProjectableResponse): boolean {
+  return Boolean(pick<boolean>(obj, "complianceMode", "compliance_mode"));
+}
+
+/** Project a SignatureResponse / verify dict into `{alg, kid, sig}`.
+ *
+ * Returns the cloud-supplied `signatureObject` when present so callers
+ * do not double-project; otherwise builds the envelope from the flat
+ * fields. Returns `undefined` for non-compliance receipts so legacy
+ * callers stay byte-stable. */
+export function signatureObjectFromResponse(
+  response: ProjectableResponse | null | undefined,
+): SignatureEnvelope | undefined {
+  if (response == null) return undefined;
+  if (response.signatureObject) {
+    // Spread to a fresh object so callers cannot mutate the source.
+    return { ...response.signatureObject };
+  }
+  if (!isComplianceMode(response)) return undefined;
+  return {
+    alg: pick<string>(response, "algorithm") ?? "",
+    kid: pick<string>(response, "key_id", "kid") ?? "",
+    sig: pick<string>(response, "signature") ?? "",
+  };
+}
+
+/** Project a SignatureResponse / verify dict into `anchors[]`.
+ *
+ * Returns the cloud-supplied list when present (deep-copied), otherwise
+ * builds entries from the flat columns. Returns `undefined` for
+ * non-compliance receipts; returns `[]` (not undefined) when
+ * complianceMode is on but no anchor columns are populated. */
+export function anchorsFromResponse(
+  response: ProjectableResponse | null | undefined,
+): AnchorEntry[] | undefined {
+  if (response == null) return undefined;
+  if (Array.isArray(response.anchors)) {
+    return response.anchors.map((e) => ({ ...e }));
+  }
+  if (!isComplianceMode(response)) return undefined;
+
+  const anchors: AnchorEntry[] = [];
+
+  const rfc3161Serial = pick<string>(response, "rfc3161Serial", "rfc3161_serial");
+  const rfc3161Tsa = pick<string>(response, "rfc3161Tsa", "rfc3161_tsa");
+  if (rfc3161Serial || rfc3161Tsa) {
+    const entry: AnchorEntry = { type: "rfc3161", value: "" };
+    if (rfc3161Serial) entry.serial = rfc3161Serial;
+    if (rfc3161Tsa) entry.tsa = rfc3161Tsa;
+    anchors.push(entry);
+  }
+
+  const bitcoinAnchor = pick<{ status?: string }>(
+    response,
+    "bitcoinAnchor",
+    "bitcoin_anchor",
+  );
+  const status = bitcoinAnchor?.status;
+  if (status) {
+    anchors.push({ type: "opentimestamps", value: "", status });
+  }
+
+  return anchors;
+}
+
+/** Helper for callers that hold raw anchor bytes locally. */
+export function encodeAnchorValue(raw: Uint8Array): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(raw).toString("base64");
+  }
+  let s = "";
+  for (const b of raw) s += String.fromCharCode(b);
+  return btoa(s);
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -39,6 +39,31 @@ export type RiskClass = "low" | "medium" | "high" | "unknown";
 /** Policy decision vocabulary; deny / rate_limit require `reason`. */
 export type PolicyDecision = "permit" | "deny" | "rate_limit";
 
+/** IETF -01 Section 4.2.1 / Devil's Advocate N3: spec-shape `decision`
+ * vocabulary on the wire is {"allow", "deny", "rate_limit"}. The legacy
+ * `policyDecision` field uses {"permit", "deny", "rate_limit"}. The SDK
+ * surfaces both so callers can read whichever they prefer.
+ */
+export type Decision = "allow" | "deny" | "rate_limit";
+
+/** Map a legacy `policyDecision` token to the spec-shape `decision`. */
+export const DECISION_MAP: Readonly<Record<string, Decision>> = Object.freeze({
+  permit: "allow",
+  allow: "allow",
+  deny: "deny",
+  rate_limit: "rate_limit",
+});
+
+/** Translate `policyDecision` to the spec-shape `decision`. Falls back
+ * to `"deny"` so a misconfigured caller never publishes an
+ * out-of-vocabulary token to a draft-strict verifier.
+ */
+export function mapPolicyDecisionToDecision(
+  policyDecision: string | null | undefined,
+): Decision {
+  return DECISION_MAP[(policyDecision ?? "").toLowerCase()] ?? "deny";
+}
+
 export { clearHooks, registerAfter, registerBefore } from "./hooks.js";
 export type { AfterHook, BeforeHook } from "./hooks.js";
 export { canonicalize, hashAction } from "./canonicalize.js";
@@ -288,6 +313,16 @@ export interface SignatureResponse {
   receiptType?: string;
   /** Resolved legal entity for this receipt. */
   issuerId?: string;
+  /** Legacy `policy_decision` value echoed from the request (one of
+   * `"permit" | "deny" | "rate_limit"`). Kept for backward compat with
+   * tooling built against the pre-spec implementation. */
+  policyDecision?: PolicyDecision;
+  /** IETF -01 N3 / Section 4.2.1: spec-shape `decision` token mirrors
+   * `policyDecision` with the spec vocabulary
+   * `"allow" | "deny" | "rate_limit"`. Either echoed from the cloud
+   * (newer servers) or mapped client-side from `policyDecision`
+   * (older servers). Undefined for non-compliance receipts. */
+  decision?: Decision;
 }
 
 export interface SessionResponse {
@@ -751,7 +786,15 @@ export class Agent {
     if (options.payloadDigest !== undefined) body.payload_digest = options.payloadDigest;
     if (options.receiptType !== undefined) body.receipt_type = options.receiptType;
     if (options.reason !== undefined) body.reason = options.reason;
-    if (options.policyDecision !== undefined) body.policy_decision = options.policyDecision;
+    if (options.policyDecision !== undefined) {
+      body.policy_decision = options.policyDecision;
+      // IETF -01 N3: when compliance_mode is on, also send the spec-shape
+      // `decision` token so a draft-strict cloud picks it up directly.
+      // Older clouds ignore the extra field harmlessly.
+      if (complianceMode) {
+        body.decision = mapPolicyDecisionToDecision(options.policyDecision);
+      }
+    }
 
     const data = await request<{
       signature: string;
@@ -773,6 +816,8 @@ export class Agent {
       policy_digest?: string;
       receipt_type?: string;
       issuer_id?: string;
+      policy_decision?: string;
+      decision?: string;
     }>("POST", `/agents/${this.agentId}/sign`, body);
 
     const response: SignatureResponse = {
@@ -799,6 +844,16 @@ export class Agent {
       policyDigest: data.policy_digest,
       receiptType: data.receipt_type,
       issuerId: data.issuer_id,
+      policyDecision: data.policy_decision as PolicyDecision | undefined,
+      // IETF -01 N3: surface the spec-shape token. Cloud emits `decision`
+      // alongside `policy_decision` under compliance_mode; older clouds
+      // get a client-side mapping so callers always read a normalised
+      // value.
+      decision: (data.decision as Decision | undefined) ?? (
+        data.compliance_mode
+          ? mapPolicyDecisionToDecision(data.policy_decision)
+          : undefined
+      ),
     };
 
     _dispatchAfter(options.actionType, response);

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -92,6 +92,41 @@ export {
 export { resolveMode, isAsqavCloudHost, type Mode } from "./mode.js";
 export { BudgetTracker, type BudgetCheckResult, type BudgetTrackerOptions } from "./budget.js";
 
+// IETF -01 wire-shape projection helpers (Section 4 + Section 4.4).
+export {
+  signatureObjectFromResponse,
+  anchorsFromResponse,
+  encodeAnchorValue,
+  type SignatureEnvelope,
+  type AnchorEntry,
+  type ProjectableResponse,
+} from "./ietfProjection.js";
+
+import {
+  signatureObjectFromResponse as _signatureObjectFromResponse,
+  anchorsFromResponse as _anchorsFromResponse,
+  type SignatureEnvelope,
+  type AnchorEntry,
+} from "./ietfProjection.js";
+
+/** IETF -01 N6 ergonomic wrapper. Returns the spec-shape envelope
+ * `{alg, kid, sig}` for a SignatureResponse, projecting from flat
+ * fields when the cloud has not emitted `signatureObject` directly. */
+export function signatureObject(
+  response: SignatureResponse | null | undefined,
+): SignatureEnvelope | undefined {
+  return _signatureObjectFromResponse(response as never);
+}
+
+/** IETF -01 N7 ergonomic wrapper. Returns the spec-shape `anchors[]`
+ * for a SignatureResponse, projecting from flat fields when the cloud
+ * has not emitted `anchors` directly. */
+export function anchors(
+  response: SignatureResponse | null | undefined,
+): AnchorEntry[] | undefined {
+  return _anchorsFromResponse(response as never);
+}
+
 const DEFAULT_BASE_URL = "https://api.asqav.com/api/v1";
 /** Metadata keys allowed alongside a hash-only request. Mirrors the
  * Python whitelist; the server enforces its own. */
@@ -323,6 +358,16 @@ export interface SignatureResponse {
    * (newer servers) or mapped client-side from `policyDecision`
    * (older servers). Undefined for non-compliance receipts. */
   decision?: Decision;
+  /** IETF -01 N6 / Section 4: spec-shape signature envelope object
+   * `{alg, kid, sig}`. Surfaced as `signatureObject` because the
+   * top-level `signature` field is already occupied by the legacy
+   * base64 flat string. Use `signatureObject()` to project from flat
+   * fields when the cloud has not emitted it directly. */
+  signatureObject?: SignatureEnvelope;
+  /** IETF -01 N7 / Section 4.4: spec-shape anchors array. Use
+   * `anchors()` to project from flat fields when the cloud has not
+   * emitted it directly. */
+  anchors?: AnchorEntry[];
 }
 
 export interface SessionResponse {
@@ -818,6 +863,8 @@ export class Agent {
       issuer_id?: string;
       policy_decision?: string;
       decision?: string;
+      signatureObject?: SignatureEnvelope;
+      anchors?: AnchorEntry[];
     }>("POST", `/agents/${this.agentId}/sign`, body);
 
     const response: SignatureResponse = {
@@ -854,6 +901,8 @@ export class Agent {
           ? mapPolicyDecisionToDecision(data.policy_decision)
           : undefined
       ),
+      signatureObject: data.signatureObject,
+      anchors: data.anchors,
     };
 
     _dispatchAfter(options.actionType, response);

--- a/typescript/tests/decisionAlias.test.ts
+++ b/typescript/tests/decisionAlias.test.ts
@@ -1,0 +1,186 @@
+/**
+ * IETF -01 N3 / Section 4.2.1: spec-shape `decision` alias on the TS SDK.
+ *
+ * Covers the DECISION_MAP, the `mapPolicyDecisionToDecision` helper, and
+ * end-to-end propagation of the `decision` token on a fake `agent.sign`
+ * call (request body MUST carry `decision` when complianceMode is on,
+ * response MUST surface both `policyDecision` and `decision`).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  DECISION_MAP,
+  _resetForTests,
+  init,
+  mapPolicyDecisionToDecision,
+} from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_decision",
+    name: "decision",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-05-04T00:00:00Z",
+  });
+}
+
+describe("DECISION_MAP", () => {
+  it("covers the full legacy vocabulary", () => {
+    expect(DECISION_MAP.permit).toBe("allow");
+    expect(DECISION_MAP.deny).toBe("deny");
+    expect(DECISION_MAP.rate_limit).toBe("rate_limit");
+  });
+
+  it("is idempotent for already-normalised input", () => {
+    expect(DECISION_MAP.allow).toBe("allow");
+    expect(mapPolicyDecisionToDecision("allow")).toBe("allow");
+  });
+
+  it("falls back to deny on unknown / null input", () => {
+    expect(mapPolicyDecisionToDecision("yolo")).toBe("deny");
+    expect(mapPolicyDecisionToDecision(null)).toBe("deny");
+    expect(mapPolicyDecisionToDecision(undefined)).toBe("deny");
+    expect(mapPolicyDecisionToDecision("")).toBe("deny");
+  });
+});
+
+describe("agent.sign decision wire field", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits decision in the request body under complianceMode", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-04T00:00:00Z",
+        verification_url: "https://verify",
+        compliance_mode: true,
+        policy_decision: "permit",
+        decision: "allow",
+      }),
+    );
+
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "t.test",
+      complianceMode: true,
+      policyDecision: "permit",
+    });
+
+    const init = fetchSpy.mock.calls[0][1];
+    const body = JSON.parse((init?.body as string) ?? "{}");
+    expect(body.policy_decision).toBe("permit");
+    expect(body.decision).toBe("allow");
+  });
+
+  it("does not emit decision when complianceMode is off", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-04T00:00:00Z",
+        verification_url: "https://verify",
+      }),
+    );
+
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "t.test",
+      policyDecision: "permit",
+    });
+
+    const init = fetchSpy.mock.calls[0][1];
+    const body = JSON.parse((init?.body as string) ?? "{}");
+    expect(body.policy_decision).toBe("permit");
+    expect(body.decision).toBeUndefined();
+  });
+
+  it("surfaces decision on the response when cloud emits it", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-04T00:00:00Z",
+        verification_url: "https://verify",
+        compliance_mode: true,
+        policy_decision: "deny",
+        decision: "deny",
+      }),
+    );
+
+    const agent = fakeAgent();
+    const resp = await agent.sign({
+      actionType: "t.test",
+      complianceMode: true,
+      policyDecision: "deny",
+      reason: "policy_violation",
+    });
+
+    expect(resp.policyDecision).toBe("deny");
+    expect(resp.decision).toBe("deny");
+  });
+
+  it("client-side maps decision when older cloud omits it", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-04T00:00:00Z",
+        verification_url: "https://verify",
+        compliance_mode: true,
+        policy_decision: "permit",
+        // older cloud: no `decision` field
+      }),
+    );
+
+    const agent = fakeAgent();
+    const resp = await agent.sign({
+      actionType: "t.test",
+      complianceMode: true,
+      policyDecision: "permit",
+    });
+
+    expect(resp.policyDecision).toBe("permit");
+    expect(resp.decision).toBe("allow");
+  });
+
+  it("decision undefined on legacy non-compliance receipts", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-04T00:00:00Z",
+        verification_url: "https://verify",
+      }),
+    );
+
+    const agent = fakeAgent();
+    const resp = await agent.sign({ actionType: "t.test" });
+
+    expect(resp.decision).toBeUndefined();
+  });
+});

--- a/typescript/tests/projection.test.ts
+++ b/typescript/tests/projection.test.ts
@@ -1,0 +1,134 @@
+/**
+ * IETF -01 N6 + N7 / T2: TS SDK projection helpers.
+ *
+ * `signatureObject(resp)` projects to `{alg, kid, sig}` per Section 4.
+ * `anchors(resp)` projects to the spec-shape array per Section 4.4.
+ * Both gated on `complianceMode=true`; legacy receipts get undefined
+ * back so the additive overlay stays byte-stable.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  type AnchorEntry,
+  type SignatureResponse,
+  type SignatureEnvelope,
+  anchors,
+  anchorsFromResponse,
+  encodeAnchorValue,
+  signatureObject,
+  signatureObjectFromResponse,
+} from "../src/index.js";
+
+function bareResponse(extra: Partial<SignatureResponse> = {}): SignatureResponse {
+  return {
+    signature: "ZmFrZQ==",
+    signatureId: "sig_test",
+    actionId: "act_test",
+    timestamp: "2026-05-04T00:00:00Z",
+    verificationUrl: "https://verify",
+    ...extra,
+  };
+}
+
+describe("signatureObject()", () => {
+  it("returns undefined for non-compliance receipts", () => {
+    expect(signatureObject(bareResponse())).toBeUndefined();
+  });
+
+  it("returns the cloud-supplied envelope when present", () => {
+    const envelope: SignatureEnvelope = {
+      alg: "ML-DSA-65",
+      kid: "key_abc",
+      sig: "ZmFrZQ==",
+    };
+    const resp = bareResponse({
+      complianceMode: true,
+      signatureObject: envelope,
+    });
+    const out = signatureObject(resp);
+    expect(out).toEqual(envelope);
+    // Mutation safety: returned object is a fresh copy.
+    out!.sig = "MUTATED";
+    expect(resp.signatureObject!.sig).toBe("ZmFrZQ==");
+  });
+
+  it("projects from flat fields when complianceMode but no envelope", () => {
+    const resp = bareResponse({
+      algorithm: "ML-DSA-65",
+      complianceMode: true,
+    });
+    const out = signatureObject(resp);
+    expect(out).toEqual({
+      alg: "ML-DSA-65",
+      kid: "",
+      sig: "ZmFrZQ==",
+    });
+  });
+
+  it("free helper accepts dict input (snake_case wire shape)", () => {
+    const out = signatureObjectFromResponse({
+      compliance_mode: true,
+      signatureObject: { alg: "Ed25519", kid: "k1", sig: "s" },
+    });
+    expect(out).toEqual({ alg: "Ed25519", kid: "k1", sig: "s" });
+  });
+});
+
+describe("anchors()", () => {
+  it("returns undefined for non-compliance receipts", () => {
+    expect(anchors(bareResponse())).toBeUndefined();
+  });
+
+  it("returns the cloud-supplied list when present", () => {
+    const cloudAnchors: AnchorEntry[] = [
+      { type: "rfc3161", value: "ZmFrZS1kZXI=", tsa: "freetsa.org" },
+      { type: "opentimestamps", value: "ZmFrZS1vdHM=", status: "pending" },
+    ];
+    const resp = bareResponse({
+      complianceMode: true,
+      anchors: cloudAnchors,
+    });
+    const out = anchors(resp);
+    expect(out).toEqual(cloudAnchors);
+    // Mutation safety: each entry is a copy.
+    out![0].tsa = "MUTATED";
+    expect(resp.anchors![0].tsa).toBe("freetsa.org");
+  });
+
+  it("returns [] under complianceMode when no anchor columns set", () => {
+    const out = anchors(bareResponse({ complianceMode: true }));
+    expect(out).toEqual([]);
+  });
+
+  it("projects rfc3161 from flat snake_case fields via free helper", () => {
+    const out = anchorsFromResponse({
+      compliance_mode: true,
+      rfc3161_serial: "0xabc",
+      rfc3161_tsa: "freetsa.org",
+    });
+    expect(out).toHaveLength(1);
+    expect(out![0]).toEqual({
+      type: "rfc3161",
+      value: "",
+      serial: "0xabc",
+      tsa: "freetsa.org",
+    });
+  });
+
+  it("projects opentimestamps from bitcoinAnchor.status via free helper", () => {
+    const out = anchorsFromResponse({
+      compliance_mode: true,
+      bitcoinAnchor: { status: "pending" },
+    });
+    expect(out!.some((e) => e.type === "opentimestamps")).toBe(true);
+  });
+});
+
+describe("encodeAnchorValue()", () => {
+  it("base64-encodes raw bytes", () => {
+    expect(encodeAnchorValue(new Uint8Array([104, 101, 108, 108, 111]))).toBe(
+      "aGVsbG8=",
+    );
+  });
+});


### PR DESCRIPTION
Mirrors cloud Fix Cycle 3 wire-shape alignment on Python + TypeScript SDKs.

## Python commits
- \`1fc781b\` decision token + DECISION_MAP + demo update
- \`0e80f45\` signature_object() projection helper
- \`4f7ff14\` anchors_array() projection helper

## TypeScript commits
- \`2868aab\` decision field + DECISION_MAP + --decision CLI flag
- \`7314015\` signatureObject() + anchors() exports + ietfProjection.ts

## Architectural note
SDK BYOK helpers continue to support local Ed25519/ES256 keypair generation for clients building their own ACTA-RECEIPTS-conformant verifiers. Asqav cloud receipts remain ML-DSA-65 only.