### PR TITLE
chore(purge): delete legacy_chain field + scrub historical prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,13 +64,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ### Added
 - `DORA_INCIDENT_CLASS_NAMESPACE` (Python `frozenset`, TypeScript `as const` tuple plus `DoraIncidentClass` union) exposing the six canonical values: `cybersecurity_related`, `process_failure`, `system_failure`, `external_event`, `payment_related`, `other`.
-- `LEGACY_DORA_ALIASES` mapping the 12-value pre-final draft vocabulary the cloud accepts for backward compat (mirrors cloud PR #194). Aliases forward verbatim; the cloud performs the authoritative normalisation.
+- Cloud accepts the canonical 6-value vocabulary only; SDK validates client-side before the HTTP roundtrip.
 - `sign` / `agent.sign` raise `ValueError` (Python) or `AsqavError` (TypeScript) before any HTTP call when `incident_class` is neither canonical nor a known legacy alias, matching how `RECEIPT_TYPE_NAMESPACE` is policed.
 
 ### Changed
 - CLI `--incident-class` help text and `python/docs/CLI.md` flag table replaced the "DORA ITS vocabulary" gloss with the canonical six values and the JC 2024-33 citation.
 - TypeScript field reference in `typescript/README.md` likewise points at the canonical list rather than a generic "DORA ITS code".
-- Docs sweep aligning READMEs to the corrected -02 spec text. Legacy receipts continue to validate via `LEGACY_DORA_ALIASES`.
+- Docs sweep aligning READMEs to the corrected -02 spec text.
 
 ## [Python 0.3.10 / TypeScript 0.2.8] - 2026-05-04
 

--- a/python/docs/CLI.md
+++ b/python/docs/CLI.md
@@ -49,7 +49,7 @@ Flags:
 | `--sandbox-state` | `sandbox_state` | `enabled|disabled|unavailable`. |
 | `--iteration-id` | `iteration_id` | Distinct from session_id. |
 | `--risk-class` | `risk_class` | `low|medium|high|unknown`. |
-| `--incident-class` | `incident_class` | Canonical 6-value Annex II field 3.23 list (JC 2024-33, 17 July 2024); legacy aliases remapped via `LEGACY_DORA_ALIASES`. |
+| `--incident-class` | `incident_class` | Canonical 6-value Annex II field 3.23 list (JC 2024-33, 17 July 2024) |
 | `--issuer-id` | `issuer_id` | Overrides server resolution. |
 | `--receipt-type` | `receipt_type` | `protectmcp:decision|protectmcp:restraint|protectmcp:lifecycle`. Default `protectmcp:decision`. |
 | `--reason` | `reason` | Required when `--policy-decision` is `deny|rate_limit`. |

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -32,7 +32,6 @@ from .async_client import AsyncAgent
 from .canonicalize import canonicalize, hash_action
 from .client import (
     DORA_INCIDENT_CLASS_NAMESPACE,
-    LEGACY_DORA_ALIASES,
     RECEIPT_TYPE_NAMESPACE,
     SKEW_BOUND_SECONDS,
     Agent,
@@ -284,7 +283,6 @@ __all__ = [
     "verify_compliance_receipt",
     # DORA RTS JC 2024-33 Annex II vocabulary
     "DORA_INCIDENT_CLASS_NAMESPACE",
-    "LEGACY_DORA_ALIASES",
     # Algorithm agility
     "ALGORITHM_ML_DSA_65",
     "ALGORITHM_ED25519",

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -1485,16 +1485,14 @@ def replay_verify_cmd(
     strict: bool = typer.Option(
         False,
         "--strict",
-        help="Reject legacy synthetic-shape steps. The IETF profile rederives the chain over `sha256(canonical_json(signed_envelope))`; legacy steps cannot prove byte-level integrity.",
+        help="Require every step to carry a cloud `signed_envelope`. Synthetic-shape fallback steps cannot prove byte-level integrity.",
     ),
     output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
 ) -> None:
     """Re-derive a session's IETF chain (`sha256(canonical_json(signed_envelope))`).
 
     Wraps :func:`asqav.replay`. With ``--strict`` the command fails
-    when any step lacks the cloud-emitted ``signed_envelope`` and falls
-    back to the synthetic shape (because that synthetic shape cannot
-    prove byte-level integrity per the IETF profile).
+    when any step lacks the cloud-emitted ``signed_envelope``.
     """
     import json as json_mod
 
@@ -1511,9 +1509,9 @@ def replay_verify_cmd(
 
     timeline.verify_chain()
     chain_valid = bool(timeline.compliance_chain_valid)
-    legacy_steps = [s for s in timeline.steps if getattr(s, "legacy_chain", False)]
-    has_legacy = bool(legacy_steps)
-    strict_pass = chain_valid and not (strict and has_legacy)
+    synthetic_steps = [s for s in timeline.steps if s.signed_envelope is None]
+    has_synthetic = bool(synthetic_steps)
+    strict_pass = chain_valid and not (strict and has_synthetic)
 
     if output == "json":
         print(json_mod.dumps({
@@ -1521,13 +1519,13 @@ def replay_verify_cmd(
             "strict": strict,
             "strict_pass": strict_pass,
             "step_count": len(timeline.steps),
-            "legacy_step_count": len(legacy_steps),
+            "synthetic_step_count": len(synthetic_steps),
             "steps": [
                 {
                     "index": s.index,
                     "signature_id": getattr(s, "signature_id", None),
                     "chain_valid": getattr(s, "chain_valid", None),
-                    "legacy_chain": getattr(s, "legacy_chain", None),
+                    "has_envelope": s.signed_envelope is not None,
                 }
                 for s in timeline.steps
             ],
@@ -1538,14 +1536,14 @@ def replay_verify_cmd(
 
     print(f"compliance_chain_valid: {chain_valid}")
     print(f"strict: {strict}")
-    print(f"steps: {len(timeline.steps)} (legacy: {len(legacy_steps)})")
+    print(f"steps: {len(timeline.steps)} (synthetic: {len(synthetic_steps)})")
     for s in timeline.steps:
         ok = getattr(s, "chain_valid", False)
-        legacy = "legacy" if getattr(s, "legacy_chain", False) else "envelope"
+        shape = "envelope" if s.signed_envelope is not None else "synthetic"
         marker = "ok  " if ok else "FAIL"
-        print(f"  [{marker}] step {s.index} ({legacy}) sig={getattr(s, 'signature_id', '?')}")
-    if strict and has_legacy:
-        print("strict mode FAILED: at least one step uses the legacy synthetic shape.")
+        print(f"  [{marker}] step {s.index} ({shape}) sig={getattr(s, 'signature_id', '?')}")
+    if strict and has_synthetic:
+        print("strict mode FAILED: at least one step lacks the cloud signed_envelope.")
     if not strict_pass:
         raise typer.Exit(code=1)
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -293,7 +293,7 @@ class SignatureResponse:
     compliance_mode: bool = False
     receipt_type: str | None = None
     action_ref: str | None = None
-    # payload_digest accepts both shapes for back-compat: legacy
+    # payload_digest accepts both shapes: the
     # "sha256:<hex>" string or the wire object form {"hash", "size"}.
     payload_digest: str | dict[str, Any] | None = None
     issuer_id: str | None = None
@@ -463,7 +463,7 @@ class VerificationResponse:
     receipts so a downstream regulator can re-check the verification
     decision without re-running the verifier). None on non-compliance
     or pre-migration receipts. Inner anchor entries on `anchors` carry a
-    `type` of `"opentimestamps"` (canonical), `"ots"` (legacy alias),
+    `type` of `"opentimestamps"` (canonical), `"ots"` (alias),
     or `"rfc3161"`.
     """
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -205,12 +205,9 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
 # The Joint Committee of the European Supervisory Authorities published
 # the final RTS on classification of major ICT-related incidents on
 # 17 July 2024 (JC 2024-33). Annex II field 3.23 fixes the controlled
-# vocabulary of `incident_class` to exactly six values. Earlier DORA
-# preliminary drafts (and the SDK's previous releases) circulated a
-# 12-value list; the cloud accepts those legacy tokens and normalises
-# them to the canonical six server-side, so this SDK forwards the
-# caller's value verbatim and only rejects tokens that are neither
-# canonical nor a known legacy alias.
+# vocabulary of `incident_class` to exactly six values. The cloud
+# accepts only these canonical tokens; this SDK forwards the caller's
+# value verbatim and rejects anything outside the canonical set.
 DORA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
     {
         "cybersecurity_related",
@@ -222,29 +219,10 @@ DORA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
     }
 )
 
-# Legacy 12-value vocabulary from pre-final DORA drafts. Mirrored from
-# the cloud's alias dict (cloud PR #194) so the SDK can accept either
-# form without a network roundtrip. The cloud performs the authoritative
-# normalisation; this map is purely for client-side acceptance checks.
-LEGACY_DORA_ALIASES: dict[str, str] = {
-    "malicious_actions": "cybersecurity_related",
-    "cyberattack": "cybersecurity_related",
-    "unauthorised_access": "cybersecurity_related",
-    "process_failure_internal": "process_failure",
-    "human_error": "process_failure",
-    "system_failure_internal": "system_failure",
-    "software_malfunction": "system_failure",
-    "hardware_failure": "system_failure",
-    "third_party_failure": "external_event",
-    "natural_disaster": "external_event",
-    "payment_fraud": "payment_related",
-    "unknown": "other",
-}
-
 # Verifier rejects receipts further than this from the wall clock.
 SKEW_BOUND_SECONDS: int = 300
 
-# Spec wire vocabulary {"allow", "deny", "rate_limit"} vs legacy
+# Spec wire vocabulary {"allow", "deny", "rate_limit"} vs original
 # `policy_decision` {"permit", "deny", "rate_limit"}; unknown -> "deny".
 DECISION_MAP: dict[str, str] = {
     "permit": "allow",
@@ -285,7 +263,7 @@ class SignatureResponse:
     cryptographically signed action from one that is also Bitcoin-anchored.
     """
 
-    # Polymorphic: str (b64) for legacy, {alg, kid, sig} dict under
+    # Polymorphic: str (b64) for non-compliance, {alg, kid, sig} dict under
     # compliance_mode. Use signature_envelope() for the dict form.
     signature: str | dict[str, str]
     signature_id: str
@@ -311,7 +289,7 @@ class SignatureResponse:
     user_intent_verified: bool | None = None
     # Compliance Receipts profile fields. Populated by the cloud only
     # when `compliance_mode=True` was passed on the sign call. None on
-    # legacy receipts so callers can branch cleanly.
+    # non-compliance receipts so callers can branch cleanly.
     compliance_mode: bool = False
     receipt_type: str | None = None
     action_ref: str | None = None
@@ -331,7 +309,7 @@ class SignatureResponse:
     decision: str | None = None
     # Three-key Compliance Receipts envelope. `payload` is the canonical
     # signed dict; `anchors` is the type-discriminated array. None on
-    # legacy receipts.
+    # non-compliance receipts.
     payload: dict[str, Any] | None = None
     anchors: list[dict[str, Any]] | None = None
 
@@ -1230,19 +1208,17 @@ class Agent:
                 "missing_reason: policy_decision=deny|rate_limit "
                 "requires a `reason` code."
             )
-        # DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check (six
-        # canonical values, plus the legacy 12-value alias set the cloud
-        # still accepts). Reject anything else before the HTTP roundtrip.
-        if incident_class is not None and (
-            incident_class not in DORA_INCIDENT_CLASS_NAMESPACE
-            and incident_class not in LEGACY_DORA_ALIASES
+        # DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check
+        # (six canonical values). Reject anything else before the HTTP
+        # roundtrip.
+        if (
+            incident_class is not None
+            and incident_class not in DORA_INCIDENT_CLASS_NAMESPACE
         ):
             raise ValueError(
                 "invalid_incident_class: must be one of "
                 f"{sorted(DORA_INCIDENT_CLASS_NAMESPACE)} "
-                "(per DORA RTS JC 2024-33 Annex II field 3.23) "
-                "or a known legacy alias "
-                f"{sorted(LEGACY_DORA_ALIASES)}."
+                "(per DORA RTS JC 2024-33 Annex II field 3.23)."
             )
         # Derive action_ref under compliance_mode when caller omits it.
         if compliance_mode and action_ref is None:

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -3,7 +3,7 @@
 Pure helpers for offline analysis of a receipt: extract the spec-shape
 signature envelope `{alg, kid, sig}` and the anchors[] array. The
 cloud emits the three-key envelope directly under compliance_mode; the
-helpers below return the cloud-supplied values and None on legacy
+helpers below return the cloud-supplied values and None on flat-shape
 receipts.
 """
 
@@ -16,7 +16,7 @@ def signature_envelope_from_response(response: Any) -> dict[str, str] | None:
     """Return `{alg, kid, sig}` when the response carries it, else None.
 
     The cloud emits `signature` as the object form under compliance_mode
-    and as a base64 string in legacy mode. None on legacy receipts so
+    and as a base64 string in flat mode. None on flat-shape receipts so
     callers can branch cleanly.
     """
     sig = _get(response, "signature")

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -31,7 +31,7 @@ def anchors_from_response(response: Any) -> list[dict[str, Any]] | None:
     """Return the `anchors[]` array when present, else None.
 
     Cloud emits the array directly under compliance_mode (possibly as
-    []). None on legacy receipts.
+    []). None on non-compliance receipts.
     """
     anchors = _get(response, "anchors")
     if isinstance(anchors, list):

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -7,7 +7,7 @@ callers can opt into Ed25519 or ES256 (in addition to the default
 ML-DSA-65) without depending on `cryptography` / `pynacl` directly.
 
 The module is import-safe even when `cryptography` is not installed:
-the import is deferred to call sites so legacy users (cloud-only,
+the import is deferred to call sites so pre-IETF users (cloud-only,
 ML-DSA-65) never see a hard dependency. Callers that ask for Ed25519
 or ES256 without the optional dep get a clear ImportError pointing
 them at the install command.

--- a/python/src/asqav/replay.py
+++ b/python/src/asqav/replay.py
@@ -1,15 +1,10 @@
-"""Audit trail replay - reconstruct and verify what any agent did, step by step.
+"""Audit trail replay: reconstruct and verify what any agent did, step by step.
 
-Two chain shapes are supported:
+Chain shape (IETF Compliance Receipts):
 
-  * **IETF v2** (default): ``previousReceiptHash = sha256(JCS(predecessor
-    signed envelope))``. First record's predecessor seed is ``"0" * 64``
-    (``FIRST_RECEIPT_SEED``).
-  * **Legacy**: hash over ``{signature_id, action_type, timestamp,
-    prev_hash}`` with empty-string seed. Kept behind ``legacy_chain=True``
-    so historical receipts (issued before the IETF profile landed) keep
-    verifying.
+  ``previousReceiptHash = sha256(JCS(predecessor signed envelope))``.
 
+The first record's predecessor seed is ``"0" * 64`` (``FIRST_RECEIPT_SEED``).
 See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
 """
 
@@ -48,16 +43,8 @@ class ReplayStep:
     # IETF Compliance Receipts profile: when the caller has the full
     # signed envelope for this step (the exact bytes the cloud put under
     # `compute_signature_record_hash_v2`), verify_chain hashes those
-    # bytes byte-for-byte and tampering of any field surfaces. Legacy
-    # bundles that pre-date the profile leave this None and fall back
-    # to the synthetic shape (internal-consistency only).
+    # bytes byte-for-byte and tampering of any field surfaces.
     signed_envelope: dict[str, Any] | None = None
-    # Marks a step that fell back to the synthetic envelope shape
-    # because no `signed_envelope` was attached. A timeline whose
-    # compliance steps all carry envelopes has `legacy_chain=False`
-    # on every step; mixed timelines flag the legacy ones so callers
-    # know which steps lack byte-level chain proof.
-    legacy_chain: bool = False
 
 
 @dataclass
@@ -71,9 +58,6 @@ class ReplayTimeline:
     # IETF Compliance Receipts profile: True only when EVERY step under
     # compliance mode carried a `signed_envelope` and verified
     # byte-for-byte against the cloud's `compute_signature_record_hash_v2`.
-    # Distinguishes "the chain links inside this bundle are
-    # self-consistent" (chain_integrity) from "this bundle survives
-    # the cloud-side byte-for-byte check" (compliance_chain_valid).
     compliance_chain_valid: bool = True
     start_time: float | None = None
     end_time: float | None = None
@@ -96,7 +80,6 @@ class ReplayTimeline:
                     "explanation": s.explanation,
                     "prev_chain_hash": s.prev_chain_hash,
                     "signed_envelope": s.signed_envelope,
-                    "legacy_chain": s.legacy_chain,
                 }
                 for s in self.steps
             ],
@@ -145,45 +128,28 @@ class ReplayTimeline:
 
         return "\n".join(lines)
 
-    def verify_chain(self, *, legacy_chain: bool = False) -> bool:
+    def verify_chain(self) -> bool:
         """Recompute each step's predecessor hash, compare to stored
         ``prev_chain_hash``. Mismatch = tampering. Steps lacking a stored
         hash are marked invalid rather than passing silently.
 
-        When a step carries `signed_envelope`, the chain hash is computed
+        Each step MUST carry `signed_envelope`. The chain hash is computed
         as ``sha256(JCS(signed_envelope))`` so the result matches the
         cloud's ``compute_signature_record_hash_v2`` byte-for-byte; any
-        tampering of any signed field is caught. When `signed_envelope`
-        is None, the step falls back to the synthetic shape (legacy
-        path); `legacy_chain=True` is set on the step and the top-level
-        ``compliance_chain_valid`` becomes False.
-
-        Args:
-            legacy_chain: When True, recomputes using the pre-IETF
-                envelope shape (``{signature_id, action_type, timestamp,
-                prev_hash}``) so receipts issued before the profile
-                landed keep verifying. Default False uses the IETF v2
-                IETF v2 envelope shape.
+        tampering of any signed field is caught. Steps without an envelope
+        cannot prove byte-level integrity and drop `compliance_chain_valid`.
         """
         if not self.steps:
             self.chain_integrity = True
             self.compliance_chain_valid = True
             return True
 
-        seed = "" if legacy_chain else FIRST_RECEIPT_SEED
-        prev_hash = seed
+        prev_hash = FIRST_RECEIPT_SEED
         all_valid = True
-        # `compliance_chain_valid` requires every step to carry a
-        # signed_envelope AND verify against it. Legacy verify_chain
-        # callers (legacy_chain=True) intentionally degrade this to
-        # False: the synthetic shape cannot prove byte-level integrity.
-        compliance_valid = not legacy_chain
+        compliance_valid = True
 
         for step in self.steps:
             if step.index == 0:
-                # First-record seed: stored prev_chain_hash should match the
-                # spec seed under v2. Legacy chains used None so we accept
-                # both for compatibility with bundles produced pre-v2.
                 step.chain_valid = True
             else:
                 stored = getattr(step, "prev_chain_hash", None)
@@ -195,62 +161,27 @@ class ReplayTimeline:
                     if not step.chain_valid:
                         all_valid = False
 
-            # Chain-link contribution. Prefer the cloud byte-for-byte
-            # shape when the envelope is present; flag the synthetic
-            # path as legacy so callers can spot which steps are
-            # internal-consistency only.
             envelope = getattr(step, "signed_envelope", None)
-            if envelope is not None and not legacy_chain:
-                step.legacy_chain = False
+            if envelope is not None:
                 prev_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
             else:
-                step.legacy_chain = True
-                if not legacy_chain:
-                    # Compliance mode requested but no envelope attached:
-                    # cloud byte-for-byte check is not possible.
-                    compliance_valid = False
-                prev_hash = _step_chain_hash(
-                    step, prev_hash, legacy_chain=legacy_chain
-                )
+                # No envelope attached: cloud byte-for-byte check is not
+                # possible. Fall back to a synthetic shape for internal
+                # consistency, but mark the chain as not fully verifiable.
+                compliance_valid = False
+                prev_hash = _step_chain_hash(step, prev_hash)
 
         self.chain_integrity = all_valid
-        # compliance_chain_valid is True only when every step verified
-        # under the cloud envelope shape. A single legacy fallback or a
-        # broken link drops it.
         self.compliance_chain_valid = bool(compliance_valid and all_valid)
         return all_valid
 
 
-def _step_chain_hash(
-    step: ReplayStep, prev_hash: str, *, legacy_chain: bool
-) -> str:
-    """Compute the chain hash a step contributes to the next link.
-
-    When a `signed_envelope` is provided, the chain hash matches the
-    cloud byte-for-byte (``sha256(JCS(signed_envelope))`` per
-    ``compute_signature_record_hash_v2``). When not, a legacy synthetic
-    shape is used and `chain_valid` is internal-consistency only:
-    tampering of fields not in the synthetic envelope (`policy_digest`,
-    `policy_decision`, `issuer_id`, `payload_digest`, etc) will NOT be
-    caught. Callers that need byte-level integrity MUST attach
-    `signed_envelope` to the ReplayStep.
-
-    Under ``legacy_chain=True`` the historic pre-IETF hash shape is
-    used so bundles exported before the profile landed still verify.
+def _step_chain_hash(step: ReplayStep, prev_hash: str) -> str:
+    """Compute the synthetic chain hash a step contributes when no
+    `signed_envelope` is attached. Internal-consistency only: tampering
+    of fields outside the synthetic shape will NOT be caught. Callers
+    that need byte-level integrity MUST attach `signed_envelope`.
     """
-    if legacy_chain:
-        entry = json.dumps(
-            {
-                "signature_id": step.signature_id,
-                "action_type": step.action_type,
-                "timestamp": step.timestamp,
-                "prev_hash": prev_hash,
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-        return hashlib.sha256(entry.encode()).hexdigest()
-
     envelope = {
         "signature_id": step.signature_id,
         "action_type": step.action_type,
@@ -261,45 +192,27 @@ def _step_chain_hash(
     return hashlib.sha256(canonical_json(envelope)).hexdigest()
 
 
-def _verify_hash_chain(
-    signatures: list[dict], *, legacy_chain: bool = False
-) -> list[bool]:
+def _verify_hash_chain(signatures: list[dict]) -> list[bool]:
     """Check each signature chains to the previous via SHA-256.
 
     Returns a list of booleans, one per signature, indicating whether
     the chain link from the previous entry is valid.
-
-    `legacy_chain` selects the pre-IETF envelope shape so old receipts
-    (recorded before the profile landed) keep verifying.
     """
     if not signatures:
         return []
 
     results: list[bool] = []
-    prev_hash = "" if legacy_chain else FIRST_RECEIPT_SEED
+    prev_hash = FIRST_RECEIPT_SEED
 
     for i, sig in enumerate(signatures):
-        if legacy_chain:
-            entry = json.dumps(
-                {
-                    "signature_id": sig.get("signature_id", ""),
-                    "action_type": sig.get("action_type", ""),
-                    "timestamp": sig.get("signed_at", sig.get("timestamp", 0)),
-                    "prev_hash": prev_hash,
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            current_hash = hashlib.sha256(entry.encode()).hexdigest()
-        else:
-            envelope = {
-                "signature_id": sig.get("signature_id", ""),
-                "action_type": sig.get("action_type", ""),
-                "context": sig.get("payload"),
-                "timestamp": sig.get("signed_at", sig.get("timestamp", 0)),
-                "previousReceiptHash": prev_hash,
-            }
-            current_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
+        envelope = {
+            "signature_id": sig.get("signature_id", ""),
+            "action_type": sig.get("action_type", ""),
+            "context": sig.get("payload"),
+            "timestamp": sig.get("signed_at", sig.get("timestamp", 0)),
+            "previousReceiptHash": prev_hash,
+        }
+        current_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
         results.append(True)  # Valid link in a freshly-built chain
         prev_hash = current_hash
 
@@ -337,40 +250,29 @@ def _build_explanation(action_type: str, context: dict[str, Any] | None) -> str:
     return base
 
 
-def replay(
-    agent_id: str, session_id: str, *, legacy_chain: bool = False
-) -> ReplayTimeline:
+def replay(agent_id: str, session_id: str) -> ReplayTimeline:
     """Fetch signatures for a session and reconstruct the audit trail.
 
     Args:
         agent_id: The agent that owns the session.
         session_id: The session to replay.
-        legacy_chain: When True, derive chain links via the pre-IETF
-            envelope shape so historical receipts verify. Default False
-            uses the IETF v2 envelope shape.
 
     Returns:
         A ReplayTimeline with ordered steps and chain verification.
     """
     raw_sigs = get_session_signatures(session_id)
-    return _build_timeline(
-        agent_id, session_id, raw_sigs, legacy_chain=legacy_chain
-    )
+    return _build_timeline(agent_id, session_id, raw_sigs)
 
 
-def replay_from_bundle(
-    bundle: ComplianceBundle, *, legacy_chain: bool = False
-) -> ReplayTimeline:
+def replay_from_bundle(bundle: ComplianceBundle) -> ReplayTimeline:
     """Reconstruct a timeline from a ComplianceBundle offline.
 
     Args:
         bundle: A previously exported ComplianceBundle.
-        legacy_chain: Use the pre-IETF chain shape; see :func:`replay`.
 
     Returns:
         A ReplayTimeline built from the bundle receipts.
     """
-    # Extract agent_id and session_id from receipts if available
     agent_id = ""
     session_id = ""
     if bundle.receipts:
@@ -381,10 +283,6 @@ def replay_from_bundle(
     if not session_id:
         session_id = "bundle"
 
-    # Convert receipts to SignedActionResponse-like objects for processing.
-    # Receipts that carry `signed_envelope` (the IETF profile bytes the
-    # cloud anchored) keep it as a sidecar so verify_chain can reproduce
-    # the cloud hash byte-for-byte.
     fake_sigs = []
     envelopes: list[dict[str, Any] | None] = []
     for r in bundle.receipts:
@@ -404,8 +302,7 @@ def replay_from_bundle(
         envelopes.append(r.get("signed_envelope"))
 
     return _build_timeline(
-        agent_id, session_id, fake_sigs,
-        legacy_chain=legacy_chain, signed_envelopes=envelopes,
+        agent_id, session_id, fake_sigs, signed_envelopes=envelopes,
     )
 
 
@@ -414,17 +311,9 @@ def _build_timeline(
     session_id: str,
     signatures: list[SignedActionResponse],
     *,
-    legacy_chain: bool = False,
     signed_envelopes: list[dict[str, Any] | None] | None = None,
 ) -> ReplayTimeline:
-    """Shared logic to build a ReplayTimeline from a list of signatures.
-
-    `signed_envelopes` is an optional parallel list of cloud-issued
-    envelope dicts indexed against `signatures`. When supplied, each
-    step carries the full envelope so `verify_chain` reproduces the
-    cloud's `compute_signature_record_hash_v2` byte-for-byte.
-    """
-    # Sort by timestamp; carry envelope alongside.
+    """Shared logic to build a ReplayTimeline from a list of signatures."""
     indexed = list(enumerate(signatures))
     indexed.sort(key=lambda pair: pair[1].signed_at)
     sorted_sigs = [s for _, s in indexed]
@@ -437,28 +326,13 @@ def _build_timeline(
     else:
         sorted_envelopes = [None] * len(sorted_sigs)
 
-    # Build normalized dicts for chain verification
     sig_dicts = [_normalize_signature(s) for s in sorted_sigs]
-    chain_results = _verify_hash_chain(sig_dicts, legacy_chain=legacy_chain)
+    chain_results = _verify_hash_chain(sig_dicts)
 
-    # Rolling chain hash; IETF v2 seeds with all-zero SHA-256 to distinguish "no predecessor".
     chain_hashes: list[str] = []
-    prev_hash = "" if legacy_chain else FIRST_RECEIPT_SEED
+    prev_hash = FIRST_RECEIPT_SEED
     for sig, env in zip(sorted_sigs, sorted_envelopes):
-        if legacy_chain:
-            entry = json.dumps(
-                {
-                    "signature_id": sig.signature_id,
-                    "action_type": sig.action_type,
-                    "timestamp": sig.signed_at,
-                    "prev_hash": prev_hash,
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            prev_hash = hashlib.sha256(entry.encode()).hexdigest()
-        elif env is not None:
-            # Compliance mode: byte-for-byte match with cloud's v2 hash.
+        if env is not None:
             prev_hash = hashlib.sha256(canonical_json(env)).hexdigest()
         else:
             envelope = {
@@ -488,18 +362,14 @@ def _build_timeline(
                 explanation=explanation,
                 prev_chain_hash=prev_chain_hash,
                 signed_envelope=env,
-                legacy_chain=(env is None and not legacy_chain) or legacy_chain,
             )
         )
 
     start_time = sorted_sigs[0].signed_at if sorted_sigs else None
     end_time = sorted_sigs[-1].signed_at if sorted_sigs else None
     chain_integrity = all(chain_results) if chain_results else True
-    # compliance_chain_valid is True only if every step has an envelope
-    # AND links verified. Mixed or legacy bundles drop it to False.
     compliance_chain_valid = (
-        not legacy_chain
-        and chain_integrity
+        chain_integrity
         and all(env is not None for env in sorted_envelopes)
         and len(sorted_envelopes) == len(sorted_sigs)
     )

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1016,7 +1016,7 @@ def test_replay_verify_chain_valid(
     step.index = 0
     step.signature_id = "sig_1"
     step.chain_valid = True
-    step.legacy_chain = False
+    step.signed_envelope = {"x": 1}
     timeline.steps = [step]
 
     def verify_chain_stub() -> bool:
@@ -1037,10 +1037,10 @@ def test_replay_verify_chain_valid(
 @patch("asqav.client._get")
 @patch("asqav.replay")
 @patch("asqav.init")
-def test_replay_verify_strict_rejects_legacy(
+def test_replay_verify_strict_rejects_steps_without_envelope(
     mock_init: MagicMock, mock_replay: MagicMock, mock_account: MagicMock
 ) -> None:
-    """replay-verify --strict fails when any step is legacy."""
+    """replay-verify --strict fails when any step lacks signed_envelope."""
     mock_account.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
     timeline = MagicMock()
     timeline.compliance_chain_valid = True
@@ -1048,7 +1048,7 @@ def test_replay_verify_strict_rejects_legacy(
     step.index = 0
     step.signature_id = "sig_1"
     step.chain_valid = True
-    step.legacy_chain = True
+    step.signed_envelope = None
     timeline.steps = [step]
     timeline.verify_chain = lambda: True
     mock_replay.return_value = timeline

--- a/python/tests/test_client_decision_alias.py
+++ b/python/tests/test_client_decision_alias.py
@@ -10,7 +10,7 @@ from asqav.client import (
 
 
 def test_decision_map_covers_full_legacy_vocabulary():
-    """Every legacy `policy_decision` token resolves to a spec token."""
+    """Every aliased `policy_decision` token resolves to a spec token."""
     assert DECISION_MAP["permit"] == "allow"
     assert DECISION_MAP["deny"] == "deny"
     assert DECISION_MAP["rate_limit"] == "rate_limit"

--- a/python/tests/test_client_decision_alias.py
+++ b/python/tests/test_client_decision_alias.py
@@ -9,7 +9,7 @@ from asqav.client import (
 )
 
 
-def test_decision_map_covers_full_legacy_vocabulary():
+def test_decision_map_covers_full_alias_vocabulary():
     """Every aliased `policy_decision` token resolves to a spec token."""
     assert DECISION_MAP["permit"] == "allow"
     assert DECISION_MAP["deny"] == "deny"
@@ -39,7 +39,7 @@ def test_signature_response_decision_default_none():
         verification_url="https://verify/example",
     )
     assert resp.decision is None
-    # Legacy field default preserved.
+    # Original-shape field default preserved.
     assert resp.policy_decision == "permit"
 
 

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -30,7 +30,6 @@ import asqav
 from asqav.canonicalize import canonicalize
 from asqav.client import (
     DORA_INCIDENT_CLASS_NAMESPACE,
-    LEGACY_DORA_ALIASES,
     RECEIPT_TYPE_NAMESPACE,
     Agent,
     SignatureResponse,
@@ -176,7 +175,7 @@ def test_no_compliance_mode_means_no_extra_fields_on_body() -> None:
     """compliance_mode is now on by default, so the body carries the
     Compliance Receipts fields without the caller having to opt in.
 
-    The legacy "no extra fields" shape is preserved by passing
+    The "no extra fields" shape is preserved by passing
     ``compliance_mode=False`` explicitly.
     """
     captured: dict = {}
@@ -201,7 +200,7 @@ def test_no_compliance_mode_means_no_extra_fields_on_body() -> None:
         "issuer_id",
         "payload_digest",
     ):
-        assert k not in body, f"unexpected legacy-mode field: {k}"
+        assert k not in body, f"unexpected compliance-mode-off field: {k}"
 
 
 # ---------------------------------------------------------------------------
@@ -373,15 +372,6 @@ def test_dora_incident_class_namespace_is_canonical_six() -> None:
     )
 
 
-def test_dora_legacy_aliases_map_into_canonical_set() -> None:
-    """Every legacy alias resolves to one of the six canonical values."""
-    assert LEGACY_DORA_ALIASES, "alias dict must not be empty"
-    for legacy, canonical in LEGACY_DORA_ALIASES.items():
-        assert canonical in DORA_INCIDENT_CLASS_NAMESPACE, (
-            f"legacy alias {legacy!r} maps to non-canonical {canonical!r}"
-        )
-
-
 @pytest.mark.parametrize("value", sorted(DORA_INCIDENT_CLASS_NAMESPACE))
 def test_canonical_incident_class_passes_validation(value: str) -> None:
     """All six canonical values are accepted and forwarded verbatim."""
@@ -401,26 +391,8 @@ def test_canonical_incident_class_passes_validation(value: str) -> None:
     assert captured["body"]["incident_class"] == value
 
 
-def test_legacy_incident_class_alias_is_accepted_and_forwarded() -> None:
-    """Legacy alias forwarded verbatim; cloud normalises authoritatively."""
-    captured: dict = {}
-
-    def fake_post(path: str, body: dict) -> dict:
-        captured["body"] = body
-        return _ok_response()
-
-    with patch("asqav.client._post", side_effect=fake_post):
-        _agent().sign(
-            "api:call",
-            {"k": "v"},
-            compliance_mode=True,
-            incident_class="cyberattack",
-        )
-    assert captured["body"]["incident_class"] == "cyberattack"
-
-
 def test_invalid_incident_class_raises_before_http() -> None:
-    """A token outside both the canonical and legacy sets is rejected."""
+    """A token outside the canonical six is rejected before the HTTP call."""
     with patch("asqav.client._post") as p:
         with pytest.raises(ValueError, match="invalid_incident_class"):
             _agent().sign(
@@ -430,3 +402,23 @@ def test_invalid_incident_class_raises_before_http() -> None:
                 incident_class="ICT-INC-001",
             )
         p.assert_not_called()
+
+
+def test_pre_alignment_token_now_rejected() -> None:
+    """The cloud purged the alias map; the SDK rejects the same tokens."""
+    for token in (
+        "cyberattack",
+        "payment_fraud",
+        "malicious_actions",
+        "human_error",
+        "unknown",
+    ):
+        with patch("asqav.client._post") as p:
+            with pytest.raises(ValueError, match="invalid_incident_class"):
+                _agent().sign(
+                    "api:call",
+                    {"k": "v"},
+                    compliance_mode=True,
+                    incident_class=token,
+                )
+            p.assert_not_called()

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -404,8 +404,8 @@ def test_invalid_incident_class_raises_before_http() -> None:
         p.assert_not_called()
 
 
-def test_pre_alignment_token_now_rejected() -> None:
-    """The cloud purged the alias map; the SDK rejects the same tokens."""
+def test_off_vocabulary_tokens_rejected_before_http() -> None:
+    """Tokens outside the canonical six values are rejected client-side."""
     for token in (
         "cyberattack",
         "payment_fraud",

--- a/python/tests/test_client_ietf_projection.py
+++ b/python/tests/test_client_ietf_projection.py
@@ -15,7 +15,7 @@ from asqav.ietf_projection import (
 )
 
 
-def test_legacy_response_signature_envelope_is_none():
+def test_flat_response_signature_envelope_is_none():
     resp = SignatureResponse(
         signature="ZmFrZQ==",
         signature_id="sig_test",
@@ -48,7 +48,7 @@ def test_signature_envelope_helper_dict_input():
     assert out == envelope
 
 
-def test_signature_envelope_helper_legacy_dict_returns_none():
+def test_signature_envelope_helper_string_returns_none():
     assert (
         signature_envelope_from_response({"signature": "ZmFrZQ=="})
         is None
@@ -71,7 +71,7 @@ def test_anchors_array_passthrough():
     assert resp.anchors_array() == cloud_anchors
 
 
-def test_anchors_array_legacy_is_none():
+def test_anchors_array_string_signature_is_none():
     resp = SignatureResponse(
         signature="ZmFrZQ==",
         signature_id="sig_test",

--- a/python/tests/test_client_ietf_projection.py
+++ b/python/tests/test_client_ietf_projection.py
@@ -3,7 +3,7 @@
 `SignatureResponse.signature_envelope()` returns `{alg, kid, sig}` when
 the response carries the object form, None otherwise. `anchors_array()`
 returns the cloud-supplied `anchors` list (possibly empty), None on
-legacy receipts.
+non-compliance receipts.
 """
 
 from __future__ import annotations

--- a/python/tests/test_jcs.py
+++ b/python/tests/test_jcs.py
@@ -165,7 +165,7 @@ def test_golden_vector_matches(name: str, obj, expected: str) -> None:
     GOLDEN_VECTORS,
     ids=[name for name, _, _ in GOLDEN_VECTORS],
 )
-def test_byte_equality_with_legacy_canonicalize(name: str, obj, expected: str) -> None:
+def test_byte_equality_with_canonicalize_alias(name: str, obj, expected: str) -> None:
     """`_jcs.canonical_json` and `canonicalize.canonicalize` agree byte-for-byte."""
     assert canonical_json(obj) == canonicalize(obj), f"{name}: drift"
 

--- a/python/tests/test_replay.py
+++ b/python/tests/test_replay.py
@@ -44,7 +44,7 @@ def _make_timeline(n: int = 3) -> ReplayTimeline:
 
     Tracks the same envelope shape `_build_timeline` produces so
     `verify_chain()` (default-mode v2) succeeds on a freshly built
-    timeline. Legacy-shape coverage lives in test_replay_ietf_chain.py.
+    timeline. Envelope coverage lives in test_replay_ietf_chain.py.
     """
     import hashlib
 

--- a/python/tests/test_replay_ietf_chain.py
+++ b/python/tests/test_replay_ietf_chain.py
@@ -1,9 +1,8 @@
-"""Tests for the IETF v2 chain shape in `asqav.replay`.
+"""Tests for the IETF chain shape in `asqav.replay`.
 
 The chain link is ``sha256(JCS(predecessor_signed_envelope))``. The
 first record's ``previousReceiptHash`` is ``"0" * 64``
-(``FIRST_RECEIPT_SEED``). The legacy shape is kept available behind
-``legacy_chain=True`` so historic bundles still verify.
+(``FIRST_RECEIPT_SEED``).
 """
 
 from __future__ import annotations
@@ -143,67 +142,12 @@ def test_v2_verify_chain_detects_tamper() -> None:
     assert timeline.steps[1].chain_valid is False
 
 
-def test_v2_chain_differs_from_legacy_for_same_signatures() -> None:
-    """The v2 envelope shape produces different bytes than the legacy
-    envelope so a forged legacy chain cannot pass v2 verification."""
-    sigs = [_make_signed_action(idx=i) for i in range(3)]
-    v2 = _build_timeline("agent_001", "sess_1", sigs, legacy_chain=False)
-    legacy = _build_timeline("agent_001", "sess_1", sigs, legacy_chain=True)
-    # First step has no predecessor in either (None), so compare step 1.
-    assert v2.steps[1].prev_chain_hash != legacy.steps[1].prev_chain_hash
-
-
-# ---------------------------------------------------------------------------
-# legacy_chain flag
-# ---------------------------------------------------------------------------
-
-
-def test_legacy_chain_uses_old_envelope_shape() -> None:
-    """legacy_chain=True reproduces the pre-IETF chain hash byte-for-byte."""
-    sigs = [_make_signed_action(idx=0), _make_signed_action(idx=1)]
-    timeline = _build_timeline(
-        "agent_001", "sess_1", sigs, legacy_chain=True
-    )
-
-    expected = hashlib.sha256(
-        json.dumps(
-            {
-                "signature_id": sigs[0].signature_id,
-                "action_type": sigs[0].action_type,
-                "timestamp": sigs[0].signed_at,
-                "prev_hash": "",
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode()
-    ).hexdigest()
-    assert timeline.steps[1].prev_chain_hash == expected
-
-
-def test_legacy_chain_verify_succeeds() -> None:
-    sigs = [_make_signed_action(idx=i) for i in range(3)]
-    timeline = _build_timeline(
-        "agent_001", "sess_1", sigs, legacy_chain=True
-    )
-    assert timeline.verify_chain(legacy_chain=True) is True
-
-
-def test_legacy_chain_verify_fails_when_called_under_v2() -> None:
-    """A timeline built under legacy shape does not verify under v2."""
-    sigs = [_make_signed_action(idx=i) for i in range(3)]
-    timeline = _build_timeline(
-        "agent_001", "sess_1", sigs, legacy_chain=True
-    )
-    # Timeline stores legacy hashes. Verifying under v2 must reject.
-    assert timeline.verify_chain(legacy_chain=False) is False
-
-
 # ---------------------------------------------------------------------------
 # _step_chain_hash helper
 # ---------------------------------------------------------------------------
 
 
-def test_step_chain_hash_v2_matches_envelope() -> None:
+def test_step_chain_hash_matches_envelope() -> None:
     step = ReplayStep(
         index=0,
         action_type="api:call",
@@ -225,36 +169,7 @@ def test_step_chain_hash_v2_matches_envelope() -> None:
             }
         )
     ).hexdigest()
-    assert (
-        _step_chain_hash(step, FIRST_RECEIPT_SEED, legacy_chain=False)
-        == expected
-    )
-
-
-def test_step_chain_hash_legacy_matches_old_shape() -> None:
-    step = ReplayStep(
-        index=0,
-        action_type="api:call",
-        context={"x": 1},
-        timestamp=1700000000.0,
-        signature_id="sid_001",
-        verification_url="x",
-        chain_valid=True,
-        explanation="x",
-    )
-    expected = hashlib.sha256(
-        json.dumps(
-            {
-                "signature_id": "sid_001",
-                "action_type": "api:call",
-                "timestamp": 1700000000.0,
-                "prev_hash": "",
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode()
-    ).hexdigest()
-    assert _step_chain_hash(step, "", legacy_chain=True) == expected
+    assert _step_chain_hash(step, FIRST_RECEIPT_SEED) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -262,10 +177,9 @@ def test_step_chain_hash_legacy_matches_old_shape() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_empty_timeline_verifies_under_both_modes() -> None:
+def test_empty_timeline_verifies() -> None:
     timeline = ReplayTimeline(agent_id="agent_001", session_id="sess_1")
     assert timeline.verify_chain() is True
-    assert timeline.verify_chain(legacy_chain=True) is True
     assert timeline.compliance_chain_valid is True
 
 
@@ -316,13 +230,11 @@ def test_envelope_path_matches_cloud_v2_hash_byte_for_byte() -> None:
     assert timeline.steps[1].prev_chain_hash == env1_prev
     assert timeline.verify_chain() is True
     assert timeline.compliance_chain_valid is True
-    assert all(s.legacy_chain is False for s in timeline.steps)
 
 
 def test_envelope_path_detects_field_tamper_outside_synthetic_shape() -> None:
     """Tampering `policy_decision` (a field NOT in the synthetic envelope)
-    is caught only when signed_envelope is attached. Without it the
-    legacy synthetic shape would silently pass."""
+    is caught only when signed_envelope is attached."""
     env0 = _compliance_envelope(idx=0, prev_hash=FIRST_RECEIPT_SEED)
     env1_prev = hashlib.sha256(canonical_json(env0)).hexdigest()
     env1 = _compliance_envelope(idx=1, prev_hash=env1_prev)
@@ -335,29 +247,26 @@ def test_envelope_path_detects_field_tamper_outside_synthetic_shape() -> None:
     # Tamper: flip policy_decision on step 0's envelope.
     timeline.steps[0].signed_envelope = {**env0, "policy_decision": "deny"}
 
-    # verify_chain re-derives prev_hash from the (tampered) envelope and
-    # the stored prev_chain_hash on step 1 no longer matches.
     assert timeline.verify_chain() is False
     assert timeline.steps[1].chain_valid is False
     assert timeline.compliance_chain_valid is False
 
 
-def test_legacy_synthetic_shape_misses_policy_decision_tamper() -> None:
-    """Documents the weakness the H-NEW-1 fix closes: without
-    signed_envelope, a `policy_decision` flip is invisible because the
-    synthetic envelope does not include it."""
+def test_synthetic_shape_misses_policy_decision_tamper() -> None:
+    """Without signed_envelope, a `policy_decision` flip is invisible
+    because the synthetic envelope does not include it."""
     sigs = [_make_signed_action(idx=i) for i in range(2)]
     timeline = _build_timeline("agent_001", "sess_1", sigs)
     # No envelopes attached; chain verifies under synthetic shape.
     assert timeline.verify_chain() is True
     # But compliance_chain_valid is False because envelopes were absent.
     assert timeline.compliance_chain_valid is False
-    assert all(s.legacy_chain is True for s in timeline.steps)
+    assert all(s.signed_envelope is None for s in timeline.steps)
 
 
-def test_mixed_envelope_steps_set_per_step_legacy_chain_flag() -> None:
-    """A timeline with envelopes on some steps and not others marks the
-    bare steps as legacy_chain=True and drops compliance_chain_valid."""
+def test_mixed_envelope_steps_drop_compliance_chain_valid() -> None:
+    """A timeline with envelopes on some steps and not others drops
+    compliance_chain_valid."""
     env0 = _compliance_envelope(idx=0, prev_hash=FIRST_RECEIPT_SEED)
 
     sigs = [_make_signed_action(idx=i) for i in range(2)]
@@ -365,8 +274,8 @@ def test_mixed_envelope_steps_set_per_step_legacy_chain_flag() -> None:
         "agent_001", "sess_1", sigs, signed_envelopes=[env0, None]
     )
     timeline.verify_chain()
-    assert timeline.steps[0].legacy_chain is False
-    assert timeline.steps[1].legacy_chain is True
+    assert timeline.steps[0].signed_envelope is not None
+    assert timeline.steps[1].signed_envelope is None
     assert timeline.compliance_chain_valid is False
 
 
@@ -380,4 +289,3 @@ def test_to_dict_includes_signed_envelope_and_compliance_flag() -> None:
     d = timeline.to_dict()
     assert d["compliance_chain_valid"] is True
     assert d["steps"][0]["signed_envelope"] == env0
-    assert d["steps"][0]["legacy_chain"] is False

--- a/python/tests/test_verify_response_fields.py
+++ b/python/tests/test_verify_response_fields.py
@@ -8,7 +8,7 @@ sub-axes (`anchor_valid_ots`, `anchor_valid_rfc3161`,
 `policy_digest_resolved`, `duplicate_emission_candidate`,
 `regimes_satisfied`). These tests pin that the SDK parser populates the
 dataclasses with all of them, and that the inner anchor `type` field
-admits both the canonical `"opentimestamps"` and the legacy `"ots"`
+admits both the canonical `"opentimestamps"` and the alias `"ots"`
 alias the cloud `/verify/example` fixture still emits.
 """
 
@@ -203,7 +203,7 @@ def test_verifier_signature_present_or_null() -> None:
 def test_anchor_type_accepts_opentimestamps_and_ots() -> None:
     """The cloud `_project_anchors` emits `type: "opentimestamps"`
     (canonical) but the `/verify/example` fixture still emits
-    `type: "ots"` (legacy). The SDK type stub admits both literals
+    `type: "ots"` (alias). The SDK type stub admits both literals
     and the parser does not silently rewrite."""
     payload = _full_cloud_payload()
     payload["anchors"] = [

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -209,7 +209,7 @@ Field reference (camelCase on the SDK, snake_case on the JSON wire):
 - `iterationId` -> `iteration_id`. Required for multi-step receipts.
 - `sandboxState` -> `sandbox_state`. One of `enabled`, `disabled`, `unavailable`. Required for High-Risk.
 - `riskClass` -> `risk_class`. One of `low`, `medium`, `high`, `unknown`.
-- `incidentClass` -> `incident_class`. Canonical 6-value Annex II field 3.23 list from JC 2024-33 (17 July 2024); legacy aliases remapped via `LEGACY_DORA_ALIASES`. Empty when not applicable.
+- `incidentClass` -> `incident_class`. Canonical 6-value Annex II field 3.23 list from JC 2024-33 (17 July 2024) Empty when not applicable.
 - `policyDecision` -> `policy_decision`. One of `permit`, `deny`, `rate_limit`.
 - `reason` -> `reason`. Required when `policyDecision` is `deny` or `rate_limit`.
 

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -419,7 +419,7 @@ async function cmdSign(args: string[]): Promise<void> {
   const issuerId = parseFlag(args, "issuer-id");
   const receiptType = parseFlag(args, "receipt-type") ?? "protectmcp:decision";
   const reason = parseFlag(args, "reason");
-  // --decision (allow|deny|rate_limit) wins over legacy --policy-decision.
+  // --decision (allow|deny|rate_limit) takes precedence over --policy-decision.
   const decisionFlag = parseFlag(args, "decision");
   const decisionMap: Record<string, string> = {
     allow: "permit",
@@ -669,12 +669,12 @@ async function cmdReplayVerify(args: string[]): Promise<void> {
     if (steps.length === 0) {
       die("Error: no replay steps returned by the cloud.");
     }
-    const legacySteps = steps.filter((s) => !s.signed_envelope);
+    const syntheticSteps = steps.filter((s) => !s.signed_envelope);
     const records = steps
       .filter((s) => !!s.signed_envelope)
       .map((s) => ({ signedEnvelope: s.signed_envelope as Record<string, unknown> }));
     const result = verifyChain(records);
-    const chainValid = result.chainIntegrity && legacySteps.length === 0;
+    const chainValid = result.chainIntegrity && syntheticSteps.length === 0;
     const strictPass = strict ? chainValid : result.chainIntegrity;
     if (output === "json") {
       process.stdout.write(
@@ -684,7 +684,7 @@ async function cmdReplayVerify(args: string[]): Promise<void> {
             strict,
             strict_pass: strictPass,
             step_count: steps.length,
-            legacy_step_count: legacySteps.length,
+            synthetic_step_count: syntheticSteps.length,
             steps: result.steps,
           },
           null,
@@ -694,14 +694,14 @@ async function cmdReplayVerify(args: string[]): Promise<void> {
     } else {
       process.stdout.write(`compliance_chain_valid: ${chainValid}\n`);
       process.stdout.write(`strict: ${strict}\n`);
-      process.stdout.write(`steps: ${steps.length} (legacy: ${legacySteps.length})\n`);
+      process.stdout.write(`steps: ${steps.length} (synthetic: ${syntheticSteps.length})\n`);
       for (const step of result.steps) {
         const ok = step.chainValid ? "ok  " : "FAIL";
         process.stdout.write(`  [${ok}] step ${step.index}\n`);
       }
-      if (strict && legacySteps.length > 0) {
+      if (strict && syntheticSteps.length > 0) {
         process.stdout.write(
-          `strict mode FAILED: ${legacySteps.length} step(s) lack signed_envelope.\n`,
+          `strict mode FAILED: ${syntheticSteps.length} step(s) lack signed_envelope.\n`,
         );
       }
     }

--- a/typescript/src/ietfProjection.ts
+++ b/typescript/src/ietfProjection.ts
@@ -5,7 +5,7 @@
  * spec-shape signature envelope `{alg, kid, sig}` and the anchors[]
  * array. The cloud emits the three-key envelope directly under
  * compliance_mode; the helpers below return the cloud-supplied values
- * and undefined on legacy receipts.
+ * and undefined on non-compliance receipts.
  */
 
 /** Spec-shape signature envelope. */

--- a/typescript/src/ietfProjection.ts
+++ b/typescript/src/ietfProjection.ts
@@ -39,7 +39,7 @@ export interface ProjectableResponse {
 
 /** Return `{alg, kid, sig}` when the response carries the object form,
  *  else undefined. The cloud emits `signature` as the object form under
- *  compliance_mode and as a base64 string in legacy mode. */
+ *  compliance_mode and as a base64 string in flat mode. */
 export function signatureEnvelopeFromResponse(
   response: ProjectableResponse | null | undefined,
 ): SignatureEnvelope | undefined {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -35,12 +35,9 @@ export type ReceiptType = (typeof RECEIPT_TYPE_NAMESPACE)[number];
  * The Joint Committee of the European Supervisory Authorities published
  * the final RTS on classification of major ICT-related incidents on
  * 17 July 2024 (JC 2024-33). Annex II field 3.23 fixes the controlled
- * vocabulary of `incident_class` to exactly six values. Earlier DORA
- * preliminary drafts (and the SDK's previous releases) circulated a
- * 12-value list; the cloud accepts those legacy tokens and normalises
- * them to the canonical six server-side, so this SDK forwards the
- * caller's value verbatim and only rejects tokens that are neither
- * canonical nor a known legacy alias.
+ * vocabulary of `incident_class` to exactly six values. The cloud
+ * accepts only these canonical tokens; this SDK forwards the caller's
+ * value verbatim and rejects anything outside the canonical set.
  */
 export const DORA_INCIDENT_CLASS_NAMESPACE = [
   "cybersecurity_related",
@@ -52,27 +49,6 @@ export const DORA_INCIDENT_CLASS_NAMESPACE = [
 ] as const;
 export type DoraIncidentClass = (typeof DORA_INCIDENT_CLASS_NAMESPACE)[number];
 
-/** Legacy 12-value vocabulary from pre-final DORA drafts. Mirrored from
- * the cloud's alias dict (cloud PR #194) so the SDK can accept either
- * form without a network roundtrip. The cloud performs the authoritative
- * normalisation; this map is purely for client-side acceptance checks.
- */
-export const LEGACY_DORA_ALIASES: Readonly<Record<string, DoraIncidentClass>> =
-  Object.freeze({
-    malicious_actions: "cybersecurity_related",
-    cyberattack: "cybersecurity_related",
-    unauthorised_access: "cybersecurity_related",
-    process_failure_internal: "process_failure",
-    human_error: "process_failure",
-    system_failure_internal: "system_failure",
-    software_malfunction: "system_failure",
-    hardware_failure: "system_failure",
-    third_party_failure: "external_event",
-    natural_disaster: "external_event",
-    payment_fraud: "payment_related",
-    unknown: "other",
-  });
-
 /** Sandbox state vocabulary per the High-Risk gate. */
 export type SandboxState = "enabled" | "disabled" | "unavailable";
 
@@ -82,10 +58,10 @@ export type RiskClass = "low" | "medium" | "high" | "unknown";
 /** Policy decision vocabulary; deny / rate_limit require `reason`. */
 export type PolicyDecision = "permit" | "deny" | "rate_limit";
 
-/** Spec-shape decision vocabulary; legacy `policyDecision` uses "permit". */
+/** Spec-shape decision vocabulary; original `policyDecision` uses "permit". */
 export type Decision = "allow" | "deny" | "rate_limit";
 
-/** Map a legacy `policyDecision` token to the spec-shape `decision`. */
+/** Map an original `policyDecision` token to the spec-shape `decision`. */
 export const DECISION_MAP: Readonly<Record<string, Decision>> = Object.freeze({
   permit: "allow",
   allow: "allow",
@@ -149,7 +125,7 @@ import {
 } from "./ietfProjection.js";
 
 /** Return the spec-shape envelope `{alg, kid, sig}` for a
- * SignatureResponse, or undefined for legacy receipts. */
+ * SignatureResponse, or undefined for non-compliance receipts. */
 export function signatureEnvelope(
   response: SignatureResponse | null | undefined,
 ): SignatureEnvelope | undefined {
@@ -157,7 +133,7 @@ export function signatureEnvelope(
 }
 
 /** Return the cloud-supplied `anchors[]` array, or undefined for
- * legacy receipts. */
+ * non-compliance receipts. */
 export function anchors(
   response: SignatureResponse | null | undefined,
 ): AnchorEntry[] | undefined {
@@ -329,7 +305,7 @@ export interface SignOptions {
    * `Organization.legal_entity` when omitted. */
   issuerId?: string;
 
-  /** Digest of the request payload. Accepts the legacy
+  /** Digest of the request payload. Accepts the
    * `"sha256:<hex>"` string or the wire object form
    * `{ hash, size?, preview? }`. */
   payloadDigest?: string | { hash: string; size?: number; preview?: string };
@@ -356,7 +332,7 @@ export interface CoSignature {
 }
 
 export interface SignatureResponse {
-  /** Polymorphic. Base64 string in legacy mode, `{alg, kid, sig}` object
+  /** Polymorphic. Base64 string in non-compliance mode, `{alg, kid, sig}` object
    * form under compliance_mode. Use `signatureEnvelope()` for the dict
    * form. */
   signature: string | SignatureEnvelope;
@@ -387,7 +363,7 @@ export interface SignatureResponse {
   receiptType?: string;
   /** Resolved legal entity for this receipt. */
   issuerId?: string;
-  /** Legacy `policy_decision` value echoed from the request (one of
+  /** Original `policy_decision` value echoed from the request (one of
    * `"permit" | "deny" | "rate_limit"`). Kept for backward compat with
    * tooling built against the pre-spec implementation. */
   policyDecision?: PolicyDecision;
@@ -395,10 +371,10 @@ export interface SignatureResponse {
    * `policyDecision` for older servers. Undefined for non-compliance. */
   decision?: Decision;
   /** Compliance Receipts envelope: the canonical signed dict. None on
-   * legacy receipts. */
+   * non-compliance receipts. */
   payload?: Record<string, unknown>;
   /** Compliance Receipts envelope: the type-discriminated anchors
-   * array. None on legacy receipts; `[]` when compliance_mode is on
+   * array. None on non-compliance receipts; `[]` when compliance_mode is on
    * before anchors land. */
   anchors?: AnchorEntry[];
 }
@@ -504,7 +480,7 @@ export interface VerificationResponse {
    * non-compliance-mode receipts. */
   signatureEnvelope?: { alg: string; kid: string } & Record<string, string>;
   /** IETF anchors projection: list of `{type, value, ...}` per anchor.
-   * `type` admits the canonical `"opentimestamps"` and the legacy
+   * `type` admits the canonical `"opentimestamps"` and the original
    * `"ots"` alias plus `"rfc3161"`; the SDK never silently rewrites,
    * callers should normalize `"ots"` to `"opentimestamps"` if they
    * compare against the cloud surface. Undefined on non-compliance-mode
@@ -861,20 +837,15 @@ export class Agent {
       );
     }
     // DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check (six
-    // canonical values, plus the legacy 12-value alias set the cloud
-    // still accepts). Reject anything else before the HTTP roundtrip.
+    // canonical values). Reject anything else before the HTTP roundtrip.
     if (options.incidentClass !== undefined && options.incidentClass !== "") {
       const incidentValues = Array.isArray(options.incidentClass)
         ? options.incidentClass
         : [options.incidentClass];
       for (const ic of incidentValues) {
-        if (
-          !(DORA_INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)
-          && !(ic in LEGACY_DORA_ALIASES)
-        ) {
+        if (!(DORA_INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)) {
           throw new AsqavError(
-            `invalid_incident_class: '${ic}' must be one of ${DORA_INCIDENT_CLASS_NAMESPACE.join(", ")} `
-              + `or a known legacy alias ${Object.keys(LEGACY_DORA_ALIASES).sort().join(", ")}`,
+            `invalid_incident_class: '${ic}' must be one of ${DORA_INCIDENT_CLASS_NAMESPACE.join(", ")}`,
           );
         }
       }
@@ -980,7 +951,7 @@ export class Agent {
       userIntentVerified: data.user_intent_verified,
       complianceMode: data.compliance_mode,
       // Accept either camelCase (per the IETF profile JSON wire) or
-      // snake_case (legacy alias for one release).
+      // snake_case (alias for one release).
       previousReceiptHash: data.previousReceiptHash ?? data.previous_receipt_hash,
       actionRef: data.action_ref,
       policyDigest: data.policy_digest,

--- a/typescript/src/replay.ts
+++ b/typescript/src/replay.ts
@@ -6,18 +6,12 @@
  * The verifier walks an ordered list of signed envelopes for one agent,
  * re-derives each predecessor's `previousReceiptHash`, and reports any
  * mismatch as a chain break. Equivalent to the Python SDK's
- * `replay.ReplayTimeline.verify_chain` rewritten for the v2 chain shape.
+ * `replay.ReplayTimeline.verify_chain`.
  *
- * v2 (default) chain link:
+ * Chain link:
  *
  *   previousReceiptHash[i+1] = sha256(canonicalJson(envelope[i]))   // 64 hex
  *   previousReceiptHash[0]   = "0".repeat(64)
- *
- * Legacy chain link (kept under `legacy: true` for one release):
- *
- *   prev_hash[i+1] = sha256(json.dumps(
- *     {signature_id, action_type, timestamp, prev_hash}, sort_keys=True
- *   ))
  *
  * This module is import-free of any HTTP / network code so it can run
  * over a downloaded ComplianceBundle.
@@ -65,11 +59,7 @@ export interface ChainVerificationResult {
   steps: ChainStepResult[];
 }
 
-export interface VerifyChainOptions {
-  /** Use the legacy v1 chain shape instead of the v2 / IETF shape.
-   * Kept for one release per the backward-compat window. */
-  legacy?: boolean;
-}
+export type VerifyChainOptions = Record<string, never>;
 
 /**
  * Re-derive the chain over an ordered list of signed envelopes for one
@@ -80,12 +70,8 @@ export interface VerifyChainOptions {
  */
 export function verifyChain(
   records: ChainRecord[],
-  options: VerifyChainOptions = {},
+  _options: VerifyChainOptions = {},
 ): ChainVerificationResult {
-  if (options.legacy === true) {
-    return verifyChainLegacy(records);
-  }
-
   const steps: ChainStepResult[] = [];
   let allValid = true;
   let expectedPrev = FIRST_RECEIPT_SEED;
@@ -121,7 +107,7 @@ export function verifyChain(
 }
 
 /**
- * Convenience: derive the v2 chain hash for one signed envelope.
+ * Convenience: derive the chain hash for one signed envelope.
  *
  *   sha256(canonicalJson(envelope))
  */
@@ -131,50 +117,4 @@ export function deriveChainHash(envelope: Record<string, unknown>): string {
 
 function sha256Hex(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-// === Pre-IETF v1 chain shape (retained for one release) ===
-
-interface LegacyMinimalRecord {
-  signature_id?: string;
-  action_type?: string;
-  timestamp?: number | string;
-  signed_at?: number | string;
-}
-
-function verifyChainLegacy(records: ChainRecord[]): ChainVerificationResult {
-  const steps: ChainStepResult[] = [];
-  let allValid = true;
-  let prevHash = "";
-
-  for (let i = 0; i < records.length; i++) {
-    const env = records[i].signedEnvelope as LegacyMinimalRecord & Record<string, unknown>;
-    const actualPrev = String(env.previousReceiptHash ?? env.previous_hash ?? "");
-
-    const chainValid = i === 0 ? true : actualPrev === prevHash;
-    if (!chainValid) allValid = false;
-
-    const entry = JSON.stringify({
-      signature_id: env.signature_id ?? "",
-      action_type: env.action_type ?? "",
-      timestamp: env.signed_at ?? env.timestamp ?? 0,
-      prev_hash: prevHash,
-    });
-    // JSON.stringify in JS does not sort keys; the Python legacy form
-    // uses sort_keys=True. We match Python's output by sorting.
-    const sortedEntry = JSON.stringify(JSON.parse(entry), Object.keys(JSON.parse(entry)).sort());
-    const derived = sha256Hex(new TextEncoder().encode(sortedEntry));
-
-    steps.push({
-      index: i,
-      chainValid,
-      expectedPreviousReceiptHash: i === 0 ? "" : prevHash,
-      actualPreviousReceiptHash: actualPrev,
-      derivedChainHash: derived,
-    });
-
-    prevHash = derived;
-  }
-
-  return { chainIntegrity: allValid, steps };
 }

--- a/typescript/tests/cli.test.ts
+++ b/typescript/tests/cli.test.ts
@@ -344,7 +344,7 @@ describe("asqav CLI (TypeScript)", () => {
     expect(output()).toContain("v3-22");
   });
 
-  it("replay-verify --strict rejects legacy steps", async () => {
+  it("replay-verify --strict rejects synthetic-shape steps", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(jsonResponse({ tier: "pro", organization_id: "o", organization_name: "n" }))
       .mockResolvedValueOnce(

--- a/typescript/tests/decisionAlias.test.ts
+++ b/typescript/tests/decisionAlias.test.ts
@@ -37,7 +37,7 @@ function fakeAgent(): Agent {
 }
 
 describe("DECISION_MAP", () => {
-  it("covers the full legacy vocabulary", () => {
+  it("covers the full alias vocabulary", () => {
     expect(DECISION_MAP.permit).toBe("allow");
     expect(DECISION_MAP.deny).toBe("deny");
     expect(DECISION_MAP.rate_limit).toBe("rate_limit");
@@ -168,7 +168,7 @@ describe("agent.sign decision wire field", () => {
     expect(resp.decision).toBe("allow");
   });
 
-  it("decision undefined on legacy non-compliance receipts", async () => {
+  it("decision undefined on non-compliance receipts", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       jsonResponse({
         signature: "sig",

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -13,7 +13,6 @@ import {
   Agent,
   AsqavError,
   DORA_INCIDENT_CLASS_NAMESPACE,
-  LEGACY_DORA_ALIASES,
   RECEIPT_TYPE_NAMESPACE,
   _resetForTests,
   init,
@@ -204,15 +203,6 @@ describe("agent.sign IETF profile fields", () => {
     );
   });
 
-  it("every legacy DORA alias maps into the canonical six", () => {
-    const canonical = new Set<string>(DORA_INCIDENT_CLASS_NAMESPACE);
-    expect(Object.keys(LEGACY_DORA_ALIASES).length).toBeGreaterThan(0);
-    for (const [legacy, target] of Object.entries(LEGACY_DORA_ALIASES)) {
-      expect(canonical.has(target)).toBe(true);
-      expect(legacy.length).toBeGreaterThan(0);
-    }
-  });
-
   it("forwards every canonical incident_class without raising", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       jsonResponse({
@@ -236,26 +226,26 @@ describe("agent.sign IETF profile fields", () => {
     }
   });
 
-  it("forwards a legacy DORA alias verbatim (cloud normalises authoritatively)", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      jsonResponse({
-        signature: "s",
-        signature_id: "sig_1",
-        action_id: "act_1",
-        timestamp: "t",
-        verification_url: "u",
-      }),
-    );
+  it("rejects pre-alignment DORA tokens before any HTTP call", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
     const agent = fakeAgent();
-    await agent.sign({
-      actionType: "api:call",
-      context: {},
-      complianceMode: true,
-      incidentClass: "cyberattack",
-    });
-    const [, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    const body = JSON.parse(calledInit.body as string) as Record<string, unknown>;
-    expect(body.incident_class).toBe("cyberattack");
+    for (const token of [
+      "cyberattack",
+      "payment_fraud",
+      "malicious_actions",
+      "human_error",
+      "unknown",
+    ]) {
+      await expect(
+        agent.sign({
+          actionType: "api:call",
+          context: {},
+          complianceMode: true,
+          incidentClass: token,
+        }),
+      ).rejects.toThrow(/invalid_incident_class/);
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("rejects an out-of-vocabulary incident_class before any HTTP call", async () => {

--- a/typescript/tests/jcs.test.ts
+++ b/typescript/tests/jcs.test.ts
@@ -73,7 +73,7 @@ describe("canonicalJson() RFC 8785 golden vectors", () => {
     expect(out).toBe("{\"s\":\"\\u0001\\u001f\"}");
   });
 
-  it("is byte-identical with canonicalize() (legacy alias)", () => {
+  it("is byte-identical with canonicalize() (alias)", () => {
     const input = { z: 1, a: { c: [1, 2, 3], b: "x" } };
     expect(canonicalJson(input)).toEqual(canonicalize(input));
   });

--- a/typescript/tests/projection.test.ts
+++ b/typescript/tests/projection.test.ts
@@ -31,7 +31,7 @@ function bareResponse(extra: Partial<SignatureResponse> = {}): SignatureResponse
 }
 
 describe("signatureEnvelope()", () => {
-  it("returns undefined for legacy receipts (string signature)", () => {
+  it("returns undefined for flat-shape receipts (string signature)", () => {
     expect(signatureEnvelope(bareResponse())).toBeUndefined();
   });
 
@@ -59,7 +59,7 @@ describe("signatureEnvelope()", () => {
     expect(out).toEqual({ alg: "Ed25519", kid: "k1", sig: "s" });
   });
 
-  it("free helper returns undefined for legacy string signature", () => {
+  it("free helper returns undefined for flat string signature", () => {
     expect(
       signatureEnvelopeFromResponse({ signature: "ZmFrZQ==" }),
     ).toBeUndefined();
@@ -67,7 +67,7 @@ describe("signatureEnvelope()", () => {
 });
 
 describe("anchors()", () => {
-  it("returns undefined for legacy receipts", () => {
+  it("returns undefined for flat-shape receipts", () => {
     expect(anchors(bareResponse())).toBeUndefined();
   });
 

--- a/typescript/tests/projection.test.ts
+++ b/typescript/tests/projection.test.ts
@@ -3,7 +3,7 @@
  *
  * `signatureEnvelope(resp)` returns `{alg, kid, sig}` when the response
  * carries the object form, undefined otherwise. `anchors(resp)` returns
- * the cloud-supplied array, undefined for legacy receipts.
+ * the cloud-supplied array, undefined for non-compliance receipts.
  */
 
 import { describe, expect, it } from "vitest";

--- a/typescript/tests/replay.test.ts
+++ b/typescript/tests/replay.test.ts
@@ -111,14 +111,4 @@ describe("verifyChain (v2, IETF profile)", () => {
     expect(result.chainIntegrity).toBe(true);
   });
 
-  it("legacy: true uses the v1 chain shape", () => {
-    const env = {
-      signature_id: "sig_1",
-      action_type: "api:call",
-      timestamp: 1,
-      previousReceiptHash: "",
-    };
-    const result = verifyChain([{ signedEnvelope: env }], { legacy: true });
-    expect(result.chainIntegrity).toBe(true);
-  });
 });

--- a/typescript/tests/verify-response-fields.test.ts
+++ b/typescript/tests/verify-response-fields.test.ts
@@ -209,7 +209,7 @@ describe("verifySignature response fields", () => {
 
   it("test_anchor_type_accepts_opentimestamps_and_ots", async () => {
     // _project_anchors emits "opentimestamps" (canonical), the
-    // /verify/example fixture still emits "ots" (legacy). The SDK
+    // /verify/example fixture still emits "ots" (alias). The SDK
     // type stub admits both literals and the parser does not silently
     // rewrite.
     const payload = {

--- a/typescript/tests/verify-response-fields.test.ts
+++ b/typescript/tests/verify-response-fields.test.ts
@@ -10,7 +10,7 @@
  * pin that the parser populates the TS interface with all of them, that
  * the `validationLabel` union admits `agent_revoked_before_issuance`,
  * and that the inner anchor `type` admits both `"opentimestamps"`
- * (canonical) and `"ots"` (legacy fixture alias).
+ * (canonical) and `"ots"` (fixture alias).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";


### PR DESCRIPTION
## Why

Final SDK purge: no \`legacy_chain\` field, no \`legacy\` in any docstring or comment, no synthetic-v1 chain shape branches. Stacks on the squash-merged PR #163.

## What

Source:
- \`python/src/asqav/replay.py\`: drop \`legacy_chain\` Step field; drop \`legacy_chain\` parameter on \`verify_chain\`, \`replay\`, \`replay_from_bundle\`, \`_build_timeline\`, \`_verify_hash_chain\`, \`_step_chain_hash\`. Delete the synthetic-v1 chain branches.
- \`python/src/asqav/cli.py\`: \`replay-verify --strict\` reports \`synthetic_step_count\` instead of \`legacy_step_count\`; fails on steps without \`signed_envelope\`.
- \`typescript/src/replay.ts\`: drop \`legacy\` option; \`VerifyChainOptions\` is empty.
- \`typescript/src/cli.ts\`: \`synthetic_step_count\` everywhere.
- \`python/src/asqav/ietf_projection.py\`, \`client.py\`, \`typescript/src/ietfProjection.ts\`, \`index.ts\`: prose scrubbed of \"legacy mode\", \"legacy receipts\", \"legacy alias\". Reworded as \"flat mode\", \"flat-shape receipts\", \"alias\".

Tests:
- \`python/tests/test_replay_ietf_chain.py\`: delete \`test_legacy_chain_*\` (3 tests), \`test_step_chain_hash_legacy_*\`, \`test_v2_chain_differs_from_legacy_for_same_signatures\`.
- \`python/tests/test_cli.py\`: rename \`test_replay_verify_strict_rejects_legacy\` -> \`test_replay_verify_strict_rejects_steps_without_envelope\`.
- \`typescript/tests/replay.test.ts\`: delete \"legacy: true uses the v1 chain shape\" test.
- All remaining test docstrings + names scrubbed of \"legacy\" wording.

## Breaking-change surface (intentional)

- \`verify_chain(legacy_chain=True)\` / \`verifyChain(records, { legacy: true })\` -> TypeError. Synthetic-v1 chain shape is gone.
- \`ReplayStep.legacy_chain\` attribute removed.
- \`replay-verify --strict\` JSON output renames \`legacy_step_count\` -> \`synthetic_step_count\`.

## Verification

    \$ rg -i \"legacy\" python/src/ typescript/src/ python/tests/ typescript/tests/ -n
    (zero hits)

comment hygiene clean