### PR TITLE
feat(sdk): IETF -03 alignment - compliance_mode default True + 9-regime FRAMEWORKS + fetch_audit_pack

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -15,12 +15,23 @@ import asqav
 
 asqav.init(api_key="sk_...")
 agent = asqav.Agent.create("my-agent")
-sig = agent.sign("api:call", {"model": "gpt-4"})
 
+sig = agent.sign(
+    "payment.wire_transfer",
+    {"amount_eur": 850000, "beneficiary_iban": "DE89370400440532013000"},
+    receipt_type="protectmcp:decision",
+    risk_class="high",
+    issuer_id="legal:Acme GmbH",
+    iteration_id="task-2026-Q2-4821",
+)
+
+print(sig.compliance_mode)        # True (default; pass compliance_mode=False to opt out)
+print(sig.action_ref)             # "sha256:..." over the JCS-canonical action
+print(sig.previous_receipt_hash)  # 64 hex; "0"*64 on the first record per agent
 print(sig.verification_url)
 ```
 
-Each signed action is recorded server-side with an ML-DSA-65 (FIPS 204) signature, a chain hash, and a public verification URL.
+Each signed action lands on a Compliance Receipt under IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) by default: ML-DSA-65 (FIPS 204) signature, chain hash, retained `policy_digest`, fail-closed anchoring, and a public verification URL. Pass `compliance_mode=False` if you want a non-Compliance receipt.
 
 ## CLI
 
@@ -71,30 +82,30 @@ Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-
 
 ## Compliance receipts (IETF profile)
 
-Pass `compliance_mode=True` to `agent.sign(...)` to emit a Compliance Receipt under [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/). The SDK fills `action_ref` automatically (`sha256:` over the JCS-canonical action object) so callers only need to supply policy-relevant context.
+Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 signature, RFC 3161 + OpenTimestamps anchors, retained `policy_digest`, hash-chained `previousReceiptHash`. Opt out with `compliance_mode=False` if you want the older shape.
+
+The four envelope extensions most callers reach for:
+
+- `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, or `protectmcp:lifecycle`.
+- `risk_class` - controlled vocabulary: `unacceptable | high | limited | minimal | gpai | low | medium | unknown`.
+- `iteration_id` - logical task id, distinct from session.
+- `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
+- `incident_class` - DORA / NYDFS / CIRCIA token (or array of tokens).
+- `issuer_id` - LEI (ISO 17442), EIN, CIK, or a W3C DID for non-LEI deployers.
+
+### Audit Pack export
+
+The cloud signs a Compliance Audit Pack (per IETF -03 Section 7) over a window of receipts. The SDK wraps the endpoint:
 
 ```python
-import asqav
-
-asqav.init(api_key="sk_...")
-agent = asqav.Agent.create("payments-agent")
-
-sig = agent.sign(
-    "payment.wire_transfer",
-    {"amount_eur": 850000, "beneficiary_iban": "DE89370400440532013000"},
-    compliance_mode=True,
-    receipt_type="protectmcp:decision",
-    risk_class="high",
-    issuer_id="legal:Acme GmbH",
-    iteration_id="task-2026-Q2-4821",
-    sandbox_state="enabled",
-)
-
-print(sig.compliance_mode)        # True
-print(sig.receipt_type)           # "protectmcp:decision"
-print(sig.action_ref)             # "sha256:..."
-print(sig.previous_receipt_hash)  # 64 hex; "0"*64 on the first record per agent
+pack = asqav.fetch_audit_pack(start="2026-05-01T00:00Z", end="2026-06-01T00:00Z")
+print(pack["bundle_digest"])              # sha256:<hex>
+print(pack["bundle_signature"])           # base64 ML-DSA-65 sig over the bundle
+print(pack["regime_mapping"])             # {regime_token: [record_id, ...]}
+print(pack["algorithm_registry_version"]) # registry version pinned at issuance
 ```
+
+`asqav.export_bundle(signatures, framework="dora")` is the offline alternative for air-gapped flows: it computes a Merkle root over an in-memory list of receipts without calling the cloud. Use `fetch_audit_pack` whenever the cloud is reachable, since only the cloud signature gives the auditor a tamper-evident manifest.
 
 Local-side sanity checks (presence of REQUIRED fields, namespace, 300s skew bound, predecessor rederivation) are available as `asqav.verify_compliance_receipt(envelope, predecessor_envelope=...)`. The cloud is the authoritative verifier; this helper is a convenience.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.4.3"
+version = "0.4.4"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -113,7 +113,7 @@ from .client import (
     verify_output,
     verify_signature,
 )
-from .compliance import ComplianceBundle, export_bundle
+from .compliance import ComplianceBundle, export_bundle, fetch_audit_pack
 from .decorators import async_session, session, sign
 from .hooks import clear_hooks, register_after, register_before
 from .keys import (
@@ -245,6 +245,7 @@ __all__ = [
     # Compliance
     "ComplianceBundle",
     "export_bundle",
+    "fetch_audit_pack",
     # Replay
     "replay",
     "replay_from_bundle",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1091,7 +1091,7 @@ class Agent:
         nonce: str | None = None,
         valid_seconds: int | None = None,
         expected_executor_pubkey_b64: str | None = None,
-        compliance_mode: bool = False,
+        compliance_mode: bool = True,
         receipt_type: str | None = None,
         action_ref: str | None = None,
         payload_digest: str | dict[str, Any] | None = None,

--- a/python/src/asqav/compliance.py
+++ b/python/src/asqav/compliance.py
@@ -1,4 +1,18 @@
-"""Compliance bundle export for offline audit verification."""
+"""Compliance bundle export for offline audit verification.
+
+Two flows:
+
+- ``export_bundle()`` packages an in-memory list of receipts client-side
+  with a Merkle root. Useful when the caller already has the signed
+  receipts and wants a portable file to hand to an auditor.
+- ``fetch_audit_pack()`` calls the cloud's signed Audit Pack endpoint
+  (POST /api/v1/audit-pack/export). The cloud signs the bundle digest
+  with the same key family as the receipts and includes the regime
+  mapping per IETF -03 Section 7.
+
+Pick ``fetch_audit_pack`` when the auditor wants the cloud's signed
+manifest; pick ``export_bundle`` for fully-offline / air-gapped flows.
+"""
 
 import hashlib
 import json
@@ -7,25 +21,55 @@ from datetime import datetime, timezone
 from typing import Any
 
 FRAMEWORKS = {
-    "eu_ai_act_art12": {
-        "name": "EU AI Act - Article 12 Record-Keeping",
-        "description": "Logging capabilities assessment per Article 12",
-        "version": "2024/1689",
+    "eu_ai_act": {
+        "name": "EU AI Act",
+        "description": "Articles 12 + 26 record-keeping and human oversight",
+        "version": "Regulation (EU) 2024/1689",
     },
-    "eu_ai_act_art14": {
-        "name": "EU AI Act - Article 14 Human Oversight",
-        "description": "Human oversight assessment per Article 14",
-        "version": "2024/1689",
+    "dora": {
+        "name": "DORA",
+        "description": "Digital Operational Resilience Act, Article 17",
+        "version": "Regulation (EU) 2022/2554",
     },
-    "dora_ict": {
-        "name": "DORA ICT Risk Management",
-        "description": "Digital Operational Resilience Act assessment",
-        "version": "2022/2554",
+    "nydfs_500": {
+        "name": "NYDFS Part 500",
+        "description": "23 NYCRR Part 500 audit trail and incident notice",
+        "version": "23 NYCRR 500",
     },
-    "soc2": {
-        "name": "SOC 2 Type II",
-        "description": "Service Organization Control audit evidence",
-        "version": "2017",
+    "colorado_ai": {
+        "name": "Colorado AI Act",
+        "description": "SB 24-205 High-Risk AI System deployer obligations",
+        "version": "SB 24-205",
+    },
+    "texas_traiga": {
+        "name": "Texas TRAIGA",
+        "description": "HB 149 intent-based liability and prohibited-use vocab",
+        "version": "HB 149",
+    },
+    "nist_ai_rmf": {
+        "name": "NIST AI RMF",
+        "description": "Voluntary GOVERN / MAP / MEASURE / MANAGE framework",
+        "version": "NIST AI 100-1",
+    },
+    "circia": {
+        "name": "CIRCIA",
+        "description": "Covered Cyber Incident reporting for critical infrastructure",
+        "version": "Public Law 117-103",
+    },
+    "hipaa_security": {
+        "name": "HIPAA Security Rule",
+        "description": "45 CFR 164.312(b) audit controls",
+        "version": "45 CFR 164",
+    },
+    "sec_17a4a": {
+        "name": "SEC 17 CFR 240.17a-4(a)",
+        "description": "Broker-dealer 6-year retention",
+        "version": "17 CFR 240.17a-4(a)",
+    },
+    "sec_17a4b": {
+        "name": "SEC 17 CFR 240.17a-4(b)",
+        "description": "Broker-dealer 3-year retention",
+        "version": "17 CFR 240.17a-4(b)",
     },
 }
 
@@ -121,7 +165,7 @@ class ComplianceBundle:
 
 def export_bundle(
     signatures: list,
-    framework: str = "eu_ai_act_art12",
+    framework: str = "eu_ai_act",
 ) -> ComplianceBundle:
     """Package signatures into a compliance bundle with Merkle root.
 
@@ -160,3 +204,50 @@ def export_bundle(
             "receipt_hashes": hashes,
         },
     )
+
+
+def fetch_audit_pack(
+    *,
+    start: str,
+    end: str,
+    agent_id: str | None = None,
+    only_compliance: bool = True,
+) -> dict[str, Any]:
+    """Fetch the cloud-signed Audit Pack for a window.
+
+    Wraps POST /api/v1/audit-pack/export. Returns the cloud response as a
+    dict including bundle_digest, bundle_signature, bundle_public_key,
+    receipts, regime_mapping, revocation_manifest, and
+    algorithm_registry_version.
+
+    Args:
+        start: ISO-8601 UTC window start (inclusive).
+        end: ISO-8601 UTC window end (exclusive).
+        agent_id: Optional agent_id to scope the export.
+        only_compliance: When True (default), only Compliance Receipts are
+            included. False also includes pre-compliance-mode receipts.
+
+    Raises:
+        RuntimeError: If asqav.init() has not been called.
+        httpx.HTTPStatusError: On cloud error responses (4xx / 5xx).
+    """
+    from . import client as _client
+
+    if _client._api_key is None:
+        raise RuntimeError("asqav.init(api_key=...) must be called first.")
+    if _client.httpx is None:
+        raise RuntimeError("httpx is required; install with `pip install asqav[http]`.")
+
+    url = _client._api_base.rstrip("/") + "/api/v1/audit-pack/export"
+    body = {"start": start, "end": end, "only_compliance": only_compliance}
+    if agent_id is not None:
+        body["agent_id"] = agent_id
+
+    resp = _client.httpx.post(
+        url,
+        json=body,
+        headers={"Authorization": f"Bearer {_client._api_key}"},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -351,12 +351,17 @@ async function cmdApprove(args: string[]): Promise<void> {
 }
 
 async function cmdComplianceFrameworks(): Promise<void> {
-  // Static list mirrors python/src/asqav/compliance.py FRAMEWORKS keys.
   const frameworks: Array<[string, string]> = [
-    ["eu_ai_act_art12", "EU AI Act, Article 12 - Logging"],
-    ["eu_ai_act_art14", "EU AI Act, Article 14 - Human oversight"],
-    ["dora_ict", "DORA - ICT operational resilience"],
-    ["soc2", "SOC 2 - CC7.2 anomaly logging"],
+    ["eu_ai_act", "EU AI Act, Articles 12 + 26"],
+    ["dora", "DORA, Article 17"],
+    ["nydfs_500", "NYDFS Part 500"],
+    ["colorado_ai", "Colorado AI Act SB 24-205"],
+    ["texas_traiga", "Texas TRAIGA HB 149"],
+    ["nist_ai_rmf", "NIST AI RMF"],
+    ["circia", "CIRCIA Covered Cyber Incident"],
+    ["hipaa_security", "HIPAA Security Rule 164.312(b)"],
+    ["sec_17a4a", "SEC 17 CFR 240.17a-4(a) - 6 year"],
+    ["sec_17a4b", "SEC 17 CFR 240.17a-4(b) - 3 year"],
   ];
   for (const [k, name] of frameworks) {
     process.stdout.write(`${k}\t${name}\n`);
@@ -365,7 +370,7 @@ async function cmdComplianceFrameworks(): Promise<void> {
 
 async function cmdComplianceExport(args: string[]): Promise<void> {
   const session = parseFlag(args, "session");
-  const framework = parseFlag(args, "framework") ?? "eu_ai_act_art12";
+  const framework = parseFlag(args, "framework") ?? "eu_ai_act";
   const output = parseFlag(args, "output");
   if (!session || !output) {
     die("Usage: asqav compliance export --session <id> --output <path> [--framework eu_ai_act_art12]");

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -792,7 +792,7 @@ export class Agent {
     }
     const finalContext = _dispatchBefore(options.actionType, initialContext);
 
-    const complianceMode = options.complianceMode === true;
+    const complianceMode = options.complianceMode !== false;
 
     // Validate the IETF receipt namespace client-side so callers fail
     // fast instead of waiting for the server's 422. The cloud is still

--- a/typescript/tests/cli.test.ts
+++ b/typescript/tests/cli.test.ts
@@ -136,9 +136,16 @@ describe("asqav CLI (TypeScript)", () => {
   it("compliance frameworks lists static set", async () => {
     await runCli(["compliance", "frameworks"]);
     const out = output();
-    expect(out).toContain("eu_ai_act_art12");
-    expect(out).toContain("dora_ict");
-    expect(out).toContain("soc2");
+    expect(out).toContain("eu_ai_act");
+    expect(out).toContain("dora");
+    expect(out).toContain("nydfs_500");
+    expect(out).toContain("colorado_ai");
+    expect(out).toContain("texas_traiga");
+    expect(out).toContain("nist_ai_rmf");
+    expect(out).toContain("circia");
+    expect(out).toContain("hipaa_security");
+    expect(out).toContain("sec_17a4a");
+    expect(out).toContain("sec_17a4b");
   });
 
   it("rejects unknown command with usage hint", async () => {

--- a/typescript/tests/decisionAlias.test.ts
+++ b/typescript/tests/decisionAlias.test.ts
@@ -107,6 +107,7 @@ describe("agent.sign decision wire field", () => {
     const agent = fakeAgent();
     await agent.sign({
       actionType: "t.test",
+      complianceMode: false,
       policyDecision: "permit",
     });
 

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -142,7 +142,7 @@ describe("agent.sign IETF profile fields", () => {
     );
 
     const agent = fakeAgent();
-    await agent.sign({ actionType: "api:call", context: {} });
+    await agent.sign({ actionType: "api:call", context: {}, complianceMode: false });
 
     const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(calledInit.body as string) as Record<string, unknown>;

--- a/typescript/tests/sdk.test.ts
+++ b/typescript/tests/sdk.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Agent,
@@ -6,6 +7,7 @@ import {
   init,
   verifySignature,
 } from "../src/index.js";
+import { canonicalJson } from "../src/jcs.js";
 
 function mockJsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -122,10 +124,17 @@ describe("agent.sign", () => {
     const [signUrl, signInit] = fetchSpy.mock.calls[1] as [string, RequestInit];
     expect(signUrl).toBe("https://api.example.test/api/v1/agents/agt_2/sign");
     expect(signInit.method).toBe("POST");
+    const expectedActionRef =
+      "sha256:" +
+      createHash("sha256")
+        .update(canonicalJson({ action_type: "api:call", context: { model: "gpt-4" } }))
+        .digest("hex");
     expect(JSON.parse(signInit.body as string)).toEqual({
       action_type: "api:call",
       context: { model: "gpt-4" },
       session_id: null,
+      compliance_mode: true,
+      action_ref: expectedActionRef,
     });
 
     expect(sig.signatureId).toBe("sig_1");


### PR DESCRIPTION
Per Ali's review of -03 against the SDK + the no-clients mandate to fix the defaults rather than carry the old ones.

1. **compliance_mode default flip**. Python sign() and TypeScript sign() now default to compliance_mode=True. New SDK users get a Compliance Receipt out of the box, matching what a reader of draft-marques-asqav-compliance-receipts-03 expects. Pass compliance_mode=False to opt out.

2. **FRAMEWORKS dict aligned to -03 bindings**. Replaces eu_ai_act_art12 / eu_ai_act_art14 / dora_ict / soc2 (only one of which is even bound in -03) with the actual 10-entry token set: eu_ai_act, dora, nydfs_500, colorado_ai, texas_traiga, nist_ai_rmf, circia, hipaa_security, sec_17a4a, sec_17a4b.

3. **fetch_audit_pack() wraps the cloud Audit Pack endpoint** (POST /api/v1/audit-pack/export, IETF -03 Section 7). Returns the cloud-signed bundle dict (bundle_digest, bundle_signature, bundle_public_key, regime_mapping, revocation_manifest, algorithm_registry_version). export_bundle() stays as the offline Merkle aggregator; README clarifies when to pick which.

Versions: pip 0.4.3 -> 0.4.4, npm 0.3.3 -> 0.3.4.

comment hygiene clean