### PR TITLE
Bump SDK pin reference to 0.4.2 in docs/github-actions.md

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -164,7 +164,7 @@ Frameworks shipped today: `eu_ai_act_art12`, `eu_ai_act_art14`, `dora_ict`,
 ## Tips
 
 - Pin `asqav` to a specific version once your governance setup is stable
-  (`pip install asqav==0.4.0`). Lockstep upgrades catch breaking changes early.
+  (`pip install asqav==0.4.2`). Lockstep upgrades catch breaking changes early.
 - The `asqav doctor` step reads only environment variables and the public API,
   so it is safe to run on forks. The bundle export touches your API key and
   produces an artifact, so guard it with


### PR DESCRIPTION
Stale pin example (`asqav==0.4.0` → `asqav==0.4.2`). PyPI 0.4.2 has been live since the R-09/R-26/R-31 close cycle.