### PR TITLE
shared canonicalize_action helper across Python + TS SDKs (py 0.4.3 + ts 0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.4.3 / TypeScript 0.3.3] - 2026-05-08
+
+### Changed
+- Shared `canonicalize_action(action_type, context)` / `canonicalizeAction(actionType, context)` helper. Both SDKs route `hash_action` / `hashAction`, `_compute_action_ref`, and the hash-only sign body through the same primitive. No wire-format change.
+
 ## [Python 0.4.2 / TypeScript 0.3.2] - 2026-05-08
 
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.4.2"
+version = "0.4.3"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/canonicalize.py
+++ b/python/src/asqav/canonicalize.py
@@ -26,7 +26,15 @@ import hmac
 import json
 from typing import Any
 
-__all__ = ["canonicalize", "hash_action"]
+__all__ = ["canonicalize", "canonicalize_action", "hash_action"]
+
+
+def canonicalize_action(
+    action_type: str,
+    context: "dict[str, Any] | None" = None,
+) -> bytes:
+    """Canonical bytes of ``{action_type, context}`` for hashing or signing."""
+    return canonicalize({"action_type": action_type, "context": context or {}})
 
 
 def canonicalize(obj: Any) -> bytes:
@@ -85,8 +93,7 @@ def hash_action(
     Returns:
         Self-describing hash string ``"sha256:<64 hex chars>"``.
     """
-    payload = {"action_type": action_type, "context": context or {}}
-    canonical = canonicalize(payload)
+    canonical = canonicalize_action(action_type, context)
     if salt is not None:
         digest = hmac.new(salt, canonical, hashlib.sha256).hexdigest()
     else:

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -835,12 +835,9 @@ def _compute_action_ref(
     The Action shape mirrors `core/canonical.py:hash_action` on the cloud
     so the SDK and cloud agree byte-for-byte under JCS encoding.
     """
-    from .canonicalize import canonicalize
+    from .canonicalize import canonicalize_action
 
-    canonical = canonicalize(
-        {"action_type": action_type, "context": context or {}}
-    )
-    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+    return "sha256:" + hashlib.sha256(canonicalize_action(action_type, context)).hexdigest()
 
 
 def _build_sign_body(
@@ -858,11 +855,9 @@ def _build_sign_body(
     whitelisted metadata bag.
     """
     if _mode == "hash-only":
-        from .canonicalize import canonicalize
+        from .canonicalize import canonicalize_action
 
-        canonical_bytes = canonicalize(
-            {"action_type": action_type, "context": context or {}}
-        )
+        canonical_bytes = canonicalize_action(action_type, context)
         payload_size = len(canonical_bytes)
         if _org_salt is not None:
             digest_hex = hmac.new(

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/canonicalize.ts
+++ b/typescript/src/canonicalize.ts
@@ -112,20 +112,24 @@ function jsonString(s: string): string {
   return out;
 }
 
+/** Canonical bytes of `{action_type, context}` for hashing or signing. */
+export function canonicalizeAction(
+  actionType: string,
+  context: Record<string, unknown> = {},
+): Uint8Array {
+  return canonicalize({ action_type: actionType, context });
+}
+
 /**
- * Compute the self-describing hash for an action.
- *
- * Hashes ``{action_type, context}`` in canonical JSON form and returns
- * the result as ``"sha256:<64 hex chars>"``. With ``salt`` set, uses
- * HMAC-SHA-256 instead of plain SHA-256 (per the asqav cloud per-org
- * keyed-hash protocol).
+ * Self-describing hash for an action: `sha256:<hex>`.
+ * With `salt` set, uses HMAC-SHA-256.
  */
 export async function hashAction(
   actionType: string,
   context: Record<string, unknown> = {},
   salt?: Uint8Array,
 ): Promise<string> {
-  const canonical = canonicalize({ action_type: actionType, context });
+  const canonical = canonicalizeAction(actionType, context);
   const hex = salt
     ? createHmac("sha256", Buffer.from(salt)).update(canonical).digest("hex")
     : createHash("sha256").update(canonical).digest("hex");

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -17,7 +17,7 @@ import {
   isSupportedAlgorithm,
   type SupportedAlgorithm,
 } from "./algorithms.js";
-import { canonicalize } from "./canonicalize.js";
+import { canonicalizeAction } from "./canonicalize.js";
 import { _dispatchAfter, _dispatchBefore } from "./hooks.js";
 import { canonicalJson } from "./jcs.js";
 import { type Mode, resolveMode } from "./mode.js";
@@ -105,7 +105,7 @@ export function mapPolicyDecisionToDecision(
 
 export { clearHooks, registerAfter, registerBefore } from "./hooks.js";
 export type { AfterHook, BeforeHook } from "./hooks.js";
-export { canonicalize, hashAction } from "./canonicalize.js";
+export { canonicalize, canonicalizeAction, hashAction } from "./canonicalize.js";
 export { canonicalJson } from "./jcs.js";
 export {
   verifyChain,
@@ -676,10 +676,7 @@ interface BuildSignBodyArgs {
 
 async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, unknown>> {
   if (config.mode === "hash-only") {
-    const canonical = canonicalize({
-      action_type: args.actionType,
-      context: args.context,
-    });
+    const canonical = canonicalizeAction(args.actionType, args.context);
     const payloadSize = canonical.byteLength;
     const salt = config.orgSalt ?? undefined;
     const hex = salt


### PR DESCRIPTION
Add a shared `canonicalize_action(action_type, context)` (Python) /
`canonicalizeAction(actionType, context)` (TypeScript) primitive that
returns the canonical bytes both SDKs hash and sign over.

Both `hash_action` / `hashAction`, the `_compute_action_ref` helper, and
the hash-only `_build_sign_body` / `buildSignBody` branch now route
through it instead of inlining `canonicalize({action_type, context})`.

No wire-format change. Same conformance vectors agree byte-for-byte.

Patch versions only: Python 0.4.3, TypeScript 0.3.3.

Tests: 181 vitest + 33 pytest local pass; CI re-runs full matrix.