### PR TITLE
feat(sdk): migrate dropped framework defaults with legacy aliases

### DIFF
--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -1648,7 +1648,7 @@ def compliance_frameworks() -> None:
 def compliance_export(
     session: str = typer.Option(..., "--session", help="Session ID to bundle signatures from."),
     framework: str = typer.Option(
-        "eu_ai_act_art12", "--framework", help="Compliance framework key."
+        "eu_ai_act", "--framework", help="Compliance framework key."
     ),
     output: str = typer.Option(..., "--output", "-o", help="File to write the bundle JSON to."),
 ) -> None:

--- a/python/src/asqav/compliance.py
+++ b/python/src/asqav/compliance.py
@@ -16,6 +16,7 @@ manifest; pick ``export_bundle`` for fully-offline / air-gapped flows.
 
 import hashlib
 import json
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -71,6 +72,16 @@ FRAMEWORKS = {
         "description": "Broker-dealer 3-year retention",
         "version": "17 CFR 240.17a-4(b)",
     },
+}
+
+# Legacy framework keys that were removed in 0.4.4. We accept them with a
+# DeprecationWarning so existing bundles + scripts keep working through the
+# next release window. Remove this map once downstream callers migrate.
+LEGACY_FRAMEWORK_ALIASES = {
+    "soc2": "eu_ai_act",
+    "eu_ai_act_art12": "eu_ai_act",
+    "eu_ai_act_art14": "eu_ai_act",
+    "dora_ict": "dora",
 }
 
 
@@ -179,6 +190,15 @@ def export_bundle(
     Raises:
         ValueError: If the framework key is not recognized.
     """
+    if framework in LEGACY_FRAMEWORK_ALIASES:
+        new = LEGACY_FRAMEWORK_ALIASES[framework]
+        warnings.warn(
+            f"Framework key {framework!r} is deprecated, use {new!r} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        framework = new
+
     if framework not in FRAMEWORKS:
         raise ValueError(
             f"Unknown framework {framework!r}. "

--- a/python/src/asqav/pytest_plugin.py
+++ b/python/src/asqav/pytest_plugin.py
@@ -38,7 +38,7 @@ class _PluginState:
     enabled: bool = False
     agent_name: str = "test-runner"
     output_path: str = "audit-bundle.json"
-    framework: str = "soc2"
+    framework: str = "eu_ai_act"
     results: list[CapturedOutcome] = field(default_factory=list)
     signatures: list[Any] = field(default_factory=list)
     agent: Any = None
@@ -70,8 +70,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     group.addoption(
         "--asqav-framework",
         action="store",
-        default="soc2",
-        help="Compliance framework key (default: soc2). See `asqav compliance frameworks`.",
+        default="eu_ai_act",
+        help="Compliance framework key (default: eu_ai_act). See `asqav compliance frameworks`.",
     )
 
 
@@ -162,7 +162,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
 
 
 def make_bundle_from_report(
-    signatures: list[Any], *, framework: str = "soc2"
+    signatures: list[Any], *, framework: str = "eu_ai_act"
 ) -> Any:
     """Build a ComplianceBundle from a list of pre-signed test results.
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -599,8 +599,8 @@ def test_compliance_frameworks_lists_known() -> None:
     result = runner.invoke(app, ["compliance", "frameworks"])
     assert result.exit_code == 0
     # FRAMEWORKS dict from compliance.py contains at least these.
-    assert "eu_ai_act_art12" in result.output
-    assert "soc2" in result.output
+    assert "eu_ai_act" in result.output
+    assert "dora" in result.output
 
 
 @patch("asqav.compliance.export_bundle")

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -173,7 +173,12 @@ def test_compliance_mode_caller_supplied_action_ref_wins() -> None:
 
 
 def test_no_compliance_mode_means_no_extra_fields_on_body() -> None:
-    """Without compliance_mode the body shape is exactly the legacy shape."""
+    """compliance_mode is now on by default, so the body carries the
+    Compliance Receipts fields without the caller having to opt in.
+
+    The legacy "no extra fields" shape is preserved by passing
+    ``compliance_mode=False`` explicitly.
+    """
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -181,7 +186,7 @@ def test_no_compliance_mode_means_no_extra_fields_on_body() -> None:
         return _ok_response()
 
     with patch("asqav.client._post", side_effect=fake_post):
-        _agent().sign("api:call", {"k": "v"})
+        _agent().sign("api:call", {"k": "v"}, compliance_mode=False)
 
     body = captured["body"]
     for k in (

--- a/python/tests/test_compliance_bundle.py
+++ b/python/tests/test_compliance_bundle.py
@@ -100,28 +100,28 @@ class TestMerkleRoot:
 class TestExportBundle:
     def test_with_signature_responses(self):
         sigs = [_make_sig_response(signature_id=f"sid_{i}") for i in range(3)]
-        bundle = export_bundle(sigs, framework="eu_ai_act_art12")
+        bundle = export_bundle(sigs, framework="eu_ai_act")
 
-        assert bundle.framework == "eu_ai_act_art12"
+        assert bundle.framework == "eu_ai_act"
         assert bundle.receipt_count == 3
         assert len(bundle.receipts) == 3
         assert bundle.merkle_root
-        assert bundle.framework_metadata == FRAMEWORKS["eu_ai_act_art12"]
+        assert bundle.framework_metadata == FRAMEWORKS["eu_ai_act"]
 
     def test_with_signed_action_responses(self):
         actions = [_make_signed_action(signature_id=f"sid_{i}") for i in range(2)]
-        bundle = export_bundle(actions, framework="soc2")
+        bundle = export_bundle(actions, framework="nist_ai_rmf")
 
-        assert bundle.framework == "soc2"
+        assert bundle.framework == "nist_ai_rmf"
         assert bundle.receipt_count == 2
-        assert bundle.framework_metadata["name"] == "SOC 2 Type II"
+        assert bundle.framework_metadata["name"] == "NIST AI RMF"
 
     def test_with_dicts(self):
         dicts = [
             {"signature_id": "sid_d1", "action": "test"},
             {"signature_id": "sid_d2", "action": "test2"},
         ]
-        bundle = export_bundle(dicts, framework="dora_ict")
+        bundle = export_bundle(dicts, framework="dora")
         assert bundle.receipt_count == 2
         assert bundle.receipts[0]["signature_id"] == "sid_d1"
 
@@ -142,7 +142,7 @@ class TestExportBundle:
             assert "nonexistent" in str(e)
 
     def test_empty_signatures(self):
-        bundle = export_bundle([], framework="eu_ai_act_art14")
+        bundle = export_bundle([], framework="hipaa_security")
         assert bundle.receipt_count == 0
         assert len(bundle.receipts) == 0
         assert bundle.merkle_root == hashlib.sha256(b"").hexdigest()
@@ -168,7 +168,7 @@ class TestExportBundle:
 
     def test_default_framework(self):
         bundle = export_bundle([_make_sig_response()])
-        assert bundle.framework == "eu_ai_act_art12"
+        assert bundle.framework == "eu_ai_act"
 
     def test_all_frameworks_valid(self):
         for fw_key in FRAMEWORKS:
@@ -186,7 +186,7 @@ class TestSerialization:
         bundle = export_bundle([_make_sig_response()])
         d = bundle.to_dict()
         assert isinstance(d, dict)
-        assert d["framework"] == "eu_ai_act_art12"
+        assert d["framework"] == "eu_ai_act"
         assert d["receipt_count"] == 1
         assert "merkle_root" in d
 
@@ -194,7 +194,7 @@ class TestSerialization:
         bundle = export_bundle([_make_sig_response()])
         j = bundle.to_json()
         parsed = json.loads(j)
-        assert parsed["framework"] == "eu_ai_act_art12"
+        assert parsed["framework"] == "eu_ai_act"
         assert parsed["receipt_count"] == 1
 
     def test_to_file(self):
@@ -207,7 +207,7 @@ class TestSerialization:
             bundle.to_file(path)
             with open(path) as f:
                 parsed = json.load(f)
-            assert parsed["framework"] == "eu_ai_act_art12"
+            assert parsed["framework"] == "eu_ai_act"
             assert parsed["receipt_count"] == 2
             assert parsed["merkle_root"] == bundle.merkle_root
         finally:
@@ -216,7 +216,7 @@ class TestSerialization:
     def test_to_json_roundtrip(self):
         bundle = export_bundle(
             [_make_sig_response(), _make_signed_action()],
-            framework="dora_ict",
+            framework="dora",
         )
         j = bundle.to_json()
         parsed = json.loads(j)

--- a/python/tests/test_legacy_framework_aliases.py
+++ b/python/tests/test_legacy_framework_aliases.py
@@ -1,0 +1,77 @@
+"""Tests for the legacy framework alias map in compliance.export_bundle.
+
+The keys ``soc2``, ``eu_ai_act_art12``, ``eu_ai_act_art14`` and
+``dora_ict`` were dropped from FRAMEWORKS in 0.4.4. To keep older bundles
+and scripts working we accept them with a DeprecationWarning that maps
+each to a current key. This test file pins that contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+from asqav.compliance import (
+    FRAMEWORKS,
+    LEGACY_FRAMEWORK_ALIASES,
+    export_bundle,
+)
+
+
+def _signature_dict(idx: int = 0) -> dict:
+    return {
+        "signature_id": f"sid_{idx}",
+        "signature": f"sig_{idx}",
+        "action_id": f"act_{idx}",
+        "timestamp": 1700000000.0 + idx,
+        "verification_url": f"https://asqav.com/verify/sid_{idx}",
+    }
+
+
+def test_alias_map_keys_match_known_legacy_set() -> None:
+    """Catch silent additions or removals: the alias set is a stable contract."""
+    assert set(LEGACY_FRAMEWORK_ALIASES) == {
+        "soc2",
+        "eu_ai_act_art12",
+        "eu_ai_act_art14",
+        "dora_ict",
+    }
+
+
+def test_alias_targets_are_current_framework_keys() -> None:
+    """Every alias must point to a key that still exists in FRAMEWORKS."""
+    for legacy, current in LEGACY_FRAMEWORK_ALIASES.items():
+        assert current in FRAMEWORKS, (
+            f"alias {legacy!r} points to {current!r} which is not in FRAMEWORKS"
+        )
+
+
+@pytest.mark.parametrize("legacy", sorted(LEGACY_FRAMEWORK_ALIASES))
+def test_legacy_key_emits_deprecation_warning_and_succeeds(legacy: str) -> None:
+    """Legacy key still produces a usable bundle but warns the caller."""
+    target = LEGACY_FRAMEWORK_ALIASES[legacy]
+    with pytest.warns(DeprecationWarning, match=legacy):
+        bundle = export_bundle([_signature_dict()], framework=legacy)
+
+    assert bundle.framework == target
+    assert bundle.framework_metadata == FRAMEWORKS[target]
+    assert bundle.receipt_count == 1
+
+
+def test_current_key_does_not_warn() -> None:
+    """eu_ai_act is a real key, so it must not trip the deprecation path."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        bundle = export_bundle([_signature_dict()], framework="eu_ai_act")
+    assert bundle.framework == "eu_ai_act"
+
+
+def test_unknown_key_still_raises_value_error() -> None:
+    """A truly unknown key must keep raising; the alias map is closed."""
+    with pytest.raises(ValueError, match="nonexistent"):
+        export_bundle([], framework="nonexistent")

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -34,7 +34,7 @@ def _config(**opts) -> MagicMock:  # type: ignore[no-untyped-def]
         "--asqav": False,
         "--asqav-agent": "test-runner",
         "--asqav-output": "audit-bundle.json",
-        "--asqav-framework": "soc2",
+        "--asqav-framework": "eu_ai_act",
     }
     defaults.update(opts)
     cfg.getoption.side_effect = lambda key: defaults[key]
@@ -62,14 +62,14 @@ def test_configure_enables_plugin(mock_init: MagicMock, mock_create: MagicMock) 
             "--asqav": True,
             "--asqav-agent": "ci-runner",
             "--asqav-output": "out.json",
-            "--asqav-framework": "soc2",
+            "--asqav-framework": "eu_ai_act",
         }))
 
     state = _get_state_for_tests()
     assert state.enabled is True
     assert state.agent_name == "ci-runner"
     assert state.output_path == "out.json"
-    assert state.framework == "soc2"
+    assert state.framework == "eu_ai_act"
     mock_create.assert_called_once_with("ci-runner")
 
 
@@ -187,11 +187,11 @@ def test_sessionfinish_writes_bundle(mock_export: MagicMock, tmp_path) -> None:
     state.enabled = True
     state.signatures = [MagicMock(), MagicMock()]
     state.output_path = str(tmp_path / "out.json")
-    state.framework = "soc2"
+    state.framework = "eu_ai_act"
 
     pytest_sessionfinish(MagicMock(), 0)
 
-    mock_export.assert_called_once_with(state.signatures, framework="soc2")
+    mock_export.assert_called_once_with(state.signatures, framework="eu_ai_act")
     mock_bundle.to_file.assert_called_once_with(state.output_path)
 
 
@@ -215,6 +215,6 @@ def test_make_bundle_from_report(mock_export: MagicMock) -> None:
     """make_bundle_from_report wraps export_bundle and forwards the framework."""
     mock_export.return_value = MagicMock(receipt_count=3)
     sigs = [MagicMock(), MagicMock(), MagicMock()]
-    bundle = make_bundle_from_report(sigs, framework="dora_ict")
-    mock_export.assert_called_once_with(sigs, framework="dora_ict")
+    bundle = make_bundle_from_report(sigs, framework="dora")
+    mock_export.assert_called_once_with(sigs, framework="dora")
     assert bundle.receipt_count == 3

--- a/python/tests/test_pytest_plugin_default.py
+++ b/python/tests/test_pytest_plugin_default.py
@@ -1,0 +1,59 @@
+"""Pin the pytest plugin's default framework key.
+
+The previous default ``soc2`` was dropped from FRAMEWORKS in 0.4.4 which
+caused ``pytest --asqav`` (no flags) to crash with ``ValueError`` at end
+of run. The current default must be a key that still exists.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav import pytest_plugin
+from asqav.compliance import FRAMEWORKS
+from asqav.pytest_plugin import _PluginState, make_bundle_from_report
+
+EXPECTED_DEFAULT = "eu_ai_act"
+
+
+def test_plugin_state_default_framework_is_eu_ai_act() -> None:
+    """The dataclass default applies before any pytest_configure hook fires."""
+    state = _PluginState()
+    assert state.framework == EXPECTED_DEFAULT
+
+
+def test_plugin_state_default_is_a_known_framework() -> None:
+    """Whatever the default is, it must resolve in FRAMEWORKS."""
+    state = _PluginState()
+    assert state.framework in FRAMEWORKS
+
+
+def test_make_bundle_from_report_default_framework() -> None:
+    """The programmatic helper mirrors the plugin's default."""
+    sig = inspect.signature(make_bundle_from_report)
+    assert sig.parameters["framework"].default == EXPECTED_DEFAULT
+
+
+def test_addoption_default_matches_state_default() -> None:
+    """`pytest --asqav` with no --asqav-framework gets the same key."""
+
+    captured: dict[str, str] = {}
+
+    class _Group:
+        def addoption(self, *args, **kwargs):
+            for arg in args:
+                if isinstance(arg, str) and arg.startswith("--asqav"):
+                    captured[arg] = kwargs.get("default")
+                    break
+
+    class _Parser:
+        def getgroup(self, *args, **kwargs):
+            return _Group()
+
+    pytest_plugin.pytest_addoption(_Parser())  # type: ignore[arg-type]
+
+    assert captured["--asqav-framework"] == EXPECTED_DEFAULT

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -369,7 +369,7 @@ async function cmdComplianceExport(args: string[]): Promise<void> {
   const framework = parseFlag(args, "framework") ?? "eu_ai_act";
   const output = parseFlag(args, "output");
   if (!session || !output) {
-    die("Usage: asqav compliance export --session <id> --output <path> [--framework eu_ai_act_art12]");
+    die("Usage: asqav compliance export --session <id> --output <path> [--framework eu_ai_act]");
   }
   ensureApiKey();
   await requireTier("business");


### PR DESCRIPTION
## Summary

Pytest plugin (`pytest_plugin.py:41,73,165`) and CLI (`cli.py:1651`) defaulted to framework keys (`soc2`, `eu_ai_act_art12`) that were removed from `FRAMEWORKS` in 0.4.4. Any default invocation crashed with `ValueError: Unknown framework`.

- New defaults: `eu_ai_act` (the closest current token in the new dict).
- New `LEGACY_FRAMEWORK_ALIASES` map: `soc2 → eu_ai_act`, `eu_ai_act_art12 → eu_ai_act`, `eu_ai_act_art14 → eu_ai_act`, `dora_ict → dora`. Existing scripts keep working with a `DeprecationWarning`.
- Realigned Python tests with the `compliance_mode=True` default flip from PR #152 (TS tests were realigned in commit 16f3591; Python equivalents were missed).

Pairs with PR #157 (cycle6/sdk-ci-honesty), which strips `|| true` from CI; together they restore honest pytest gating.

Surfaced by the cycle 6 cold-reader (finding 4) and devil's advocate (finding b) audits.

## Test plan

- [x] `python -m pytest python/tests/test_legacy_framework_aliases.py python/tests/test_pytest_plugin_default.py -v` passes.
- [x] `python -m pytest python/tests/test_compliance_bundle.py python/tests/test_cli.py -v` passes (these were the bulk of the 17-22 framework-default failures).

comment hygiene clean