### PR TITLE
chore(release): asqav 0.3.11 + @asqav/sdk 0.2.9 (DORA vocab fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
-## [Unreleased: Python 0.3.11 / TypeScript 0.2.9] - 2026-05-04
+## [Python 0.3.11 / TypeScript 0.2.9] - 2026-05-06
 
 ### Fixed
 - DORA `incident_class` vocabulary now matches the canonical six-value list from JC 2024-33 Annex II field 3.23 (the EBA / ESMA / EIOPA Joint Committee Final Report on the draft RTS and ITS on incident reporting under Regulation (EU) 2022/2554, published 17 July 2024). Previous releases forwarded an opaque string with no client-side schema, so callers passing pre-final draft tokens hit a server 422 with no actionable error.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.10"
+version = "0.3.11"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -132,7 +132,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -32,7 +32,7 @@ import {
   type LocalSigningAlgorithm,
 } from "./index.js";
 
-const CLI_VERSION = "0.2.8";
+const CLI_VERSION = "0.2.9";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,


### PR DESCRIPTION
Patch bump for the DORA vocab work that landed in #136. CHANGELOG section already prepared (just changes the header from `Unreleased` to dated). Versions bumped in 4 places:
- `python/pyproject.toml`: 0.3.10 → 0.3.11
- `python/src/asqav/__init__.py` `__version__`: 0.3.10 → 0.3.11
- `typescript/package.json`: 0.2.8 → 0.2.9
- `typescript/src/cli.ts` `CLI_VERSION`: 0.2.8 → 0.2.9

Build verified locally: `tsc --noEmit` clean, `python -m build` produces `asqav-0.3.11.tar.gz` + `asqav-0.3.11-py3-none-any.whl`. PyPI + npm publish after CI green.