### PR TITLE
feat(sdk): three-key Compliance Receipts envelope; py 0.4.0 + ts 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.4.0 / TypeScript 0.3.0] - 2026-05-08
+
+### Changed
+- **Wire shape**: under `compliance_mode`, the cloud emits the three-key Compliance Receipts envelope `{payload, signature, anchors}` plus pure metadata. The SDKs expose `payload`, `signature` (polymorphic: string in legacy, `{alg, kid, sig}` object form under compliance_mode), and `anchors` directly on `SignatureResponse`.
+- **Removed `signatureObject`**: the polymorphic `signature` field carries the same value. Use `response.signature_envelope()` (Python) or `signatureEnvelope(response)` (TypeScript) for the dict form.
+- **Removed flat-field projection fallbacks**: the projection helpers no longer rebuild `{alg, kid, sig}` from `algorithm` + `signature_b64`. Older receipts return None / undefined from the helpers.
+- **Anchor entries carry `commit_hash`** sourced from the cloud's `anchor_commit_hash` column. Field is `None` on legacy rows.
+
 ## [Python 0.3.13 / TypeScript 0.2.11] - 2026-05-08
 
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.3.13"
+version = "0.4.0"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -132,7 +132,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.3.13"
+__version__ = "0.4.0"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -295,7 +295,9 @@ class SignatureResponse:
     cryptographically signed action from one that is also Bitcoin-anchored.
     """
 
-    signature: str
+    # Polymorphic: str (b64) for legacy, {alg, kid, sig} dict under
+    # compliance_mode. Use signature_envelope() for the dict form.
+    signature: str | dict[str, str]
     signature_id: str
     action_id: str
     timestamp: float
@@ -317,7 +319,7 @@ class SignatureResponse:
     countersign_url: str | None = None
     # True when the server validated a user_intent envelope on this record.
     user_intent_verified: bool | None = None
-    # IETF Compliance Receipts profile fields. Populated by the cloud only
+    # Compliance Receipts profile fields. Populated by the cloud only
     # when `compliance_mode=True` was passed on the sign call. None on
     # legacy receipts so callers can branch cleanly.
     compliance_mode: bool = False
@@ -334,45 +336,33 @@ class SignatureResponse:
     incident_class: str | list[str] | None = None
     reason: str | None = None
     previous_receipt_hash: str | None = None
-    # IETF -01 N3 / Section 4.2.1: spec-shape `decision` token mirrors
-    # `policy_decision` with the spec vocabulary {"allow", "deny",
-    # "rate_limit"}. Mapped client-side from `policy_decision` ("permit"
-    # -> "allow") so callers reading `.decision` get the spec value
-    # without having to know the legacy mapping. None on non-compliance
-    # receipts so legacy code paths stay byte-stable.
+    # Spec `decision` token (allow | deny | rate_limit). None on
+    # non-compliance receipts.
     decision: str | None = None
-    # IETF -01 N6: spec-shape signature envelope object {alg, kid, sig}
-    # surfaced as `signatureObject` on the wire. Cloud emits it directly
-    # under compliance_mode; older clouds populate the flat fields and
-    # the SDK projects via `signature_object()` below.
-    signatureObject: dict[str, str] | None = None
-    # IETF -01 N7: spec-shape anchors array. Cloud emits it directly;
-    # older clouds populate the flat fields and the SDK projects via
-    # `anchors_array()` below.
+    # Three-key Compliance Receipts envelope. `payload` is the canonical
+    # signed dict; `anchors` is the type-discriminated array. None on
+    # legacy receipts.
+    payload: dict[str, Any] | None = None
     anchors: list[dict[str, Any]] | None = None
 
-    def signature_object(self) -> dict[str, str] | None:
+    def signature_envelope(self) -> dict[str, str] | None:
         """Return the spec-shape signature envelope `{alg, kid, sig}`.
 
-        IETF -01 N6 / Section 4. Returns the cloud-supplied
-        `signatureObject` when available, else projects from the flat
-        fields. None for non-compliance receipts.
+        Returns the cloud-supplied object form when present (compliance
+        mode); None otherwise.
         """
-        from .ietf_projection import signature_object_from_response
-
-        return signature_object_from_response(self)
+        if isinstance(self.signature, dict):
+            keys = set(self.signature.keys())
+            if keys >= {"alg", "kid", "sig"}:
+                return self.signature  # type: ignore[return-value]
+        return None
 
     def anchors_array(self) -> list[dict[str, Any]] | None:
-        """Return the spec-shape `anchors[]` array.
-
-        IETF -01 N7 / Section 4.4. Returns the cloud-supplied list when
-        available, else projects from the flat columns. None for
-        non-compliance receipts; [] when compliance_mode is on but no
-        anchor columns are populated.
+        """Return the cloud-supplied `anchors[]` array. None on
+        non-compliance receipts; [] under compliance_mode before
+        anchors land.
         """
-        from .ietf_projection import anchors_from_response
-
-        return anchors_from_response(self)
+        return self.anchors
 
 
 @dataclass
@@ -1325,12 +1315,7 @@ class Agent:
                     else None
                 )
             ),
-            # signature may arrive as the object form directly or under signatureObject.
-            signatureObject=(
-                data["signature"]
-                if isinstance(data.get("signature"), dict)
-                else data.get("signatureObject")
-            ),
+            payload=data.get("payload"),
             anchors=data.get("anchors"),
         )
 

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -1,14 +1,10 @@
-"""IETF Compliance Receipts -01 wire-shape projection helpers.
+"""Compliance Receipts wire-shape projection helpers.
 
-Mirror of `asqav_cloud.core.ietf_projection`. Pure functions that
-re-shape the legacy flat fields (algorithm/key_id/signature_b64) into
-the spec-shape JSON structures the IETF profile defines (Section 4
-"JSON Receipt Structure").
-
-Callers use these helpers to produce a draft-conformant view of a
-receipt for offline verification or audit-pack export when working
-against an older cloud that does not yet emit `signatureObject`
-directly.
+Pure helpers for offline analysis of a receipt: extract the spec-shape
+signature envelope `{alg, kid, sig}` and the anchors[] array. The
+cloud emits the three-key envelope directly under compliance_mode; the
+helpers below return the cloud-supplied values and None on legacy
+receipts.
 """
 
 from __future__ import annotations
@@ -16,80 +12,31 @@ from __future__ import annotations
 from typing import Any
 
 
-def signature_object_from_response(response: Any) -> dict[str, str] | None:
-    """Project a SignatureResponse / verify dict into `{alg, kid, sig}`.
+def signature_envelope_from_response(response: Any) -> dict[str, str] | None:
+    """Return `{alg, kid, sig}` when the response carries it, else None.
 
-    Returns the cloud-supplied `signatureObject` when present so callers
-    do not double-project; otherwise builds the envelope from the flat
-    fields (`algorithm`, `key_id` if exposed, `signature`). Returns None
-    when the response is non-compliance (no `compliance_mode=True`) so
-    legacy receipts are not silently re-shaped.
+    The cloud emits `signature` as the object form under compliance_mode
+    and as a base64 string in legacy mode. None on legacy receipts so
+    callers can branch cleanly.
     """
-    # signature may be the object form directly or under signatureObject.
-    direct_signature = _get(response, "signature")
-    if isinstance(direct_signature, dict) and direct_signature:
-        return dict(direct_signature)
-    cloud_supplied = _get(response, "signatureObject")
-    if isinstance(cloud_supplied, dict) and cloud_supplied:
-        return dict(cloud_supplied)
-
-    if not _get(response, "compliance_mode"):
-        return None
-
-    alg = _get(response, "algorithm") or ""
-    sig = _get(response, "signature_b64") or _get(response, "signature") or ""
-    sig = sig if isinstance(sig, str) else ""
-    kid = _get(response, "kid") or _get(response, "issuer_id") or _get(response, "key_id") or ""
-    return {"alg": alg, "kid": kid, "sig": sig}
+    sig = _get(response, "signature")
+    if isinstance(sig, dict):
+        keys = set(sig.keys())
+        if keys >= {"alg", "kid", "sig"}:
+            return dict(sig)
+    return None
 
 
 def anchors_from_response(response: Any) -> list[dict[str, Any]] | None:
-    """Project a SignatureResponse / verify dict into `anchors[]`.
+    """Return the `anchors[]` array when present, else None.
 
-    IETF -01 N7 / Section 4.4. Returns the cloud-supplied list when
-    present (deep-copied so callers cannot mutate the response),
-    otherwise builds entries from the flat columns
-    (`rfc3161_serial`, `rfc3161_tsa`, `bitcoin_anchor.status`).
-    Returns None when the response is non-compliance so legacy
-    callers stay byte-stable; returns [] (not None) when
-    compliance_mode is on but no anchor columns are populated.
+    Cloud emits the array directly under compliance_mode (possibly as
+    []). None on legacy receipts.
     """
-    cloud_supplied = _get(response, "anchors")
-    if isinstance(cloud_supplied, list):
-        return [dict(e) for e in cloud_supplied]
-
-    if not _get(response, "compliance_mode"):
-        return None
-
-    anchors: list[dict[str, Any]] = []
-
-    rfc3161_serial = _get(response, "rfc3161_serial")
-    rfc3161_tsa = _get(response, "rfc3161_tsa")
-    if rfc3161_serial or rfc3161_tsa:
-        entry: dict[str, Any] = {"type": "rfc3161", "value": ""}
-        if rfc3161_serial:
-            entry["serial"] = rfc3161_serial
-        if rfc3161_tsa:
-            entry["tsa"] = rfc3161_tsa
-        anchors.append(entry)
-
-    bitcoin_anchor = _get(response, "bitcoin_anchor")
-    if bitcoin_anchor is not None:
-        # The SDK BitcoinAnchor dataclass exposes `status`; the OTS
-        # proof bytes are not in the SDK type, so we surface a
-        # presence-only entry. Strict verifiers ignore this projection
-        # unless the cloud has populated `anchors[]` directly.
-        status = _get(bitcoin_anchor, "status")
-        if status:
-            anchors.append(
-                {
-                    "type": "opentimestamps",
-                    "value": "",
-                    "status": status,
-                }
-            )
-
-    return anchors
+    anchors = _get(response, "anchors")
+    if isinstance(anchors, list):
+        return [dict(e) for e in anchors]
+    return None
 
 
 def encode_anchor_value(raw: bytes) -> str:
@@ -100,7 +47,6 @@ def encode_anchor_value(raw: bytes) -> str:
 
 
 def _get(obj: Any, name: str) -> Any:
-    """Read attribute or dict key, whichever exists. None when absent."""
     if obj is None:
         return None
     if isinstance(obj, dict):

--- a/python/tests/test_client_ietf_projection.py
+++ b/python/tests/test_client_ietf_projection.py
@@ -1,18 +1,21 @@
-"""IETF -01 N6 / S2: SDK-side `signature_object()` projection helper.
+"""SDK projection helpers for the three-key Compliance Receipts envelope.
 
-`signature_object()` returns `{alg, kid, sig}` per Section 4
-"JSON Receipt Structure". Gated on `compliance_mode=True`; legacy
-receipts get None back so the additive overlay stays byte-stable.
+`SignatureResponse.signature_envelope()` returns `{alg, kid, sig}` when
+the response carries the object form, None otherwise. `anchors_array()`
+returns the cloud-supplied `anchors` list (possibly empty), None on
+legacy receipts.
 """
 
 from __future__ import annotations
 
 from asqav.client import SignatureResponse
-from asqav.ietf_projection import signature_object_from_response
+from asqav.ietf_projection import (
+    anchors_from_response,
+    signature_envelope_from_response,
+)
 
 
-def test_signature_object_none_for_non_compliance_response():
-    """Non-compliance receipts MUST get None back."""
+def test_legacy_response_signature_envelope_is_none():
     resp = SignatureResponse(
         signature="ZmFrZQ==",
         signature_id="sig_test",
@@ -20,56 +23,66 @@ def test_signature_object_none_for_non_compliance_response():
         timestamp=0.0,
         verification_url="https://verify/example",
     )
-    assert resp.signature_object() is None
+    assert resp.signature_envelope() is None
 
 
-def test_signature_object_returns_cloud_supplied_when_present():
-    """When the cloud emits `signatureObject`, the SDK passes it through."""
+def test_compliance_response_signature_envelope_returns_object_form():
     envelope = {"alg": "ML-DSA-65", "kid": "key_abc", "sig": "ZmFrZQ=="}
     resp = SignatureResponse(
-        signature="ZmFrZQ==",
+        signature=envelope,
         signature_id="sig_test",
         action_id="act_test",
         timestamp=0.0,
         verification_url="https://verify/example",
         compliance_mode=True,
-        signatureObject=envelope,
     )
-    out = resp.signature_object()
+    out = resp.signature_envelope()
     assert out == envelope
-    # Returned dict is a copy (callers cannot mutate the response).
-    out["sig"] = "MUTATED"
-    assert resp.signatureObject["sig"] == "ZmFrZQ=="
 
 
-def test_signature_object_projects_from_flat_fields_under_compliance():
-    """Older clouds without `signatureObject` get projected from flats."""
+def test_signature_envelope_helper_dict_input():
+    envelope = {"alg": "Ed25519", "kid": "k1", "sig": "s"}
+    out = signature_envelope_from_response(
+        {"compliance_mode": True, "signature": envelope}
+    )
+    assert out == envelope
+
+
+def test_signature_envelope_helper_legacy_dict_returns_none():
+    assert (
+        signature_envelope_from_response({"signature": "ZmFrZQ=="})
+        is None
+    )
+
+
+def test_anchors_array_passthrough():
+    cloud_anchors = [
+        {"type": "rfc3161", "value": "ZmFrZQ==", "commit_hash": "h" * 64}
+    ]
+    resp = SignatureResponse(
+        signature={"alg": "ML-DSA-65", "kid": "k", "sig": "s"},
+        signature_id="sig_test",
+        action_id="act_test",
+        timestamp=0.0,
+        verification_url="https://verify/example",
+        compliance_mode=True,
+        anchors=cloud_anchors,
+    )
+    assert resp.anchors_array() == cloud_anchors
+
+
+def test_anchors_array_legacy_is_none():
     resp = SignatureResponse(
         signature="ZmFrZQ==",
         signature_id="sig_test",
         action_id="act_test",
         timestamp=0.0,
         verification_url="https://verify/example",
-        algorithm="ML-DSA-65",
-        compliance_mode=True,
     )
-    out = resp.signature_object()
-    assert set(out.keys()) == {"alg", "kid", "sig"}
-    assert out["alg"] == "ML-DSA-65"
-    # kid not exposed on the dataclass yet -> empty string.
-    assert out["kid"] == ""
-    assert out["sig"] == "ZmFrZQ=="
+    assert resp.anchors_array() is None
 
 
-def test_signature_object_helper_works_on_dict_input():
-    """The free helper accepts both objects and dicts (verify response)."""
-    envelope = {"alg": "ML-DSA-65", "kid": "key_abc", "sig": "ZmFrZQ=="}
-    out = signature_object_from_response(
-        {"compliance_mode": True, "signatureObject": envelope}
-    )
-    assert out == envelope
-
-
-def test_signature_object_helper_none_for_legacy_dict():
-    """Dict input without compliance_mode returns None."""
-    assert signature_object_from_response({"algorithm": "ML-DSA-65"}) is None
+def test_anchors_helper_dict_input():
+    out = anchors_from_response({"anchors": [{"type": "rfc3161"}]})
+    assert out == [{"type": "rfc3161"}]
+    assert anchors_from_response({}) is None

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "asqav"
-version = "0.3.9"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/ietfProjection.ts
+++ b/typescript/src/ietfProjection.ts
@@ -1,110 +1,57 @@
 /**
- * IETF Compliance Receipts -01 wire-shape projection helpers.
+ * Compliance Receipts wire-shape projection helpers.
  *
- * Mirror of `asqav.ietf_projection` (Python) and
- * `asqav_cloud.core.ietf_projection`. Pure functions that re-shape the
- * legacy flat fields into the spec-shape JSON structures the IETF
- * profile defines (Section 4 "JSON Receipt Structure" + Section 4.4
- * "Anchors").
- *
- * Callers use these helpers to produce a draft-conformant view of a
- * receipt for offline verification or audit-pack export when working
- * against an older cloud that does not yet emit `signatureObject` /
- * `anchors` directly.
+ * Pure helpers for offline analysis of a receipt: extract the
+ * spec-shape signature envelope `{alg, kid, sig}` and the anchors[]
+ * array. The cloud emits the three-key envelope directly under
+ * compliance_mode; the helpers below return the cloud-supplied values
+ * and undefined on legacy receipts.
  */
 
-/** Spec-shape signature envelope per Section 4. */
+/** Spec-shape signature envelope. */
 export interface SignatureEnvelope {
   alg: string;
   kid: string;
   sig: string;
 }
 
-/** Spec-shape anchor entry per Section 4.4. */
+/** Spec-shape anchor entry. */
 export interface AnchorEntry {
   type: "rfc3161" | "opentimestamps" | string;
   value: string;
   serial?: string;
   tsa?: string;
   status?: string;
+  commit_hash?: string | null;
   [key: string]: unknown;
 }
 
 /** Minimal duck-typed slice of a SignatureResponse / verify dict the
  * projection helpers read. */
 export interface ProjectableResponse {
-  algorithm?: string;
-  // signature is either the object form or a base64 string.
   signature?: string | SignatureEnvelope;
-  signature_b64?: string;
-  signatureB64?: string;
-  key_id?: string;
-  kid?: string;
-  issuer_id?: string;
-  issuerId?: string;
+  anchors?: AnchorEntry[] | null;
+  payload?: Record<string, unknown> | null;
   complianceMode?: boolean;
   compliance_mode?: boolean;
-  signatureObject?: SignatureEnvelope | null;
-  anchors?: AnchorEntry[] | null;
-  rfc3161_serial?: string;
-  rfc3161_tsa?: string;
-  rfc3161Serial?: string;
-  rfc3161Tsa?: string;
-  bitcoinAnchor?: { status?: string } | null;
-  bitcoin_anchor?: { status?: string } | null;
   [key: string]: unknown;
 }
 
-function pick<T>(obj: ProjectableResponse, ...names: string[]): T | undefined {
-  for (const n of names) {
-    const v = (obj as Record<string, unknown>)[n];
-    if (v !== undefined && v !== null) return v as T;
+/** Return `{alg, kid, sig}` when the response carries the object form,
+ *  else undefined. The cloud emits `signature` as the object form under
+ *  compliance_mode and as a base64 string in legacy mode. */
+export function signatureEnvelopeFromResponse(
+  response: ProjectableResponse | null | undefined,
+): SignatureEnvelope | undefined {
+  if (response == null) return undefined;
+  const sig = response.signature;
+  if (sig && typeof sig === "object" && "alg" in sig && "kid" in sig && "sig" in sig) {
+    return { ...(sig as SignatureEnvelope) };
   }
   return undefined;
 }
 
-function isComplianceMode(obj: ProjectableResponse): boolean {
-  return Boolean(pick<boolean>(obj, "complianceMode", "compliance_mode"));
-}
-
-/** Project a SignatureResponse / verify dict into `{alg, kid, sig}`.
- *
- * Returns the cloud-supplied `signatureObject` when present so callers
- * do not double-project; otherwise builds the envelope from the flat
- * fields. Returns `undefined` for non-compliance receipts so legacy
- * callers stay byte-stable. */
-export function signatureObjectFromResponse(
-  response: ProjectableResponse | null | undefined,
-): SignatureEnvelope | undefined {
-  if (response == null) return undefined;
-  const directSignature = response.signature;
-  if (
-    directSignature &&
-    typeof directSignature === "object" &&
-    "alg" in directSignature
-  ) {
-    return { ...(directSignature as SignatureEnvelope) };
-  }
-  if (response.signatureObject) {
-    return { ...response.signatureObject };
-  }
-  if (!isComplianceMode(response)) return undefined;
-  const flatSig =
-    typeof directSignature === "string" ? directSignature : undefined;
-  return {
-    alg: pick<string>(response, "algorithm") ?? "",
-    kid:
-      pick<string>(response, "kid", "issuer_id", "issuerId", "key_id") ?? "",
-    sig: pick<string>(response, "signature_b64", "signatureB64") ?? flatSig ?? "",
-  };
-}
-
-/** Project a SignatureResponse / verify dict into `anchors[]`.
- *
- * Returns the cloud-supplied list when present (deep-copied), otherwise
- * builds entries from the flat columns. Returns `undefined` for
- * non-compliance receipts; returns `[]` (not undefined) when
- * complianceMode is on but no anchor columns are populated. */
+/** Return the `anchors[]` array when present, else undefined. */
 export function anchorsFromResponse(
   response: ProjectableResponse | null | undefined,
 ): AnchorEntry[] | undefined {
@@ -112,30 +59,7 @@ export function anchorsFromResponse(
   if (Array.isArray(response.anchors)) {
     return response.anchors.map((e) => ({ ...e }));
   }
-  if (!isComplianceMode(response)) return undefined;
-
-  const anchors: AnchorEntry[] = [];
-
-  const rfc3161Serial = pick<string>(response, "rfc3161Serial", "rfc3161_serial");
-  const rfc3161Tsa = pick<string>(response, "rfc3161Tsa", "rfc3161_tsa");
-  if (rfc3161Serial || rfc3161Tsa) {
-    const entry: AnchorEntry = { type: "rfc3161", value: "" };
-    if (rfc3161Serial) entry.serial = rfc3161Serial;
-    if (rfc3161Tsa) entry.tsa = rfc3161Tsa;
-    anchors.push(entry);
-  }
-
-  const bitcoinAnchor = pick<{ status?: string }>(
-    response,
-    "bitcoinAnchor",
-    "bitcoin_anchor",
-  );
-  const status = bitcoinAnchor?.status;
-  if (status) {
-    anchors.push({ type: "opentimestamps", value: "", status });
-  }
-
-  return anchors;
+  return undefined;
 }
 
 /** Helper for callers that hold raw anchor bytes locally. */

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -135,9 +135,9 @@ export {
 export { resolveMode, isAsqavCloudHost, type Mode } from "./mode.js";
 export { BudgetTracker, type BudgetCheckResult, type BudgetTrackerOptions } from "./budget.js";
 
-// IETF -01 wire-shape projection helpers (Section 4 + Section 4.4).
+// Compliance Receipts wire-shape projection helpers.
 export {
-  signatureObjectFromResponse,
+  signatureEnvelopeFromResponse,
   anchorsFromResponse,
   encodeAnchorValue,
   type SignatureEnvelope,
@@ -146,24 +146,22 @@ export {
 } from "./ietfProjection.js";
 
 import {
-  signatureObjectFromResponse as _signatureObjectFromResponse,
+  signatureEnvelopeFromResponse as _signatureEnvelopeFromResponse,
   anchorsFromResponse as _anchorsFromResponse,
   type SignatureEnvelope,
   type AnchorEntry,
 } from "./ietfProjection.js";
 
-/** IETF -01 N6 ergonomic wrapper. Returns the spec-shape envelope
- * `{alg, kid, sig}` for a SignatureResponse, projecting from flat
- * fields when the cloud has not emitted `signatureObject` directly. */
-export function signatureObject(
+/** Return the spec-shape envelope `{alg, kid, sig}` for a
+ * SignatureResponse, or undefined for legacy receipts. */
+export function signatureEnvelope(
   response: SignatureResponse | null | undefined,
 ): SignatureEnvelope | undefined {
-  return _signatureObjectFromResponse(response as never);
+  return _signatureEnvelopeFromResponse(response as never);
 }
 
-/** IETF -01 N7 ergonomic wrapper. Returns the spec-shape `anchors[]`
- * for a SignatureResponse, projecting from flat fields when the cloud
- * has not emitted `anchors` directly. */
+/** Return the cloud-supplied `anchors[]` array, or undefined for
+ * legacy receipts. */
 export function anchors(
   response: SignatureResponse | null | undefined,
 ): AnchorEntry[] | undefined {
@@ -365,7 +363,10 @@ export interface CoSignature {
 }
 
 export interface SignatureResponse {
-  signature: string;
+  /** Polymorphic. Base64 string in legacy mode, `{alg, kid, sig}` object
+   * form under compliance_mode. Use `signatureEnvelope()` for the dict
+   * form. */
+  signature: string | SignatureEnvelope;
   signatureId: string;
   actionId: string;
   timestamp: string;
@@ -403,15 +404,12 @@ export interface SignatureResponse {
    * (newer servers) or mapped client-side from `policyDecision`
    * (older servers). Undefined for non-compliance receipts. */
   decision?: Decision;
-  /** IETF -01 N6 / Section 4: spec-shape signature envelope object
-   * `{alg, kid, sig}`. Surfaced as `signatureObject` because the
-   * top-level `signature` field is already occupied by the legacy
-   * base64 flat string. Use `signatureObject()` to project from flat
-   * fields when the cloud has not emitted it directly. */
-  signatureObject?: SignatureEnvelope;
-  /** IETF -01 N7 / Section 4.4: spec-shape anchors array. Use
-   * `anchors()` to project from flat fields when the cloud has not
-   * emitted it directly. */
+  /** Compliance Receipts envelope: the canonical signed dict. None on
+   * legacy receipts. */
+  payload?: Record<string, unknown>;
+  /** Compliance Receipts envelope: the type-discriminated anchors
+   * array. None on legacy receipts; `[]` when compliance_mode is on
+   * before anchors land. */
   anchors?: AnchorEntry[];
 }
 
@@ -927,7 +925,7 @@ export class Agent {
       issuer_id?: string;
       policy_decision?: string;
       decision?: string;
-      signatureObject?: SignatureEnvelope;
+      payload?: Record<string, unknown>;
       anchors?: AnchorEntry[];
     }>("POST", `/agents/${this.agentId}/sign`, body);
 
@@ -965,7 +963,7 @@ export class Agent {
           ? mapPolicyDecisionToDecision(data.policy_decision)
           : undefined
       ),
-      signatureObject: data.signatureObject,
+      payload: data.payload,
       anchors: data.anchors,
     };
 

--- a/typescript/tests/projection.test.ts
+++ b/typescript/tests/projection.test.ts
@@ -1,10 +1,9 @@
 /**
- * IETF -01 N6 + N7 / T2: TS SDK projection helpers.
+ * TS SDK projection helpers for the three-key Compliance Receipts envelope.
  *
- * `signatureObject(resp)` projects to `{alg, kid, sig}` per Section 4.
- * `anchors(resp)` projects to the spec-shape array per Section 4.4.
- * Both gated on `complianceMode=true`; legacy receipts get undefined
- * back so the additive overlay stays byte-stable.
+ * `signatureEnvelope(resp)` returns `{alg, kid, sig}` when the response
+ * carries the object form, undefined otherwise. `anchors(resp)` returns
+ * the cloud-supplied array, undefined for legacy receipts.
  */
 
 import { describe, expect, it } from "vitest";
@@ -16,8 +15,8 @@ import {
   anchors,
   anchorsFromResponse,
   encodeAnchorValue,
-  signatureObject,
-  signatureObjectFromResponse,
+  signatureEnvelope,
+  signatureEnvelopeFromResponse,
 } from "../src/index.js";
 
 function bareResponse(extra: Partial<SignatureResponse> = {}): SignatureResponse {
@@ -25,18 +24,18 @@ function bareResponse(extra: Partial<SignatureResponse> = {}): SignatureResponse
     signature: "ZmFrZQ==",
     signatureId: "sig_test",
     actionId: "act_test",
-    timestamp: "2026-05-04T00:00:00Z",
+    timestamp: "2026-05-08T00:00:00Z",
     verificationUrl: "https://verify",
     ...extra,
   };
 }
 
-describe("signatureObject()", () => {
-  it("returns undefined for non-compliance receipts", () => {
-    expect(signatureObject(bareResponse())).toBeUndefined();
+describe("signatureEnvelope()", () => {
+  it("returns undefined for legacy receipts (string signature)", () => {
+    expect(signatureEnvelope(bareResponse())).toBeUndefined();
   });
 
-  it("returns the cloud-supplied envelope when present", () => {
+  it("returns {alg, kid, sig} when signature is the object form", () => {
     const envelope: SignatureEnvelope = {
       alg: "ML-DSA-65",
       kid: "key_abc",
@@ -44,39 +43,31 @@ describe("signatureObject()", () => {
     };
     const resp = bareResponse({
       complianceMode: true,
-      signatureObject: envelope,
+      signature: envelope,
     });
-    const out = signatureObject(resp);
+    const out = signatureEnvelope(resp);
     expect(out).toEqual(envelope);
-    // Mutation safety: returned object is a fresh copy.
     out!.sig = "MUTATED";
-    expect(resp.signatureObject!.sig).toBe("ZmFrZQ==");
+    expect((resp.signature as SignatureEnvelope).sig).toBe("ZmFrZQ==");
   });
 
-  it("projects from flat fields when complianceMode but no envelope", () => {
-    const resp = bareResponse({
-      algorithm: "ML-DSA-65",
-      complianceMode: true,
-    });
-    const out = signatureObject(resp);
-    expect(out).toEqual({
-      alg: "ML-DSA-65",
-      kid: "",
-      sig: "ZmFrZQ==",
-    });
-  });
-
-  it("free helper accepts dict input (snake_case wire shape)", () => {
-    const out = signatureObjectFromResponse({
+  it("free helper accepts dict input", () => {
+    const out = signatureEnvelopeFromResponse({
       compliance_mode: true,
-      signatureObject: { alg: "Ed25519", kid: "k1", sig: "s" },
+      signature: { alg: "Ed25519", kid: "k1", sig: "s" },
     });
     expect(out).toEqual({ alg: "Ed25519", kid: "k1", sig: "s" });
+  });
+
+  it("free helper returns undefined for legacy string signature", () => {
+    expect(
+      signatureEnvelopeFromResponse({ signature: "ZmFrZQ==" }),
+    ).toBeUndefined();
   });
 });
 
 describe("anchors()", () => {
-  it("returns undefined for non-compliance receipts", () => {
+  it("returns undefined for legacy receipts", () => {
     expect(anchors(bareResponse())).toBeUndefined();
   });
 
@@ -91,37 +82,15 @@ describe("anchors()", () => {
     });
     const out = anchors(resp);
     expect(out).toEqual(cloudAnchors);
-    // Mutation safety: each entry is a copy.
     out![0].tsa = "MUTATED";
     expect(resp.anchors![0].tsa).toBe("freetsa.org");
   });
 
-  it("returns [] under complianceMode when no anchor columns set", () => {
-    const out = anchors(bareResponse({ complianceMode: true }));
-    expect(out).toEqual([]);
-  });
-
-  it("projects rfc3161 from flat snake_case fields via free helper", () => {
+  it("free helper passes through dict input", () => {
     const out = anchorsFromResponse({
-      compliance_mode: true,
-      rfc3161_serial: "0xabc",
-      rfc3161_tsa: "freetsa.org",
+      anchors: [{ type: "rfc3161", value: "v", commit_hash: "h" }],
     });
-    expect(out).toHaveLength(1);
-    expect(out![0]).toEqual({
-      type: "rfc3161",
-      value: "",
-      serial: "0xabc",
-      tsa: "freetsa.org",
-    });
-  });
-
-  it("projects opentimestamps from bitcoinAnchor.status via free helper", () => {
-    const out = anchorsFromResponse({
-      compliance_mode: true,
-      bitcoinAnchor: { status: "pending" },
-    });
-    expect(out!.some((e) => e.type === "opentimestamps")).toBe(true);
+    expect(out).toEqual([{ type: "rfc3161", value: "v", commit_hash: "h" }]);
   });
 });
 


### PR DESCRIPTION
## Summary

SDKs aligned with the cloud 0.3.0 three-key Compliance Receipts envelope. Wire-shape break: no flat-field projection fallbacks, no \`signatureObject\` alias.

- \`SignatureResponse\` now carries \`payload\` (signed dict), \`signature\` (polymorphic: base64 string in legacy, \`{alg, kid, sig}\` object form under \`compliance_mode\`), and \`anchors\` directly.
- \`signature_envelope()\` (Python) / \`signatureEnvelope()\` (TypeScript) returns the dict form when present, None / undefined otherwise.
- \`anchors_array()\` / \`anchors()\` returns the cloud-supplied list (possibly empty under \`compliance_mode\`), None / undefined for legacy receipts.
- \`signatureObject\` removed. \`signature_object_from_response\` helper removed. The polymorphic \`signature\` field carries the same value.
- Anchor entries carry \`commit_hash\` (sha256 of \`envelope_minus_anchors_jcs\`); \`None\` on legacy rows.

Versions:
- Python: 0.3.13 -> 0.4.0
- TypeScript: 0.2.11 -> 0.3.0

## Test plan

- [x] 7 Python projection tests pass (\`uv run pytest tests/test_client_ietf_projection.py\`)
- [x] 180 TypeScript tests pass (\`npm test\`)
- [x] TypeScript build clean (\`npm run build\`)
- [ ] CI green
- [ ] py-v0.4.0 tag pushed -> PyPI publish workflow runs
- [ ] ts-v0.3.0 tag pushed -> npm publish workflow runs