### PR TITLE
trim verbose hash-only mode comments + payloadDigest README line

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -858,14 +858,10 @@ def _build_sign_body(
     user_intent: dict[str, Any] | None = None,
     compliance_fields: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Build the JSON body for a ``POST /agents/{id}/sign`` request.
+    """Build the JSON body for ``POST /agents/{id}/sign``.
 
-    Branches on the SDK-level ``_mode``: full-payload sends ``context``
-    as before; hash-only sends a ``hash`` field plus a whitelisted
-    ``metadata`` bag. ``compliance_fields`` carries the IETF Compliance
-    Receipts profile kwargs (``compliance_mode``, ``action_ref`` etc).
-    They are added at the top level of the request body so the cloud's
-    Pydantic ``SignRequest`` model can validate them.
+    full-payload sends ``context``; hash-only sends a digest plus a
+    whitelisted metadata bag.
     """
     if _mode == "hash-only":
         from .canonicalize import canonicalize
@@ -887,11 +883,7 @@ def _build_sign_body(
         }
         if session_id is not None:
             metadata["session_id"] = session_id
-        # Pull optional model_name / tool_name / parent_id from context if
-        # the caller opted in by adding underscored sentinel keys. Other
-        # context keys are NEVER copied; that's the whole point of
-        # hash-only. These three identifiers power the agent graph view
-        # in the dashboard (no prompt or tool-arg content travels).
+        # Opt-in via underscored sentinel keys; nothing else from context travels.
         for src_key, dst_key in (
             ("_model_name", "model_name"),
             ("_tool_name", "tool_name"),
@@ -901,8 +893,6 @@ def _build_sign_body(
                 value = context[src_key]
                 if isinstance(value, str):
                     metadata[dst_key] = value
-        # Defensive: only ship whitelisted keys even if a future caller
-        # mutates `metadata` above.
         metadata = {k: v for k, v in metadata.items() if k in _HASH_ONLY_METADATA_WHITELIST}
         body: dict[str, Any] = {
             "action_type": action_type,

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -204,7 +204,7 @@ Field reference (camelCase on the SDK, snake_case on the JSON wire):
 - `complianceMode` -> `compliance_mode`. Default `false`.
 - `receiptType` -> `receipt_type`. One of `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`. Validated client-side.
 - `actionRef` -> `action_ref`. `sha256:<hex>` of the canonical action. SDK derives it under `complianceMode` when omitted.
-- `payloadDigest` -> `payload_digest`. Wire object form `{ hash, size, preview? }`. The SDK forwards `payload_size` (byte length of the canonical fingerprint) on every hash-mode sign so the cloud can build the object. Legacy receipts emitted as plain `sha256:<hex>` strings continue to verify on the read path.
+- `payloadDigest` -> `payload_digest`. Wire object form `{ hash, size, preview? }`. SDK forwards `payload_size` on every hash-mode sign. Legacy plain-string `sha256:<hex>` receipts still verify.
 - `issuerId` -> `issuer_id`. Legal entity. Resolved server-side when omitted.
 - `iterationId` -> `iteration_id`. Required for multi-step receipts.
 - `sandboxState` -> `sandbox_state`. One of `enabled`, `disabled`, `unavailable`. Required for High-Risk.

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -686,9 +686,6 @@ interface BuildSignBodyArgs {
 
 async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, unknown>> {
   if (config.mode === "hash-only") {
-    // Compute the canonical bytes once so we can derive both the
-    // self-describing hash and the byte size for the wire
-    // payload_digest object {hash, size}.
     const canonical = canonicalize({
       action_type: args.actionType,
       context: args.context,
@@ -704,16 +701,11 @@ async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, un
       action_type: args.actionType,
     };
     if (args.sessionId !== null) metadata.session_id = args.sessionId;
-    // Optional opt-in: caller adds ``_model_name`` / ``_tool_name`` /
-    // ``_parent_id`` to the context. Other context keys are NEVER
-    // copied. These three identifiers power the agent graph view in
-    // the dashboard - only the name strings travel, never prompts or
-    // tool args.
+    // Opt-in via underscored sentinel keys; nothing else from context travels.
     const ctx = args.context as Record<string, unknown>;
     if (typeof ctx._model_name === "string") metadata.model_name = ctx._model_name;
     if (typeof ctx._tool_name === "string") metadata.tool_name = ctx._tool_name;
     if (typeof ctx._parent_id === "string") metadata.parent_id = ctx._parent_id;
-    // Defensive: drop anything that snuck in outside the whitelist.
     for (const k of Object.keys(metadata)) {
       if (!HASH_ONLY_METADATA_WHITELIST.has(k)) delete metadata[k];
     }


### PR DESCRIPTION
Mechanical comment trim sweep on SDK paths called out in NEXT.md Phase 0.

Targets the multi-paragraph hash-only mode commentary in `python/src/asqav/client.py:_build_sign_body` and `typescript/src/index.ts:buildSignBody`, plus the multi-sentence `payloadDigest` field reference in `typescript/README.md`.

Comment-only. No version bump. No behavioural change.