### PR TITLE
docs(sweep): align DORA citations with corrected -02 spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Unreleased] - 2026-05-04 (docs)
+
+### Changed
+- DORA citation sweep aligning READMEs and docs to the corrected `-02` spec text. The vocabulary source is the canonical 6-value Annex II field 3.23 list from JC 2024-33 (17 July 2024), the EBA / ESMA / EIOPA Joint Committee Final Report on the draft RTS and ITS on incident reporting under Regulation (EU) 2022/2554. Legacy receipts continue to validate via `LEGACY_DORA_ALIASES`. CLI flag tables and TypeScript field reference updated to point at the canonical list rather than a generic "DORA ITS vocabulary" paraphrase.
+
 ## [Python 0.3.10 / TypeScript 0.2.8] - 2026-05-04
 
 ### Added

--- a/python/docs/CLI.md
+++ b/python/docs/CLI.md
@@ -49,7 +49,7 @@ Flags:
 | `--sandbox-state` | `sandbox_state` | `enabled|disabled|unavailable`. |
 | `--iteration-id` | `iteration_id` | Distinct from session_id. |
 | `--risk-class` | `risk_class` | `low|medium|high|unknown`. |
-| `--incident-class` | `incident_class` | DORA ITS vocabulary. |
+| `--incident-class` | `incident_class` | Canonical 6-value Annex II field 3.23 list (JC 2024-33, 17 July 2024); legacy aliases remapped via `LEGACY_DORA_ALIASES`. |
 | `--issuer-id` | `issuer_id` | Overrides server resolution. |
 | `--receipt-type` | `receipt_type` | `protectmcp:decision|protectmcp:restraint|protectmcp:lifecycle`. Default `protectmcp:decision`. |
 | `--reason` | `reason` | Required when `--policy-decision` is `deny|rate_limit`. |

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -209,7 +209,7 @@ Field reference (camelCase on the SDK, snake_case on the JSON wire):
 - `iterationId` -> `iteration_id`. Required for multi-step receipts.
 - `sandboxState` -> `sandbox_state`. One of `enabled`, `disabled`, `unavailable`. Required for High-Risk.
 - `riskClass` -> `risk_class`. One of `low`, `medium`, `high`, `unknown`.
-- `incidentClass` -> `incident_class`. DORA ITS code; empty when not applicable.
+- `incidentClass` -> `incident_class`. Canonical 6-value Annex II field 3.23 list from JC 2024-33 (17 July 2024); legacy aliases remapped via `LEGACY_DORA_ALIASES`. Empty when not applicable.
 - `policyDecision` -> `policy_decision`. One of `permit`, `deny`, `rate_limit`.
 - `reason` -> `reason`. Required when `policyDecision` is `deny` or `rate_limit`.
 


### PR DESCRIPTION
## Summary

SDK companion sweep to the cloud-side `docs/sweep-dora-citations` PR. Aligns the public SDK docs with the corrected `-02` spec text so the wire vocabulary, the docs, and the cloud schema agree.

- `typescript/README.md`: replaces the "DORA ITS code" gloss on the `incidentClass` field with the canonical 6-value Annex II field 3.23 list (JC 2024-33, 17 July 2024) and a note that legacy receipts remap via `LEGACY_DORA_ALIASES`.
- `CHANGELOG.md`: adds an Unreleased docs entry summarizing the sweep without bumping any version.

The Python `python/docs/CLI.md` row for `--incident-class` was already corrected to the canonical list in the prior commit on this branch (`b03caf7`), so no further edit was needed on that file.

## Out of scope (intentional)

- No version bump on either Python or TypeScript packages.
- The IETF Internet-Draft URL line in the top-level `README.md`, `python/README.md`, and `typescript/README.md` already cites `draft-marques-asqav-compliance-receipts` and `draft-farley-acta-signed-receipts` by code-name without paraphrasing the upstream title; no fix to the "Signed Decision Receipts for Machine-to-Machine Access Control" naming was needed.
- `python/src/asqav/client.py`, `python/src/asqav/__init__.py`, and the related test file carry an in-flight refactor on a separate branch; this PR is docs-only and does not touch them.

## Test plan

- [ ] CI green on `docs/sweep-dora-citations`.
- [ ] `npm pack` + `pip wheel .` build cleanly with the docs change.
- [ ] Do not merge: orchestrator handles landing this together with the matching cloud PR.