### PR TITLE
doc: bump SDK pin to 0.4.3/0.3.3 (HOLD until publish)

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -164,7 +164,7 @@ Frameworks shipped today: `eu_ai_act_art12`, `eu_ai_act_art14`, `dora_ict`,
 ## Tips
 
 - Pin `asqav` to a specific version once your governance setup is stable
-  (`pip install asqav==0.4.2`). Lockstep upgrades catch breaking changes early.
+  (`pip install asqav==0.4.3`). Lockstep upgrades catch breaking changes early.
 - The `asqav doctor` step reads only environment variables and the public API,
   so it is safe to run on forks. The bundle export touches your API key and
   produces an artifact, so guard it with


### PR DESCRIPTION
## Summary

- Bumps the pinned install example in `docs/github-actions.md` from `asqav==0.4.2` to `asqav==0.4.3`.
- Pin to current published versions only after PyPI 0.4.3 + npm 0.3.3 publish.

**HOLD: do not enable auto-merge. Hold until PyPI 0.4.3 + npm 0.3.3 publish.**

## Test plan

- [ ] Confirm `asqav==0.4.3` is live on PyPI.
- [ ] Confirm `@asqav/sdk@0.3.3` is live on npm.
- [ ] Then merge.