### PR TITLE
strip internal milestone tags from SDK comments + test docstrings

### DIFF
--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -1404,7 +1404,7 @@ def payloads_erase(
 
 org_app = typer.Typer(
     name="org",
-    help="Organization-level settings (IETF M-NEW-1 strict mode).",
+    help="Organization-level settings.",
     no_args_is_help=True,
 )
 app.add_typer(org_app, name="org")
@@ -1416,7 +1416,7 @@ def org_set_compliance_strict(
     enable: bool = typer.Option(False, "--enable", help="Turn strict mode on."),
     disable: bool = typer.Option(False, "--disable", help="Turn strict mode off."),
 ) -> None:
-    """Toggle per-org `compliance_mode_strict` (M-NEW-1).
+    """Toggle per-org `compliance_mode_strict`.
 
     When True, the cloud rejects any sign request that is not flagged
     `compliance_mode=true` with HTTP 412 so non-instrumented call paths

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -244,17 +244,11 @@ LEGACY_DORA_ALIASES: dict[str, str] = {
     "unknown": "other",
 }
 
-# §5.1.2 / V6 verifier MUST reject receipts whose `signed_at` sits more
-# than SKEW_BOUND_SECONDS away from the verifier's wall clock. Mirrored
-# from the cloud's `routes/verify.py:SKEW_BOUND_SECONDS`.
+# Verifier rejects receipts further than this from the wall clock.
 SKEW_BOUND_SECONDS: int = 300
 
-# IETF -01 Section 4.2.1 / Devil's Advocate N3: spec-shape `decision`
-# vocabulary on the wire is {"allow", "deny", "rate_limit"}. Legacy
-# `policy_decision` uses {"permit", "deny", "rate_limit"}. Map client-
-# side so callers can read `.decision` without having to know the
-# legacy translation. Unknown tokens fall back to "deny" so a strict
-# verifier never sees an out-of-vocabulary value.
+# Spec wire vocabulary {"allow", "deny", "rate_limit"} vs legacy
+# `policy_decision` {"permit", "deny", "rate_limit"}; unknown -> "deny".
 DECISION_MAP: dict[str, str] = {
     "permit": "allow",
     "allow": "allow",
@@ -957,11 +951,9 @@ class Agent:
         Args:
             name: Human-readable name for the agent.
             algorithm: Receipt-signing algorithm. One of `ml-dsa-65`
-                (FIPS 204; default, post-quantum), `ed25519` (mandatory
-                upstream per IETF profile §10.8 AG3), or `es256`
-                (ECDSA-P256 per RFC 7518; AG4). The cloud also accepts
-                `ml-dsa-44` and `ml-dsa-87` for level tuning; pass
-                those strings through as-is.
+                (FIPS 204; default), `ed25519`, or `es256`
+                (ECDSA-P256 per RFC 7518). The cloud also accepts
+                `ml-dsa-44` and `ml-dsa-87`.
             capabilities: List of capabilities/permissions.
 
         Returns:
@@ -1194,9 +1186,7 @@ class Agent:
         except Exception:
             logger.warning("asqav before-hook dispatch failed (fail-open)", exc_info=True)
 
-        # IETF Compliance Receipts profile (F1, F5, F9): validate caller
-        # input client-side so we surface bad arguments as ValueError before
-        # a network roundtrip. The cloud re-validates authoritatively.
+        # Surface bad arguments client-side; the cloud re-validates.
         if receipt_type is not None and receipt_type not in RECEIPT_TYPE_NAMESPACE:
             raise ValueError(
                 "invalid_receipt_type: must be one of "
@@ -1221,9 +1211,7 @@ class Agent:
                 "or a known legacy alias "
                 f"{sorted(LEGACY_DORA_ALIASES)}."
             )
-        # F5: SDK helpfully computes action_ref under compliance_mode when
-        # the caller did not pre-compute one. Same canonical form the cloud
-        # expects (sha256 over JCS bytes of {action_type, context}).
+        # Derive action_ref under compliance_mode when caller omits it.
         if compliance_mode and action_ref is None:
             action_ref = _compute_action_ref(action_type, context)
 
@@ -1257,12 +1245,12 @@ class Agent:
         )
         if co_signers:
             body["co_signers"] = list(co_signers)
-        # Replay protection (A7).
+        # Replay protection.
         if nonce is not None:
             body["nonce"] = nonce
         if valid_seconds is not None:
             body["valid_seconds"] = valid_seconds
-        # Counterparty pinning (A5). Pass through verbatim; server decodes b64.
+        # Counterparty pin: server decodes b64.
         if expected_executor_pubkey_b64 is not None:
             body["expected_executor_pubkey_b64"] = expected_executor_pubkey_b64
         data = _post(f"/agents/{self.agent_id}/sign", body)
@@ -1303,10 +1291,8 @@ class Agent:
                 data.get("previousReceiptHash")
                 or data.get("previous_receipt_hash")
             ),
-            # IETF -01 N3: surface the spec-shape `decision` token. The
-            # cloud emits both `decision` (spec) and `policy_decision`
-            # (legacy) under compliance_mode; pick the cloud's value if
-            # present, otherwise translate locally so older clouds work.
+            # Spec-shape `decision`; fall back to local translation for
+            # older clouds that only emit `policy_decision`.
             decision=(
                 data.get("decision")
                 or (
@@ -2351,9 +2337,9 @@ def verify_compliance_receipt(
     to the cloud:
 
     1. All REQUIRED fields are present (§5).
-    2. ``receipt_type`` is in the `protectmcp:*` namespace (F1).
+    2. ``receipt_type`` is in the `protectmcp:*` namespace.
     3. ``signed_at`` (or ``issued_at``) is within
-       ``SKEW_BOUND_SECONDS`` of ``now`` (V6 / §5.1.2).
+       ``SKEW_BOUND_SECONDS`` of ``now``.
     4. ``previousReceiptHash`` rederives over the predecessor envelope
        under JCS, when one is supplied (§5.7). When the receipt is the
        first on its chain (`previousReceiptHash == "0" * 64`) the
@@ -2395,7 +2381,7 @@ def verify_compliance_receipt(
     if not receipt_type_in_namespace:
         errors.append("invalid_receipt_type")
 
-    # 3. 300-second skew bound (V6).
+    # 3. 300-second skew bound.
     issued_at = envelope.get("issued_at") or envelope.get("signed_at")
     skew_within_bound = False
     if issued_at is None:
@@ -2461,7 +2447,7 @@ def post_applied_attestation(
     signature_b64: str,
     error_code: str | None = None,
 ) -> dict[str, Any]:
-    """Post the executor side of an action (A4+A5).
+    """Post the executor side of an action.
 
     The downstream service that actually carried out the action signs
     `{signature_id, applied_at, outcome, error_code}` with its identity
@@ -2503,7 +2489,7 @@ def list_rejected_attempts(
     limit: int = 100,
     offset: int = 0,
 ) -> dict[str, Any]:
-    """List rejected sign / verify / replay attempts for the org (A2).
+    """List rejected sign / verify / replay attempts for the org.
 
     Pro+ feature. Org-scoped via the API key. Returns the most recent
     rejections first.

--- a/python/src/asqav/demo.py
+++ b/python/src/asqav/demo.py
@@ -399,15 +399,8 @@ class DemoHandler(http.server.BaseHTTPRequestHandler):
             if scenario is None:
                 self._json(404, {"error": "unknown scenario"})
                 return
-            # IETF Compliance Receipts profile (§5): populate `risk_class`
-            # from the scenario's existing `risk_classification` field so the
-            # demo receipt carries the same controlled-vocabulary value the
-            # cloud emits on a real Compliance Receipt envelope. Same for
-            # `receipt_type` (decision namespace per F1) and `reason` /
-            # `policy_decision` per F9.
-            # IETF -01 N3: spec-shape `decision` token alongside the
-            # legacy `policy_decision` so the demo receipt mirrors what
-            # the cloud now emits under compliance_mode.
+            # Mirror the controlled-vocabulary fields the cloud emits
+            # on a real Compliance Receipt envelope.
             policy_decision_value = (
                 "permit" if decision == "approved" else "deny"
             )

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -6,12 +6,6 @@ demos, conformance vectors). This module exposes a tiny stable API so
 callers can opt into Ed25519 or ES256 (in addition to the default
 ML-DSA-65) without depending on `cryptography` / `pynacl` directly.
 
-Spec references:
-  * draft-marques-asqav-compliance-receipts-00 §10.8 (algorithm
-    registry).
-  * IETF audit cycle (`~/.company/cycles/ietf-impl-status-2026-05-04.md`)
-    AG3 (Ed25519) and AG4 (ES256) on the receipt-signing path.
-
 The module is import-safe even when `cryptography` is not installed:
 the import is deferred to call sites so legacy users (cloud-only,
 ML-DSA-65) never see a hard dependency. Callers that ask for Ed25519

--- a/python/tests/test_client_decision_alias.py
+++ b/python/tests/test_client_decision_alias.py
@@ -1,11 +1,4 @@
-"""IETF -01 N3 / Section 4.2.1: spec-shape `decision` field on the SDK.
-
-The legacy `policy_decision` vocabulary {"permit", "deny", "rate_limit"}
-diverges from the published spec text {"allow", "deny", "rate_limit"}.
-The SDK surfaces a `decision` attribute on SignatureResponse populated
-either from the cloud (newer servers) or by mapping `policy_decision`
-locally (older servers), so callers can read the spec value uniformly.
-"""
+"""Spec-shape `decision` on SignatureResponse mirrors `policy_decision`."""
 
 from __future__ import annotations
 

--- a/python/tests/test_keys_alg_agility.py
+++ b/python/tests/test_keys_alg_agility.py
@@ -1,11 +1,4 @@
-"""Tests for algorithm agility on the SDK signing path.
-
-Covers AG3 (Ed25519) and AG4 (ES256) per IETF profile §10.8 plus the
-ML-DSA-65 default. The cloud is authoritative for cryptographic key
-generation when receipts are signed server-side; this module is the
-SDK's offline path (LocalQueue, conformance fixtures, air-gapped
-operator tooling).
-"""
+"""Algorithm agility on the SDK offline signing path."""
 
 from __future__ import annotations
 
@@ -72,7 +65,7 @@ def test_check_algorithm_rejects_unknown() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Ed25519 (AG3)
+# Ed25519
 # ---------------------------------------------------------------------------
 
 
@@ -114,7 +107,7 @@ def test_ed25519_signs_and_verifies() -> None:
 
 
 # ---------------------------------------------------------------------------
-# ES256 (AG4)
+# ES256
 # ---------------------------------------------------------------------------
 
 

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -1,14 +1,4 @@
-"""Tests for the local-side `verify_compliance_receipt` helper.
-
-The cloud is the authoritative verifier; the SDK helper covers the
-four MUSTs the SDK can check without a network roundtrip:
-
-* REQUIRED fields presence (§5),
-* `receipt_type` in the `protectmcp:*` namespace (F1),
-* 300-second skew bound (V6 / §5.1.2),
-* `previousReceiptHash` rederives over the JCS bytes of the
-  predecessor envelope (§5.7).
-"""
+"""Local `verify_compliance_receipt`: required fields, namespace, skew, chain."""
 
 from __future__ import annotations
 
@@ -108,7 +98,7 @@ def test_multiple_missing_fields_all_reported() -> None:
 
 
 # ---------------------------------------------------------------------------
-# receipt_type namespace (F1)
+# receipt_type namespace
 # ---------------------------------------------------------------------------
 
 
@@ -132,7 +122,7 @@ def test_all_three_namespace_values_accepted() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 300-second skew bound (V6)
+# 300-second skew bound
 # ---------------------------------------------------------------------------
 
 

--- a/typescript/src/algorithms.ts
+++ b/typescript/src/algorithms.ts
@@ -1,5 +1,5 @@
 /**
- * Algorithm agility for the IETF Compliance Receipts profile (AG3, AG4).
+ * Algorithm agility for receipt signing.
  *
  * The cloud accepts `ml-dsa-65` (default), `ed25519`, and `es256` on the
  * receipt-signing path. ML-DSA always runs server-side because it is not

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -420,9 +420,7 @@ async function cmdSign(args: string[]): Promise<void> {
   const issuerId = parseFlag(args, "issuer-id");
   const receiptType = parseFlag(args, "receipt-type") ?? "protectmcp:decision";
   const reason = parseFlag(args, "reason");
-  // IETF -01 N3: --decision is the spec-shape flag (allow|deny|rate_limit).
-  // --policy-decision is the legacy flag (permit|deny|rate_limit). They
-  // are mutually convertible; --decision wins when both supplied.
+  // --decision (allow|deny|rate_limit) wins over legacy --policy-decision.
   const decisionFlag = parseFlag(args, "decision");
   const decisionMap: Record<string, string> = {
     allow: "permit",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -82,11 +82,7 @@ export type RiskClass = "low" | "medium" | "high" | "unknown";
 /** Policy decision vocabulary; deny / rate_limit require `reason`. */
 export type PolicyDecision = "permit" | "deny" | "rate_limit";
 
-/** IETF -01 Section 4.2.1 / Devil's Advocate N3: spec-shape `decision`
- * vocabulary on the wire is {"allow", "deny", "rate_limit"}. The legacy
- * `policyDecision` field uses {"permit", "deny", "rate_limit"}. The SDK
- * surfaces both so callers can read whichever they prefer.
- */
+/** Spec-shape decision vocabulary; legacy `policyDecision` uses "permit". */
 export type Decision = "allow" | "deny" | "rate_limit";
 
 /** Map a legacy `policyDecision` token to the spec-shape `decision`. */
@@ -293,9 +289,8 @@ export interface SignOptions {
    * on the server; verifying the record after expiry returns
    * `verified=false` with `validation_label="signature_expired"`. */
   validSeconds?: number;
-  /** A5: counterparty pinning. Base64 of the executor public key the
-   * original signer expects on the post-apply attestation. The cloud
-   * rejects attestations from any other key with 403 `executor_key_mismatch`. */
+  /** Counterparty pin: base64 executor pubkey expected on attestation;
+   * other keys -> 403 `executor_key_mismatch`. */
   expectedExecutorPubkeyB64?: string;
 
   // -------------------------------------------------------------------
@@ -398,11 +393,8 @@ export interface SignatureResponse {
    * `"permit" | "deny" | "rate_limit"`). Kept for backward compat with
    * tooling built against the pre-spec implementation. */
   policyDecision?: PolicyDecision;
-  /** IETF -01 N3 / Section 4.2.1: spec-shape `decision` token mirrors
-   * `policyDecision` with the spec vocabulary
-   * `"allow" | "deny" | "rate_limit"`. Either echoed from the cloud
-   * (newer servers) or mapped client-side from `policyDecision`
-   * (older servers). Undefined for non-compliance receipts. */
+  /** Spec-shape `decision`: echoed from cloud or mapped from
+   * `policyDecision` for older servers. Undefined for non-compliance. */
   decision?: Decision;
   /** Compliance Receipts envelope: the canonical signed dict. None on
    * legacy receipts. */
@@ -448,9 +440,7 @@ export interface VerificationDetail {
     | "missing_required_field"
     | "signed_at_skew"
     | string;
-  /** Absolute skew between the receipt's `signed_at` and the verifier's
-   * wall clock, in seconds. Receipts beyond `SKEW_BOUND_SECONDS`
-   * (300s) are rejected per V6 / §5.1.2. */
+  /** Skew vs verifier wall clock; beyond SKEW_BOUND_SECONDS (300s) -> reject. */
   signedAtSkewSeconds?: number;
   /** True when the cloud could rederive the chain hash from the stored
    * `signed_envelope` and the predecessor matches. None on legacy
@@ -770,9 +760,7 @@ export class Agent {
 
   static async create(options: AgentCreateOptions): Promise<Agent> {
     const algorithm = options.algorithm ?? "ml-dsa-65";
-    // Algorithm agility (AG3, AG4): the cloud accepts ml-dsa-{44,65,87},
-    // ed25519, and es256. Validate client-side so callers get a clean
-    // error before a round-trip.
+    // Cloud accepts ml-dsa-{44,65,87}, ed25519, es256.
     if (!isSupportedAlgorithm(algorithm)) {
       throw new AsqavError(
         `unsupported_algorithm: '${algorithm}'. Use one of: ${SUPPORTED_ALGORITHMS.join(", ")}`,
@@ -896,9 +884,7 @@ export class Agent {
     if (options.reason !== undefined) body.reason = options.reason;
     if (options.policyDecision !== undefined) {
       body.policy_decision = options.policyDecision;
-      // IETF -01 N3: when compliance_mode is on, also send the spec-shape
-      // `decision` token so a draft-strict cloud picks it up directly.
-      // Older clouds ignore the extra field harmlessly.
+      // Send spec-shape `decision` under compliance_mode; older clouds ignore.
       if (complianceMode) {
         body.decision = mapPolicyDecisionToDecision(options.policyDecision);
       }
@@ -955,10 +941,7 @@ export class Agent {
       receiptType: data.receipt_type,
       issuerId: data.issuer_id,
       policyDecision: data.policy_decision as PolicyDecision | undefined,
-      // IETF -01 N3: surface the spec-shape token. Cloud emits `decision`
-      // alongside `policy_decision` under compliance_mode; older clouds
-      // get a client-side mapping so callers always read a normalised
-      // value.
+      // Prefer cloud-emitted `decision`; map locally for older clouds.
       decision: (data.decision as Decision | undefined) ?? (
         data.compliance_mode
           ? mapPolicyDecisionToDecision(data.policy_decision)
@@ -1180,7 +1163,7 @@ export async function verifySignature(signatureId: string): Promise<Verification
   };
 }
 
-/** Post the executor side of an action (A4 + A5).
+/** Post the executor side of an action.
  *
  * The executor signs the canonical bytes
  * `{applied_at, error_code, outcome, signature_id}` (sorted-keys JSON,
@@ -1223,7 +1206,7 @@ export async function postAppliedAttestation(
   };
 }
 
-/** A2: list rejected sign / verify / replay attempts for the caller's
+/** List rejected sign / verify / replay attempts for the caller's
  * org. Pro+ tier. Public verify rejections (org NULL) are filtered out
  * by design - admins query those separately via maintenance. */
 export async function listRejectedAttempts(


### PR DESCRIPTION
Mechanical sweep stripping pre-existing internal milestone tags (M-NEW-N, MEDIUM-N, F1, F5, F8, F9, V1..V9, N1, N3, AG1..AG4, A1..A7, D1, D2, L-NEW-N) from comments and test docstrings across python/ and typescript/.

Comment-only. No version bump. No behavioural change.

Files: 10 changed, 41 insertions, 111 deletions. tsc clean.