### PR TITLE
chore(sdk): regen TS lockfile + drop stub default + tighten CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ### Changed
 - **`complianceMode` defaults to `True`**. New SDK callers get a Compliance Receipt out of the box; pass `complianceMode: false` to opt out. Both Python and TypeScript.
-- **`FRAMEWORKS` list** replaced with the 9 regime tokens the cloud actually emits: `eu_ai_act`, `dora`, `nydfs_500`, `colorado_ai`, `texas_traiga`, `nist_ai_rmf`, `circia`, `hipaa_security`, `sec_17a4a`, `sec_17a4b`. Drops the four placeholder tokens (`eu_ai_act_art12`, `eu_ai_act_art14`, `dora_ict`, `soc2`).
+- **`FRAMEWORKS` list** replaced with the 10 regime tokens the cloud actually emits: `eu_ai_act`, `dora`, `nydfs_500`, `colorado_ai`, `texas_traiga`, `nist_ai_rmf`, `circia`, `hipaa_security`, `sec_17a4a`, `sec_17a4b`. Drops the four placeholder tokens (`eu_ai_act_art12`, `eu_ai_act_art14`, `dora_ict`, `soc2`).
 
 ### Added
-- `fetch_audit_pack()` (Python) / `fetchAuditPack()` (TypeScript): wraps the cloud `/api/v1/audit-pack/export` endpoint and returns the cloud-signed bundle (`bundle_digest`, `bundle_signature`, `regime_mapping`, `revocation_manifest`). Use this to pull a regulator-ready Audit Pack; the offline `export_bundle` aggregator stays for self-hosted-signer use.
+- `fetch_audit_pack()` (Python): wraps the cloud `/api/v1/audit-pack/export` endpoint and returns the cloud-signed bundle (`bundle_digest`, `bundle_signature`, `regime_mapping`, `revocation_manifest`). Use this to pull a regulator-ready Audit Pack; the offline `export_bundle` aggregator stays for self-hosted-signer use. (TypeScript helper lands in a follow-up release.)
 
 ### Internal
 - Comment-hygiene + AI-navigation gold standard sweep across both SDK source trees (47 multi-line comment blocks collapsed; 14 forbidden framing tokens reworded; SignatureResponse / ReplayStep / ReplayTimeline class docstrings expanded).

--- a/python/src/asqav/extras/letta.py
+++ b/python/src/asqav/extras/letta.py
@@ -43,7 +43,7 @@ class AsqavLettaHook(AsqavAdapter):
     operations. Signs ``memory:read``, ``memory:read.end``,
     ``memory:read.error``, ``memory:write``, ``memory:write.end``, and
     ``memory:write.error`` events on every memory block access. All
-    signing is fail-open — governance failures are logged but never
+    signing is fail-open - governance failures are logged but never
     interrupt client or agent execution.
 
     Args:

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -97,8 +97,7 @@ def _generate_ed25519() -> LocalKeypair:
     except ImportError as e:
         raise ImportError(
             "ed25519 keypair generation requires the `cryptography` "
-            "package. Install with `pip install asqav[crypto]` or "
-            "`pip install cryptography`."
+            "package. Install with `pip install cryptography`."
         ) from e
 
     private_key = ed25519.Ed25519PrivateKey.generate()
@@ -126,8 +125,7 @@ def _generate_es256() -> LocalKeypair:
     except ImportError as e:
         raise ImportError(
             "es256 keypair generation requires the `cryptography` "
-            "package. Install with `pip install asqav[crypto]` or "
-            "`pip install cryptography`."
+            "package. Install with `pip install cryptography`."
         ) from e
 
     private_key = ec.generate_private_key(ec.SECP256R1())
@@ -150,12 +148,14 @@ def _generate_es256() -> LocalKeypair:
 def _generate_ml_dsa_65() -> LocalKeypair:
     """Stub for ML-DSA-65; the cloud is authoritative for this algorithm.
 
-    A pure-Python or Rust ML-DSA library is not yet in our optional deps.
-    Calling this raises NotImplementedError with a pointer to the cloud
-    `Agent.create()` flow which the SDK already supports.
+    Local ML-DSA-65 keypair generation is not implemented in this release.
+    The cloud signs ML-DSA-65 receipts server-side; call
+    `asqav.Agent.create(name, algorithm='ml-dsa-65')` to mint the
+    keypair via the cloud KMS. See https://asqav.com/docs for details.
     """
     raise NotImplementedError(
-        "ml-dsa-65 keypair generation runs server-side; call "
+        "ml-dsa-65 keypair generation is not implemented locally; "
+        "ML-DSA-65 keys are minted server-side. Call "
         "`asqav.Agent.create(name, algorithm='ml-dsa-65')` to have the "
-        "cloud generate the keypair."
+        "cloud KMS generate the keypair. See https://asqav.com/docs."
     )

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.2.6",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.2.6",
+      "version": "0.3.4",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"


### PR DESCRIPTION
## Summary

Five small atomic SDK cleanups bundled together. Each one is a single-line or single-file fix. References cycle 6 audit findings 5, 7, 9, 10.

1. **typescript/package-lock.json**: regenerated via `npm install --package-lock-only` so the lockfile root metadata matches `package.json` (`0.3.4`). The lockfile was stale at `0.2.6` (two minor-version bumps behind). Transitive deps were already correct; only the root metadata was out of sync.
2. **CHANGELOG.md**: corrected "9 regime tokens" to "10 regime tokens". The actual `compliance.py` FRAMEWORKS dict has ten keys: `eu_ai_act`, `dora`, `nydfs_500`, `colorado_ai`, `texas_traiga`, `nist_ai_rmf`, `circia`, `hipaa_security`, `sec_17a4a`, `sec_17a4b`.
3. **CHANGELOG.md**: dropped the unimplemented `fetchAuditPack()` (TypeScript) claim from the Added section. Only the Python `fetch_audit_pack()` ships in this release; no `fetchAuditPack` exists on the TypeScript surface (only the CLI subcommand `cmdAuditPackExport` is wired up). The TypeScript helper will land in a follow-up release.
4. **python/src/asqav/extras/letta.py**: replaced an em dash in the `AsqavLettaHook` docstring with a regular hyphen, per brand-and-prose rules (no em dashes).
5. **python/src/asqav/keys.py**: removed the misleading `pip install asqav[crypto]` reference from the ed25519 / es256 `ImportError` messages (no `crypto` extra is declared in `pyproject.toml`) and rewrote the ml-dsa-65 `NotImplementedError` to clearly point callers at the cloud KMS path. Public surface is unchanged (CLI and tests rely on `generate_local_keypair` for the ed25519 / es256 paths, which work end-to-end).

## Test plan

- [x] `npm install --package-lock-only` succeeds; `head -5 package-lock.json` reports `"version": "0.3.4"`.
- [x] `cd typescript && npm test`: 181 / 181 vitest cases pass.
- [x] `cd python && python3 -m pytest tests/test_keys_alg_agility.py -v`: all 15 pass (including the ml-dsa-65 NotImplementedError assertion).
- [x] `ruff check python/src/asqav/keys.py python/src/asqav/extras/letta.py`: clean.
- [x] Pre-existing 11 framework-default failures in `test_compliance_bundle.py` / `test_cli.py` / `test_client_ietf_fields.py` remain (unrelated; addressed in the parallel sdk-default-frameworks branch).