### PR TITLE
feat(sdk): R-09 forward payload_size on hash-mode signs (py 0.4.2 + ts 0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.4.2 / TypeScript 0.3.2] - 2026-05-08
+
+### Changed
+- **`payload_digest` size on hash-mode signs**: hash-only mode now forwards `payload_size` (byte length of the canonical fingerprint) on every request. The cloud builds the wire `payload_digest` as `{hash, size}` instead of `{hash}` alone. Both SDKs compute the size from the same canonical bytes used for the hash, so callers see no API change. Previous releases relied on the cloud filling size from server-side context, which left hash-only compliance signs without the `size` axis required by the spec.
+
 ## [Python 0.4.0 / TypeScript 0.3.0] - 2026-05-08
 
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.4.1"
+version = "0.4.2"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -132,7 +132,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import functools
 import hashlib
+import hmac
 import json as _json
 import logging
 import os
@@ -867,9 +868,19 @@ def _build_sign_body(
     Pydantic ``SignRequest`` model can validate them.
     """
     if _mode == "hash-only":
-        from .canonicalize import hash_action
+        from .canonicalize import canonicalize
 
-        digest = hash_action(action_type, context or {}, salt=_org_salt)
+        canonical_bytes = canonicalize(
+            {"action_type": action_type, "context": context or {}}
+        )
+        payload_size = len(canonical_bytes)
+        if _org_salt is not None:
+            digest_hex = hmac.new(
+                _org_salt, canonical_bytes, hashlib.sha256
+            ).hexdigest()
+        else:
+            digest_hex = hashlib.sha256(canonical_bytes).hexdigest()
+        digest = f"sha256:{digest_hex}"
         metadata: dict[str, Any] = {
             "agent_id": agent_id,
             "action_type": action_type,
@@ -897,6 +908,7 @@ def _build_sign_body(
             "action_type": action_type,
             "hash": digest,
             "hash_algo": "sha256",
+            "payload_size": payload_size,
             "metadata": metadata,
             "session_id": session_id,
         }

--- a/python/tests/test_client_hash_mode.py
+++ b/python/tests/test_client_hash_mode.py
@@ -90,6 +90,28 @@ def test_hash_only_mode_sends_hash_not_context() -> None:
     assert len(body["hash"]) == len("sha256:") + 64
     assert body["hash_algo"] == "sha256"
     assert body["action_type"] == "api:call"
+    # Wire payload_digest carries {hash, size}; the SDK forwards size
+    # alongside the hash so the cloud can build the upstream object form.
+    assert "payload_size" in body
+    assert isinstance(body["payload_size"], int) and body["payload_size"] > 0
+
+
+def test_hash_only_payload_size_matches_canonical_bytes_length() -> None:
+    """payload_size MUST equal the byte length of the canonical fingerprint."""
+    from asqav.canonicalize import canonicalize
+
+    client_mod._mode = "hash-only"
+    client_mod._org_salt = None
+    agent = _make_agent()
+
+    context = {"prompt": "hi", "user_id": "u_001"}
+    expected_bytes = canonicalize({"action_type": "api:call", "context": context})
+
+    with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
+        agent.sign("api:call", context)
+
+    _, body = mock_post.call_args[0]
+    assert body["payload_size"] == len(expected_bytes)
 
 
 def test_hash_only_metadata_does_not_leak_user_fields() -> None:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -204,7 +204,7 @@ Field reference (camelCase on the SDK, snake_case on the JSON wire):
 - `complianceMode` -> `compliance_mode`. Default `false`.
 - `receiptType` -> `receipt_type`. One of `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`. Validated client-side.
 - `actionRef` -> `action_ref`. `sha256:<hex>` of the canonical action. SDK derives it under `complianceMode` when omitted.
-- `payloadDigest` -> `payload_digest`. `sha256:<hex>` of the request payload.
+- `payloadDigest` -> `payload_digest`. Wire object form `{ hash, size, preview? }`. The SDK forwards `payload_size` (byte length of the canonical fingerprint) on every hash-mode sign so the cloud can build the object. Legacy receipts emitted as plain `sha256:<hex>` strings continue to verify on the read path.
 - `issuerId` -> `issuer_id`. Legal entity. Resolved server-side when omitted.
 - `iterationId` -> `iteration_id`. Required for multi-step receipts.
 - `sandboxState` -> `sandbox_state`. One of `enabled`, `disabled`, `unavailable`. Required for High-Risk.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -32,7 +32,7 @@ import {
   type LocalSigningAlgorithm,
 } from "./index.js";
 
-const CLI_VERSION = "0.3.0";
+const CLI_VERSION = "0.3.2";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -11,13 +11,13 @@
  *   const sig = await agent.sign({ actionType: "api:call", context: { model: "gpt-4" } });
  */
 
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import {
   SUPPORTED_ALGORITHMS,
   isSupportedAlgorithm,
   type SupportedAlgorithm,
 } from "./algorithms.js";
-import { canonicalize, hashAction } from "./canonicalize.js";
+import { canonicalize } from "./canonicalize.js";
 import { _dispatchAfter, _dispatchBefore } from "./hooks.js";
 import { canonicalJson } from "./jcs.js";
 import { type Mode, resolveMode } from "./mode.js";
@@ -686,11 +686,19 @@ interface BuildSignBodyArgs {
 
 async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, unknown>> {
   if (config.mode === "hash-only") {
-    const digest = await hashAction(
-      args.actionType,
-      args.context,
-      config.orgSalt ?? undefined,
-    );
+    // Compute the canonical bytes once so we can derive both the
+    // self-describing hash and the byte size for the wire
+    // payload_digest object {hash, size}.
+    const canonical = canonicalize({
+      action_type: args.actionType,
+      context: args.context,
+    });
+    const payloadSize = canonical.byteLength;
+    const salt = config.orgSalt ?? undefined;
+    const hex = salt
+      ? createHmac("sha256", Buffer.from(salt)).update(canonical).digest("hex")
+      : createHash("sha256").update(canonical).digest("hex");
+    const digest = `sha256:${hex}`;
     const metadata: Record<string, unknown> = {
       agent_id: args.agentId,
       action_type: args.actionType,
@@ -713,6 +721,7 @@ async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, un
       action_type: args.actionType,
       hash: digest,
       hash_algo: "sha256",
+      payload_size: payloadSize,
       metadata,
       session_id: args.sessionId,
     };

--- a/typescript/tests/clientHashMode.test.ts
+++ b/typescript/tests/clientHashMode.test.ts
@@ -95,6 +95,27 @@ describe("Agent.sign body shape across modes", () => {
     expect(body.hash.length).toBe("sha256:".length + 64);
     expect(body.hash_algo).toBe("sha256");
     expect(body.action_type).toBe("api:call");
+    expect(typeof body.payload_size).toBe("number");
+    expect(body.payload_size).toBeGreaterThan(0);
+  });
+
+  it("hash-only payload_size matches canonical bytes length", async () => {
+    const { canonicalize } = await import("../src/canonicalize.js");
+    _setModeForTests("hash-only");
+    const agent = await makeAgent();
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+
+    const ctx = { prompt: "hi", user_id: "u_001" };
+    await agent.sign({ actionType: "api:call", context: ctx });
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    const expected = canonicalize({ action_type: "api:call", context: ctx });
+    expect(body.payload_size).toBe(expected.byteLength);
   });
 
   it("hash-only mode does not leak context fields into metadata", async () => {


### PR DESCRIPTION
## Summary

Closes the SDK half of R-09 (Compliance Receipts §4.1.4): under `compliance_mode`, the wire `payload_digest` MUST follow the upstream object form `{hash, size, optional preview}`. Both SDKs now compute and forward `payload_size` (byte length of the canonical fingerprint) on every hash-mode `/agents/{id}/sign` request. The cloud (asqav#210, version 0.3.4) builds the wire envelope as `{hash, size}` from the request payload_size field.

- Python `python/src/asqav/client.py`: in `_build_sign_body`, hash-only mode computes `canonical_bytes` once, derives `digest = sha256(canonical_bytes)` and `payload_size = len(canonical_bytes)`, forwards both. The hash and size are derived from byte-identical input so SDK + cloud agree on the value the receipt envelope carries.
- TypeScript `typescript/src/index.ts`: `buildSignBody` mirrors the Python path. `payload_size = canonical.byteLength` from the same canonical-JSON bytes used to compute the hash.
- Version pins:
  - Python `__version__` and `pyproject.toml` -> `0.4.2`
  - TypeScript `package.json` -> `0.3.2`
  - `typescript/src/cli.ts` `CLI_VERSION` corrected to `0.3.2` (was drifted at `0.3.0`).
- CHANGELOG entry added.

## Test plan

- [x] `ruff check python/src` clean.
- [x] `npm run lint` (`tsc --noEmit`) clean.
- [x] `pytest python/tests` 641 passed; new test `test_hash_only_payload_size_matches_canonical_bytes_length` asserts the wire size equals `len(canonicalize({action_type, context}))`.
- [x] `npm test` 181 passed; new test `hash-only payload_size matches canonical bytes length` mirrors the Python coverage.
- [ ] Conformance against cloud 0.3.4 (after asqav#210 ships): cloud rejects compliance hash-mode signs without `payload_size` with `payload_digest_missing_size`; with size, the wire envelope carries `{hash, size}`.

## Cross-language byte-identical claim

The conformance vectors at `conformance/vectors.json` already pin SDK byte-for-byte agreement on the canonical bytes. `payload_size` rides on the same canonical bytes, so Python + TypeScript SDKs agree on the wire size for the same input.