### PR TITLE
feat(sdk): expose IETF projection fields the cloud already returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `VerificationResponse` exposes `type`, `bitcoinAnchor`, `signatureEnvelope`, `anchors`, `algorithmRegistryVersion` (Python: snake_case). Match the cloud `/verify` response per IETF -03 §8.1.
+- `VerificationDetail` exposes `anchorValidOts`, `anchorValidRfc3161`, `policyDigestResolved`, `duplicateEmissionCandidate`.
+- TypeScript validation-label union includes `agent_revoked_before_issuance`.
+
 ## [Python 0.4.4 / TypeScript 0.3.4] - 2026-05-10
 
 ### Changed

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -41,6 +41,7 @@ from .client import (
     ApprovalResponse,
     AsqavError,
     AuthenticationError,
+    BitcoinAnchorStatus,
     BudgetCheckResult,
     BudgetTracker,
     CertificateResponse,
@@ -202,6 +203,7 @@ __all__ = [
     "verify_signature",
     "verify_output",
     "VerificationDetail",
+    "BitcoinAnchorStatus",
     # May 2026 release helpers
     "post_applied_attestation",
     "list_rejected_attempts",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -419,19 +419,20 @@ class CertificateResponse:
 
 @dataclass
 class VerificationDetail:
-    """Granular per-axis verification outcome (May 2026 release).
+    """Granular per-axis verification outcome.
 
-    Optional on the response; older servers do not return it.
-    `validation_label` is one of: valid, invalid_signature,
-    signature_expired, signer_key_changed, algorithm_mismatch,
-    agent_inactive, agent_unknown, chain_break, anchor_invalid,
-    missing_required_field, signed_at_skew.
+    Optional on the response. `validation_label` vocabulary:
+    valid, invalid_signature, signature_expired, signer_key_changed,
+    algorithm_mismatch, agent_inactive, agent_unknown, chain_break,
+    anchor_invalid, missing_required_field, signed_at_skew,
+    agent_revoked_before_issuance.
 
-    The IETF Compliance Receipts profile fields (`signed_at_skew_seconds`,
-    `chain_valid`, `anchor_status_ots`, `anchor_status_rfc3161`,
-    `missing_fields`) are populated only when the cloud returns them on
-    a compliance-mode receipt; older receipts and older deployments
-    leave them None for back-compat.
+    The IETF profile sub-axes (`signed_at_skew_seconds`, `chain_valid`,
+    `anchor_valid_ots`, `anchor_valid_rfc3161`, `anchor_status_ots`,
+    `anchor_status_rfc3161`, `missing_fields`, `policy_digest_resolved`,
+    `duplicate_emission_candidate`) populate only when the cloud emits
+    them on a compliance-mode receipt; non-compliance-mode receipts leave
+    them None.
     """
 
     signer_key_match: bool
@@ -439,17 +440,41 @@ class VerificationDetail:
     algorithm_match: bool
     agent_active: bool
     validation_label: str
-    # IETF profile sub-axes (cloud may omit on legacy receipts).
     signed_at_skew_seconds: float | None = None
     chain_valid: bool | None = None
+    anchor_valid_ots: bool | None = None
+    anchor_valid_rfc3161: bool | None = None
     anchor_status_ots: str | None = None
     anchor_status_rfc3161: str | None = None
     missing_fields: list[str] | None = None
+    policy_digest_resolved: bool | None = None
+    duplicate_emission_candidate: bool | None = None
+
+
+@dataclass
+class BitcoinAnchorStatus:
+    """Bitcoin anchor state on a verification response.
+
+    `status` vocabulary: none, pending, confirmed, failed.
+    `bitcoin_tx` and `bitcoin_block` populate once the OpenTimestamps
+    proof upgrades to a confirmed Bitcoin attestation.
+    """
+
+    status: str
+    bitcoin_tx: str | None = None
+    bitcoin_block: int | None = None
 
 
 @dataclass
 class VerificationResponse:
-    """Public verification response."""
+    """Public verification response.
+
+    `verified` is signature-only; anchor outcome lives on `bitcoin_anchor`.
+    `signature_envelope` and `anchors` are the IETF Compliance Receipts
+    projection (`{alg, kid}` and the cloud anchors list); both are None
+    on non-compliance-mode receipts. `algorithm_registry_version` is the
+    registry version in force at issuance.
+    """
 
     signature_id: str
     agent_id: str
@@ -463,6 +488,11 @@ class VerificationResponse:
     verified: bool
     verification_url: str
     verification_detail: VerificationDetail | None = None
+    type: str = "signature"
+    bitcoin_anchor: BitcoinAnchorStatus | None = None
+    signature_envelope: dict[str, str] | None = None
+    anchors: list[dict[str, Any]] | None = None
+    algorithm_registry_version: str | None = None
 
 
 @dataclass
@@ -2269,11 +2299,25 @@ def verify_signature(signature_id: str) -> VerificationResponse:
             validation_label=detail_raw["validation_label"],
             signed_at_skew_seconds=detail_raw.get("signed_at_skew_seconds"),
             chain_valid=detail_raw.get("chain_valid"),
+            anchor_valid_ots=detail_raw.get("anchor_valid_ots"),
+            anchor_valid_rfc3161=detail_raw.get("anchor_valid_rfc3161"),
             anchor_status_ots=detail_raw.get("anchor_status_ots"),
             anchor_status_rfc3161=detail_raw.get("anchor_status_rfc3161"),
             missing_fields=detail_raw.get("missing_fields"),
+            policy_digest_resolved=detail_raw.get("policy_digest_resolved"),
+            duplicate_emission_candidate=detail_raw.get("duplicate_emission_candidate"),
         )
         if isinstance(detail_raw, dict)
+        else None
+    )
+    anchor_raw = data.get("bitcoin_anchor")
+    bitcoin_anchor = (
+        BitcoinAnchorStatus(
+            status=anchor_raw.get("status", "none"),
+            bitcoin_tx=anchor_raw.get("bitcoin_tx"),
+            bitcoin_block=anchor_raw.get("bitcoin_block"),
+        )
+        if isinstance(anchor_raw, dict)
         else None
     )
     return VerificationResponse(
@@ -2289,6 +2333,11 @@ def verify_signature(signature_id: str) -> VerificationResponse:
         verified=data["verified"],
         verification_url=data["verification_url"],
         verification_detail=detail,
+        type=data.get("type", "signature"),
+        bitcoin_anchor=bitcoin_anchor,
+        signature_envelope=data.get("signature_envelope"),
+        anchors=data.get("anchors"),
+        algorithm_registry_version=data.get("algorithm_registry_version"),
     )
 
 

--- a/python/tests/test_verify_response_fields.py
+++ b/python/tests/test_verify_response_fields.py
@@ -1,0 +1,174 @@
+"""SDK parser surfaces every field the cloud `/verify` returns.
+
+The cloud's `VerificationResponse` (in `asqav_cloud/api/routes/verify.py`)
+emits the IETF projection (`signature_envelope`, `anchors`,
+`algorithm_registry_version`), the Bitcoin anchor block, the receipt
+`type` discriminator, and four extra `VerificationDetail` sub-axes
+(`anchor_valid_ots`, `anchor_valid_rfc3161`, `policy_digest_resolved`,
+`duplicate_emission_candidate`). These tests pin that the SDK parser
+populates the dataclasses with all of them.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import (
+    BitcoinAnchorStatus,
+    VerificationDetail,
+    VerificationResponse,
+    verify_signature,
+)
+
+
+def _full_cloud_payload() -> dict:
+    """Mirror the cloud's `VerificationResponse` shape with every field set."""
+    return {
+        "type": "signature",
+        "signature_id": "sig_test_full",
+        "agent_id": "agent_full",
+        "agent_name": "full-agent",
+        "action_id": "act_full",
+        "action_type": "payment.wire_transfer",
+        "payload": {"amount": 100},
+        "signature": "ZmFrZQ==",
+        "algorithm": "ML-DSA-65",
+        "signed_at": "2026-05-10T12:00:00+00:00",
+        "verified": True,
+        "verification_url": "https://verify.example/sig_test_full",
+        "bitcoin_anchor": {
+            "status": "confirmed",
+            "bitcoin_tx": "abc123",
+            "bitcoin_block": 850000,
+        },
+        "verification_detail": {
+            "signer_key_match": True,
+            "signature_valid": True,
+            "algorithm_match": True,
+            "agent_active": True,
+            "validation_label": "valid",
+            "signed_at_skew_seconds": 1.5,
+            "chain_valid": True,
+            "anchor_valid_ots": True,
+            "anchor_valid_rfc3161": True,
+            "anchor_status_ots": "valid",
+            "anchor_status_rfc3161": "valid",
+            "missing_fields": [],
+            "policy_digest_resolved": True,
+            "duplicate_emission_candidate": False,
+        },
+        "signature_envelope": {"alg": "ML-DSA-65", "kid": "key_full"},
+        "anchors": [
+            {"type": "rfc3161", "value": "ZmFrZQ=="},
+            {"type": "ots", "value": "b3RzZmFrZQ=="},
+        ],
+        "algorithm_registry_version": "2026-05",
+    }
+
+
+def _mock_httpx(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = payload
+    return response
+
+
+def test_verification_response_exposes_ietf_projection_fields() -> None:
+    """`type`, `bitcoin_anchor`, `signature_envelope`, `anchors`,
+    `algorithm_registry_version` are accessible on the parsed response."""
+    payload = _full_cloud_payload()
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        response = verify_signature("sig_test_full")
+
+    assert isinstance(response, VerificationResponse)
+    assert response.type == "signature"
+    assert isinstance(response.bitcoin_anchor, BitcoinAnchorStatus)
+    assert response.bitcoin_anchor.status == "confirmed"
+    assert response.bitcoin_anchor.bitcoin_tx == "abc123"
+    assert response.bitcoin_anchor.bitcoin_block == 850000
+    assert response.signature_envelope == {"alg": "ML-DSA-65", "kid": "key_full"}
+    assert response.anchors is not None
+    assert len(response.anchors) == 2
+    assert response.anchors[0]["type"] == "rfc3161"
+    assert response.algorithm_registry_version == "2026-05"
+
+
+def test_verification_detail_exposes_extra_sub_axes() -> None:
+    """`anchor_valid_ots`, `anchor_valid_rfc3161`, `policy_digest_resolved`,
+    `duplicate_emission_candidate` populate from the parser."""
+    payload = _full_cloud_payload()
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        response = verify_signature("sig_test_full")
+
+    detail = response.verification_detail
+    assert isinstance(detail, VerificationDetail)
+    assert detail.anchor_valid_ots is True
+    assert detail.anchor_valid_rfc3161 is True
+    assert detail.policy_digest_resolved is True
+    assert detail.duplicate_emission_candidate is False
+
+
+def test_minimal_response_leaves_new_fields_none() -> None:
+    """A response that omits the new fields parses without crashing and
+    leaves them None for back-compat."""
+    payload = {
+        "signature_id": "sig_minimal",
+        "agent_id": "agent_minimal",
+        "agent_name": "minimal",
+        "action_id": "act_minimal",
+        "action_type": "x.y",
+        "payload": None,
+        "signature": "ZmFrZQ==",
+        "algorithm": "Ed25519",
+        "signed_at": "2026-05-10T12:00:00+00:00",
+        "verified": True,
+        "verification_url": "https://verify.example/sig_minimal",
+    }
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        response = verify_signature("sig_minimal")
+
+    assert response.type == "signature"
+    assert response.bitcoin_anchor is None
+    assert response.signature_envelope is None
+    assert response.anchors is None
+    assert response.algorithm_registry_version is None
+    assert response.verification_detail is None
+
+
+def test_dataclass_defaults_construct_without_new_fields() -> None:
+    """`VerificationResponse` and `VerificationDetail` keep all new
+    fields optional so call sites that hand-build them keep working."""
+    detail = VerificationDetail(
+        signer_key_match=True,
+        signature_valid=True,
+        algorithm_match=True,
+        agent_active=True,
+        validation_label="valid",
+    )
+    assert detail.anchor_valid_ots is None
+    assert detail.anchor_valid_rfc3161 is None
+    assert detail.policy_digest_resolved is None
+    assert detail.duplicate_emission_candidate is None
+
+    response = VerificationResponse(
+        signature_id="sig",
+        agent_id="agent",
+        agent_name="name",
+        action_id="act",
+        action_type="x",
+        payload=None,
+        signature="ZmFrZQ==",
+        algorithm="Ed25519",
+        signed_at=0.0,
+        verified=True,
+        verification_url="https://verify.example/sig",
+    )
+    assert response.type == "signature"
+    assert response.bitcoin_anchor is None
+    assert response.signature_envelope is None
+    assert response.anchors is None
+    assert response.algorithm_registry_version is None

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -415,11 +415,12 @@ export interface SessionResponse {
  * `validationLabel` string is the dominant failure reason when
  * `verified=false`, e.g. `signature_expired` or `signer_key_changed`.
  *
- * The IETF Compliance Receipts profile sub-axes (`chainValid`,
- * `anchorStatusOts`, `anchorStatusRfc3161`, `signedAtSkewSeconds`,
- * `missingFields`) are populated only when the cloud emits them on a
- * compliance-mode receipt; older receipts and older deployments leave
- * them undefined for back-compat. */
+ * The IETF profile sub-axes (`chainValid`, `anchorValidOts`,
+ * `anchorValidRfc3161`, `anchorStatusOts`, `anchorStatusRfc3161`,
+ * `signedAtSkewSeconds`, `missingFields`, `policyDigestResolved`,
+ * `duplicateEmissionCandidate`) populate only when the cloud emits
+ * them on a compliance-mode receipt; non-compliance-mode receipts
+ * leave them undefined. */
 export interface VerificationDetail {
   signerKeyMatch: boolean;
   signatureValid: boolean;
@@ -433,29 +434,49 @@ export interface VerificationDetail {
     | "algorithm_mismatch"
     | "agent_inactive"
     | "agent_unknown"
+    | "agent_revoked_before_issuance"
     | "chain_break"
     | "anchor_invalid"
     | "missing_required_field"
     | "signed_at_skew"
     | string;
-  /** Skew vs verifier wall clock; beyond SKEW_BOUND_SECONDS (300s) -> reject. */
+  /** Skew vs verifier wall clock; beyond the cloud's bound -> reject. */
   signedAtSkewSeconds?: number;
   /** True when the cloud could rederive the chain hash from the stored
-   * `signed_envelope` and the predecessor matches. None on legacy
-   * (pre-IETF) records. */
+   * `signed_envelope` and the predecessor matches. Undefined on
+   * non-compliance-mode records. */
   chainValid?: boolean;
-  /** Tri-state OTS status. `pending` means the proof is still inside
-   * the upgrade window; `invalid` means corruption or stale; `valid`
-   * mirrors the Bitcoin block-confirmed case. */
+  /** OTS proof bool form. True when the OpenTimestamps proof rederived. */
+  anchorValidOts?: boolean;
+  /** Timestamp anchor bool form. True when the timestamp rederived. */
+  anchorValidRfc3161?: boolean;
+  /** Tri-state OTS status. `pending` means inside the upgrade window;
+   * `invalid` means corruption or stale; `valid` mirrors the Bitcoin
+   * block-confirmed case. */
   anchorStatusOts?: "valid" | "pending" | "invalid";
   /** Timestamp anchor outcome. Deterministic at issuance; never
    * `pending`. */
   anchorStatusRfc3161?: "valid" | "pending" | "invalid";
-  /** REQUIRED-fields presence check. When the record is
-   * `compliance_mode=true` and any spec-mandated field has been NULLed
-   * post-issuance, surfaces the missing column names. Empty list /
-   * undefined means every required field is present. */
+  /** REQUIRED-fields presence check. Surfaces column names NULLed
+   * post-issuance on a compliance-mode receipt; empty / undefined means
+   * every required field is present. */
   missingFields?: string[];
+  /** True when the policy digest at issuance resolved to a known artefact. */
+  policyDigestResolved?: boolean;
+  /** True / non-empty when more than one receipt exists for the
+   * (action_ref, issuer_id) pair; reporting flag, not a verification
+   * downgrade. */
+  duplicateEmissionCandidate?: boolean | string;
+}
+
+/** Bitcoin anchor state on a verification response. `status` vocabulary:
+ * none | pending | confirmed | failed. `bitcoinTx` and `bitcoinBlock`
+ * populate once the OpenTimestamps proof upgrades to a confirmed
+ * Bitcoin attestation. */
+export interface BitcoinAnchorStatus {
+  status: "none" | "pending" | "confirmed" | "failed" | string;
+  bitcoinTx?: string | null;
+  bitcoinBlock?: number | null;
 }
 
 export interface VerificationResponse {
@@ -471,6 +492,19 @@ export interface VerificationResponse {
   verified: boolean;
   verificationUrl?: string;
   verificationDetail?: VerificationDetail;
+  /** Receipt kind. Always `"signature"` for this response shape. */
+  type?: string;
+  /** Bitcoin anchor state; `status: "none"` when the receipt has no anchor. */
+  bitcoinAnchor?: BitcoinAnchorStatus;
+  /** IETF projection of the signed envelope: `{alg, kid}`. Undefined on
+   * non-compliance-mode receipts. */
+  signatureEnvelope?: { alg: string; kid: string } & Record<string, string>;
+  /** IETF anchors projection: list of `{type, value, ...}` per anchor.
+   * Undefined on non-compliance-mode receipts. */
+  anchors?: Array<{ type: string; value: string } & Record<string, unknown>>;
+  /** Algorithm registry version in force at issuance. Undefined on
+   * pre-migration rows. */
+  algorithmRegistryVersion?: string;
 }
 
 export interface AppliedAttestationOptions {
@@ -1122,10 +1156,23 @@ export async function verifySignature(signatureId: string): Promise<Verification
       validation_label: string;
       signed_at_skew_seconds?: number;
       chain_valid?: boolean;
+      anchor_valid_ots?: boolean;
+      anchor_valid_rfc3161?: boolean;
       anchor_status_ots?: "valid" | "pending" | "invalid";
       anchor_status_rfc3161?: "valid" | "pending" | "invalid";
       missing_fields?: string[];
+      policy_digest_resolved?: boolean;
+      duplicate_emission_candidate?: boolean | string;
     };
+    type?: string;
+    bitcoin_anchor?: {
+      status: string;
+      bitcoin_tx?: string | null;
+      bitcoin_block?: number | null;
+    };
+    signature_envelope?: { alg: string; kid: string } & Record<string, string>;
+    anchors?: Array<{ type: string; value: string } & Record<string, unknown>>;
+    algorithm_registry_version?: string;
   }>("GET", `/verify/${signatureId}`);
 
   return {
@@ -1149,11 +1196,26 @@ export async function verifySignature(signatureId: string): Promise<Verification
           validationLabel: data.verification_detail.validation_label,
           signedAtSkewSeconds: data.verification_detail.signed_at_skew_seconds,
           chainValid: data.verification_detail.chain_valid,
+          anchorValidOts: data.verification_detail.anchor_valid_ots,
+          anchorValidRfc3161: data.verification_detail.anchor_valid_rfc3161,
           anchorStatusOts: data.verification_detail.anchor_status_ots,
           anchorStatusRfc3161: data.verification_detail.anchor_status_rfc3161,
           missingFields: data.verification_detail.missing_fields,
+          policyDigestResolved: data.verification_detail.policy_digest_resolved,
+          duplicateEmissionCandidate: data.verification_detail.duplicate_emission_candidate,
         }
       : undefined,
+    type: data.type,
+    bitcoinAnchor: data.bitcoin_anchor
+      ? {
+          status: data.bitcoin_anchor.status,
+          bitcoinTx: data.bitcoin_anchor.bitcoin_tx,
+          bitcoinBlock: data.bitcoin_anchor.bitcoin_block,
+        }
+      : undefined,
+    signatureEnvelope: data.signature_envelope,
+    anchors: data.anchors,
+    algorithmRegistryVersion: data.algorithm_registry_version,
   };
 }
 

--- a/typescript/tests/verify-response-fields.test.ts
+++ b/typescript/tests/verify-response-fields.test.ts
@@ -1,0 +1,168 @@
+/**
+ * SDK parser surfaces every field the cloud `/verify` returns.
+ *
+ * The cloud's `VerificationResponse` emits the IETF projection
+ * (`signature_envelope`, `anchors`, `algorithm_registry_version`), the
+ * `bitcoin_anchor` block, the receipt `type` discriminator, and four
+ * extra `VerificationDetail` sub-axes (`anchor_valid_ots`,
+ * `anchor_valid_rfc3161`, `policy_digest_resolved`,
+ * `duplicate_emission_candidate`). These tests pin that the parser
+ * populates the TS interface with all of them, and that the
+ * `validationLabel` union admits `agent_revoked_before_issuance`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetForTests,
+  init,
+  verifySignature,
+  type VerificationResponse,
+} from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fullCloudPayload() {
+  return {
+    type: "signature",
+    signature_id: "sig_test_full",
+    agent_id: "agent_full",
+    agent_name: "full-agent",
+    action_id: "act_full",
+    action_type: "payment.wire_transfer",
+    payload: { amount: 100 },
+    signature: "ZmFrZQ==",
+    algorithm: "ML-DSA-65",
+    signed_at: "2026-05-10T12:00:00+00:00",
+    verified: true,
+    verification_url: "https://verify.example/sig_test_full",
+    bitcoin_anchor: {
+      status: "confirmed",
+      bitcoin_tx: "abc123",
+      bitcoin_block: 850000,
+    },
+    verification_detail: {
+      signer_key_match: true,
+      signature_valid: true,
+      algorithm_match: true,
+      agent_active: true,
+      validation_label: "valid",
+      signed_at_skew_seconds: 1.5,
+      chain_valid: true,
+      anchor_valid_ots: true,
+      anchor_valid_rfc3161: true,
+      anchor_status_ots: "valid",
+      anchor_status_rfc3161: "valid",
+      missing_fields: [],
+      policy_digest_resolved: true,
+      duplicate_emission_candidate: false,
+    },
+    signature_envelope: { alg: "ML-DSA-65", kid: "key_full" },
+    anchors: [
+      { type: "rfc3161", value: "ZmFrZQ==" },
+      { type: "ots", value: "b3RzZmFrZQ==" },
+    ],
+    algorithm_registry_version: "2026-05",
+  };
+}
+
+describe("verifySignature response fields", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes IETF projection fields on the parsed response", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(fullCloudPayload()),
+    );
+
+    const response: VerificationResponse = await verifySignature("sig_test_full");
+
+    expect(response.type).toBe("signature");
+    expect(response.bitcoinAnchor).toEqual({
+      status: "confirmed",
+      bitcoinTx: "abc123",
+      bitcoinBlock: 850000,
+    });
+    expect(response.signatureEnvelope).toEqual({
+      alg: "ML-DSA-65",
+      kid: "key_full",
+    });
+    expect(response.anchors).toHaveLength(2);
+    expect(response.anchors?.[0]).toEqual({
+      type: "rfc3161",
+      value: "ZmFrZQ==",
+    });
+    expect(response.algorithmRegistryVersion).toBe("2026-05");
+  });
+
+  it("exposes the four extra VerificationDetail sub-axes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(fullCloudPayload()),
+    );
+
+    const response = await verifySignature("sig_test_full");
+    const detail = response.verificationDetail;
+
+    expect(detail?.anchorValidOts).toBe(true);
+    expect(detail?.anchorValidRfc3161).toBe(true);
+    expect(detail?.policyDigestResolved).toBe(true);
+    expect(detail?.duplicateEmissionCandidate).toBe(false);
+  });
+
+  it("leaves new fields undefined when the server omits them", async () => {
+    const minimalPayload = {
+      signature_id: "sig_minimal",
+      agent_id: "agent_minimal",
+      agent_name: "minimal",
+      action_id: "act_minimal",
+      action_type: "x.y",
+      payload: null,
+      signature: "ZmFrZQ==",
+      algorithm: "Ed25519",
+      signed_at: "2026-05-10T12:00:00+00:00",
+      verified: true,
+      verification_url: "https://verify.example/sig_minimal",
+    };
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(minimalPayload));
+
+    const response = await verifySignature("sig_minimal");
+
+    expect(response.type).toBeUndefined();
+    expect(response.bitcoinAnchor).toBeUndefined();
+    expect(response.signatureEnvelope).toBeUndefined();
+    expect(response.anchors).toBeUndefined();
+    expect(response.algorithmRegistryVersion).toBeUndefined();
+    expect(response.verificationDetail).toBeUndefined();
+  });
+
+  it("admits agent_revoked_before_issuance on the validation-label union", async () => {
+    const revokedPayload = {
+      ...fullCloudPayload(),
+      verified: false,
+      verification_detail: {
+        ...fullCloudPayload().verification_detail,
+        validation_label: "agent_revoked_before_issuance",
+      },
+    };
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(revokedPayload));
+
+    const response = await verifySignature("sig_test_full");
+
+    expect(response.verificationDetail?.validationLabel).toBe(
+      "agent_revoked_before_issuance",
+    );
+  });
+});


### PR DESCRIPTION
## Why

The cloud `/verify` response returns five top-level fields and four `VerificationDetail` sub-axes that both SDKs were stripping in the parser. A caller of `asqav.verify_signature(...)` / `verifySignature(...)` could never see the receipt `type`, the Bitcoin anchor block, the IETF `{alg, kid}` envelope projection, the IETF anchors list, the algorithm registry version, or the four extra detail axes the cloud emits on compliance-mode receipts. This PR wires them through end-to-end.

## What

**Python (`python/src/asqav/client.py`)**

- New `BitcoinAnchorStatus` dataclass mirroring the cloud's shape (`status`, `bitcoin_tx`, `bitcoin_block`).
- `VerificationResponse` adds `type`, `bitcoin_anchor`, `signature_envelope`, `anchors`, `algorithm_registry_version`.
- `VerificationDetail` adds `anchor_valid_ots`, `anchor_valid_rfc3161`, `policy_digest_resolved`, `duplicate_emission_candidate`.
- `verify_signature` parser populates every new field from the response JSON.
- `BitcoinAnchorStatus` is exported at the package root alongside `VerificationDetail`.

**TypeScript (`typescript/src/index.ts`)**

- New `BitcoinAnchorStatus` interface.
- `VerificationResponse` adds `type`, `bitcoinAnchor`, `signatureEnvelope`, `anchors`, `algorithmRegistryVersion`.
- `VerificationDetail` adds `anchorValidOts`, `anchorValidRfc3161`, `policyDigestResolved`, `duplicateEmissionCandidate`.
- `validationLabel` union now admits `agent_revoked_before_issuance`, which the cloud emits and the README already documents.
- `verifySignature` parser maps every snake_case wire key to the camelCase TS field.

## Tests

- `python/tests/test_verify_response_fields.py` (4 cases): full fixture round-trips through the parser and surfaces every field; minimal response leaves new fields None for back-compat; dataclass defaults keep new fields optional.
- `typescript/tests/verify-response-fields.test.ts` (4 cases): same coverage in TS via vitest, plus an `agent_revoked_before_issuance` case to pin the union.

Local validation:

- `python -m pytest tests/test_verify_response_fields.py -v` -> 4 passed.
- `python -m pytest tests/` -> 515 passed (no regressions).
- `npm test` -> 186 passed (19 files, 4 new).
- `npm run lint` -> clean (`tsc --noEmit`).

## Refs

`~/.company/audits/cycle6-regulator-2026-05-10.md` findings E1, E2, E3, E4.

## Test plan

- [x] Python new tests pass.
- [x] Python full suite still passes.
- [x] TypeScript new tests pass.
- [x] TypeScript full suite still passes.
- [x] `tsc --noEmit` clean.
- [ ] CI green on this PR.

comment hygiene clean