### PR TITLE
fix(sdk): align DORA incident_class vocabulary with JC 2024-33 (Py + TS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,20 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
-## [Unreleased] - 2026-05-04 (docs)
+## [Unreleased: Python 0.3.11 / TypeScript 0.2.9] - 2026-05-04
+
+### Fixed
+- DORA `incident_class` vocabulary now matches the canonical six-value list from JC 2024-33 Annex II field 3.23 (the EBA / ESMA / EIOPA Joint Committee Final Report on the draft RTS and ITS on incident reporting under Regulation (EU) 2022/2554, published 17 July 2024). Previous releases forwarded an opaque string with no client-side schema, so callers passing pre-final draft tokens hit a server 422 with no actionable error.
+
+### Added
+- `DORA_INCIDENT_CLASS_NAMESPACE` (Python `frozenset`, TypeScript `as const` tuple plus `DoraIncidentClass` union) exposing the six canonical values: `cybersecurity_related`, `process_failure`, `system_failure`, `external_event`, `payment_related`, `other`.
+- `LEGACY_DORA_ALIASES` mapping the 12-value pre-final draft vocabulary the cloud accepts for backward compat (mirrors cloud PR #194). Aliases forward verbatim; the cloud performs the authoritative normalisation.
+- `sign` / `agent.sign` raise `ValueError` (Python) or `AsqavError` (TypeScript) before any HTTP call when `incident_class` is neither canonical nor a known legacy alias, matching how `RECEIPT_TYPE_NAMESPACE` is policed.
 
 ### Changed
-- DORA citation sweep aligning READMEs and docs to the corrected `-02` spec text. The vocabulary source is the canonical 6-value Annex II field 3.23 list from JC 2024-33 (17 July 2024), the EBA / ESMA / EIOPA Joint Committee Final Report on the draft RTS and ITS on incident reporting under Regulation (EU) 2022/2554. Legacy receipts continue to validate via `LEGACY_DORA_ALIASES`. CLI flag tables and TypeScript field reference updated to point at the canonical list rather than a generic "DORA ITS vocabulary" paraphrase.
+- CLI `--incident-class` help text and `python/docs/CLI.md` flag table replaced the "DORA ITS vocabulary" gloss with the canonical six values and the JC 2024-33 citation.
+- TypeScript field reference in `typescript/README.md` likewise points at the canonical list rather than a generic "DORA ITS code".
+- Docs sweep aligning READMEs to the corrected -02 spec text. Legacy receipts continue to validate via `LEGACY_DORA_ALIASES`.
 
 ## [Python 0.3.10 / TypeScript 0.2.8] - 2026-05-04
 

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -31,6 +31,8 @@ from ._jcs import canonical_json
 from .async_client import AsyncAgent
 from .canonicalize import canonicalize, hash_action
 from .client import (
+    DORA_INCIDENT_CLASS_NAMESPACE,
+    LEGACY_DORA_ALIASES,
     RECEIPT_TYPE_NAMESPACE,
     SKEW_BOUND_SECONDS,
     Agent,
@@ -277,6 +279,9 @@ __all__ = [
     "SKEW_BOUND_SECONDS",
     "ComplianceReceiptVerification",
     "verify_compliance_receipt",
+    # DORA RTS JC 2024-33 Annex II vocabulary
+    "DORA_INCIDENT_CLASS_NAMESPACE",
+    "LEGACY_DORA_ALIASES",
     # Algorithm agility
     "ALGORITHM_ML_DSA_65",
     "ALGORITHM_ED25519",

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -190,7 +190,7 @@ def sign(
     sandbox_state: str = typer.Option("", "--sandbox-state", help="enabled|disabled|unavailable."),
     iteration_id: str = typer.Option("", "--iteration-id", help="Logical task iteration id (distinct from session_id)."),
     risk_class: str = typer.Option("", "--risk-class", help="low|medium|high|unknown."),
-    incident_class: str = typer.Option("", "--incident-class", help="DORA ITS vocabulary."),
+    incident_class: str = typer.Option("", "--incident-class", help="DORA RTS JC 2024-33 Annex II field 3.23: cybersecurity_related|process_failure|system_failure|external_event|payment_related|other."),
     issuer_id: str = typer.Option("", "--issuer-id", help="Legal entity issuing this receipt; overrides server resolution."),
     receipt_type: str = typer.Option(
         "protectmcp:decision",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -203,6 +203,46 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
     }
 )
 
+# DORA RTS JC 2024-33 Annex II field 3.23 canonical incident classification.
+# The Joint Committee of the European Supervisory Authorities published
+# the final RTS on classification of major ICT-related incidents on
+# 17 July 2024 (JC 2024-33). Annex II field 3.23 fixes the controlled
+# vocabulary of `incident_class` to exactly six values. Earlier DORA
+# preliminary drafts (and the SDK's previous releases) circulated a
+# 12-value list; the cloud accepts those legacy tokens and normalises
+# them to the canonical six server-side, so this SDK forwards the
+# caller's value verbatim and only rejects tokens that are neither
+# canonical nor a known legacy alias.
+DORA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
+    {
+        "cybersecurity_related",
+        "process_failure",
+        "system_failure",
+        "external_event",
+        "payment_related",
+        "other",
+    }
+)
+
+# Legacy 12-value vocabulary from pre-final DORA drafts. Mirrored from
+# the cloud's alias dict (cloud PR #194) so the SDK can accept either
+# form without a network roundtrip. The cloud performs the authoritative
+# normalisation; this map is purely for client-side acceptance checks.
+LEGACY_DORA_ALIASES: dict[str, str] = {
+    "malicious_actions": "cybersecurity_related",
+    "cyberattack": "cybersecurity_related",
+    "unauthorised_access": "cybersecurity_related",
+    "process_failure_internal": "process_failure",
+    "human_error": "process_failure",
+    "system_failure_internal": "system_failure",
+    "software_malfunction": "system_failure",
+    "hardware_failure": "system_failure",
+    "third_party_failure": "external_event",
+    "natural_disaster": "external_event",
+    "payment_fraud": "payment_related",
+    "unknown": "other",
+}
+
 # §5.1.2 / V6 verifier MUST reject receipts whose `signed_at` sits more
 # than SKEW_BOUND_SECONDS away from the verifier's wall clock. Mirrored
 # from the cloud's `routes/verify.py:SKEW_BOUND_SECONDS`.
@@ -1171,6 +1211,20 @@ class Agent:
             raise ValueError(
                 "missing_reason: policy_decision=deny|rate_limit "
                 "requires a `reason` code."
+            )
+        # DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check (six
+        # canonical values, plus the legacy 12-value alias set the cloud
+        # still accepts). Reject anything else before the HTTP roundtrip.
+        if incident_class is not None and (
+            incident_class not in DORA_INCIDENT_CLASS_NAMESPACE
+            and incident_class not in LEGACY_DORA_ALIASES
+        ):
+            raise ValueError(
+                "invalid_incident_class: must be one of "
+                f"{sorted(DORA_INCIDENT_CLASS_NAMESPACE)} "
+                "(per DORA RTS JC 2024-33 Annex II field 3.23) "
+                "or a known legacy alias "
+                f"{sorted(LEGACY_DORA_ALIASES)}."
             )
         # F5: SDK helpfully computes action_ref under compliance_mode when
         # the caller did not pre-compute one. Same canonical form the cloud

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -31,6 +31,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 import asqav
 from asqav.canonicalize import canonicalize
 from asqav.client import (
+    DORA_INCIDENT_CLASS_NAMESPACE,
+    LEGACY_DORA_ALIASES,
     RECEIPT_TYPE_NAMESPACE,
     Agent,
     SignatureResponse,
@@ -221,7 +223,7 @@ def test_all_profile_fields_passthrough_in_body() -> None:
             iteration_id="iter_42",
             sandbox_state="enabled",
             risk_class="high",
-            incident_class="ICT-INC-001",
+            incident_class="cybersecurity_related",
             issuer_id="legal:Acme GmbH",
             payload_digest="sha256:" + "b" * 64,
         )
@@ -232,7 +234,7 @@ def test_all_profile_fields_passthrough_in_body() -> None:
     assert body["iteration_id"] == "iter_42"
     assert body["sandbox_state"] == "enabled"
     assert body["risk_class"] == "high"
-    assert body["incident_class"] == "ICT-INC-001"
+    assert body["incident_class"] == "cybersecurity_related"
     assert body["issuer_id"] == "legal:Acme GmbH"
     assert body["payload_digest"] == "sha256:" + "b" * 64
 
@@ -273,7 +275,7 @@ def test_signature_response_surfaces_new_fields() -> None:
         "iteration_id": "iter_42",
         "sandbox_state": "enabled",
         "risk_class": "high",
-        "incident_class": "ICT-INC-001",
+        "incident_class": "cybersecurity_related",
         "reason": None,
         "previousReceiptHash": "0" * 64,
     }
@@ -291,7 +293,7 @@ def test_signature_response_surfaces_new_fields() -> None:
     assert resp.iteration_id == "iter_42"
     assert resp.sandbox_state == "enabled"
     assert resp.risk_class == "high"
-    assert resp.incident_class == "ICT-INC-001"
+    assert resp.incident_class == "cybersecurity_related"
     assert resp.previous_receipt_hash == "0" * 64
 
 
@@ -347,3 +349,81 @@ def test_build_sign_body_omits_compliance_when_no_fields() -> None:
         agent_id="agent_001",
     )
     assert "compliance_mode" not in body
+
+
+# ---------------------------------------------------------------------------
+# DORA RTS JC 2024-33 Annex II vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_dora_incident_class_namespace_is_canonical_six() -> None:
+    """Namespace matches Annex II of JC 2024-33 (RTS published 17 July 2024)."""
+    assert DORA_INCIDENT_CLASS_NAMESPACE == frozenset(
+        {
+            "cybersecurity_related",
+            "process_failure",
+            "system_failure",
+            "external_event",
+            "payment_related",
+            "other",
+        }
+    )
+
+
+def test_dora_legacy_aliases_map_into_canonical_set() -> None:
+    """Every legacy alias resolves to one of the six canonical values."""
+    assert LEGACY_DORA_ALIASES, "alias dict must not be empty"
+    for legacy, canonical in LEGACY_DORA_ALIASES.items():
+        assert canonical in DORA_INCIDENT_CLASS_NAMESPACE, (
+            f"legacy alias {legacy!r} maps to non-canonical {canonical!r}"
+        )
+
+
+@pytest.mark.parametrize("value", sorted(DORA_INCIDENT_CLASS_NAMESPACE))
+def test_canonical_incident_class_passes_validation(value: str) -> None:
+    """All six canonical values are accepted and forwarded verbatim."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            incident_class=value,
+        )
+    assert captured["body"]["incident_class"] == value
+
+
+def test_legacy_incident_class_alias_is_accepted_and_forwarded() -> None:
+    """Legacy alias forwarded verbatim; cloud normalises authoritatively."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            incident_class="cyberattack",
+        )
+    assert captured["body"]["incident_class"] == "cyberattack"
+
+
+def test_invalid_incident_class_raises_before_http() -> None:
+    """A token outside both the canonical and legacy sets is rejected."""
+    with patch("asqav.client._post") as p:
+        with pytest.raises(ValueError, match="invalid_incident_class"):
+            _agent().sign(
+                "api:call",
+                {"k": "v"},
+                compliance_mode=True,
+                incident_class="ICT-INC-001",
+            )
+        p.assert_not_called()

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -30,6 +30,49 @@ export const RECEIPT_TYPE_NAMESPACE = [
 ] as const;
 export type ReceiptType = (typeof RECEIPT_TYPE_NAMESPACE)[number];
 
+/** DORA RTS JC 2024-33 Annex II field 3.23 canonical incident classification.
+ *
+ * The Joint Committee of the European Supervisory Authorities published
+ * the final RTS on classification of major ICT-related incidents on
+ * 17 July 2024 (JC 2024-33). Annex II field 3.23 fixes the controlled
+ * vocabulary of `incident_class` to exactly six values. Earlier DORA
+ * preliminary drafts (and the SDK's previous releases) circulated a
+ * 12-value list; the cloud accepts those legacy tokens and normalises
+ * them to the canonical six server-side, so this SDK forwards the
+ * caller's value verbatim and only rejects tokens that are neither
+ * canonical nor a known legacy alias.
+ */
+export const DORA_INCIDENT_CLASS_NAMESPACE = [
+  "cybersecurity_related",
+  "process_failure",
+  "system_failure",
+  "external_event",
+  "payment_related",
+  "other",
+] as const;
+export type DoraIncidentClass = (typeof DORA_INCIDENT_CLASS_NAMESPACE)[number];
+
+/** Legacy 12-value vocabulary from pre-final DORA drafts. Mirrored from
+ * the cloud's alias dict (cloud PR #194) so the SDK can accept either
+ * form without a network roundtrip. The cloud performs the authoritative
+ * normalisation; this map is purely for client-side acceptance checks.
+ */
+export const LEGACY_DORA_ALIASES: Readonly<Record<string, DoraIncidentClass>> =
+  Object.freeze({
+    malicious_actions: "cybersecurity_related",
+    cyberattack: "cybersecurity_related",
+    unauthorised_access: "cybersecurity_related",
+    process_failure_internal: "process_failure",
+    human_error: "process_failure",
+    system_failure_internal: "system_failure",
+    software_malfunction: "system_failure",
+    hardware_failure: "system_failure",
+    third_party_failure: "external_event",
+    natural_disaster: "external_event",
+    payment_fraud: "payment_related",
+    unknown: "other",
+  });
+
 /** Sandbox state vocabulary per the High-Risk gate. */
 export type SandboxState = "enabled" | "disabled" | "unavailable";
 
@@ -287,7 +330,10 @@ export interface SignOptions {
   /** Risk classification controlled vocabulary. */
   riskClass?: RiskClass;
 
-  /** DORA ITS incident class; empty string when not applicable. */
+  /** DORA RTS JC 2024-33 Annex II field 3.23 incident class; one of the
+   * six canonical values in `DORA_INCIDENT_CLASS_NAMESPACE`, or a known
+   * legacy alias from `LEGACY_DORA_ALIASES`. Empty string when not
+   * applicable. */
   incidentClass?: string;
 
   /** Names a legal entity. Resolved server-side from
@@ -779,6 +825,19 @@ export class Agent {
       && !options.reason) {
       throw new AsqavError(
         "missing_reason: policy_decision=deny|rate_limit requires a `reason` code",
+      );
+    }
+    // DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check (six
+    // canonical values, plus the legacy 12-value alias set the cloud
+    // still accepts). Reject anything else before the HTTP roundtrip.
+    if (options.incidentClass !== undefined
+      && options.incidentClass !== ""
+      && !(DORA_INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(options.incidentClass)
+      && !(options.incidentClass in LEGACY_DORA_ALIASES)) {
+      throw new AsqavError(
+        `invalid_incident_class: must be one of ${DORA_INCIDENT_CLASS_NAMESPACE.join(", ")} `
+          + "(per DORA RTS JC 2024-33 Annex II field 3.23) "
+          + `or a known legacy alias ${Object.keys(LEGACY_DORA_ALIASES).sort().join(", ")}`,
       );
     }
 

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -12,6 +12,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Agent,
   AsqavError,
+  DORA_INCIDENT_CLASS_NAMESPACE,
+  LEGACY_DORA_ALIASES,
   RECEIPT_TYPE_NAMESPACE,
   _resetForTests,
   init,
@@ -71,7 +73,7 @@ describe("agent.sign IETF profile fields", () => {
       sandboxState: "enabled",
       iterationId: "iter-7",
       riskClass: "high",
-      incidentClass: "ICT-INC-001",
+      incidentClass: "cybersecurity_related",
       issuerId: "Acme Legal Entity Ltd",
       payloadDigest: "sha256:" + "b".repeat(64),
       actionRef: "sha256:" + "c".repeat(64),
@@ -87,7 +89,7 @@ describe("agent.sign IETF profile fields", () => {
     expect(body.sandbox_state).toBe("enabled");
     expect(body.iteration_id).toBe("iter-7");
     expect(body.risk_class).toBe("high");
-    expect(body.incident_class).toBe("ICT-INC-001");
+    expect(body.incident_class).toBe("cybersecurity_related");
     expect(body.issuer_id).toBe("Acme Legal Entity Ltd");
     expect(body.payload_digest).toBe("sha256:" + "b".repeat(64));
     expect(body.receipt_type).toBe("protectmcp:decision");
@@ -187,5 +189,86 @@ describe("agent.sign IETF profile fields", () => {
         agent.sign({ actionType: "api:call", context: {}, receiptType: t }),
       ).resolves.toBeDefined();
     }
+  });
+
+  it("DORA_INCIDENT_CLASS_NAMESPACE is the canonical six values from JC 2024-33 Annex II", () => {
+    expect([...DORA_INCIDENT_CLASS_NAMESPACE].sort()).toEqual(
+      [
+        "cybersecurity_related",
+        "external_event",
+        "other",
+        "payment_related",
+        "process_failure",
+        "system_failure",
+      ],
+    );
+  });
+
+  it("every legacy DORA alias maps into the canonical six", () => {
+    const canonical = new Set<string>(DORA_INCIDENT_CLASS_NAMESPACE);
+    expect(Object.keys(LEGACY_DORA_ALIASES).length).toBeGreaterThan(0);
+    for (const [legacy, target] of Object.entries(LEGACY_DORA_ALIASES)) {
+      expect(canonical.has(target)).toBe(true);
+      expect(legacy.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("forwards every canonical incident_class without raising", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      jsonResponse({
+        signature: "s",
+        signature_id: "sig_1",
+        action_id: "act_1",
+        timestamp: "t",
+        verification_url: "u",
+      }),
+    );
+    const agent = fakeAgent();
+    for (const v of DORA_INCIDENT_CLASS_NAMESPACE) {
+      await expect(
+        agent.sign({
+          actionType: "api:call",
+          context: {},
+          complianceMode: true,
+          incidentClass: v,
+        }),
+      ).resolves.toBeDefined();
+    }
+  });
+
+  it("forwards a legacy DORA alias verbatim (cloud normalises authoritatively)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "s",
+        signature_id: "sig_1",
+        action_id: "act_1",
+        timestamp: "t",
+        verification_url: "u",
+      }),
+    );
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "api:call",
+      context: {},
+      complianceMode: true,
+      incidentClass: "cyberattack",
+    });
+    const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(calledInit.body as string) as Record<string, unknown>;
+    expect(body.incident_class).toBe("cyberattack");
+  });
+
+  it("rejects an out-of-vocabulary incident_class before any HTTP call", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "api:call",
+        context: {},
+        complianceMode: true,
+        incidentClass: "ICT-INC-001",
+      }),
+    ).rejects.toThrow(/invalid_incident_class/);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Adds canonical 6-value JC 2024-33 Annex II 3.23 namespace and 12-value legacy alias map to both SDKs. Mirrors cloud PR #194. Pre-HTTP validation rejects unknown values; legacy aliases forward verbatim (cloud performs authoritative normalisation).

- Python: `DORA_INCIDENT_CLASS_NAMESPACE`, `LEGACY_DORA_ALIASES`, validation in `Agent.sign`. Tests: 646 pass (24 in test_client_ietf_fields, 6 new DORA tests).
- TypeScript: same constants + `DoraIncidentClass` type, validation raising AsqavError. Tests: 182 pass (11 in ietfProfile, 5 new DORA tests). `tsc --noEmit` clean.
- CHANGELOG: noted Python 0.3.11 / TS 0.2.9 unreleased entry.
- Neither SDK had a prior enum (was opaque `str`); namespace added alongside RECEIPT_TYPE_NAMESPACE.