### PR TITLE
Consolidate public-facing emails on info@asqav.com

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting Vulnerabilities
 
-Email support@asqav.com with details. We will respond within 48 hours.
+Email info@asqav.com with details. We will respond within 48 hours.
 
 Do not open public issues for security vulnerabilities.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
-    { name = "Asqav", email = "support@asqav.com" }
+    { name = "Asqav", email = "info@asqav.com" }
 ]
 keywords = [
     "ai",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -12,7 +12,7 @@
     "policy-enforcement"
   ],
   "license": "MIT",
-  "author": "Asqav <support@asqav.com>",
+  "author": "Asqav <info@asqav.com>",
   "homepage": "https://asqav.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Replace `support@asqav.com` with `info@asqav.com` in SECURITY.md and the package author metadata (Python + TypeScript). Single inbox now.

Author-email change in pyproject.toml / package.json takes effect on the next published artifact; current PyPI 0.4.2 + npm 0.3.2 still show the old address until a republish.