### PR TITLE
feat(sdk): accept new payload_digest object form; py 0.3.12 + ts 0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.3.12 / TypeScript 0.2.10] - 2026-05-07
+
+### Changed
+- Both SDKs accept the cloud's wire-shape-aligned `payload_digest`. The legacy `"sha256:<hex>"` string keeps parsing; the new upstream object form `{hash, size?, preview?}` (cloud 0.2.13+) parses too. Type widened on `SignatureResponse.payload_digest` (Python) and `SignActionOptions.payloadDigest` (TypeScript) to `str | dict | None` and `string | { hash; size?; preview? }` respectively.
+- No callsite or behaviour change beyond the type widening. Receipts issued by older clouds and receipts issued by 0.2.13+ both verify on the same path.
+
 ## [Python 0.3.11 / TypeScript 0.2.9] - 2026-05-06
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.11"
+version = "0.3.12"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -132,7 +132,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.11"
+__version__ = "0.3.12"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -323,7 +323,9 @@ class SignatureResponse:
     compliance_mode: bool = False
     receipt_type: str | None = None
     action_ref: str | None = None
-    payload_digest: str | None = None
+    # payload_digest accepts both shapes for back-compat: legacy
+    # "sha256:<hex>" string or the wire object form {"hash", "size"}.
+    payload_digest: str | dict[str, Any] | None = None
     issuer_id: str | None = None
     iteration_id: str | None = None
     sandbox_state: str | None = None
@@ -1112,7 +1114,7 @@ class Agent:
         compliance_mode: bool = False,
         receipt_type: str | None = None,
         action_ref: str | None = None,
-        payload_digest: str | None = None,
+        payload_digest: str | dict[str, Any] | None = None,
         issuer_id: str | None = None,
         iteration_id: str | None = None,
         sandbox_state: str | None = None,

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -32,7 +32,7 @@ import {
   type LocalSigningAlgorithm,
 } from "./index.js";
 
-const CLI_VERSION = "0.2.9";
+const CLI_VERSION = "0.2.10";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -340,9 +340,10 @@ export interface SignOptions {
    * `Organization.legal_entity` when omitted. */
   issuerId?: string;
 
-  /** `sha256:<hex>` of the request payload. Conceptually the same value
-   * as `context_hash`; emitted under both names for one release. */
-  payloadDigest?: string;
+  /** Digest of the request payload. Accepts the legacy
+   * `"sha256:<hex>"` string or the wire object form
+   * `{ hash, size?, preview? }`. */
+  payloadDigest?: string | { hash: string; size?: number; preview?: string };
 
   /** Receipt namespace. One of `protectmcp:decision` |
    * `protectmcp:restraint` | `protectmcp:lifecycle`. Defaults to


### PR DESCRIPTION
## Summary

Cloud 0.2.13 (PR jagmarques/asqav#202) shifted the Compliance Receipt `payload_digest` from the legacy `"sha256:<hex>"` string to the upstream object form `{hash, size?, preview?}`. This PR widens both SDK readers to accept either shape.

## What changed

- **Python**: `SignatureResponse.payload_digest` and `Agent.sign(..., payload_digest=...)` parameter widened from `str | None` to `str | dict[str, Any] | None`.
- **TypeScript**: `SignActionOptions.payloadDigest` widened from `string` to `string | { hash: string; size?: number; preview?: string }`.
- Versions: `asqav 0.3.11 -> 0.3.12`, `@asqav/sdk 0.2.9 -> 0.2.10`.

## Back-compat

- Legacy callers passing `"sha256:<hex>"` keep working byte-stable.
- Legacy receipts in customer storage continue to parse via `verify_compliance_receipt` (presence-only check, shape-agnostic).

## Test plan

- [x] Python AST-clean.
- [x] TypeScript `tsc --noEmit` passes.
- [ ] CI green on this branch.
- [ ] Tag-trigger publishes succeed: `py-v0.3.12` -> PyPI, `ts-v0.2.10` -> npm.