### PR TITLE
docs(readme): align SDK READMEs with website "evidence layer" wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 <p align="center">
-  Governance for AI agents. Audit trails, policy enforcement, and compliance.
+  The evidence layer for AI agents. Audit trails, approvals, policy gates, and compliance reports for every action.
 </p>
 <p align="center">
   <a href="https://pypi.org/project/asqav/"><img src="https://img.shields.io/pypi/v/asqav?style=flat-square&logo=pypi&logoColor=white&label=pypi" alt="PyPI version"></a>
@@ -22,7 +22,7 @@
 
 # Asqav SDK - Python + TypeScript
 
-The official client SDKs for [Asqav](https://asqav.com), the governance layer for AI agents. Sign every action with ML-DSA-65 (FIPS 204), enforce policies before execution, and produce regulator-ready audit trails.
+The official client SDKs for [Asqav](https://asqav.com), the evidence layer for AI agents. Sign every action with ML-DSA-65 (FIPS 204), enforce policies before execution, and produce regulator-ready audit trails.
 
 This repository ships two SDKs from a single monorepo:
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # asqav
 
-Python SDK for [asqav.com](https://asqav.com). All ML-DSA cryptography runs server-side. Drop-in for AI agent governance: audit trails, policy enforcement, compliance.
+Python SDK for [asqav.com](https://asqav.com), the evidence layer for AI agents. All ML-DSA cryptography runs server-side. Drop-in audit trails, approvals, policy gates, and compliance reports.
 
 ## Install
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,6 +1,6 @@
 # asqav
 
-TypeScript SDK for [asqav.com](https://asqav.com). All ML-DSA cryptography runs server-side. Zero native dependencies.
+TypeScript SDK for [asqav.com](https://asqav.com), the evidence layer for AI agents. All ML-DSA cryptography runs server-side. Zero native dependencies.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Brings the asqav-sdk READMEs into line with the website hero copy.

The website hero says "The **evidence layer** for AI agents", but three SDK README lines were still using the older "governance" / "governance layer" framing:

- `README.md:7` (centered tagline) - was "Governance for AI agents..."
- `README.md:25` (one-liner under H1) - was "...the governance layer for AI agents..."
- `python/README.md:3` - was "Drop-in for AI agent governance..."
- `typescript/README.md:3` - now also explicitly anchored to "evidence layer for AI agents"

All four now mirror the canonical wording on asqav.com:
"the evidence layer for AI agents. Audit trails, approvals, policy gates, and compliance reports for every action."

Cloud README (`jagmarques/asqav` `README.md:7`) already used the new wording, so this closes the last drift across READMEs.

## Test plan

- [x] grep "governance layer" returns zero hits across asqav-sdk/
- [x] grep "evidence layer" matches on each README that previously said "governance layer"
- [x] Markdown still renders the centered tagline + badges block
- [ ] CI green (ci-ok required by branch protection)