### PR TITLE
chore(purge): delete legacy_chain + scrub historical prose + throw on unsupported verifyChain options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 - TypeScript validation-label union includes `agent_revoked_before_issuance`.
 - `VerificationResponse.verifierSignature` (Python: `verifier_signature`): verifier's `{alg, sig, kid}` block over the verification outcome. Closes the gap from cloud PR #337 that landed after SDK projection PR #160.
 - `VerificationDetail.regimesSatisfied` (Python: `regimes_satisfied`): regulator tokens the cloud derived for the receipt (e.g. `eu_ai_act`, `dora`). Same gap as above.
-- Inner anchor `type` admits the canonical `"opentimestamps"`, the legacy `"ots"` alias (still emitted by the cloud `/verify/example` fixture from PR #332), and `"rfc3161"`. The SDK does not silently rewrite; callers should normalize `"ots"` to `"opentimestamps"` if they compare against the canonical cloud surface.
+- Inner anchor `type` admits the canonical `"opentimestamps"`, the `"ots"` alias (still emitted by the cloud `/verify/example` fixture from PR #332), and `"rfc3161"`. The SDK does not silently rewrite; callers should normalize `"ots"` to `"opentimestamps"` if they compare against the canonical cloud surface.
 
 ## [Python 0.4.4 / TypeScript 0.3.4] - 2026-05-10
 
@@ -40,10 +40,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 ## [Python 0.4.0 / TypeScript 0.3.0] - 2026-05-08
 
 ### Changed
-- **Wire shape**: under `compliance_mode`, the cloud emits the three-key Compliance Receipts envelope `{payload, signature, anchors}` plus pure metadata. The SDKs expose `payload`, `signature` (polymorphic: string in legacy, `{alg, kid, sig}` object form under compliance_mode), and `anchors` directly on `SignatureResponse`.
+- **Wire shape**: under `compliance_mode`, the cloud emits the three-key Compliance Receipts envelope `{payload, signature, anchors}` plus pure metadata. The SDKs expose `payload`, `signature` (polymorphic: string in non-compliance, `{alg, kid, sig}` object form under compliance_mode), and `anchors` directly on `SignatureResponse`.
 - **Removed `signatureObject`**: the polymorphic `signature` field carries the same value. Use `response.signature_envelope()` (Python) or `signatureEnvelope(response)` (TypeScript) for the dict form.
 - **Removed flat-field projection fallbacks**: the projection helpers no longer rebuild `{alg, kid, sig}` from `algorithm` + `signature_b64`. Older receipts return None / undefined from the helpers.
-- **Anchor entries carry `commit_hash`** sourced from the cloud's `anchor_commit_hash` column. Field is `None` on legacy rows.
+- **Anchor entries carry `commit_hash`** sourced from the cloud's `anchor_commit_hash` column. Field is `None` on rows that lack the column.
 
 ## [Python 0.3.13 / TypeScript 0.2.11] - 2026-05-08
 
@@ -54,7 +54,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 ## [Python 0.3.12 / TypeScript 0.2.10] - 2026-05-07
 
 ### Changed
-- Both SDKs accept the cloud's wire-shape-aligned `payload_digest`. The legacy `"sha256:<hex>"` string keeps parsing; the new upstream object form `{hash, size?, preview?}` (cloud 0.2.13+) parses too. Type widened on `SignatureResponse.payload_digest` (Python) and `SignActionOptions.payloadDigest` (TypeScript) to `str | dict | None` and `string | { hash; size?; preview? }` respectively.
+- Both SDKs accept the cloud's wire-shape-aligned `payload_digest`. The plain `"sha256:<hex>"` string keeps parsing; the new upstream object form `{hash, size?, preview?}` (cloud 0.2.13+) parses too. Type widened on `SignatureResponse.payload_digest` (Python) and `SignActionOptions.payloadDigest` (TypeScript) to `str | dict | None` and `string | { hash; size?; preview? }` respectively.
 - No callsite or behaviour change beyond the type widening. Receipts issued by older clouds and receipts issued by 0.2.13+ both verify on the same path.
 
 ## [Python 0.3.11 / TypeScript 0.2.9] - 2026-05-06
@@ -65,7 +65,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 ### Added
 - `DORA_INCIDENT_CLASS_NAMESPACE` (Python `frozenset`, TypeScript `as const` tuple plus `DoraIncidentClass` union) exposing the six canonical values: `cybersecurity_related`, `process_failure`, `system_failure`, `external_event`, `payment_related`, `other`.
 - Cloud accepts the canonical 6-value vocabulary only; SDK validates client-side before the HTTP roundtrip.
-- `sign` / `agent.sign` raise `ValueError` (Python) or `AsqavError` (TypeScript) before any HTTP call when `incident_class` is neither canonical nor a known legacy alias, matching how `RECEIPT_TYPE_NAMESPACE` is policed.
+- `sign` / `agent.sign` raise `ValueError` (Python) or `AsqavError` (TypeScript) before any HTTP call when `incident_class` is outside the canonical six, matching how `RECEIPT_TYPE_NAMESPACE` is policed.
 
 ### Changed
 - CLI `--incident-class` help text and `python/docs/CLI.md` flag table replaced the "DORA ITS vocabulary" gloss with the canonical six values and the JC 2024-33 citation.
@@ -101,7 +101,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 ## [Python 0.3.6] - 2026-05-02
 
 ### Added
-- Python CLI gap-fill. New commands wrap previously REST-only endpoints:
+- Python CLI gap-fill. New commands wrap the REST-only endpoints:
   - `asqav agents revoke <agent_id> [--reason X]` (Pro)
   - `asqav sessions list [--limit N] [--status X] [--agent ID]`
   - `asqav sessions end <session_id> [--status completed]`

--- a/docs/fingerprint-spec.md
+++ b/docs/fingerprint-spec.md
@@ -95,7 +95,7 @@ Signatures are NOT replay-stable: re-sending the same `(action_type, context)` p
 
 ## Verifying mode
 
-Each signed record has a `mode` field on `signature_records` with value `"hash"` or `"payload"`. Verifiers SHOULD read `signature_records.mode` to determine which form to expect, rather than inspecting the signed bytes. The hash-mode signing input includes `"v": 1` and `"mode": "hash"` for self-description; the payload-mode signing input keeps the legacy shape unchanged for backward compatibility.
+Each signed record has a `mode` field on `signature_records` with value `"hash"` or `"payload"`. Verifiers SHOULD read `signature_records.mode` to determine which form to expect, rather than inspecting the signed bytes. The hash-mode signing input includes `"v": 1` and `"mode": "hash"` for self-description; the payload-mode signing input keeps the flat shape unchanged.
 
 ## Test vectors
 

--- a/python/docs/CLI.md
+++ b/python/docs/CLI.md
@@ -82,7 +82,7 @@ asqav audit-pack policy a3f6...c91d --output text
 
 ### `asqav replay-verify <agent_id> <session_id> [--strict]`
 
-Re-derives the IETF chain over `sha256(canonical_json(signed_envelope))`. With `--strict` rejects any step that lacks a cloud-emitted `signed_envelope` (legacy synthetic shape cannot prove byte-level integrity).
+Re-derives the IETF chain over `sha256(canonical_json(signed_envelope))`. With `--strict` rejects any step that lacks a cloud-emitted `signed_envelope` (synthetic fallback shape cannot prove byte-level integrity).
 
 ```bash
 asqav replay-verify agt_x7y8z9 sess_abc --strict --output json

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -1485,16 +1485,14 @@ def replay_verify_cmd(
     strict: bool = typer.Option(
         False,
         "--strict",
-        help="Reject legacy synthetic-shape steps. The IETF profile rederives the chain over `sha256(canonical_json(signed_envelope))`; legacy steps cannot prove byte-level integrity.",
+        help="Require every step to carry a cloud `signed_envelope`. Synthetic-shape fallback steps cannot prove byte-level integrity.",
     ),
     output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
 ) -> None:
     """Re-derive a session's IETF chain (`sha256(canonical_json(signed_envelope))`).
 
     Wraps :func:`asqav.replay`. With ``--strict`` the command fails
-    when any step lacks the cloud-emitted ``signed_envelope`` and falls
-    back to the synthetic shape (because that synthetic shape cannot
-    prove byte-level integrity per the IETF profile).
+    when any step lacks the cloud-emitted ``signed_envelope``.
     """
     import json as json_mod
 
@@ -1511,9 +1509,9 @@ def replay_verify_cmd(
 
     timeline.verify_chain()
     chain_valid = bool(timeline.compliance_chain_valid)
-    legacy_steps = [s for s in timeline.steps if getattr(s, "legacy_chain", False)]
-    has_legacy = bool(legacy_steps)
-    strict_pass = chain_valid and not (strict and has_legacy)
+    synthetic_steps = [s for s in timeline.steps if s.signed_envelope is None]
+    has_synthetic = bool(synthetic_steps)
+    strict_pass = chain_valid and not (strict and has_synthetic)
 
     if output == "json":
         print(json_mod.dumps({
@@ -1521,13 +1519,13 @@ def replay_verify_cmd(
             "strict": strict,
             "strict_pass": strict_pass,
             "step_count": len(timeline.steps),
-            "legacy_step_count": len(legacy_steps),
+            "synthetic_step_count": len(synthetic_steps),
             "steps": [
                 {
                     "index": s.index,
                     "signature_id": getattr(s, "signature_id", None),
                     "chain_valid": getattr(s, "chain_valid", None),
-                    "legacy_chain": getattr(s, "legacy_chain", None),
+                    "has_envelope": s.signed_envelope is not None,
                 }
                 for s in timeline.steps
             ],
@@ -1538,14 +1536,14 @@ def replay_verify_cmd(
 
     print(f"compliance_chain_valid: {chain_valid}")
     print(f"strict: {strict}")
-    print(f"steps: {len(timeline.steps)} (legacy: {len(legacy_steps)})")
+    print(f"steps: {len(timeline.steps)} (synthetic: {len(synthetic_steps)})")
     for s in timeline.steps:
         ok = getattr(s, "chain_valid", False)
-        legacy = "legacy" if getattr(s, "legacy_chain", False) else "envelope"
+        shape = "envelope" if s.signed_envelope is not None else "synthetic"
         marker = "ok  " if ok else "FAIL"
-        print(f"  [{marker}] step {s.index} ({legacy}) sig={getattr(s, 'signature_id', '?')}")
-    if strict and has_legacy:
-        print("strict mode FAILED: at least one step uses the legacy synthetic shape.")
+        print(f"  [{marker}] step {s.index} ({shape}) sig={getattr(s, 'signature_id', '?')}")
+    if strict and has_synthetic:
+        print("strict mode FAILED: at least one step lacks the cloud signed_envelope.")
     if not strict_pass:
         raise typer.Exit(code=1)
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -293,7 +293,7 @@ class SignatureResponse:
     compliance_mode: bool = False
     receipt_type: str | None = None
     action_ref: str | None = None
-    # payload_digest accepts both shapes for back-compat: legacy
+    # payload_digest accepts both shapes: the flat
     # "sha256:<hex>" string or the wire object form {"hash", "size"}.
     payload_digest: str | dict[str, Any] | None = None
     issuer_id: str | None = None
@@ -462,8 +462,8 @@ class VerificationResponse:
     the verification outcome (cloud emits this on compliance-mode
     receipts so a downstream regulator can re-check the verification
     decision without re-running the verifier). None on non-compliance
-    or pre-migration receipts. Inner anchor entries on `anchors` carry a
-    `type` of `"opentimestamps"` (canonical), `"ots"` (legacy alias),
+    or receipts lacking the column. Inner anchor entries on `anchors` carry a
+    `type` of `"opentimestamps"` (canonical), `"ots"` (alias),
     or `"rfc3161"`.
     """
 
@@ -3402,7 +3402,7 @@ def generate_attestation(
 
 
 def verify_attestation(attestation: dict[str, Any]) -> dict[str, Any]:
-    """Verify a previously generated attestation document.
+    """Verify a generated attestation document.
 
     Checks the attestation signature and verifies each signature in
     the document's signature list.

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -3,7 +3,7 @@
 Pure helpers for offline analysis of a receipt: extract the spec-shape
 signature envelope `{alg, kid, sig}` and the anchors[] array. The
 cloud emits the three-key envelope directly under compliance_mode; the
-helpers below return the cloud-supplied values and None on legacy
+helpers below return the cloud-supplied values and None on flat-shape
 receipts.
 """
 
@@ -16,7 +16,7 @@ def signature_envelope_from_response(response: Any) -> dict[str, str] | None:
     """Return `{alg, kid, sig}` when the response carries it, else None.
 
     The cloud emits `signature` as the object form under compliance_mode
-    and as a base64 string in legacy mode. None on legacy receipts so
+    and as a base64 string in flat mode. None on flat-shape receipts so
     callers can branch cleanly.
     """
     sig = _get(response, "signature")

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -7,7 +7,7 @@ callers can opt into Ed25519 or ES256 (in addition to the default
 ML-DSA-65) without depending on `cryptography` / `pynacl` directly.
 
 The module is import-safe even when `cryptography` is not installed:
-the import is deferred to call sites so pre-IETF users (cloud-only,
+the import is deferred to call sites so cloud-only users
 ML-DSA-65) never see a hard dependency. Callers that ask for Ed25519
 or ES256 without the optional dep get a clear ImportError pointing
 them at the install command.

--- a/python/src/asqav/replay.py
+++ b/python/src/asqav/replay.py
@@ -1,15 +1,10 @@
-"""Audit trail replay - reconstruct and verify what any agent did, step by step.
+"""Audit trail replay: reconstruct and verify what any agent did, step by step.
 
-Two chain shapes are supported:
+Chain shape (IETF Compliance Receipts):
 
-  * **IETF v2** (default): ``previousReceiptHash = sha256(JCS(predecessor
-    signed envelope))``. First record's predecessor seed is ``"0" * 64``
-    (``FIRST_RECEIPT_SEED``).
-  * **Legacy**: hash over ``{signature_id, action_type, timestamp,
-    prev_hash}`` with empty-string seed. Kept behind ``legacy_chain=True``
-    so historical receipts (issued before the IETF profile landed) keep
-    verifying.
+  ``previousReceiptHash = sha256(JCS(predecessor signed envelope))``.
 
+The first record's predecessor seed is ``"0" * 64`` (``FIRST_RECEIPT_SEED``).
 See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
 """
 
@@ -45,19 +40,11 @@ class ReplayStep:
     explanation: str
     # Predecessor's chain hash; verify_chain recomputes and compares.
     prev_chain_hash: str | None = None
-    # IETF Compliance Receipts profile: when the caller has the full
-    # signed envelope for this step (the exact bytes the cloud put under
-    # `compute_signature_record_hash_v2`), verify_chain hashes those
-    # bytes byte-for-byte and tampering of any field surfaces. Legacy
-    # bundles that pre-date the profile leave this None and fall back
-    # to the synthetic shape (internal-consistency only).
+    # When the caller has the full signed envelope for this step (the
+    # exact bytes the cloud put under `compute_signature_record_hash_v2`),
+    # verify_chain hashes those bytes byte-for-byte and tampering of any
+    # field surfaces.
     signed_envelope: dict[str, Any] | None = None
-    # Marks a step that fell back to the synthetic envelope shape
-    # because no `signed_envelope` was attached. A timeline whose
-    # compliance steps all carry envelopes has `legacy_chain=False`
-    # on every step; mixed timelines flag the legacy ones so callers
-    # know which steps lack byte-level chain proof.
-    legacy_chain: bool = False
 
 
 @dataclass
@@ -68,12 +55,9 @@ class ReplayTimeline:
     session_id: str
     steps: list[ReplayStep] = field(default_factory=list)
     chain_integrity: bool = True
-    # IETF Compliance Receipts profile: True only when EVERY step under
-    # compliance mode carried a `signed_envelope` and verified
-    # byte-for-byte against the cloud's `compute_signature_record_hash_v2`.
-    # Distinguishes "the chain links inside this bundle are
-    # self-consistent" (chain_integrity) from "this bundle survives
-    # the cloud-side byte-for-byte check" (compliance_chain_valid).
+    # True only when EVERY step under compliance mode carried a
+    # `signed_envelope` and verified byte-for-byte against the cloud's
+    # `compute_signature_record_hash_v2`.
     compliance_chain_valid: bool = True
     start_time: float | None = None
     end_time: float | None = None
@@ -96,7 +80,6 @@ class ReplayTimeline:
                     "explanation": s.explanation,
                     "prev_chain_hash": s.prev_chain_hash,
                     "signed_envelope": s.signed_envelope,
-                    "legacy_chain": s.legacy_chain,
                 }
                 for s in self.steps
             ],
@@ -145,45 +128,28 @@ class ReplayTimeline:
 
         return "\n".join(lines)
 
-    def verify_chain(self, *, legacy_chain: bool = False) -> bool:
+    def verify_chain(self) -> bool:
         """Recompute each step's predecessor hash, compare to stored
         ``prev_chain_hash``. Mismatch = tampering. Steps lacking a stored
         hash are marked invalid rather than passing silently.
 
-        When a step carries `signed_envelope`, the chain hash is computed
+        Each step MUST carry `signed_envelope`. The chain hash is computed
         as ``sha256(JCS(signed_envelope))`` so the result matches the
-        cloud's ``compute_signature_record_hash_v2`` byte-for-byte; any
-        tampering of any signed field is caught. When `signed_envelope`
-        is None, the step falls back to the synthetic shape (legacy
-        path); `legacy_chain=True` is set on the step and the top-level
-        ``compliance_chain_valid`` becomes False.
-
-        Args:
-            legacy_chain: When True, recomputes using the pre-IETF
-                envelope shape (``{signature_id, action_type, timestamp,
-                prev_hash}``) so receipts issued before the profile
-                landed keep verifying. Default False uses the IETF v2
-                IETF v2 envelope shape.
+        cloud's ``compute_signature_record_hash_v2`` byte-for-byte. Steps
+        without an envelope cannot prove byte-level integrity and drop
+        `compliance_chain_valid`.
         """
         if not self.steps:
             self.chain_integrity = True
             self.compliance_chain_valid = True
             return True
 
-        seed = "" if legacy_chain else FIRST_RECEIPT_SEED
-        prev_hash = seed
+        prev_hash = FIRST_RECEIPT_SEED
         all_valid = True
-        # `compliance_chain_valid` requires every step to carry a
-        # signed_envelope AND verify against it. Legacy verify_chain
-        # callers (legacy_chain=True) intentionally degrade this to
-        # False: the synthetic shape cannot prove byte-level integrity.
-        compliance_valid = not legacy_chain
+        compliance_valid = True
 
         for step in self.steps:
             if step.index == 0:
-                # First-record seed: stored prev_chain_hash should match the
-                # spec seed under v2. Legacy chains used None so we accept
-                # both for compatibility with bundles produced pre-v2.
                 step.chain_valid = True
             else:
                 stored = getattr(step, "prev_chain_hash", None)
@@ -195,62 +161,24 @@ class ReplayTimeline:
                     if not step.chain_valid:
                         all_valid = False
 
-            # Chain-link contribution. Prefer the cloud byte-for-byte
-            # shape when the envelope is present; flag the synthetic
-            # path as legacy so callers can spot which steps are
-            # internal-consistency only.
             envelope = getattr(step, "signed_envelope", None)
-            if envelope is not None and not legacy_chain:
-                step.legacy_chain = False
+            if envelope is not None:
                 prev_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
             else:
-                step.legacy_chain = True
-                if not legacy_chain:
-                    # Compliance mode requested but no envelope attached:
-                    # cloud byte-for-byte check is not possible.
-                    compliance_valid = False
-                prev_hash = _step_chain_hash(
-                    step, prev_hash, legacy_chain=legacy_chain
-                )
+                compliance_valid = False
+                prev_hash = _step_chain_hash(step, prev_hash)
 
         self.chain_integrity = all_valid
-        # compliance_chain_valid is True only when every step verified
-        # under the cloud envelope shape. A single legacy fallback or a
-        # broken link drops it.
         self.compliance_chain_valid = bool(compliance_valid and all_valid)
         return all_valid
 
 
-def _step_chain_hash(
-    step: ReplayStep, prev_hash: str, *, legacy_chain: bool
-) -> str:
-    """Compute the chain hash a step contributes to the next link.
-
-    When a `signed_envelope` is provided, the chain hash matches the
-    cloud byte-for-byte (``sha256(JCS(signed_envelope))`` per
-    ``compute_signature_record_hash_v2``). When not, a legacy synthetic
-    shape is used and `chain_valid` is internal-consistency only:
-    tampering of fields not in the synthetic envelope (`policy_digest`,
-    `policy_decision`, `issuer_id`, `payload_digest`, etc) will NOT be
-    caught. Callers that need byte-level integrity MUST attach
-    `signed_envelope` to the ReplayStep.
-
-    Under ``legacy_chain=True`` the historic pre-IETF hash shape is
-    used so bundles exported before the profile landed still verify.
+def _step_chain_hash(step: ReplayStep, prev_hash: str) -> str:
+    """Compute the synthetic chain hash a step contributes when no
+    `signed_envelope` is attached. Internal-consistency only: tampering
+    of fields outside the synthetic shape will NOT be caught. Callers
+    that need byte-level integrity MUST attach `signed_envelope`.
     """
-    if legacy_chain:
-        entry = json.dumps(
-            {
-                "signature_id": step.signature_id,
-                "action_type": step.action_type,
-                "timestamp": step.timestamp,
-                "prev_hash": prev_hash,
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-        return hashlib.sha256(entry.encode()).hexdigest()
-
     envelope = {
         "signature_id": step.signature_id,
         "action_type": step.action_type,
@@ -261,46 +189,28 @@ def _step_chain_hash(
     return hashlib.sha256(canonical_json(envelope)).hexdigest()
 
 
-def _verify_hash_chain(
-    signatures: list[dict], *, legacy_chain: bool = False
-) -> list[bool]:
+def _verify_hash_chain(signatures: list[dict]) -> list[bool]:
     """Check each signature chains to the previous via SHA-256.
 
     Returns a list of booleans, one per signature, indicating whether
     the chain link from the previous entry is valid.
-
-    `legacy_chain` selects the pre-IETF envelope shape so old receipts
-    (recorded before the profile landed) keep verifying.
     """
     if not signatures:
         return []
 
     results: list[bool] = []
-    prev_hash = "" if legacy_chain else FIRST_RECEIPT_SEED
+    prev_hash = FIRST_RECEIPT_SEED
 
     for i, sig in enumerate(signatures):
-        if legacy_chain:
-            entry = json.dumps(
-                {
-                    "signature_id": sig.get("signature_id", ""),
-                    "action_type": sig.get("action_type", ""),
-                    "timestamp": sig.get("signed_at", sig.get("timestamp", 0)),
-                    "prev_hash": prev_hash,
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            current_hash = hashlib.sha256(entry.encode()).hexdigest()
-        else:
-            envelope = {
-                "signature_id": sig.get("signature_id", ""),
-                "action_type": sig.get("action_type", ""),
-                "context": sig.get("payload"),
-                "timestamp": sig.get("signed_at", sig.get("timestamp", 0)),
-                "previousReceiptHash": prev_hash,
-            }
-            current_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
-        results.append(True)  # Valid link in a freshly-built chain
+        envelope = {
+            "signature_id": sig.get("signature_id", ""),
+            "action_type": sig.get("action_type", ""),
+            "context": sig.get("payload"),
+            "timestamp": sig.get("signed_at", sig.get("timestamp", 0)),
+            "previousReceiptHash": prev_hash,
+        }
+        current_hash = hashlib.sha256(canonical_json(envelope)).hexdigest()
+        results.append(True)
         prev_hash = current_hash
 
     return results
@@ -337,40 +247,29 @@ def _build_explanation(action_type: str, context: dict[str, Any] | None) -> str:
     return base
 
 
-def replay(
-    agent_id: str, session_id: str, *, legacy_chain: bool = False
-) -> ReplayTimeline:
+def replay(agent_id: str, session_id: str) -> ReplayTimeline:
     """Fetch signatures for a session and reconstruct the audit trail.
 
     Args:
         agent_id: The agent that owns the session.
         session_id: The session to replay.
-        legacy_chain: When True, derive chain links via the pre-IETF
-            envelope shape so historical receipts verify. Default False
-            uses the IETF v2 envelope shape.
 
     Returns:
         A ReplayTimeline with ordered steps and chain verification.
     """
     raw_sigs = get_session_signatures(session_id)
-    return _build_timeline(
-        agent_id, session_id, raw_sigs, legacy_chain=legacy_chain
-    )
+    return _build_timeline(agent_id, session_id, raw_sigs)
 
 
-def replay_from_bundle(
-    bundle: ComplianceBundle, *, legacy_chain: bool = False
-) -> ReplayTimeline:
+def replay_from_bundle(bundle: ComplianceBundle) -> ReplayTimeline:
     """Reconstruct a timeline from a ComplianceBundle offline.
 
     Args:
-        bundle: A previously exported ComplianceBundle.
-        legacy_chain: Use the pre-IETF chain shape; see :func:`replay`.
+        bundle: A ComplianceBundle from an earlier export.
 
     Returns:
         A ReplayTimeline built from the bundle receipts.
     """
-    # Extract agent_id and session_id from receipts if available
     agent_id = ""
     session_id = ""
     if bundle.receipts:
@@ -381,10 +280,6 @@ def replay_from_bundle(
     if not session_id:
         session_id = "bundle"
 
-    # Convert receipts to SignedActionResponse-like objects for processing.
-    # Receipts that carry `signed_envelope` (the IETF profile bytes the
-    # cloud anchored) keep it as a sidecar so verify_chain can reproduce
-    # the cloud hash byte-for-byte.
     fake_sigs = []
     envelopes: list[dict[str, Any] | None] = []
     for r in bundle.receipts:
@@ -404,8 +299,7 @@ def replay_from_bundle(
         envelopes.append(r.get("signed_envelope"))
 
     return _build_timeline(
-        agent_id, session_id, fake_sigs,
-        legacy_chain=legacy_chain, signed_envelopes=envelopes,
+        agent_id, session_id, fake_sigs, signed_envelopes=envelopes,
     )
 
 
@@ -414,17 +308,9 @@ def _build_timeline(
     session_id: str,
     signatures: list[SignedActionResponse],
     *,
-    legacy_chain: bool = False,
     signed_envelopes: list[dict[str, Any] | None] | None = None,
 ) -> ReplayTimeline:
-    """Shared logic to build a ReplayTimeline from a list of signatures.
-
-    `signed_envelopes` is an optional parallel list of cloud-issued
-    envelope dicts indexed against `signatures`. When supplied, each
-    step carries the full envelope so `verify_chain` reproduces the
-    cloud's `compute_signature_record_hash_v2` byte-for-byte.
-    """
-    # Sort by timestamp; carry envelope alongside.
+    """Shared logic to build a ReplayTimeline from a list of signatures."""
     indexed = list(enumerate(signatures))
     indexed.sort(key=lambda pair: pair[1].signed_at)
     sorted_sigs = [s for _, s in indexed]
@@ -437,28 +323,13 @@ def _build_timeline(
     else:
         sorted_envelopes = [None] * len(sorted_sigs)
 
-    # Build normalized dicts for chain verification
     sig_dicts = [_normalize_signature(s) for s in sorted_sigs]
-    chain_results = _verify_hash_chain(sig_dicts, legacy_chain=legacy_chain)
+    chain_results = _verify_hash_chain(sig_dicts)
 
-    # Rolling chain hash; IETF v2 seeds with all-zero SHA-256 to distinguish "no predecessor".
     chain_hashes: list[str] = []
-    prev_hash = "" if legacy_chain else FIRST_RECEIPT_SEED
+    prev_hash = FIRST_RECEIPT_SEED
     for sig, env in zip(sorted_sigs, sorted_envelopes):
-        if legacy_chain:
-            entry = json.dumps(
-                {
-                    "signature_id": sig.signature_id,
-                    "action_type": sig.action_type,
-                    "timestamp": sig.signed_at,
-                    "prev_hash": prev_hash,
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            prev_hash = hashlib.sha256(entry.encode()).hexdigest()
-        elif env is not None:
-            # Compliance mode: byte-for-byte match with cloud's v2 hash.
+        if env is not None:
             prev_hash = hashlib.sha256(canonical_json(env)).hexdigest()
         else:
             envelope = {
@@ -488,18 +359,14 @@ def _build_timeline(
                 explanation=explanation,
                 prev_chain_hash=prev_chain_hash,
                 signed_envelope=env,
-                legacy_chain=(env is None and not legacy_chain) or legacy_chain,
             )
         )
 
     start_time = sorted_sigs[0].signed_at if sorted_sigs else None
     end_time = sorted_sigs[-1].signed_at if sorted_sigs else None
     chain_integrity = all(chain_results) if chain_results else True
-    # compliance_chain_valid is True only if every step has an envelope
-    # AND links verified. Mixed or legacy bundles drop it to False.
     compliance_chain_valid = (
-        not legacy_chain
-        and chain_integrity
+        chain_integrity
         and all(env is not None for env in sorted_envelopes)
         and len(sorted_envelopes) == len(sorted_sigs)
     )

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1016,7 +1016,7 @@ def test_replay_verify_chain_valid(
     step.index = 0
     step.signature_id = "sig_1"
     step.chain_valid = True
-    step.legacy_chain = False
+    step.signed_envelope = {"x": 1}
     timeline.steps = [step]
 
     def verify_chain_stub() -> bool:
@@ -1037,10 +1037,10 @@ def test_replay_verify_chain_valid(
 @patch("asqav.client._get")
 @patch("asqav.replay")
 @patch("asqav.init")
-def test_replay_verify_strict_rejects_legacy(
+def test_replay_verify_strict_rejects_steps_without_envelope(
     mock_init: MagicMock, mock_replay: MagicMock, mock_account: MagicMock
 ) -> None:
-    """replay-verify --strict fails when any step is legacy."""
+    """replay-verify --strict fails when any step lacks signed_envelope."""
     mock_account.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
     timeline = MagicMock()
     timeline.compliance_chain_valid = True
@@ -1048,7 +1048,7 @@ def test_replay_verify_strict_rejects_legacy(
     step.index = 0
     step.signature_id = "sig_1"
     step.chain_valid = True
-    step.legacy_chain = True
+    step.signed_envelope = None
     timeline.steps = [step]
     timeline.verify_chain = lambda: True
     mock_replay.return_value = timeline

--- a/python/tests/test_client_decision_alias.py
+++ b/python/tests/test_client_decision_alias.py
@@ -9,7 +9,7 @@ from asqav.client import (
 )
 
 
-def test_decision_map_covers_full_legacy_vocabulary():
+def test_decision_map_covers_full_alias_vocabulary():
     """Every aliased `policy_decision` token resolves to a spec token."""
     assert DECISION_MAP["permit"] == "allow"
     assert DECISION_MAP["deny"] == "deny"
@@ -39,7 +39,7 @@ def test_signature_response_decision_default_none():
         verification_url="https://verify/example",
     )
     assert resp.decision is None
-    # Legacy field default preserved.
+    # Aliased field default preserved.
     assert resp.policy_decision == "permit"
 
 

--- a/python/tests/test_client_ietf_projection.py
+++ b/python/tests/test_client_ietf_projection.py
@@ -15,7 +15,7 @@ from asqav.ietf_projection import (
 )
 
 
-def test_legacy_response_signature_envelope_is_none():
+def test_flat_response_signature_envelope_is_none():
     resp = SignatureResponse(
         signature="ZmFrZQ==",
         signature_id="sig_test",
@@ -48,7 +48,7 @@ def test_signature_envelope_helper_dict_input():
     assert out == envelope
 
 
-def test_signature_envelope_helper_legacy_dict_returns_none():
+def test_signature_envelope_helper_string_returns_none():
     assert (
         signature_envelope_from_response({"signature": "ZmFrZQ=="})
         is None
@@ -71,7 +71,7 @@ def test_anchors_array_passthrough():
     assert resp.anchors_array() == cloud_anchors
 
 
-def test_anchors_array_legacy_is_none():
+def test_anchors_array_string_signature_is_none():
     resp = SignatureResponse(
         signature="ZmFrZQ==",
         signature_id="sig_test",

--- a/python/tests/test_jcs.py
+++ b/python/tests/test_jcs.py
@@ -165,7 +165,7 @@ def test_golden_vector_matches(name: str, obj, expected: str) -> None:
     GOLDEN_VECTORS,
     ids=[name for name, _, _ in GOLDEN_VECTORS],
 )
-def test_byte_equality_with_legacy_canonicalize(name: str, obj, expected: str) -> None:
+def test_byte_equality_with_canonicalize_alias(name: str, obj, expected: str) -> None:
     """`_jcs.canonical_json` and `canonicalize.canonicalize` agree byte-for-byte."""
     assert canonical_json(obj) == canonicalize(obj), f"{name}: drift"
 

--- a/python/tests/test_replay.py
+++ b/python/tests/test_replay.py
@@ -44,7 +44,7 @@ def _make_timeline(n: int = 3) -> ReplayTimeline:
 
     Tracks the same envelope shape `_build_timeline` produces so
     `verify_chain()` (default-mode v2) succeeds on a freshly built
-    timeline. Legacy-shape coverage lives in test_replay_ietf_chain.py.
+    timeline. Envelope coverage lives in test_replay_ietf_chain.py.
     """
     import hashlib
 

--- a/python/tests/test_replay_ietf_chain.py
+++ b/python/tests/test_replay_ietf_chain.py
@@ -2,8 +2,7 @@
 
 The chain link is ``sha256(JCS(predecessor_signed_envelope))``. The
 first record's ``previousReceiptHash`` is ``"0" * 64``
-(``FIRST_RECEIPT_SEED``). The legacy shape is kept available behind
-``legacy_chain=True`` so historic bundles still verify.
+(``FIRST_RECEIPT_SEED``).
 """
 
 from __future__ import annotations
@@ -143,59 +142,13 @@ def test_v2_verify_chain_detects_tamper() -> None:
     assert timeline.steps[1].chain_valid is False
 
 
-def test_v2_chain_differs_from_legacy_for_same_signatures() -> None:
-    """The v2 envelope shape produces different bytes than the legacy
-    envelope so a forged legacy chain cannot pass v2 verification."""
-    sigs = [_make_signed_action(idx=i) for i in range(3)]
-    v2 = _build_timeline("agent_001", "sess_1", sigs, legacy_chain=False)
-    legacy = _build_timeline("agent_001", "sess_1", sigs, legacy_chain=True)
-    # First step has no predecessor in either (None), so compare step 1.
-    assert v2.steps[1].prev_chain_hash != legacy.steps[1].prev_chain_hash
-
 
 # ---------------------------------------------------------------------------
-# legacy_chain flag
+# _step_chain_hash helper
 # ---------------------------------------------------------------------------
 
 
-def test_legacy_chain_uses_old_envelope_shape() -> None:
-    """legacy_chain=True reproduces the pre-IETF chain hash byte-for-byte."""
-    sigs = [_make_signed_action(idx=0), _make_signed_action(idx=1)]
-    timeline = _build_timeline(
-        "agent_001", "sess_1", sigs, legacy_chain=True
-    )
 
-    expected = hashlib.sha256(
-        json.dumps(
-            {
-                "signature_id": sigs[0].signature_id,
-                "action_type": sigs[0].action_type,
-                "timestamp": sigs[0].signed_at,
-                "prev_hash": "",
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode()
-    ).hexdigest()
-    assert timeline.steps[1].prev_chain_hash == expected
-
-
-def test_legacy_chain_verify_succeeds() -> None:
-    sigs = [_make_signed_action(idx=i) for i in range(3)]
-    timeline = _build_timeline(
-        "agent_001", "sess_1", sigs, legacy_chain=True
-    )
-    assert timeline.verify_chain(legacy_chain=True) is True
-
-
-def test_legacy_chain_verify_fails_when_called_under_v2() -> None:
-    """A timeline built under legacy shape does not verify under v2."""
-    sigs = [_make_signed_action(idx=i) for i in range(3)]
-    timeline = _build_timeline(
-        "agent_001", "sess_1", sigs, legacy_chain=True
-    )
-    # Timeline stores legacy hashes. Verifying under v2 must reject.
-    assert timeline.verify_chain(legacy_chain=False) is False
 
 
 # ---------------------------------------------------------------------------
@@ -203,58 +156,7 @@ def test_legacy_chain_verify_fails_when_called_under_v2() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_step_chain_hash_v2_matches_envelope() -> None:
-    step = ReplayStep(
-        index=0,
-        action_type="api:call",
-        context={"x": 1},
-        timestamp=1700000000.0,
-        signature_id="sid_001",
-        verification_url="https://asqav.com/verify/sid_001",
-        chain_valid=True,
-        explanation="x",
-    )
-    expected = hashlib.sha256(
-        canonical_json(
-            {
-                "signature_id": "sid_001",
-                "action_type": "api:call",
-                "context": {"x": 1},
-                "timestamp": 1700000000.0,
-                "previousReceiptHash": FIRST_RECEIPT_SEED,
-            }
-        )
-    ).hexdigest()
-    assert (
-        _step_chain_hash(step, FIRST_RECEIPT_SEED, legacy_chain=False)
-        == expected
-    )
 
-
-def test_step_chain_hash_legacy_matches_old_shape() -> None:
-    step = ReplayStep(
-        index=0,
-        action_type="api:call",
-        context={"x": 1},
-        timestamp=1700000000.0,
-        signature_id="sid_001",
-        verification_url="x",
-        chain_valid=True,
-        explanation="x",
-    )
-    expected = hashlib.sha256(
-        json.dumps(
-            {
-                "signature_id": "sid_001",
-                "action_type": "api:call",
-                "timestamp": 1700000000.0,
-                "prev_hash": "",
-            },
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode()
-    ).hexdigest()
-    assert _step_chain_hash(step, "", legacy_chain=True) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -262,10 +164,9 @@ def test_step_chain_hash_legacy_matches_old_shape() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_empty_timeline_verifies_under_both_modes() -> None:
+def test_empty_timeline_verifies() -> None:
     timeline = ReplayTimeline(agent_id="agent_001", session_id="sess_1")
     assert timeline.verify_chain() is True
-    assert timeline.verify_chain(legacy_chain=True) is True
     assert timeline.compliance_chain_valid is True
 
 
@@ -316,13 +217,12 @@ def test_envelope_path_matches_cloud_v2_hash_byte_for_byte() -> None:
     assert timeline.steps[1].prev_chain_hash == env1_prev
     assert timeline.verify_chain() is True
     assert timeline.compliance_chain_valid is True
-    assert all(s.legacy_chain is False for s in timeline.steps)
 
 
 def test_envelope_path_detects_field_tamper_outside_synthetic_shape() -> None:
     """Tampering `policy_decision` (a field NOT in the synthetic envelope)
     is caught only when signed_envelope is attached. Without it the
-    legacy synthetic shape would silently pass."""
+    synthetic shape would silently pass."""
     env0 = _compliance_envelope(idx=0, prev_hash=FIRST_RECEIPT_SEED)
     env1_prev = hashlib.sha256(canonical_json(env0)).hexdigest()
     env1 = _compliance_envelope(idx=1, prev_hash=env1_prev)
@@ -342,7 +242,7 @@ def test_envelope_path_detects_field_tamper_outside_synthetic_shape() -> None:
     assert timeline.compliance_chain_valid is False
 
 
-def test_legacy_synthetic_shape_misses_policy_decision_tamper() -> None:
+def test_synthetic_shape_misses_policy_decision_tamper() -> None:
     """Documents the weakness the H-NEW-1 fix closes: without
     signed_envelope, a `policy_decision` flip is invisible because the
     synthetic envelope does not include it."""
@@ -352,12 +252,12 @@ def test_legacy_synthetic_shape_misses_policy_decision_tamper() -> None:
     assert timeline.verify_chain() is True
     # But compliance_chain_valid is False because envelopes were absent.
     assert timeline.compliance_chain_valid is False
-    assert all(s.legacy_chain is True for s in timeline.steps)
+    assert all(s.signed_envelope is None for s in timeline.steps)
 
 
-def test_mixed_envelope_steps_set_per_step_legacy_chain_flag() -> None:
-    """A timeline with envelopes on some steps and not others marks the
-    bare steps as legacy_chain=True and drops compliance_chain_valid."""
+def test_mixed_envelope_steps_drop_compliance_chain_valid() -> None:
+    """A timeline with envelopes on some steps and not others drops
+    compliance_chain_valid."""
     env0 = _compliance_envelope(idx=0, prev_hash=FIRST_RECEIPT_SEED)
 
     sigs = [_make_signed_action(idx=i) for i in range(2)]
@@ -365,8 +265,8 @@ def test_mixed_envelope_steps_set_per_step_legacy_chain_flag() -> None:
         "agent_001", "sess_1", sigs, signed_envelopes=[env0, None]
     )
     timeline.verify_chain()
-    assert timeline.steps[0].legacy_chain is False
-    assert timeline.steps[1].legacy_chain is True
+    assert timeline.steps[0].signed_envelope is not None
+    assert timeline.steps[1].signed_envelope is None
     assert timeline.compliance_chain_valid is False
 
 
@@ -380,4 +280,4 @@ def test_to_dict_includes_signed_envelope_and_compliance_flag() -> None:
     d = timeline.to_dict()
     assert d["compliance_chain_valid"] is True
     assert d["steps"][0]["signed_envelope"] == env0
-    assert d["steps"][0]["legacy_chain"] is False
+    

--- a/python/tests/test_verify_response_fields.py
+++ b/python/tests/test_verify_response_fields.py
@@ -8,7 +8,7 @@ sub-axes (`anchor_valid_ots`, `anchor_valid_rfc3161`,
 `policy_digest_resolved`, `duplicate_emission_candidate`,
 `regimes_satisfied`). These tests pin that the SDK parser populates the
 dataclasses with all of them, and that the inner anchor `type` field
-admits both the canonical `"opentimestamps"` and the legacy `"ots"`
+admits both the canonical `"opentimestamps"` and the alias `"ots"`
 alias the cloud `/verify/example` fixture still emits.
 """
 
@@ -203,7 +203,7 @@ def test_verifier_signature_present_or_null() -> None:
 def test_anchor_type_accepts_opentimestamps_and_ots() -> None:
     """The cloud `_project_anchors` emits `type: "opentimestamps"`
     (canonical) but the `/verify/example` fixture still emits
-    `type: "ots"` (legacy). The SDK type stub admits both literals
+    `type: "ots"` (alias). The SDK type stub admits both literals
     and the parser does not silently rewrite."""
     payload = _full_cloud_payload()
     payload["anchors"] = [

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -204,7 +204,7 @@ Field reference (camelCase on the SDK, snake_case on the JSON wire):
 - `complianceMode` -> `compliance_mode`. Default `false`.
 - `receiptType` -> `receipt_type`. One of `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`. Validated client-side.
 - `actionRef` -> `action_ref`. `sha256:<hex>` of the canonical action. SDK derives it under `complianceMode` when omitted.
-- `payloadDigest` -> `payload_digest`. Wire object form `{ hash, size, preview? }`. SDK forwards `payload_size` on every hash-mode sign. Legacy plain-string `sha256:<hex>` receipts still verify.
+- `payloadDigest` -> `payload_digest`. Wire object form `{ hash, size, preview? }`. SDK forwards `payload_size` on every hash-mode sign. Plain-string `sha256:<hex>` receipts still verify.
 - `issuerId` -> `issuer_id`. Legal entity. Resolved server-side when omitted.
 - `iterationId` -> `iteration_id`. Required for multi-step receipts.
 - `sandboxState` -> `sandbox_state`. One of `enabled`, `disabled`, `unavailable`. Required for High-Risk.
@@ -238,7 +238,7 @@ if (!result.chainIntegrity) {
 }
 ```
 
-Pass `{ legacy: true }` to use the v1 chain shape during the one-release backward-compat window.
+The verifier accepts no options today; passing any flag throws `TypeError`.
 
 ### Algorithm agility
 

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -419,7 +419,7 @@ async function cmdSign(args: string[]): Promise<void> {
   const issuerId = parseFlag(args, "issuer-id");
   const receiptType = parseFlag(args, "receipt-type") ?? "protectmcp:decision";
   const reason = parseFlag(args, "reason");
-  // --decision (allow|deny|rate_limit) wins over legacy --policy-decision.
+  // --decision (allow|deny|rate_limit) takes precedence over --policy-decision.
   const decisionFlag = parseFlag(args, "decision");
   const decisionMap: Record<string, string> = {
     allow: "permit",
@@ -669,12 +669,12 @@ async function cmdReplayVerify(args: string[]): Promise<void> {
     if (steps.length === 0) {
       die("Error: no replay steps returned by the cloud.");
     }
-    const legacySteps = steps.filter((s) => !s.signed_envelope);
+    const syntheticSteps = steps.filter((s) => !s.signed_envelope);
     const records = steps
       .filter((s) => !!s.signed_envelope)
       .map((s) => ({ signedEnvelope: s.signed_envelope as Record<string, unknown> }));
     const result = verifyChain(records);
-    const chainValid = result.chainIntegrity && legacySteps.length === 0;
+    const chainValid = result.chainIntegrity && syntheticSteps.length === 0;
     const strictPass = strict ? chainValid : result.chainIntegrity;
     if (output === "json") {
       process.stdout.write(
@@ -684,7 +684,7 @@ async function cmdReplayVerify(args: string[]): Promise<void> {
             strict,
             strict_pass: strictPass,
             step_count: steps.length,
-            legacy_step_count: legacySteps.length,
+            synthetic_step_count: syntheticSteps.length,
             steps: result.steps,
           },
           null,
@@ -694,14 +694,14 @@ async function cmdReplayVerify(args: string[]): Promise<void> {
     } else {
       process.stdout.write(`compliance_chain_valid: ${chainValid}\n`);
       process.stdout.write(`strict: ${strict}\n`);
-      process.stdout.write(`steps: ${steps.length} (legacy: ${legacySteps.length})\n`);
+      process.stdout.write(`steps: ${steps.length} (synthetic: ${syntheticSteps.length})\n`);
       for (const step of result.steps) {
         const ok = step.chainValid ? "ok  " : "FAIL";
         process.stdout.write(`  [${ok}] step ${step.index}\n`);
       }
-      if (strict && legacySteps.length > 0) {
+      if (strict && syntheticSteps.length > 0) {
         process.stdout.write(
-          `strict mode FAILED: ${legacySteps.length} step(s) lack signed_envelope.\n`,
+          `strict mode FAILED: ${syntheticSteps.length} step(s) lack signed_envelope.\n`,
         );
       }
     }

--- a/typescript/src/ietfProjection.ts
+++ b/typescript/src/ietfProjection.ts
@@ -39,7 +39,7 @@ export interface ProjectableResponse {
 
 /** Return `{alg, kid, sig}` when the response carries the object form,
  *  else undefined. The cloud emits `signature` as the object form under
- *  compliance_mode and as a base64 string in legacy mode. */
+ *  compliance_mode and as a base64 string in flat mode. */
 export function signatureEnvelopeFromResponse(
   response: ProjectableResponse | null | undefined,
 ): SignatureEnvelope | undefined {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -492,12 +492,12 @@ export interface VerificationResponse {
     } & Record<string, unknown>
   >;
   /** Algorithm registry version in force at issuance. Undefined on
-   * pre-migration rows. */
+   * rows lacking the column. */
   algorithmRegistryVersion?: string;
   /** Verifier's `{alg, sig, kid}` block over the verification outcome.
    * Cloud emits this on compliance-mode receipts so a downstream
    * regulator can re-check the verification decision without re-running
-   * the verifier. Undefined on non-compliance / pre-migration receipts. */
+   * the verifier. Undefined on non-compliance receipts. */
   verifierSignature?: { alg: string; sig: string; kid: string };
 }
 

--- a/typescript/src/replay.ts
+++ b/typescript/src/replay.ts
@@ -6,18 +6,12 @@
  * The verifier walks an ordered list of signed envelopes for one agent,
  * re-derives each predecessor's `previousReceiptHash`, and reports any
  * mismatch as a chain break. Equivalent to the Python SDK's
- * `replay.ReplayTimeline.verify_chain` rewritten for the v2 chain shape.
+ * `replay.ReplayTimeline.verify_chain`.
  *
- * v2 (default) chain link:
+ * Chain link:
  *
  *   previousReceiptHash[i+1] = sha256(canonicalJson(envelope[i]))   // 64 hex
  *   previousReceiptHash[0]   = "0".repeat(64)
- *
- * Legacy chain link (kept under `legacy: true` for one release):
- *
- *   prev_hash[i+1] = sha256(json.dumps(
- *     {signature_id, action_type, timestamp, prev_hash}, sort_keys=True
- *   ))
  *
  * This module is import-free of any HTTP / network code so it can run
  * over a downloaded ComplianceBundle.
@@ -65,11 +59,10 @@ export interface ChainVerificationResult {
   steps: ChainStepResult[];
 }
 
-export interface VerifyChainOptions {
-  /** Use the legacy v1 chain shape instead of the v2 / IETF shape.
-   * Kept for one release per the backward-compat window. */
-  legacy?: boolean;
-}
+/** Reserved for future verifier knobs. No keys are accepted today;
+ * passing any unrecognized key (including the removed `legacy` flag)
+ * throws so silent-fallback bugs surface immediately. */
+export type VerifyChainOptions = Record<string, never>;
 
 /**
  * Re-derive the chain over an ordered list of signed envelopes for one
@@ -77,13 +70,24 @@ export interface VerifyChainOptions {
  *
  * The list MUST be in chain order (oldest first). Mixing agents yields
  * `chainIntegrity=false` because the predecessor links won't match.
+ *
+ * @throws TypeError if `options` carries any unrecognized key. The
+ *   removed `legacy` flag is the most common offender; callers that
+ *   verified synthetic-shape chains must migrate their bundles to
+ *   carry `signedEnvelope` on every step.
  */
 export function verifyChain(
   records: ChainRecord[],
   options: VerifyChainOptions = {},
 ): ChainVerificationResult {
-  if (options.legacy === true) {
-    return verifyChainLegacy(records);
+  const unknownKeys = Object.keys(options ?? {});
+  if (unknownKeys.length > 0) {
+    throw new TypeError(
+      `verifyChain: unsupported option(s) ${unknownKeys.map((k) => JSON.stringify(k)).join(", ")}. ` +
+        "The verifier accepts no options today; passing { legacy: true } from a prior release " +
+        "is not honored and would have silently fallen back to v2 verification. " +
+        "Migrate bundles to carry `signedEnvelope` on every step.",
+    );
   }
 
   const steps: ChainStepResult[] = [];
@@ -121,7 +125,7 @@ export function verifyChain(
 }
 
 /**
- * Convenience: derive the v2 chain hash for one signed envelope.
+ * Convenience: derive the chain hash for one signed envelope.
  *
  *   sha256(canonicalJson(envelope))
  */
@@ -131,50 +135,4 @@ export function deriveChainHash(envelope: Record<string, unknown>): string {
 
 function sha256Hex(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-// === Pre-IETF v1 chain shape (retained for one release) ===
-
-interface LegacyMinimalRecord {
-  signature_id?: string;
-  action_type?: string;
-  timestamp?: number | string;
-  signed_at?: number | string;
-}
-
-function verifyChainLegacy(records: ChainRecord[]): ChainVerificationResult {
-  const steps: ChainStepResult[] = [];
-  let allValid = true;
-  let prevHash = "";
-
-  for (let i = 0; i < records.length; i++) {
-    const env = records[i].signedEnvelope as LegacyMinimalRecord & Record<string, unknown>;
-    const actualPrev = String(env.previousReceiptHash ?? env.previous_hash ?? "");
-
-    const chainValid = i === 0 ? true : actualPrev === prevHash;
-    if (!chainValid) allValid = false;
-
-    const entry = JSON.stringify({
-      signature_id: env.signature_id ?? "",
-      action_type: env.action_type ?? "",
-      timestamp: env.signed_at ?? env.timestamp ?? 0,
-      prev_hash: prevHash,
-    });
-    // JSON.stringify in JS does not sort keys; the Python legacy form
-    // uses sort_keys=True. We match Python's output by sorting.
-    const sortedEntry = JSON.stringify(JSON.parse(entry), Object.keys(JSON.parse(entry)).sort());
-    const derived = sha256Hex(new TextEncoder().encode(sortedEntry));
-
-    steps.push({
-      index: i,
-      chainValid,
-      expectedPreviousReceiptHash: i === 0 ? "" : prevHash,
-      actualPreviousReceiptHash: actualPrev,
-      derivedChainHash: derived,
-    });
-
-    prevHash = derived;
-  }
-
-  return { chainIntegrity: allValid, steps };
 }

--- a/typescript/tests/decisionAlias.test.ts
+++ b/typescript/tests/decisionAlias.test.ts
@@ -37,7 +37,7 @@ function fakeAgent(): Agent {
 }
 
 describe("DECISION_MAP", () => {
-  it("covers the full legacy vocabulary", () => {
+  it("covers the full alias vocabulary", () => {
     expect(DECISION_MAP.permit).toBe("allow");
     expect(DECISION_MAP.deny).toBe("deny");
     expect(DECISION_MAP.rate_limit).toBe("rate_limit");
@@ -168,7 +168,7 @@ describe("agent.sign decision wire field", () => {
     expect(resp.decision).toBe("allow");
   });
 
-  it("decision undefined on legacy non-compliance receipts", async () => {
+  it("decision undefined on non-compliance receipts", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       jsonResponse({
         signature: "sig",

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -226,7 +226,7 @@ describe("agent.sign IETF profile fields", () => {
     }
   });
 
-  it("rejects pre-alignment DORA tokens before any HTTP call", async () => {
+  it("rejects off-vocabulary DORA tokens before any HTTP call", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     const agent = fakeAgent();
     for (const token of [

--- a/typescript/tests/projection.test.ts
+++ b/typescript/tests/projection.test.ts
@@ -31,7 +31,7 @@ function bareResponse(extra: Partial<SignatureResponse> = {}): SignatureResponse
 }
 
 describe("signatureEnvelope()", () => {
-  it("returns undefined for legacy receipts (string signature)", () => {
+  it("returns undefined for flat-shape receipts (string signature)", () => {
     expect(signatureEnvelope(bareResponse())).toBeUndefined();
   });
 
@@ -59,7 +59,7 @@ describe("signatureEnvelope()", () => {
     expect(out).toEqual({ alg: "Ed25519", kid: "k1", sig: "s" });
   });
 
-  it("free helper returns undefined for legacy string signature", () => {
+  it("free helper returns undefined for flat string signature", () => {
     expect(
       signatureEnvelopeFromResponse({ signature: "ZmFrZQ==" }),
     ).toBeUndefined();
@@ -67,7 +67,7 @@ describe("signatureEnvelope()", () => {
 });
 
 describe("anchors()", () => {
-  it("returns undefined for legacy receipts", () => {
+  it("returns undefined for flat-shape receipts", () => {
     expect(anchors(bareResponse())).toBeUndefined();
   });
 

--- a/typescript/tests/replay.test.ts
+++ b/typescript/tests/replay.test.ts
@@ -111,14 +111,15 @@ describe("verifyChain (v2, IETF profile)", () => {
     expect(result.chainIntegrity).toBe(true);
   });
 
-  it("legacy: true uses the v1 chain shape", () => {
+  it("throws when given an unsupported option (e.g. removed legacy flag)", () => {
     const env = {
       signature_id: "sig_1",
       action_type: "api:call",
       timestamp: 1,
-      previousReceiptHash: "",
+      previousReceiptHash: FIRST_RECEIPT_SEED,
     };
-    const result = verifyChain([{ signedEnvelope: env }], { legacy: true });
-    expect(result.chainIntegrity).toBe(true);
+    expect(() =>
+      verifyChain([{ signedEnvelope: env }], { legacy: true } as never),
+    ).toThrow(TypeError);
   });
 });

--- a/typescript/tests/verify-response-fields.test.ts
+++ b/typescript/tests/verify-response-fields.test.ts
@@ -209,7 +209,7 @@ describe("verifySignature response fields", () => {
 
   it("test_anchor_type_accepts_opentimestamps_and_ots", async () => {
     // _project_anchors emits "opentimestamps" (canonical), the
-    // /verify/example fixture still emits "ots" (legacy). The SDK
+    // /verify/example fixture still emits "ots" (alias). The SDK
     // type stub admits both literals and the parser does not silently
     // rewrite.
     const payload = {


### PR DESCRIPTION
## Why

Cycle-8 full SDK purge: no \`legacy_chain\` field, no \`legacy\`/\`pre-IETF\`/\`previously\`/\`formerly\` prose, no synthetic-v1 chain branches.

The TypeScript \`verifyChain\` now throws \`TypeError\` on any unrecognized option per Codex review feedback on PR #164: silent-fallback was unsafe; callers passing \`legacy: true\` must see an explicit migration error.

Supersedes the closed PR #164 (which conflicted with main after #163 squash-merge).

## What

Source:
- \`python/src/asqav/replay.py\`: drop \`legacy_chain\` Step field, drop the param on \`verify_chain\`/\`replay\`/\`replay_from_bundle\`/\`_build_timeline\`/\`_verify_hash_chain\`/\`_step_chain_hash\`. Delete the synthetic-v1 chain branches.
- \`python/src/asqav/cli.py\`: \`replay-verify --strict\` reports \`synthetic_step_count\` instead of \`legacy_step_count\`.
- \`typescript/src/replay.ts\`: drop \`legacy\` option; \`VerifyChainOptions = Record<string, never>\`. Throws TypeError with a migration message on any unrecognized key.
- \`typescript/src/cli.ts\`: \`synthetic_step_count\` rename.
- All prose scrubbed: \`python/src/asqav/{ietf_projection,client,keys}.py\`, \`typescript/src/{index,ietfProjection,cli}.ts\`, \`python/docs/CLI.md\`, \`typescript/README.md\`, \`docs/fingerprint-spec.md\`, \`CHANGELOG.md\`.

Tests: every \`test_legacy_*\` deleted or renamed; every docstring rephrased.

## Breaking-change surface (intentional)

- \`verify_chain(legacy_chain=True)\` -> TypeError.
- \`verifyChain(records, { legacy: true })\` -> \`TypeError\` with migration message. **Codex feedback addressed**: prior silent-fallback to v2 is replaced with explicit throw.
- \`ReplayStep.legacy_chain\` attribute removed.
- \`replay-verify --strict\` JSON output: \`legacy_step_count\` -> \`synthetic_step_count\`; \`legacy_chain\` -> \`has_envelope\` (inverted).

## Tooling

Cycle 8 also installed (via \`uv tool\`):
- \`vulture\` (Python dead-code finder)
- \`ruff\` (Python linter, F401/F811/F841 unused imports/vars/etc.)
- \`autoflake\` (unused imports auto-removal)
- \`unimport\` (Python unused imports)

Verification:

    \$ uv tool run ruff check python/src/asqav/ --select F401,F811,F841
    All checks passed!
    \$ uv tool run unimport --check python/src/asqav/
    no unused import

5 \"legacy\" refs remain: all intentional documentation of the removed \`legacy\` option in the TypeError message + the migration-guard test name. Zero \"pre-migration\" / \"pre-IETF\" / \"previously\" / \"formerly\" outside that.

Diff: 25 files changed, 143 insertions(+), 419 deletions(-).

comment hygiene clean