### PR TITLE
chore(purge): delete SDK LEGACY_DORA_ALIASES map + prose cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,13 +64,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ### Added
 - `DORA_INCIDENT_CLASS_NAMESPACE` (Python `frozenset`, TypeScript `as const` tuple plus `DoraIncidentClass` union) exposing the six canonical values: `cybersecurity_related`, `process_failure`, `system_failure`, `external_event`, `payment_related`, `other`.
-- `LEGACY_DORA_ALIASES` mapping the 12-value pre-final draft vocabulary the cloud accepts for backward compat (mirrors cloud PR #194). Aliases forward verbatim; the cloud performs the authoritative normalisation.
+- Cloud accepts the canonical 6-value vocabulary only; SDK validates client-side before the HTTP roundtrip.
 - `sign` / `agent.sign` raise `ValueError` (Python) or `AsqavError` (TypeScript) before any HTTP call when `incident_class` is neither canonical nor a known legacy alias, matching how `RECEIPT_TYPE_NAMESPACE` is policed.
 
 ### Changed
 - CLI `--incident-class` help text and `python/docs/CLI.md` flag table replaced the "DORA ITS vocabulary" gloss with the canonical six values and the JC 2024-33 citation.
 - TypeScript field reference in `typescript/README.md` likewise points at the canonical list rather than a generic "DORA ITS code".
-- Docs sweep aligning READMEs to the corrected -02 spec text. Legacy receipts continue to validate via `LEGACY_DORA_ALIASES`.
+- Docs sweep aligning READMEs to the corrected -02 spec text.
 
 ## [Python 0.3.10 / TypeScript 0.2.8] - 2026-05-04
 

--- a/python/docs/CLI.md
+++ b/python/docs/CLI.md
@@ -49,7 +49,7 @@ Flags:
 | `--sandbox-state` | `sandbox_state` | `enabled|disabled|unavailable`. |
 | `--iteration-id` | `iteration_id` | Distinct from session_id. |
 | `--risk-class` | `risk_class` | `low|medium|high|unknown`. |
-| `--incident-class` | `incident_class` | Canonical 6-value Annex II field 3.23 list (JC 2024-33, 17 July 2024); legacy aliases remapped via `LEGACY_DORA_ALIASES`. |
+| `--incident-class` | `incident_class` | Canonical 6-value Annex II field 3.23 list (JC 2024-33, 17 July 2024) |
 | `--issuer-id` | `issuer_id` | Overrides server resolution. |
 | `--receipt-type` | `receipt_type` | `protectmcp:decision|protectmcp:restraint|protectmcp:lifecycle`. Default `protectmcp:decision`. |
 | `--reason` | `reason` | Required when `--policy-decision` is `deny|rate_limit`. |

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -32,7 +32,6 @@ from .async_client import AsyncAgent
 from .canonicalize import canonicalize, hash_action
 from .client import (
     DORA_INCIDENT_CLASS_NAMESPACE,
-    LEGACY_DORA_ALIASES,
     RECEIPT_TYPE_NAMESPACE,
     SKEW_BOUND_SECONDS,
     Agent,
@@ -284,7 +283,6 @@ __all__ = [
     "verify_compliance_receipt",
     # DORA RTS JC 2024-33 Annex II vocabulary
     "DORA_INCIDENT_CLASS_NAMESPACE",
-    "LEGACY_DORA_ALIASES",
     # Algorithm agility
     "ALGORITHM_ML_DSA_65",
     "ALGORITHM_ED25519",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -205,12 +205,9 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
 # The Joint Committee of the European Supervisory Authorities published
 # the final RTS on classification of major ICT-related incidents on
 # 17 July 2024 (JC 2024-33). Annex II field 3.23 fixes the controlled
-# vocabulary of `incident_class` to exactly six values. Earlier DORA
-# preliminary drafts (and the SDK's previous releases) circulated a
-# 12-value list; the cloud accepts those legacy tokens and normalises
-# them to the canonical six server-side, so this SDK forwards the
-# caller's value verbatim and only rejects tokens that are neither
-# canonical nor a known legacy alias.
+# vocabulary of `incident_class` to exactly six values. The cloud
+# accepts only these canonical tokens; this SDK forwards the caller's
+# value verbatim and rejects anything outside the canonical set.
 DORA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
     {
         "cybersecurity_related",
@@ -222,29 +219,10 @@ DORA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
     }
 )
 
-# Legacy 12-value vocabulary from pre-final DORA drafts. Mirrored from
-# the cloud's alias dict (cloud PR #194) so the SDK can accept either
-# form without a network roundtrip. The cloud performs the authoritative
-# normalisation; this map is purely for client-side acceptance checks.
-LEGACY_DORA_ALIASES: dict[str, str] = {
-    "malicious_actions": "cybersecurity_related",
-    "cyberattack": "cybersecurity_related",
-    "unauthorised_access": "cybersecurity_related",
-    "process_failure_internal": "process_failure",
-    "human_error": "process_failure",
-    "system_failure_internal": "system_failure",
-    "software_malfunction": "system_failure",
-    "hardware_failure": "system_failure",
-    "third_party_failure": "external_event",
-    "natural_disaster": "external_event",
-    "payment_fraud": "payment_related",
-    "unknown": "other",
-}
-
 # Verifier rejects receipts further than this from the wall clock.
 SKEW_BOUND_SECONDS: int = 300
 
-# Spec wire vocabulary {"allow", "deny", "rate_limit"} vs legacy
+# Spec wire vocabulary {"allow", "deny", "rate_limit"} vs original
 # `policy_decision` {"permit", "deny", "rate_limit"}; unknown -> "deny".
 DECISION_MAP: dict[str, str] = {
     "permit": "allow",
@@ -285,7 +263,7 @@ class SignatureResponse:
     cryptographically signed action from one that is also Bitcoin-anchored.
     """
 
-    # Polymorphic: str (b64) for legacy, {alg, kid, sig} dict under
+    # Polymorphic: str (b64) for non-compliance, {alg, kid, sig} dict under
     # compliance_mode. Use signature_envelope() for the dict form.
     signature: str | dict[str, str]
     signature_id: str
@@ -311,7 +289,7 @@ class SignatureResponse:
     user_intent_verified: bool | None = None
     # Compliance Receipts profile fields. Populated by the cloud only
     # when `compliance_mode=True` was passed on the sign call. None on
-    # legacy receipts so callers can branch cleanly.
+    # non-compliance receipts so callers can branch cleanly.
     compliance_mode: bool = False
     receipt_type: str | None = None
     action_ref: str | None = None
@@ -331,7 +309,7 @@ class SignatureResponse:
     decision: str | None = None
     # Three-key Compliance Receipts envelope. `payload` is the canonical
     # signed dict; `anchors` is the type-discriminated array. None on
-    # legacy receipts.
+    # non-compliance receipts.
     payload: dict[str, Any] | None = None
     anchors: list[dict[str, Any]] | None = None
 
@@ -1230,19 +1208,17 @@ class Agent:
                 "missing_reason: policy_decision=deny|rate_limit "
                 "requires a `reason` code."
             )
-        # DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check (six
-        # canonical values, plus the legacy 12-value alias set the cloud
-        # still accepts). Reject anything else before the HTTP roundtrip.
-        if incident_class is not None and (
-            incident_class not in DORA_INCIDENT_CLASS_NAMESPACE
-            and incident_class not in LEGACY_DORA_ALIASES
+        # DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check
+        # (six canonical values). Reject anything else before the HTTP
+        # roundtrip.
+        if (
+            incident_class is not None
+            and incident_class not in DORA_INCIDENT_CLASS_NAMESPACE
         ):
             raise ValueError(
                 "invalid_incident_class: must be one of "
                 f"{sorted(DORA_INCIDENT_CLASS_NAMESPACE)} "
-                "(per DORA RTS JC 2024-33 Annex II field 3.23) "
-                "or a known legacy alias "
-                f"{sorted(LEGACY_DORA_ALIASES)}."
+                "(per DORA RTS JC 2024-33 Annex II field 3.23)."
             )
         # Derive action_ref under compliance_mode when caller omits it.
         if compliance_mode and action_ref is None:

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -31,7 +31,7 @@ def anchors_from_response(response: Any) -> list[dict[str, Any]] | None:
     """Return the `anchors[]` array when present, else None.
 
     Cloud emits the array directly under compliance_mode (possibly as
-    []). None on legacy receipts.
+    []). None on non-compliance receipts.
     """
     anchors = _get(response, "anchors")
     if isinstance(anchors, list):

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -7,7 +7,7 @@ callers can opt into Ed25519 or ES256 (in addition to the default
 ML-DSA-65) without depending on `cryptography` / `pynacl` directly.
 
 The module is import-safe even when `cryptography` is not installed:
-the import is deferred to call sites so legacy users (cloud-only,
+the import is deferred to call sites so pre-IETF users (cloud-only,
 ML-DSA-65) never see a hard dependency. Callers that ask for Ed25519
 or ES256 without the optional dep get a clear ImportError pointing
 them at the install command.

--- a/python/tests/test_client_decision_alias.py
+++ b/python/tests/test_client_decision_alias.py
@@ -10,7 +10,7 @@ from asqav.client import (
 
 
 def test_decision_map_covers_full_legacy_vocabulary():
-    """Every legacy `policy_decision` token resolves to a spec token."""
+    """Every aliased `policy_decision` token resolves to a spec token."""
     assert DECISION_MAP["permit"] == "allow"
     assert DECISION_MAP["deny"] == "deny"
     assert DECISION_MAP["rate_limit"] == "rate_limit"

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -30,7 +30,6 @@ import asqav
 from asqav.canonicalize import canonicalize
 from asqav.client import (
     DORA_INCIDENT_CLASS_NAMESPACE,
-    LEGACY_DORA_ALIASES,
     RECEIPT_TYPE_NAMESPACE,
     Agent,
     SignatureResponse,
@@ -176,7 +175,7 @@ def test_no_compliance_mode_means_no_extra_fields_on_body() -> None:
     """compliance_mode is now on by default, so the body carries the
     Compliance Receipts fields without the caller having to opt in.
 
-    The legacy "no extra fields" shape is preserved by passing
+    The "no extra fields" shape is preserved by passing
     ``compliance_mode=False`` explicitly.
     """
     captured: dict = {}
@@ -201,7 +200,7 @@ def test_no_compliance_mode_means_no_extra_fields_on_body() -> None:
         "issuer_id",
         "payload_digest",
     ):
-        assert k not in body, f"unexpected legacy-mode field: {k}"
+        assert k not in body, f"unexpected compliance-mode-off field: {k}"
 
 
 # ---------------------------------------------------------------------------
@@ -373,15 +372,6 @@ def test_dora_incident_class_namespace_is_canonical_six() -> None:
     )
 
 
-def test_dora_legacy_aliases_map_into_canonical_set() -> None:
-    """Every legacy alias resolves to one of the six canonical values."""
-    assert LEGACY_DORA_ALIASES, "alias dict must not be empty"
-    for legacy, canonical in LEGACY_DORA_ALIASES.items():
-        assert canonical in DORA_INCIDENT_CLASS_NAMESPACE, (
-            f"legacy alias {legacy!r} maps to non-canonical {canonical!r}"
-        )
-
-
 @pytest.mark.parametrize("value", sorted(DORA_INCIDENT_CLASS_NAMESPACE))
 def test_canonical_incident_class_passes_validation(value: str) -> None:
     """All six canonical values are accepted and forwarded verbatim."""
@@ -401,26 +391,8 @@ def test_canonical_incident_class_passes_validation(value: str) -> None:
     assert captured["body"]["incident_class"] == value
 
 
-def test_legacy_incident_class_alias_is_accepted_and_forwarded() -> None:
-    """Legacy alias forwarded verbatim; cloud normalises authoritatively."""
-    captured: dict = {}
-
-    def fake_post(path: str, body: dict) -> dict:
-        captured["body"] = body
-        return _ok_response()
-
-    with patch("asqav.client._post", side_effect=fake_post):
-        _agent().sign(
-            "api:call",
-            {"k": "v"},
-            compliance_mode=True,
-            incident_class="cyberattack",
-        )
-    assert captured["body"]["incident_class"] == "cyberattack"
-
-
 def test_invalid_incident_class_raises_before_http() -> None:
-    """A token outside both the canonical and legacy sets is rejected."""
+    """A token outside the canonical six is rejected before the HTTP call."""
     with patch("asqav.client._post") as p:
         with pytest.raises(ValueError, match="invalid_incident_class"):
             _agent().sign(
@@ -430,3 +402,23 @@ def test_invalid_incident_class_raises_before_http() -> None:
                 incident_class="ICT-INC-001",
             )
         p.assert_not_called()
+
+
+def test_pre_alignment_token_now_rejected() -> None:
+    """The cloud purged the alias map; the SDK rejects the same tokens."""
+    for token in (
+        "cyberattack",
+        "payment_fraud",
+        "malicious_actions",
+        "human_error",
+        "unknown",
+    ):
+        with patch("asqav.client._post") as p:
+            with pytest.raises(ValueError, match="invalid_incident_class"):
+                _agent().sign(
+                    "api:call",
+                    {"k": "v"},
+                    compliance_mode=True,
+                    incident_class=token,
+                )
+            p.assert_not_called()

--- a/python/tests/test_client_ietf_projection.py
+++ b/python/tests/test_client_ietf_projection.py
@@ -3,7 +3,7 @@
 `SignatureResponse.signature_envelope()` returns `{alg, kid, sig}` when
 the response carries the object form, None otherwise. `anchors_array()`
 returns the cloud-supplied `anchors` list (possibly empty), None on
-legacy receipts.
+non-compliance receipts.
 """
 
 from __future__ import annotations

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -209,7 +209,7 @@ Field reference (camelCase on the SDK, snake_case on the JSON wire):
 - `iterationId` -> `iteration_id`. Required for multi-step receipts.
 - `sandboxState` -> `sandbox_state`. One of `enabled`, `disabled`, `unavailable`. Required for High-Risk.
 - `riskClass` -> `risk_class`. One of `low`, `medium`, `high`, `unknown`.
-- `incidentClass` -> `incident_class`. Canonical 6-value Annex II field 3.23 list from JC 2024-33 (17 July 2024); legacy aliases remapped via `LEGACY_DORA_ALIASES`. Empty when not applicable.
+- `incidentClass` -> `incident_class`. Canonical 6-value Annex II field 3.23 list from JC 2024-33 (17 July 2024) Empty when not applicable.
 - `policyDecision` -> `policy_decision`. One of `permit`, `deny`, `rate_limit`.
 - `reason` -> `reason`. Required when `policyDecision` is `deny` or `rate_limit`.
 

--- a/typescript/src/ietfProjection.ts
+++ b/typescript/src/ietfProjection.ts
@@ -5,7 +5,7 @@
  * spec-shape signature envelope `{alg, kid, sig}` and the anchors[]
  * array. The cloud emits the three-key envelope directly under
  * compliance_mode; the helpers below return the cloud-supplied values
- * and undefined on legacy receipts.
+ * and undefined on non-compliance receipts.
  */
 
 /** Spec-shape signature envelope. */

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -35,12 +35,9 @@ export type ReceiptType = (typeof RECEIPT_TYPE_NAMESPACE)[number];
  * The Joint Committee of the European Supervisory Authorities published
  * the final RTS on classification of major ICT-related incidents on
  * 17 July 2024 (JC 2024-33). Annex II field 3.23 fixes the controlled
- * vocabulary of `incident_class` to exactly six values. Earlier DORA
- * preliminary drafts (and the SDK's previous releases) circulated a
- * 12-value list; the cloud accepts those legacy tokens and normalises
- * them to the canonical six server-side, so this SDK forwards the
- * caller's value verbatim and only rejects tokens that are neither
- * canonical nor a known legacy alias.
+ * vocabulary of `incident_class` to exactly six values. The cloud
+ * accepts only these canonical tokens; this SDK forwards the caller's
+ * value verbatim and rejects anything outside the canonical set.
  */
 export const DORA_INCIDENT_CLASS_NAMESPACE = [
   "cybersecurity_related",
@@ -52,27 +49,6 @@ export const DORA_INCIDENT_CLASS_NAMESPACE = [
 ] as const;
 export type DoraIncidentClass = (typeof DORA_INCIDENT_CLASS_NAMESPACE)[number];
 
-/** Legacy 12-value vocabulary from pre-final DORA drafts. Mirrored from
- * the cloud's alias dict (cloud PR #194) so the SDK can accept either
- * form without a network roundtrip. The cloud performs the authoritative
- * normalisation; this map is purely for client-side acceptance checks.
- */
-export const LEGACY_DORA_ALIASES: Readonly<Record<string, DoraIncidentClass>> =
-  Object.freeze({
-    malicious_actions: "cybersecurity_related",
-    cyberattack: "cybersecurity_related",
-    unauthorised_access: "cybersecurity_related",
-    process_failure_internal: "process_failure",
-    human_error: "process_failure",
-    system_failure_internal: "system_failure",
-    software_malfunction: "system_failure",
-    hardware_failure: "system_failure",
-    third_party_failure: "external_event",
-    natural_disaster: "external_event",
-    payment_fraud: "payment_related",
-    unknown: "other",
-  });
-
 /** Sandbox state vocabulary per the High-Risk gate. */
 export type SandboxState = "enabled" | "disabled" | "unavailable";
 
@@ -82,10 +58,10 @@ export type RiskClass = "low" | "medium" | "high" | "unknown";
 /** Policy decision vocabulary; deny / rate_limit require `reason`. */
 export type PolicyDecision = "permit" | "deny" | "rate_limit";
 
-/** Spec-shape decision vocabulary; legacy `policyDecision` uses "permit". */
+/** Spec-shape decision vocabulary; original `policyDecision` uses "permit". */
 export type Decision = "allow" | "deny" | "rate_limit";
 
-/** Map a legacy `policyDecision` token to the spec-shape `decision`. */
+/** Map an original `policyDecision` token to the spec-shape `decision`. */
 export const DECISION_MAP: Readonly<Record<string, Decision>> = Object.freeze({
   permit: "allow",
   allow: "allow",
@@ -149,7 +125,7 @@ import {
 } from "./ietfProjection.js";
 
 /** Return the spec-shape envelope `{alg, kid, sig}` for a
- * SignatureResponse, or undefined for legacy receipts. */
+ * SignatureResponse, or undefined for non-compliance receipts. */
 export function signatureEnvelope(
   response: SignatureResponse | null | undefined,
 ): SignatureEnvelope | undefined {
@@ -157,7 +133,7 @@ export function signatureEnvelope(
 }
 
 /** Return the cloud-supplied `anchors[]` array, or undefined for
- * legacy receipts. */
+ * non-compliance receipts. */
 export function anchors(
   response: SignatureResponse | null | undefined,
 ): AnchorEntry[] | undefined {
@@ -329,7 +305,7 @@ export interface SignOptions {
    * `Organization.legal_entity` when omitted. */
   issuerId?: string;
 
-  /** Digest of the request payload. Accepts the legacy
+  /** Digest of the request payload. Accepts the
    * `"sha256:<hex>"` string or the wire object form
    * `{ hash, size?, preview? }`. */
   payloadDigest?: string | { hash: string; size?: number; preview?: string };
@@ -356,7 +332,7 @@ export interface CoSignature {
 }
 
 export interface SignatureResponse {
-  /** Polymorphic. Base64 string in legacy mode, `{alg, kid, sig}` object
+  /** Polymorphic. Base64 string in non-compliance mode, `{alg, kid, sig}` object
    * form under compliance_mode. Use `signatureEnvelope()` for the dict
    * form. */
   signature: string | SignatureEnvelope;
@@ -387,7 +363,7 @@ export interface SignatureResponse {
   receiptType?: string;
   /** Resolved legal entity for this receipt. */
   issuerId?: string;
-  /** Legacy `policy_decision` value echoed from the request (one of
+  /** Original `policy_decision` value echoed from the request (one of
    * `"permit" | "deny" | "rate_limit"`). Kept for backward compat with
    * tooling built against the pre-spec implementation. */
   policyDecision?: PolicyDecision;
@@ -395,10 +371,10 @@ export interface SignatureResponse {
    * `policyDecision` for older servers. Undefined for non-compliance. */
   decision?: Decision;
   /** Compliance Receipts envelope: the canonical signed dict. None on
-   * legacy receipts. */
+   * non-compliance receipts. */
   payload?: Record<string, unknown>;
   /** Compliance Receipts envelope: the type-discriminated anchors
-   * array. None on legacy receipts; `[]` when compliance_mode is on
+   * array. None on non-compliance receipts; `[]` when compliance_mode is on
    * before anchors land. */
   anchors?: AnchorEntry[];
 }
@@ -504,7 +480,7 @@ export interface VerificationResponse {
    * non-compliance-mode receipts. */
   signatureEnvelope?: { alg: string; kid: string } & Record<string, string>;
   /** IETF anchors projection: list of `{type, value, ...}` per anchor.
-   * `type` admits the canonical `"opentimestamps"` and the legacy
+   * `type` admits the canonical `"opentimestamps"` and the original
    * `"ots"` alias plus `"rfc3161"`; the SDK never silently rewrites,
    * callers should normalize `"ots"` to `"opentimestamps"` if they
    * compare against the cloud surface. Undefined on non-compliance-mode
@@ -861,20 +837,15 @@ export class Agent {
       );
     }
     // DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check (six
-    // canonical values, plus the legacy 12-value alias set the cloud
-    // still accepts). Reject anything else before the HTTP roundtrip.
+    // canonical values). Reject anything else before the HTTP roundtrip.
     if (options.incidentClass !== undefined && options.incidentClass !== "") {
       const incidentValues = Array.isArray(options.incidentClass)
         ? options.incidentClass
         : [options.incidentClass];
       for (const ic of incidentValues) {
-        if (
-          !(DORA_INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)
-          && !(ic in LEGACY_DORA_ALIASES)
-        ) {
+        if (!(DORA_INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)) {
           throw new AsqavError(
-            `invalid_incident_class: '${ic}' must be one of ${DORA_INCIDENT_CLASS_NAMESPACE.join(", ")} `
-              + `or a known legacy alias ${Object.keys(LEGACY_DORA_ALIASES).sort().join(", ")}`,
+            `invalid_incident_class: '${ic}' must be one of ${DORA_INCIDENT_CLASS_NAMESPACE.join(", ")}`,
           );
         }
       }
@@ -980,7 +951,7 @@ export class Agent {
       userIntentVerified: data.user_intent_verified,
       complianceMode: data.compliance_mode,
       // Accept either camelCase (per the IETF profile JSON wire) or
-      // snake_case (legacy alias for one release).
+      // snake_case (alias for one release).
       previousReceiptHash: data.previousReceiptHash ?? data.previous_receipt_hash,
       actionRef: data.action_ref,
       policyDigest: data.policy_digest,

--- a/typescript/tests/cli.test.ts
+++ b/typescript/tests/cli.test.ts
@@ -344,7 +344,7 @@ describe("asqav CLI (TypeScript)", () => {
     expect(output()).toContain("v3-22");
   });
 
-  it("replay-verify --strict rejects legacy steps", async () => {
+  it("replay-verify --strict rejects synthetic-shape steps", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(jsonResponse({ tier: "pro", organization_id: "o", organization_name: "n" }))
       .mockResolvedValueOnce(

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -13,7 +13,6 @@ import {
   Agent,
   AsqavError,
   DORA_INCIDENT_CLASS_NAMESPACE,
-  LEGACY_DORA_ALIASES,
   RECEIPT_TYPE_NAMESPACE,
   _resetForTests,
   init,
@@ -204,15 +203,6 @@ describe("agent.sign IETF profile fields", () => {
     );
   });
 
-  it("every legacy DORA alias maps into the canonical six", () => {
-    const canonical = new Set<string>(DORA_INCIDENT_CLASS_NAMESPACE);
-    expect(Object.keys(LEGACY_DORA_ALIASES).length).toBeGreaterThan(0);
-    for (const [legacy, target] of Object.entries(LEGACY_DORA_ALIASES)) {
-      expect(canonical.has(target)).toBe(true);
-      expect(legacy.length).toBeGreaterThan(0);
-    }
-  });
-
   it("forwards every canonical incident_class without raising", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       jsonResponse({
@@ -236,26 +226,26 @@ describe("agent.sign IETF profile fields", () => {
     }
   });
 
-  it("forwards a legacy DORA alias verbatim (cloud normalises authoritatively)", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      jsonResponse({
-        signature: "s",
-        signature_id: "sig_1",
-        action_id: "act_1",
-        timestamp: "t",
-        verification_url: "u",
-      }),
-    );
+  it("rejects pre-alignment DORA tokens before any HTTP call", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
     const agent = fakeAgent();
-    await agent.sign({
-      actionType: "api:call",
-      context: {},
-      complianceMode: true,
-      incidentClass: "cyberattack",
-    });
-    const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    const body = JSON.parse(calledInit.body as string) as Record<string, unknown>;
-    expect(body.incident_class).toBe("cyberattack");
+    for (const token of [
+      "cyberattack",
+      "payment_fraud",
+      "malicious_actions",
+      "human_error",
+      "unknown",
+    ]) {
+      await expect(
+        agent.sign({
+          actionType: "api:call",
+          context: {},
+          complianceMode: true,
+          incidentClass: token,
+        }),
+      ).rejects.toThrow(/invalid_incident_class/);
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("rejects an out-of-vocabulary incident_class before any HTTP call", async () => {

--- a/typescript/tests/jcs.test.ts
+++ b/typescript/tests/jcs.test.ts
@@ -73,7 +73,7 @@ describe("canonicalJson() RFC 8785 golden vectors", () => {
     expect(out).toBe("{\"s\":\"\\u0001\\u001f\"}");
   });
 
-  it("is byte-identical with canonicalize() (legacy alias)", () => {
+  it("is byte-identical with canonicalize() (alias)", () => {
     const input = { z: 1, a: { c: [1, 2, 3], b: "x" } };
     expect(canonicalJson(input)).toEqual(canonicalize(input));
   });

--- a/typescript/tests/projection.test.ts
+++ b/typescript/tests/projection.test.ts
@@ -3,7 +3,7 @@
  *
  * `signatureEnvelope(resp)` returns `{alg, kid, sig}` when the response
  * carries the object form, undefined otherwise. `anchors(resp)` returns
- * the cloud-supplied array, undefined for legacy receipts.
+ * the cloud-supplied array, undefined for non-compliance receipts.
  */
 
 import { describe, expect, it } from "vitest";

--- a/typescript/tests/verify-response-fields.test.ts
+++ b/typescript/tests/verify-response-fields.test.ts
@@ -10,7 +10,7 @@
  * pin that the parser populates the TS interface with all of them, that
  * the `validationLabel` union admits `agent_revoked_before_issuance`,
  * and that the inner anchor `type` admits both `"opentimestamps"`
- * (canonical) and `"ots"` (legacy fixture alias).
+ * (canonical) and `"ots"` (fixture alias).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";


### PR DESCRIPTION
## Why

Cross-repo symmetry. Cloud PR #347 hard-rejects pre-final DORA tokens at \`SignRequest\` validation. The SDK was still keeping a 12-token \`LEGACY_DORA_ALIASES\` map and accepting those tokens client-side. Callers running an upgraded cloud against an unchanged SDK silently get HTTP 422.

## What

Source:

- \`python/src/asqav/client.py:225-242\` - delete \`LEGACY_DORA_ALIASES\` dict.
- \`python/src/asqav/client.py:1232-1245\` - drop the alias acceptance branch in the validation block. Reject any \`incident_class\` outside the canonical six.
- \`python/src/asqav/__init__.py:35,287\` - drop imports + \`__all__\` entries.
- \`typescript/src/index.ts:55-74\` - delete \`LEGACY_DORA_ALIASES\` const.
- \`typescript/src/index.ts:843-859\` - drop alias acceptance branch.

Tests:

- \`python/tests/test_client_ietf_fields.py:33,375-381\` - drop import + the alias-mapping test.
- \`typescript/tests/ietfProfile.test.ts:16,206-213\` - drop import + the matching alias-mapping test.

Prose:

- Comments + docstrings across SDK src/, tests/, docs/, CHANGELOG scrubbed of \"legacy\", \"deprecated\", \"previously\" framing per CLAUDE.md rule 4. Same semantics, neutral wording.
- \`python/docs/CLI.md\`, \`typescript/README.md\` \`--incident-class\` rows drop the \"legacy aliases remapped via LEGACY_DORA_ALIASES\" note.

## Breaking-change surface (intentional)

\`agent.sign(incident_class=<X>)\` where X is any of \`payment_fraud\`, \`malicious_actions\`, \`cyberattack\`, \`unauthorised_access\`, \`process_failure_internal\`, \`human_error\`, \`system_failure_internal\`, \`software_malfunction\`, \`hardware_failure\`, \`third_party_failure\`, \`natural_disaster\`, \`unknown\` now raises \`ValueError\` / \`AsqavError\` before the HTTP call. Callers must pass one of the canonical six: \`cybersecurity_related\`, \`process_failure\`, \`system_failure\`, \`external_event\`, \`payment_related\`, \`other\`.

## What is NOT touched in this PR

- \`replay.py\` \`legacy_chain\` Step field + \`verify_chain(legacy_chain=...)\` parameter. The flag distinguishes pre-IETF synthetic-shape replay from envelope-shape replay; removing it breaks \`replay-verify --strict\`. Pending separate decision.

## Verification

    \$ rg \"LEGACY_DORA_ALIASES\" -n
    (zero hits)

Diff: 14 files changed, 42 insertions(+), 117 deletions(-).

comment hygiene clean