### PR TITLE
feat(sdk): accept signature object form + incident_class array; py 0.3.13 + ts 0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.3.13 / TypeScript 0.2.11] - 2026-05-08
+
+### Changed
+- Both SDK readers accept the new `signature` object form (cloud 0.2.14+) directly, falling back to `signatureObject` for older clouds. Polymorphic `signature: string | object` typed across the public surface. `kid` is read from `kid`, `issuer_id`, or `key_id` in that order.
+- `incident_class` widened to `string | string[] | undefined`. Validator runs vocabulary check element-wise. Array form covers multi-regime cases (e.g. simultaneously DORA + CIRCIA).
+
 ## [Python 0.3.12 / TypeScript 0.2.10] - 2026-05-07
 
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.12"
+version = "0.3.13"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -132,7 +132,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.12"
+__version__ = "0.3.13"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -330,7 +330,8 @@ class SignatureResponse:
     iteration_id: str | None = None
     sandbox_state: str | None = None
     risk_class: str | None = None
-    incident_class: str | None = None
+    # str or list of strings for multi-regime cases.
+    incident_class: str | list[str] | None = None
     reason: str | None = None
     previous_receipt_hash: str | None = None
     # IETF -01 N3 / Section 4.2.1: spec-shape `decision` token mirrors
@@ -1119,7 +1120,7 @@ class Agent:
         iteration_id: str | None = None,
         sandbox_state: str | None = None,
         risk_class: str | None = None,
-        incident_class: str | None = None,
+        incident_class: str | list[str] | None = None,
         reason: str | None = None,
         policy_decision: str = "permit",
     ) -> SignatureResponse:
@@ -1324,7 +1325,12 @@ class Agent:
                     else None
                 )
             ),
-            signatureObject=data.get("signatureObject"),
+            # signature may arrive as the object form directly or under signatureObject.
+            signatureObject=(
+                data["signature"]
+                if isinstance(data.get("signature"), dict)
+                else data.get("signatureObject")
+            ),
             anchors=data.get("anchors"),
         )
 

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -25,6 +25,10 @@ def signature_object_from_response(response: Any) -> dict[str, str] | None:
     when the response is non-compliance (no `compliance_mode=True`) so
     legacy receipts are not silently re-shaped.
     """
+    # signature may be the object form directly or under signatureObject.
+    direct_signature = _get(response, "signature")
+    if isinstance(direct_signature, dict) and direct_signature:
+        return dict(direct_signature)
     cloud_supplied = _get(response, "signatureObject")
     if isinstance(cloud_supplied, dict) and cloud_supplied:
         return dict(cloud_supplied)
@@ -33,11 +37,9 @@ def signature_object_from_response(response: Any) -> dict[str, str] | None:
         return None
 
     alg = _get(response, "algorithm") or ""
-    sig = _get(response, "signature") or ""
-    # `key_id` is not surfaced on the dataclass today; cloud will pass
-    # it via `signatureObject` once available. Fall back to the empty
-    # string so the envelope keeps the spec-shape three keys.
-    kid = _get(response, "key_id") or _get(response, "kid") or ""
+    sig = _get(response, "signature_b64") or _get(response, "signature") or ""
+    sig = sig if isinstance(sig, str) else ""
+    kid = _get(response, "kid") or _get(response, "issuer_id") or _get(response, "key_id") or ""
     return {"alg": alg, "kid": kid, "sig": sig}
 
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -32,7 +32,7 @@ import {
   type LocalSigningAlgorithm,
 } from "./index.js";
 
-const CLI_VERSION = "0.2.10";
+const CLI_VERSION = "0.2.11";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/ietfProjection.ts
+++ b/typescript/src/ietfProjection.ts
@@ -34,9 +34,14 @@ export interface AnchorEntry {
  * projection helpers read. */
 export interface ProjectableResponse {
   algorithm?: string;
-  signature?: string;
+  // signature is either the object form or a base64 string.
+  signature?: string | SignatureEnvelope;
+  signature_b64?: string;
+  signatureB64?: string;
   key_id?: string;
   kid?: string;
+  issuer_id?: string;
+  issuerId?: string;
   complianceMode?: boolean;
   compliance_mode?: boolean;
   signatureObject?: SignatureEnvelope | null;
@@ -72,15 +77,25 @@ export function signatureObjectFromResponse(
   response: ProjectableResponse | null | undefined,
 ): SignatureEnvelope | undefined {
   if (response == null) return undefined;
+  const directSignature = response.signature;
+  if (
+    directSignature &&
+    typeof directSignature === "object" &&
+    "alg" in directSignature
+  ) {
+    return { ...(directSignature as SignatureEnvelope) };
+  }
   if (response.signatureObject) {
-    // Spread to a fresh object so callers cannot mutate the source.
     return { ...response.signatureObject };
   }
   if (!isComplianceMode(response)) return undefined;
+  const flatSig =
+    typeof directSignature === "string" ? directSignature : undefined;
   return {
     alg: pick<string>(response, "algorithm") ?? "",
-    kid: pick<string>(response, "key_id", "kid") ?? "",
-    sig: pick<string>(response, "signature") ?? "",
+    kid:
+      pick<string>(response, "kid", "issuer_id", "issuerId", "key_id") ?? "",
+    sig: pick<string>(response, "signature_b64", "signatureB64") ?? flatSig ?? "",
   };
 }
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -330,11 +330,9 @@ export interface SignOptions {
   /** Risk classification controlled vocabulary. */
   riskClass?: RiskClass;
 
-  /** DORA RTS JC 2024-33 Annex II field 3.23 incident class; one of the
-   * six canonical values in `DORA_INCIDENT_CLASS_NAMESPACE`, or a known
-   * legacy alias from `LEGACY_DORA_ALIASES`. Empty string when not
-   * applicable. */
-  incidentClass?: string;
+  /** Incident class; canonical string or array of strings for
+   * multi-regime cases. */
+  incidentClass?: string | string[];
 
   /** Names a legal entity. Resolved server-side from
    * `Organization.legal_entity` when omitted. */
@@ -831,15 +829,21 @@ export class Agent {
     // DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check (six
     // canonical values, plus the legacy 12-value alias set the cloud
     // still accepts). Reject anything else before the HTTP roundtrip.
-    if (options.incidentClass !== undefined
-      && options.incidentClass !== ""
-      && !(DORA_INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(options.incidentClass)
-      && !(options.incidentClass in LEGACY_DORA_ALIASES)) {
-      throw new AsqavError(
-        `invalid_incident_class: must be one of ${DORA_INCIDENT_CLASS_NAMESPACE.join(", ")} `
-          + "(per DORA RTS JC 2024-33 Annex II field 3.23) "
-          + `or a known legacy alias ${Object.keys(LEGACY_DORA_ALIASES).sort().join(", ")}`,
-      );
+    if (options.incidentClass !== undefined && options.incidentClass !== "") {
+      const incidentValues = Array.isArray(options.incidentClass)
+        ? options.incidentClass
+        : [options.incidentClass];
+      for (const ic of incidentValues) {
+        if (
+          !(DORA_INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)
+          && !(ic in LEGACY_DORA_ALIASES)
+        ) {
+          throw new AsqavError(
+            `invalid_incident_class: '${ic}' must be one of ${DORA_INCIDENT_CLASS_NAMESPACE.join(", ")} `
+              + `or a known legacy alias ${Object.keys(LEGACY_DORA_ALIASES).sort().join(", ")}`,
+          );
+        }
+      }
     }
 
     // Compute action_ref client-side when the caller is in compliance


### PR DESCRIPTION
## Summary

Cloud 0.2.14 (asqav#203) emits `signature` directly as the spec object form `{alg, kid, sig}` and accepts `incident_class` as an array for multi-regime cases. This PR widens both SDK readers to accept the new shapes while staying back-compat with prior clouds.

## What changed

- **Python** `signatureObjectFromResponse` / `signature_object_from_response`: read `signature` directly when it's a dict; fall back to `signatureObject`; final fallback to flat fields with `kid` resolution from `kid` -> `issuer_id` -> `key_id`.
- **TypeScript** mirror in `ietfProjection.ts`. `ProjectableResponse.signature` typed as `string | SignatureEnvelope`.
- Both SDKs widen `incident_class` / `incidentClass` to `str | list[str]` / `string | string[]`. Validator runs element-wise.
- Versions: `asqav 0.3.12 -> 0.3.13`, `@asqav/sdk 0.2.10 -> 0.2.11`.

## Back-compat

- Legacy callers passing string-form `signature`, `incidentClass`, etc. keep working byte-stable.
- Legacy receipts in customer storage continue to parse via `verify_compliance_receipt` (presence-only check, shape-agnostic).

## Test plan

- [x] Python AST clean.
- [x] TypeScript `tsc --noEmit` passes.
- [ ] CI green.
- [ ] Tag-trigger publishes succeed: `py-v0.3.13` -> PyPI, `ts-v0.2.11` -> npm.