### PR TITLE
docs(user-intent): webauthn is now cryptographically verified

### DIFF
--- a/docs/user-intent.md
+++ b/docs/user-intent.md
@@ -23,7 +23,7 @@ Supported algorithms today:
 
 - `ed25519` - verified server-side via the cryptography library.
 - `ecdsa-p256` - verified server-side via the cryptography library.
-- `webauthn` - stored advisory only. Full WebAuthn assertion verification is on the roadmap. The signature bytes still travel and persist; `user_intent_verified` will be `false` until the WebAuthn worker ships.
+- `webauthn` - cryptographically verified server-side. `public_key` is a CBOR-encoded COSE credential key (EdDSA or ES256), `signature` is the assertion signature, `signed_message` is the bytes the authenticator signed (per WebAuthn, `authenticatorData || SHA-256(clientDataJSON)`). Higher-level checks (challenge match, RP ID, origin, user-present flag) live with the relying-party front end.
 
 If verification fails, the backend returns 400 with `code: USER_INTENT_INVALID` and does not sign over a bogus envelope.
 


### PR DESCRIPTION
## Summary
- Removes the "stored advisory only / on the roadmap" framing for the \`webauthn\` algorithm.
- Documents the COSE encoding contract (CBOR map per the IANA COSE registry) and the relying-party-side responsibility split.
- Mirrors the cloud-side change (jagmarques/asqav PR landing in same cycle) that adds real \`_verify_webauthn()\` covering EdDSA + ES256.

## Test plan
- [x] Cloud test suite: 12/12 user_intent cases pass including 4 new webauthn cases (EdDSA happy, ES256 happy, signature mismatch, unsupported COSE alg).

comment hygiene clean