### PR TITLE
feat(sdk): expose regimes_satisfied + verifier_signature + accept opentimestamps anchor type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 - `VerificationResponse` exposes `type`, `bitcoinAnchor`, `signatureEnvelope`, `anchors`, `algorithmRegistryVersion` (Python: snake_case). Match the cloud `/verify` response per IETF -03 §8.1.
 - `VerificationDetail` exposes `anchorValidOts`, `anchorValidRfc3161`, `policyDigestResolved`, `duplicateEmissionCandidate`.
 - TypeScript validation-label union includes `agent_revoked_before_issuance`.
+- `VerificationResponse.verifierSignature` (Python: `verifier_signature`): verifier's `{alg, sig, kid}` block over the verification outcome. Closes the gap from cloud PR #337 that landed after SDK projection PR #160.
+- `VerificationDetail.regimesSatisfied` (Python: `regimes_satisfied`): regulator tokens the cloud derived for the receipt (e.g. `eu_ai_act`, `dora`). Same gap as above.
+- Inner anchor `type` admits the canonical `"opentimestamps"`, the legacy `"ots"` alias (still emitted by the cloud `/verify/example` fixture from PR #332), and `"rfc3161"`. The SDK does not silently rewrite; callers should normalize `"ots"` to `"opentimestamps"` if they compare against the canonical cloud surface.
 
 ## [Python 0.4.4 / TypeScript 0.3.4] - 2026-05-10
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -430,9 +430,13 @@ class VerificationDetail:
     The IETF profile sub-axes (`signed_at_skew_seconds`, `chain_valid`,
     `anchor_valid_ots`, `anchor_valid_rfc3161`, `anchor_status_ots`,
     `anchor_status_rfc3161`, `missing_fields`, `policy_digest_resolved`,
-    `duplicate_emission_candidate`) populate only when the cloud emits
-    them on a compliance-mode receipt; non-compliance-mode receipts leave
-    them None.
+    `duplicate_emission_candidate`, `regimes_satisfied`) populate only
+    when the cloud emits them on a compliance-mode receipt;
+    non-compliance-mode receipts leave them None / empty.
+
+    `regimes_satisfied` is the regulator-token list the cloud derived for
+    the receipt (e.g. `eu_ai_act`, `dora`); empty list when the cloud
+    surface omits the field.
     """
 
     signer_key_match: bool
@@ -449,6 +453,7 @@ class VerificationDetail:
     missing_fields: list[str] | None = None
     policy_digest_resolved: bool | None = None
     duplicate_emission_candidate: bool | None = None
+    regimes_satisfied: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -474,6 +479,14 @@ class VerificationResponse:
     projection (`{alg, kid}` and the cloud anchors list); both are None
     on non-compliance-mode receipts. `algorithm_registry_version` is the
     registry version in force at issuance.
+
+    `verifier_signature` is the verifier's `{alg, sig, kid}` block over
+    the verification outcome (cloud emits this on compliance-mode
+    receipts so a downstream regulator can re-check the verification
+    decision without re-running the verifier). None on non-compliance
+    or pre-migration receipts. Inner anchor entries on `anchors` carry a
+    `type` of `"opentimestamps"` (canonical), `"ots"` (legacy alias),
+    or `"rfc3161"`.
     """
 
     signature_id: str
@@ -493,6 +506,7 @@ class VerificationResponse:
     signature_envelope: dict[str, str] | None = None
     anchors: list[dict[str, Any]] | None = None
     algorithm_registry_version: str | None = None
+    verifier_signature: dict[str, str] | None = None
 
 
 @dataclass
@@ -2306,6 +2320,7 @@ def verify_signature(signature_id: str) -> VerificationResponse:
             missing_fields=detail_raw.get("missing_fields"),
             policy_digest_resolved=detail_raw.get("policy_digest_resolved"),
             duplicate_emission_candidate=detail_raw.get("duplicate_emission_candidate"),
+            regimes_satisfied=list(detail_raw.get("regimes_satisfied") or []),
         )
         if isinstance(detail_raw, dict)
         else None
@@ -2338,6 +2353,7 @@ def verify_signature(signature_id: str) -> VerificationResponse:
         signature_envelope=data.get("signature_envelope"),
         anchors=data.get("anchors"),
         algorithm_registry_version=data.get("algorithm_registry_version"),
+        verifier_signature=data.get("verifier_signature"),
     )
 
 

--- a/python/tests/test_verify_response_fields.py
+++ b/python/tests/test_verify_response_fields.py
@@ -2,11 +2,14 @@
 
 The cloud's `VerificationResponse` (in `asqav_cloud/api/routes/verify.py`)
 emits the IETF projection (`signature_envelope`, `anchors`,
-`algorithm_registry_version`), the Bitcoin anchor block, the receipt
-`type` discriminator, and four extra `VerificationDetail` sub-axes
-(`anchor_valid_ots`, `anchor_valid_rfc3161`, `policy_digest_resolved`,
-`duplicate_emission_candidate`). These tests pin that the SDK parser
-populates the dataclasses with all of them.
+`algorithm_registry_version`, `verifier_signature`), the Bitcoin anchor
+block, the receipt `type` discriminator, and the `VerificationDetail`
+sub-axes (`anchor_valid_ots`, `anchor_valid_rfc3161`,
+`policy_digest_resolved`, `duplicate_emission_candidate`,
+`regimes_satisfied`). These tests pin that the SDK parser populates the
+dataclasses with all of them, and that the inner anchor `type` field
+admits both the canonical `"opentimestamps"` and the legacy `"ots"`
+alias the cloud `/verify/example` fixture still emits.
 """
 
 from __future__ import annotations
@@ -60,13 +63,19 @@ def _full_cloud_payload() -> dict:
             "missing_fields": [],
             "policy_digest_resolved": True,
             "duplicate_emission_candidate": False,
+            "regimes_satisfied": ["eu_ai_act", "dora"],
         },
         "signature_envelope": {"alg": "ML-DSA-65", "kid": "key_full"},
         "anchors": [
             {"type": "rfc3161", "value": "ZmFrZQ=="},
-            {"type": "ots", "value": "b3RzZmFrZQ=="},
+            {"type": "opentimestamps", "value": "b3RzZmFrZQ=="},
         ],
         "algorithm_registry_version": "2026-05",
+        "verifier_signature": {
+            "alg": "ML-DSA-65",
+            "sig": "dmVyaWZpZXJzaWc=",
+            "kid": "verifier_kid_full",
+        },
     }
 
 
@@ -94,7 +103,13 @@ def test_verification_response_exposes_ietf_projection_fields() -> None:
     assert response.anchors is not None
     assert len(response.anchors) == 2
     assert response.anchors[0]["type"] == "rfc3161"
+    assert response.anchors[1]["type"] == "opentimestamps"
     assert response.algorithm_registry_version == "2026-05"
+    assert response.verifier_signature == {
+        "alg": "ML-DSA-65",
+        "sig": "dmVyaWZpZXJzaWc=",
+        "kid": "verifier_kid_full",
+    }
 
 
 def test_verification_detail_exposes_extra_sub_axes() -> None:
@@ -136,7 +151,72 @@ def test_minimal_response_leaves_new_fields_none() -> None:
     assert response.signature_envelope is None
     assert response.anchors is None
     assert response.algorithm_registry_version is None
+    assert response.verifier_signature is None
     assert response.verification_detail is None
+
+
+def test_regimes_satisfied_present() -> None:
+    """`regimes_satisfied` parses through to `VerificationDetail` as a
+    list of regulator tokens. Cloud PR #337 added this field after the
+    SDK projection PR #160 landed; this pins the SDK now reads it."""
+    payload = _full_cloud_payload()
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        response = verify_signature("sig_test_full")
+
+    detail = response.verification_detail
+    assert isinstance(detail, VerificationDetail)
+    assert detail.regimes_satisfied == ["eu_ai_act", "dora"]
+
+
+def test_verifier_signature_present_or_null() -> None:
+    """`verifier_signature` is the verifier's `{alg, sig, kid}` block.
+    Populated on compliance-mode receipts, None otherwise. Cloud PR #337
+    added this; pin both branches."""
+    payload = _full_cloud_payload()
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        response = verify_signature("sig_test_full")
+
+    assert response.verifier_signature == {
+        "alg": "ML-DSA-65",
+        "sig": "dmVyaWZpZXJzaWc=",
+        "kid": "verifier_kid_full",
+    }
+
+    minimal = {
+        "signature_id": "sig_no_vs",
+        "agent_id": "agent_no_vs",
+        "agent_name": "no-vs",
+        "action_id": "act",
+        "action_type": "x.y",
+        "payload": None,
+        "signature": "ZmFrZQ==",
+        "algorithm": "Ed25519",
+        "signed_at": "2026-05-10T12:00:00+00:00",
+        "verified": True,
+        "verification_url": "https://verify.example/sig_no_vs",
+    }
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(minimal)):
+        response = verify_signature("sig_no_vs")
+    assert response.verifier_signature is None
+
+
+def test_anchor_type_accepts_opentimestamps_and_ots() -> None:
+    """The cloud `_project_anchors` emits `type: "opentimestamps"`
+    (canonical) but the `/verify/example` fixture still emits
+    `type: "ots"` (legacy). The SDK type stub admits both literals
+    and the parser does not silently rewrite."""
+    payload = _full_cloud_payload()
+    payload["anchors"] = [
+        {"type": "rfc3161", "value": "ZmFrZQ=="},
+        {"type": "opentimestamps", "value": "Y2Fub25pY2Fs"},
+        {"type": "ots", "value": "bGVnYWN5"},
+    ]
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        response = verify_signature("sig_test_full")
+
+    assert response.anchors is not None
+    types = [a["type"] for a in response.anchors]
+    assert types == ["rfc3161", "opentimestamps", "ots"]
 
 
 def test_dataclass_defaults_construct_without_new_fields() -> None:
@@ -153,6 +233,7 @@ def test_dataclass_defaults_construct_without_new_fields() -> None:
     assert detail.anchor_valid_rfc3161 is None
     assert detail.policy_digest_resolved is None
     assert detail.duplicate_emission_candidate is None
+    assert detail.regimes_satisfied == []
 
     response = VerificationResponse(
         signature_id="sig",
@@ -172,3 +253,4 @@ def test_dataclass_defaults_construct_without_new_fields() -> None:
     assert response.signature_envelope is None
     assert response.anchors is None
     assert response.algorithm_registry_version is None
+    assert response.verifier_signature is None

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "asqav"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -418,9 +418,9 @@ export interface SessionResponse {
  * The IETF profile sub-axes (`chainValid`, `anchorValidOts`,
  * `anchorValidRfc3161`, `anchorStatusOts`, `anchorStatusRfc3161`,
  * `signedAtSkewSeconds`, `missingFields`, `policyDigestResolved`,
- * `duplicateEmissionCandidate`) populate only when the cloud emits
- * them on a compliance-mode receipt; non-compliance-mode receipts
- * leave them undefined. */
+ * `duplicateEmissionCandidate`, `regimesSatisfied`) populate only
+ * when the cloud emits them on a compliance-mode receipt;
+ * non-compliance-mode receipts leave them undefined. */
 export interface VerificationDetail {
   signerKeyMatch: boolean;
   signatureValid: boolean;
@@ -467,6 +467,10 @@ export interface VerificationDetail {
    * (action_ref, issuer_id) pair; reporting flag, not a verification
    * downgrade. */
   duplicateEmissionCandidate?: boolean | string;
+  /** Regulator tokens the cloud derived for the receipt (e.g.
+   * `eu_ai_act`, `dora`). Empty / undefined on non-compliance-mode
+   * receipts. */
+  regimesSatisfied?: string[];
 }
 
 /** Bitcoin anchor state on a verification response. `status` vocabulary:
@@ -500,11 +504,25 @@ export interface VerificationResponse {
    * non-compliance-mode receipts. */
   signatureEnvelope?: { alg: string; kid: string } & Record<string, string>;
   /** IETF anchors projection: list of `{type, value, ...}` per anchor.
-   * Undefined on non-compliance-mode receipts. */
-  anchors?: Array<{ type: string; value: string } & Record<string, unknown>>;
+   * `type` admits the canonical `"opentimestamps"` and the legacy
+   * `"ots"` alias plus `"rfc3161"`; the SDK never silently rewrites,
+   * callers should normalize `"ots"` to `"opentimestamps"` if they
+   * compare against the cloud surface. Undefined on non-compliance-mode
+   * receipts. */
+  anchors?: Array<
+    {
+      type: "opentimestamps" | "ots" | "rfc3161" | string;
+      value: string;
+    } & Record<string, unknown>
+  >;
   /** Algorithm registry version in force at issuance. Undefined on
    * pre-migration rows. */
   algorithmRegistryVersion?: string;
+  /** Verifier's `{alg, sig, kid}` block over the verification outcome.
+   * Cloud emits this on compliance-mode receipts so a downstream
+   * regulator can re-check the verification decision without re-running
+   * the verifier. Undefined on non-compliance / pre-migration receipts. */
+  verifierSignature?: { alg: string; sig: string; kid: string };
 }
 
 export interface AppliedAttestationOptions {
@@ -1163,6 +1181,7 @@ export async function verifySignature(signatureId: string): Promise<Verification
       missing_fields?: string[];
       policy_digest_resolved?: boolean;
       duplicate_emission_candidate?: boolean | string;
+      regimes_satisfied?: string[];
     };
     type?: string;
     bitcoin_anchor?: {
@@ -1171,8 +1190,14 @@ export async function verifySignature(signatureId: string): Promise<Verification
       bitcoin_block?: number | null;
     };
     signature_envelope?: { alg: string; kid: string } & Record<string, string>;
-    anchors?: Array<{ type: string; value: string } & Record<string, unknown>>;
+    anchors?: Array<
+      {
+        type: "opentimestamps" | "ots" | "rfc3161" | string;
+        value: string;
+      } & Record<string, unknown>
+    >;
     algorithm_registry_version?: string;
+    verifier_signature?: { alg: string; sig: string; kid: string };
   }>("GET", `/verify/${signatureId}`);
 
   return {
@@ -1203,6 +1228,7 @@ export async function verifySignature(signatureId: string): Promise<Verification
           missingFields: data.verification_detail.missing_fields,
           policyDigestResolved: data.verification_detail.policy_digest_resolved,
           duplicateEmissionCandidate: data.verification_detail.duplicate_emission_candidate,
+          regimesSatisfied: data.verification_detail.regimes_satisfied,
         }
       : undefined,
     type: data.type,
@@ -1216,6 +1242,7 @@ export async function verifySignature(signatureId: string): Promise<Verification
     signatureEnvelope: data.signature_envelope,
     anchors: data.anchors,
     algorithmRegistryVersion: data.algorithm_registry_version,
+    verifierSignature: data.verifier_signature,
   };
 }
 

--- a/typescript/tests/verify-response-fields.test.ts
+++ b/typescript/tests/verify-response-fields.test.ts
@@ -2,13 +2,15 @@
  * SDK parser surfaces every field the cloud `/verify` returns.
  *
  * The cloud's `VerificationResponse` emits the IETF projection
- * (`signature_envelope`, `anchors`, `algorithm_registry_version`), the
- * `bitcoin_anchor` block, the receipt `type` discriminator, and four
- * extra `VerificationDetail` sub-axes (`anchor_valid_ots`,
- * `anchor_valid_rfc3161`, `policy_digest_resolved`,
- * `duplicate_emission_candidate`). These tests pin that the parser
- * populates the TS interface with all of them, and that the
- * `validationLabel` union admits `agent_revoked_before_issuance`.
+ * (`signature_envelope`, `anchors`, `algorithm_registry_version`,
+ * `verifier_signature`), the `bitcoin_anchor` block, the receipt `type`
+ * discriminator, and the `VerificationDetail` sub-axes
+ * (`anchor_valid_ots`, `anchor_valid_rfc3161`, `policy_digest_resolved`,
+ * `duplicate_emission_candidate`, `regimes_satisfied`). These tests
+ * pin that the parser populates the TS interface with all of them, that
+ * the `validationLabel` union admits `agent_revoked_before_issuance`,
+ * and that the inner anchor `type` admits both `"opentimestamps"`
+ * (canonical) and `"ots"` (legacy fixture alias).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -61,13 +63,19 @@ function fullCloudPayload() {
       missing_fields: [],
       policy_digest_resolved: true,
       duplicate_emission_candidate: false,
+      regimes_satisfied: ["eu_ai_act", "dora"],
     },
     signature_envelope: { alg: "ML-DSA-65", kid: "key_full" },
     anchors: [
       { type: "rfc3161", value: "ZmFrZQ==" },
-      { type: "ots", value: "b3RzZmFrZQ==" },
+      { type: "opentimestamps", value: "b3RzZmFrZQ==" },
     ],
     algorithm_registry_version: "2026-05",
+    verifier_signature: {
+      alg: "ML-DSA-65",
+      sig: "dmVyaWZpZXJzaWc=",
+      kid: "verifier_kid_full",
+    },
   };
 }
 
@@ -103,7 +111,13 @@ describe("verifySignature response fields", () => {
       type: "rfc3161",
       value: "ZmFrZQ==",
     });
+    expect(response.anchors?.[1]?.type).toBe("opentimestamps");
     expect(response.algorithmRegistryVersion).toBe("2026-05");
+    expect(response.verifierSignature).toEqual({
+      alg: "ML-DSA-65",
+      sig: "dmVyaWZpZXJzaWc=",
+      kid: "verifier_kid_full",
+    });
   });
 
   it("exposes the four extra VerificationDetail sub-axes", async () => {
@@ -144,7 +158,73 @@ describe("verifySignature response fields", () => {
     expect(response.signatureEnvelope).toBeUndefined();
     expect(response.anchors).toBeUndefined();
     expect(response.algorithmRegistryVersion).toBeUndefined();
+    expect(response.verifierSignature).toBeUndefined();
     expect(response.verificationDetail).toBeUndefined();
+  });
+
+  it("test_regimes_satisfied_present", async () => {
+    // Cloud PR #337 added regimes_satisfied after the SDK projection
+    // PR #160 landed; pin that the SDK parser now reads it.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(fullCloudPayload()),
+    );
+
+    const response = await verifySignature("sig_test_full");
+    expect(response.verificationDetail?.regimesSatisfied).toEqual([
+      "eu_ai_act",
+      "dora",
+    ]);
+  });
+
+  it("test_verifier_signature_present_or_null", async () => {
+    // verifier_signature is the verifier's {alg, sig, kid} block.
+    // Populated on compliance-mode receipts, undefined otherwise.
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse(fullCloudPayload()),
+    );
+    const full = await verifySignature("sig_test_full");
+    expect(full.verifierSignature).toEqual({
+      alg: "ML-DSA-65",
+      sig: "dmVyaWZpZXJzaWc=",
+      kid: "verifier_kid_full",
+    });
+
+    const minimal = {
+      signature_id: "sig_no_vs",
+      agent_id: "agent_no_vs",
+      agent_name: "no-vs",
+      action_id: "act",
+      action_type: "x.y",
+      payload: null,
+      signature: "ZmFrZQ==",
+      algorithm: "Ed25519",
+      signed_at: "2026-05-10T12:00:00+00:00",
+      verified: true,
+      verification_url: "https://verify.example/sig_no_vs",
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(minimal));
+    const bare = await verifySignature("sig_no_vs");
+    expect(bare.verifierSignature).toBeUndefined();
+  });
+
+  it("test_anchor_type_accepts_opentimestamps_and_ots", async () => {
+    // _project_anchors emits "opentimestamps" (canonical), the
+    // /verify/example fixture still emits "ots" (legacy). The SDK
+    // type stub admits both literals and the parser does not silently
+    // rewrite.
+    const payload = {
+      ...fullCloudPayload(),
+      anchors: [
+        { type: "rfc3161", value: "ZmFrZQ==" },
+        { type: "opentimestamps", value: "Y2Fub25pY2Fs" },
+        { type: "ots", value: "bGVnYWN5" },
+      ],
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(payload));
+
+    const response = await verifySignature("sig_test_full");
+    const types = response.anchors?.map((a) => a.type);
+    expect(types).toEqual(["rfc3161", "opentimestamps", "ots"]);
   });
 
   it("admits agent_revoked_before_issuance on the validation-label union", async () => {


### PR DESCRIPTION
## Why

SDK projection PR #160 landed the same day as cloud PR #337, but the cloud PR added two fields the SDK projection did not include:
- `verification_detail.regimes_satisfied` (regulator tokens the cloud derived for the receipt)
- top-level `verifier_signature: {alg, sig, kid}` (verifier's block over the verification outcome)

Plus cloud PR #332 wired the `/verify/example` fixture to emit `type: "ots"` while the real `_project_anchors` helper emits `type: "opentimestamps"`. SDK callers that hit both surfaces saw a vocabulary mismatch at the type-stub level.

This PR closes those three gaps in a single drop, Python + TypeScript.

## What changed

Python (`python/src/asqav/client.py`):
- `VerificationDetail.regimes_satisfied: list[str]` (default empty).
- `VerificationResponse.verifier_signature: dict[str, str] | None` (default None).
- Parser in `verify_signature(...)` reads both new fields.

TypeScript (`typescript/src/index.ts`):
- `VerificationDetail.regimesSatisfied?: string[]`.
- `VerificationResponse.verifierSignature?: { alg: string; sig: string; kid: string }`.
- Parser in `verifySignature(...)` wires both.

Vocabulary (both languages):
- Inner anchor `type` admits `"opentimestamps"` (canonical), `"ots"` (legacy alias), `"rfc3161"`.
- No silent rewrite; callers normalize if they want the canonical cloud surface.

Tests:
- `python/tests/test_verify_response_fields.py` adds `test_regimes_satisfied_present`, `test_verifier_signature_present_or_null`, `test_anchor_type_accepts_opentimestamps_and_ots`. Existing tests extended with the new fields in the full payload.
- `typescript/tests/verify-response-fields.test.ts` mirrors the same.

CHANGELOG entry appended to the existing `[Unreleased]` block from #160.

## Validation

- 663 Python tests pass (`uv run pytest`).
- 189 TypeScript tests pass (`npm test`).
- Ruff clean on touched files.
- `tsc --noEmit` clean.

## Compat

Pure additive on the SDK surface. Old cloud responses that omit `regimes_satisfied` / `verifier_signature` parse to `[]` / `None` (Python) / `undefined` (TS). The `"ots"` literal stays admitted so existing callers don't break.