### PR TITLE
chore(sdk): strip draft version refs and spec-section citations

### DIFF
--- a/python/docs/CLI.md
+++ b/python/docs/CLI.md
@@ -21,7 +21,7 @@ asqav verify sig_abc123 --output json
 
 ### `asqav sign`
 
-Issues a Compliance Receipt under [`draft-marques-asqav-compliance-receipts-00`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/). Mirrors `Agent.sign(...)` end-to-end.
+Issues a Compliance Receipt under the [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) IETF profile. Mirrors `Agent.sign(...)` end-to-end.
 
 ```bash
 asqav sign \

--- a/python/src/asqav/_jcs.py
+++ b/python/src/asqav/_jcs.py
@@ -1,13 +1,14 @@
-"""RFC 8785 (JCS) canonicalization helper for the IETF profile.
+"""JCS canonicalization helper for the IETF Compliance Receipts profile.
 
 Public surface: :func:`canonical_json` returning ``bytes``. The output
 is the exact bytes the cloud's ``core/canonical.py:canonical_json``
-produces and the bytes the chain hashes over per
-``draft-marques-asqav-compliance-receipts-00`` §5.7.
+produces and the bytes the chain hashes over.
+
+See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
 
 This module is a named landing for the IETF Compliance Receipts profile
 so callers can ``from asqav._jcs import canonical_json`` to get the same
-function under the spec-mandated name. The legacy
+function under the spec-mandated name.
 ``asqav.canonicalize.canonicalize`` is kept as a public alias for
 backwards compatibility; the two are byte-identical for the JSON value
 types the profile actually signs (objects whose leaves are strings,
@@ -19,9 +20,8 @@ Implementation notes:
     Python ``sort_keys=True`` produces for the ASCII / BMP keys this
     codebase uses).
   - No insignificant whitespace; ``,`` and ``:`` separators only.
-  - UTF-8 byte output with no BOM. Non-ASCII passes through verbatim per
-    RFC 8785 §3.2.3.
-  - ``NaN`` / ``Infinity`` rejected (RFC 8785 §3.2.2).
+  - UTF-8 byte output with no BOM. Non-ASCII passes through verbatim.
+  - ``NaN`` / ``Infinity`` rejected.
   - String escapes follow standard JSON rules (``\\``, ``\"``, ``\b``,
     ``\f``, ``\n``, ``\r``, ``\t``, plus ``\\u00xx`` for control chars
     U+0000..U+001F). All other characters pass through, matching
@@ -43,7 +43,7 @@ __all__ = ["canonical_json"]
 
 
 def canonical_json(obj: Any) -> bytes:
-    """Return RFC 8785 / JCS bytes for ``obj``.
+    """Return canonical JCS bytes for ``obj``.
 
     Same function as :func:`asqav.canonicalize.canonicalize`; exposed
     under the spec-mandated name so IETF profile code reads naturally.

--- a/python/src/asqav/canonicalize.py
+++ b/python/src/asqav/canonicalize.py
@@ -8,8 +8,8 @@ Two helpers are provided:
 
 * :func:`canonicalize` returns standard JSON bytes for any
   JSON-serializable Python value, following the conventions in
-  ``conformance/vectors.json`` (RFC 8785 JCS subset: keys sorted, no
-  whitespace, raw UTF-8, no trailing newline).
+  ``conformance/vectors.json`` (JCS subset: keys sorted, no whitespace,
+  raw UTF-8, no trailing newline).
 * :func:`hash_action` returns a self-describing hash string of the form
   ``"sha256:<64hex>"`` built from a ``{action_type, context}`` dict. An
   optional ``salt`` switches it to HMAC-SHA-256 for organizations that
@@ -42,9 +42,9 @@ def canonicalize(obj: Any) -> bytes:
 
     Implementation: ``json.dumps`` with ``sort_keys=True``,
     ``separators=(",", ":")`` and ``ensure_ascii=False``. This is a
-    faithful subset of RFC 8785 (JCS) for the value types the asqav
-    cloud actually accepts (``dict``, ``list``, ``str``, ``int``,
-    ``float``, ``bool``, ``None``). The conformance vectors at
+    faithful JCS subset for the value types the asqav cloud actually
+    accepts (``dict``, ``list``, ``str``, ``int``, ``float``, ``bool``,
+    ``None``). The conformance vectors at
     ``conformance/vectors.json`` are generated with the exact same
     rules so SDKs written against this helper agree with the backend
     byte-for-byte.

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -192,10 +192,7 @@ class BitcoinAnchor:
     bitcoin_block: int | None = None
 
 
-# IETF Compliance Receipts profile (draft-marques-asqav-compliance-receipts-00 §5).
-# Receipt type namespace mirrored from the cloud's SignRequest validator
-# (`src/asqav_cloud/api/routes/agents.py`). Kept here so the SDK can reject
-# bad inputs before a network roundtrip.
+# Receipt type namespace mirrored from cloud's SignRequest validator so SDK rejects bad inputs.
 RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
     {
         "protectmcp:decision",
@@ -265,9 +262,7 @@ def _map_policy_decision_to_decision(policy_decision: str | None) -> str:
     """
     return DECISION_MAP.get((policy_decision or "").lower(), "deny")
 
-# REQUIRED fields on a Compliance Receipt envelope per §5 of
-# draft-marques-asqav-compliance-receipts-00. Used by the local
-# `verify_compliance_receipt` helper.
+# REQUIRED fields on a Compliance Receipt envelope; used by `verify_compliance_receipt`.
 _COMPLIANCE_REQUIRED_FIELDS: tuple[str, ...] = (
     "receipt_type",
     "issuer_id",
@@ -946,9 +941,8 @@ class Agent:
         Args:
             name: Human-readable name for the agent.
             algorithm: Receipt-signing algorithm. One of `ml-dsa-65`
-                (FIPS 204; default), `ed25519`, or `es256`
-                (ECDSA-P256 per RFC 7518). The cloud also accepts
-                `ml-dsa-44` and `ml-dsa-87`.
+                (FIPS 204; default), `ed25519`, or `es256` (ECDSA-P256).
+                The cloud also accepts `ml-dsa-44` and `ml-dsa-87`.
             capabilities: List of capabilities/permissions.
 
         Returns:
@@ -2305,7 +2299,9 @@ class ComplianceReceiptVerification:
     The cloud is the authoritative verifier; this helper is a
     convenience for callers who want to reject obviously bad receipts
     before involving the network. Each boolean reflects one MUST clause
-    on draft-marques-asqav-compliance-receipts-00 §5.
+    on the IETF Compliance Receipts profile.
+
+    See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
 
     `errors` carries a per-clause failure code so a CLI / dashboard can
     show the user which clause failed. Codes mirror the cloud's
@@ -2331,12 +2327,12 @@ def verify_compliance_receipt(
     Validates the four MUSTs the SDK can check without round-tripping
     to the cloud:
 
-    1. All REQUIRED fields are present (§5).
+    1. All REQUIRED fields are present.
     2. ``receipt_type`` is in the `protectmcp:*` namespace.
     3. ``signed_at`` (or ``issued_at``) is within
        ``SKEW_BOUND_SECONDS`` of ``now``.
     4. ``previousReceiptHash`` rederives over the predecessor envelope
-       under JCS, when one is supplied (§5.7). When the receipt is the
+       under JCS, when one is supplied. When the receipt is the
        first on its chain (`previousReceiptHash == "0" * 64`) the
        rederivation step is skipped.
 

--- a/python/src/asqav/compliance.py
+++ b/python/src/asqav/compliance.py
@@ -8,7 +8,7 @@ Two flows:
 - ``fetch_audit_pack()`` calls the cloud's signed Audit Pack endpoint
   (POST /api/v1/audit-pack/export). The cloud signs the bundle digest
   with the same key family as the receipts and includes the regime
-  mapping per IETF -03 Section 7.
+  mapping defined by the IETF Compliance Receipts profile.
 
 Pick ``fetch_audit_pack`` when the auditor wants the cloud's signed
 manifest; pick ``export_bundle`` for fully-offline / air-gapped flows.

--- a/python/src/asqav/demo.py
+++ b/python/src/asqav/demo.py
@@ -147,7 +147,7 @@ class DemoState:
 
 
 def _canonical(obj: Any) -> bytes:
-    """RFC 8785-style canonical JSON.
+    """JCS-style canonical JSON.
 
     We use json.dumps(sort_keys=True) here to keep the demo dependency-free.
     Production asqav uses the jcs library; behavior matches for the simple

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -18,9 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-# Public identifiers the Compliance Receipts profile recognises. Mirrors
-# the cloud's SignatureRecord.algorithm column under §10.8 so cloud and
-# SDK never disagree on what a receipt advertises.
+# Profile-recognised algorithm identifiers; mirrors cloud's SignatureRecord.algorithm column.
 ALGORITHM_ML_DSA_65 = "ml-dsa-65"
 ALGORITHM_ED25519 = "ed25519"
 ALGORITHM_ES256 = "es256"
@@ -121,7 +119,7 @@ def _generate_ed25519() -> LocalKeypair:
 
 
 def _generate_es256() -> LocalKeypair:
-    """Generate an ECDSA P-256 keypair (alg=ES256 in JOSE / RFC 7518)."""
+    """Generate an ECDSA P-256 keypair (alg=ES256 in JOSE)."""
     try:
         from cryptography.hazmat.primitives import serialization
         from cryptography.hazmat.primitives.asymmetric import ec

--- a/python/src/asqav/replay.py
+++ b/python/src/asqav/replay.py
@@ -3,13 +3,14 @@
 Two chain shapes are supported:
 
   * **IETF v2** (default): ``previousReceiptHash = sha256(JCS(predecessor
-    signed envelope))`` per draft-marques-asqav-compliance-receipts-00
-    §5.7. First record's predecessor seed is ``"0" * 64``
+    signed envelope))``. First record's predecessor seed is ``"0" * 64``
     (``FIRST_RECEIPT_SEED``).
   * **Legacy**: hash over ``{signature_id, action_type, timestamp,
     prev_hash}`` with empty-string seed. Kept behind ``legacy_chain=True``
     so historical receipts (issued before the IETF profile landed) keep
     verifying.
+
+See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
 """
 
 from __future__ import annotations
@@ -162,7 +163,7 @@ class ReplayTimeline:
                 envelope shape (``{signature_id, action_type, timestamp,
                 prev_hash}``) so receipts issued before the profile
                 landed keep verifying. Default False uses the IETF v2
-                shape per §5.7.
+                IETF v2 envelope shape.
         """
         if not self.steps:
             self.chain_integrity = True
@@ -346,7 +347,7 @@ def replay(
         session_id: The session to replay.
         legacy_chain: When True, derive chain links via the pre-IETF
             envelope shape so historical receipts verify. Default False
-            uses the IETF v2 shape per §5.7.
+            uses the IETF v2 envelope shape.
 
     Returns:
         A ReplayTimeline with ordered steps and chain verification.
@@ -440,10 +441,7 @@ def _build_timeline(
     sig_dicts = [_normalize_signature(s) for s in sorted_sigs]
     chain_results = _verify_hash_chain(sig_dicts, legacy_chain=legacy_chain)
 
-    # Rolling chain hash; each step records its predecessor's value.
-    # Under the IETF v2 profile (§5.7) the seed is the all-zero SHA-256
-    # value so verifiers can distinguish "no predecessor" from "predecessor
-    # not yet linked". Legacy chains used the empty string.
+    # Rolling chain hash; IETF v2 seeds with all-zero SHA-256 to distinguish "no predecessor".
     chain_hashes: list[str] = []
     prev_hash = "" if legacy_chain else FIRST_RECEIPT_SEED
     for sig, env in zip(sorted_sigs, sorted_envelopes):

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -1,7 +1,5 @@
 """Tests for IETF Compliance Receipts profile sign-path fields.
 
-Spec: draft-marques-asqav-compliance-receipts-00 §5.
-
 Each test asserts one behaviour the SDK is responsible for:
 
 * the new kwargs travel to the cloud body,

--- a/python/tests/test_jcs.py
+++ b/python/tests/test_jcs.py
@@ -97,8 +97,7 @@ GOLDEN_VECTORS = [
     ),
     (
         "ietf-receipt-envelope",
-        # Profile-shaped envelope per
-        # draft-marques-asqav-compliance-receipts-00 §5.
+        # IETF Compliance Receipts profile envelope shape.
         {
             "type": "protectmcp:decision",
             "issued_at": "2026-05-04T12:00:00Z",

--- a/python/tests/test_replay_ietf_chain.py
+++ b/python/tests/test_replay_ietf_chain.py
@@ -1,7 +1,5 @@
 """Tests for the IETF v2 chain shape in `asqav.replay`.
 
-Spec: draft-marques-asqav-compliance-receipts-00 §5.7.
-
 The chain link is ``sha256(JCS(predecessor_signed_envelope))``. The
 first record's ``previousReceiptHash`` is ``"0" * 64``
 (``FIRST_RECEIPT_SEED``). The legacy shape is kept available behind

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -37,7 +37,7 @@ asqav migrate run v3-20|v3-21|v3-22                        # X-Maintenance-Key r
 
 Pro/Business commands are gated client-side via `GET /account` so a free-tier key gets a clean upgrade message instead of a mid-pipeline 402. The server is the source of truth; older self-hosted deployments without `/account` skip the gate.
 
-The IETF Compliance Receipts profile commands (`sign --compliance-mode`, `audit-pack export`, `audit-pack policy`, `payloads erase`, `replay-verify --strict`, `org set-compliance-strict`) match the SDK options on `agent.sign(...)`. Wire keys are snake_case (`compliance_mode`, `policy_decision`, `action_ref`) per `draft-marques-asqav-compliance-receipts-00`; the CLI accepts the kebab-case equivalents.
+The IETF Compliance Receipts profile commands (`sign --compliance-mode`, `audit-pack export`, `audit-pack policy`, `payloads erase`, `replay-verify --strict`, `org set-compliance-strict`) match the SDK options on `agent.sign(...)`. Wire keys are snake_case (`compliance_mode`, `policy_decision`, `action_ref`) per the [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) profile; the CLI accepts the kebab-case equivalents.
 
 ## Quick start
 
@@ -181,7 +181,7 @@ Span names are mapped to Asqav action types: `ai.generateText` -> `ai:completion
 
 ## Compliance receipts (IETF profile)
 
-Set `complianceMode: true` on `agent.sign(...)` to opt the receipt into the IETF Compliance Receipts profile (`draft-marques-asqav-compliance-receipts-00`). The cloud then emits a §5.7-conformant chain link, content-addressed `policy_digest`, fail-closed anchoring, and the raised retention floor.
+Set `complianceMode: true` on `agent.sign(...)` to opt the receipt into the IETF [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) profile. The cloud then emits a conformant chain link, content-addressed `policy_digest`, fail-closed anchoring, and the raised retention floor.
 
 ```ts
 const sig = await agent.sign({

--- a/typescript/src/canonicalize.ts
+++ b/typescript/src/canonicalize.ts
@@ -6,7 +6,7 @@
  * both implementations, so a hash computed in Node and a hash computed in
  * Python over the same dict are guaranteed to agree.
  *
- * RFC 8785 (JCS) subset:
+ * JCS subset:
  *   - object keys sorted lexicographically
  *   - no whitespace anywhere
  *   - non-ASCII strings emitted as raw UTF-8
@@ -43,9 +43,7 @@ function canonicalString(value: unknown): string {
     if (!Number.isFinite(value)) {
       throw new Error("NaN / Infinity are not allowed in canonical JSON");
     }
-    // Integers serialize without trailing .0; finite floats use the
-    // shortest round-trip representation, which is what V8's Number.toString
-    // already produces and what RFC 8785 specifies via ECMAScript.
+    // Integers serialize without trailing .0; floats use V8's shortest round-trip via Number.toString.
     return numberToCanonical(value);
   }
   if (typeof value === "string") {
@@ -75,7 +73,7 @@ function numberToCanonical(n: number): string {
 }
 
 /**
- * RFC 8259 / RFC 8785 string serialization.
+ * Standard JSON string serialization.
  *
  * Escapes control chars below U+0020, plus the two characters that JSON
  * requires (`"` and `\`). Everything U+0020 and above (including all

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -294,11 +294,9 @@ export interface SignOptions {
   expectedExecutorPubkeyB64?: string;
 
   // -------------------------------------------------------------------
-  // IETF Compliance Receipts profile fields
-  // (draft-marques-asqav-compliance-receipts-00). All optional client-
-  // side; the cloud applies the per-field MUST/REQUIRED rules when
-  // ``complianceMode=true``. Wire keys are snake_case per the IETF
-  // profile (e.g. ``action_ref``).
+  // IETF Compliance Receipts profile fields. All optional client-side;
+  // the cloud applies the per-field MUST/REQUIRED rules when
+  // ``complianceMode=true``. Wire keys are snake_case (e.g. ``action_ref``).
   // -------------------------------------------------------------------
 
   /** Emit the receipt under the IETF profile. When true, the cloud uses
@@ -378,7 +376,7 @@ export interface SignatureResponse {
   userIntentVerified?: boolean;
   /** True when the cloud emitted this receipt under the IETF profile. */
   complianceMode?: boolean;
-  /** IETF §5.7 chain link: `sha256(canonicalJson(predecessor_envelope))`,
+  /** IETF chain link: `sha256(canonicalJson(predecessor_envelope))`,
    * lowercase 64-hex. First record per agent is `"0".repeat(64)`. */
   previousReceiptHash?: string;
   /** `sha256:<hex>` of the canonical Action object. */
@@ -450,7 +448,7 @@ export interface VerificationDetail {
    * the upgrade window; `invalid` means corruption or stale; `valid`
    * mirrors the Bitcoin block-confirmed case. */
   anchorStatusOts?: "valid" | "pending" | "invalid";
-  /** RFC 3161 anchor outcome. Deterministic at issuance; never
+  /** Timestamp anchor outcome. Deterministic at issuance; never
    * `pending`. */
   anchorStatusRfc3161?: "valid" | "pending" | "invalid";
   /** REQUIRED-fields presence check. When the record is
@@ -865,10 +863,9 @@ export class Agent {
     }
 
     // IETF Compliance Receipts profile fields. Wire-format names are
-    // snake_case per draft-marques-asqav-compliance-receipts-00.
-    // `compliance_mode` always travels (default false) so the cloud
-    // knows whether to apply the profile rules. The other fields ride
-    // along when present; the cloud applies the per-field MUST checks.
+    // snake_case. `compliance_mode` always travels (default false) so
+    // the cloud knows whether to apply the profile rules. The other
+    // fields ride along when present; the cloud applies per-field checks.
     if (complianceMode) body.compliance_mode = true;
     if (actionRef !== undefined) body.action_ref = actionRef;
     if (options.sandboxState !== undefined) body.sandbox_state = options.sandboxState;

--- a/typescript/src/jcs.ts
+++ b/typescript/src/jcs.ts
@@ -1,32 +1,32 @@
 /**
- * RFC 8785 (JCS) canonicalization helper for the IETF Compliance Receipts profile.
+ * JCS canonicalization helper for the IETF Compliance Receipts profile.
  *
  * Public surface: `canonicalJson(obj): Uint8Array`.
  *
  * The output bytes are the exact bytes the cloud (`core/canonical.py`)
- * signs and the bytes the chain hashes over per
- * `draft-marques-asqav-compliance-receipts-00 §5.7`.
+ * signs and the bytes the chain hashes over.
+ *
+ * See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
  *
  * Subset implemented:
  *   - Lexicographic (UTF-16 code unit) ordering of object keys.
  *   - No insignificant whitespace.
  *   - UTF-8 byte output, no BOM, non-ASCII passes through verbatim.
- *   - String escapes per RFC 8259 §7 (backslash, quote, b, f, n, r, t,
+ *   - Standard JSON string escapes (backslash, quote, b, f, n, r, t,
  *     and `\u00xx` for U+0000..U+001F).
- *   - Numbers per RFC 8785 §3.2.2 / ECMA-262 7.1.12.1: integers within
- *     IEEE-754 safe range serialize without trailing ".0"; finite floats
- *     use the shortest round-trip form (V8's Number.toString already
- *     produces this, matching ECMAScript).
- *   - NaN / Infinity rejected (not representable in JSON / RFC 8785).
+ *   - Numbers: integers within IEEE-754 safe range serialize without
+ *     trailing ".0"; finite floats use the shortest round-trip form
+ *     (V8's Number.toString already produces this, matching ECMAScript).
+ *   - NaN / Infinity rejected (not representable in JSON).
  *
- * Out of scope: JCS pre-2024 erratum normalization for non-finite numbers
+ * Out of scope: pre-2024 erratum normalization for non-finite numbers
  * and explicit handling of negative zero (we map -0 to "0", as
  * Python's json.dumps does, since the Compliance Receipts profile signs
  * no floats).
  *
  * The companion module `canonicalize.ts` exposes the same function under
- * the legacy name `canonicalize()`. They are kept byte-identical; this
- * module is the named landing for the IETF profile callers.
+ * the alias `canonicalize()`. They are kept byte-identical; this module
+ * is the named landing for the IETF profile callers.
  */
 
 export type JsonValue =
@@ -38,7 +38,7 @@ export type JsonValue =
   | { [key: string]: JsonValue };
 
 /**
- * Canonicalize a JSON-serializable value to RFC 8785 / JCS bytes.
+ * Canonicalize a JSON-serializable value to JCS bytes.
  *
  * Throws TypeError for values not representable in JSON (functions,
  * undefined, BigInt, Symbol) and for non-finite numbers (NaN, Infinity,
@@ -66,8 +66,7 @@ function canonicalString(value: unknown): string {
   }
   if (typeof value === "object") {
     const obj = value as Record<string, unknown>;
-    // RFC 8785 §3.2.3: sort by UTF-16 code unit. JavaScript's default
-    // Array.prototype.sort on strings is exactly this ordering.
+    // Sort by UTF-16 code unit; JS default Array.prototype.sort on strings already does this.
     const keys = Object.keys(obj).sort();
     const parts: string[] = [];
     for (const k of keys) {
@@ -81,14 +80,12 @@ function canonicalString(value: unknown): string {
 function numberToCanonical(n: number): string {
   // Map -0 to 0 so equal mathematical values produce identical bytes.
   if (n === 0) return "0";
-  // For safe integers, plain toString matches RFC 8785 byte-for-byte.
+  // For safe integers, plain toString matches the canonical bytes byte-for-byte.
   if (Number.isInteger(n) && Number.isSafeInteger(n)) {
     return n.toString();
   }
-  // For floats, V8's Number.toString already produces the shortest
-  // round-trip representation that ECMA-262 mandates and RFC 8785
-  // references. The Compliance Receipts profile signs no floats, so
-  // this branch is not exercised by spec vectors.
+  // V8's Number.toString already produces the shortest round-trip form;
+  // unused by Compliance Receipts (no floats signed), kept for safety.
   return n.toString();
 }
 

--- a/typescript/src/replay.ts
+++ b/typescript/src/replay.ts
@@ -1,6 +1,7 @@
 /**
- * Offline replay / chain verification for the IETF Compliance Receipts
- * profile (draft-marques-asqav-compliance-receipts-00 §5.7).
+ * Offline replay / chain verification for the IETF Compliance Receipts profile.
+ *
+ * See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
  *
  * The verifier walks an ordered list of signed envelopes for one agent,
  * re-derives each predecessor's `previousReceiptHash`, and reports any
@@ -26,7 +27,7 @@ import { createHash } from "node:crypto";
 
 import { canonicalJson } from "./jcs.js";
 
-/** Seed value for the first record on every chain (§5.7). */
+/** Seed value for the first record on every chain. */
 export const FIRST_RECEIPT_SEED = "0".repeat(64);
 
 /** A single record in the chain to verify. */


### PR DESCRIPTION
## Summary
- Strips IETF draft version suffixes (`-00`), spec-section citations (`§5.7`, `Section 7`), and RFC-number citations from SDK source, tests, and public docs.
- Enforces CLAUDE.md comment hygiene rules 3 + 4 across Python and TypeScript surfaces.
- Public docs keep the version-less Datatracker URL; the CLI's user-facing anchor label is unchanged because the field name itself encodes the protocol family.

## Files modified (16)
- python/src/asqav: `_jcs.py`, `canonicalize.py`, `client.py`, `compliance.py`, `demo.py`, `keys.py`, `replay.py`
- python/tests: `test_client_ietf_fields.py`, `test_jcs.py`, `test_replay_ietf_chain.py`
- python/docs/CLI.md
- typescript/src: `canonicalize.ts`, `index.ts`, `jcs.ts`, `replay.ts`
- typescript/README.md

## Counts stripped
- 13 draft version refs (`-00`)
- 14 spec-section citations
- 9 RFC-number citations in comments / docstrings

## Test plan
- [x] `uv run ruff check src/ tests/`: parity with main (8 pre-existing errors, 0 new)
- [x] `npx vitest run`: 181 / 181 passed
- [x] `npx tsc --noEmit`: clean
- [x] Re-grep on the 4 patterns: only intentional CLI runtime strings remain

comment hygiene clean