### PR TITLE
chore(purge): scrub remaining legacy mentions from verifyChain throw

### DIFF
--- a/typescript/src/replay.ts
+++ b/typescript/src/replay.ts
@@ -60,7 +60,7 @@ export interface ChainVerificationResult {
 }
 
 /** Reserved for future verifier knobs. No keys are accepted today;
- * passing any unrecognized key (including the removed `legacy` flag)
+ * passing any unrecognized key (including flag names removed in this release)
  * throws so silent-fallback bugs surface immediately. */
 export type VerifyChainOptions = Record<string, never>;
 
@@ -72,9 +72,9 @@ export type VerifyChainOptions = Record<string, never>;
  * `chainIntegrity=false` because the predecessor links won't match.
  *
  * @throws TypeError if `options` carries any unrecognized key. The
- *   removed `legacy` flag is the most common offender; callers that
- *   verified synthetic-shape chains must migrate their bundles to
- *   carry `signedEnvelope` on every step.
+ *   `signedEnvelope` is now required on every step; callers that
+ *   relied on a synthetic chain shape must migrate their bundles
+ *   accordingly.
  */
 export function verifyChain(
   records: ChainRecord[],
@@ -84,7 +84,7 @@ export function verifyChain(
   if (unknownKeys.length > 0) {
     throw new TypeError(
       `verifyChain: unsupported option(s) ${unknownKeys.map((k) => JSON.stringify(k)).join(", ")}. ` +
-        "The verifier accepts no options today; passing { legacy: true } from a prior release " +
+        "The verifier accepts no options today. " +
         "is not honored and would have silently fallen back to v2 verification. " +
         "Migrate bundles to carry `signedEnvelope` on every step.",
     );

--- a/typescript/tests/replay.test.ts
+++ b/typescript/tests/replay.test.ts
@@ -111,7 +111,7 @@ describe("verifyChain (v2, IETF profile)", () => {
     expect(result.chainIntegrity).toBe(true);
   });
 
-  it("throws when given an unsupported option (e.g. removed legacy flag)", () => {
+  it("throws when given an unsupported option", () => {
     const env = {
       signature_id: "sig_1",
       action_type: "api:call",
@@ -119,7 +119,7 @@ describe("verifyChain (v2, IETF profile)", () => {
       previousReceiptHash: FIRST_RECEIPT_SEED,
     };
     expect(() =>
-      verifyChain([{ signedEnvelope: env }], { legacy: true } as never),
+      verifyChain([{ signedEnvelope: env }], { unknownFlag: true } as never),
     ).toThrow(TypeError);
   });
 });


### PR DESCRIPTION
## Why

Maintainer directive: zero \"legacy\" anywhere in source. PR #165 left 5 intentional references inside the TypeError message + migration-guard test name; this removes them. Migration documentation lives in the PR body + CHANGELOG (not source).

## What

- \`typescript/src/replay.ts\`: migration note + TypeError message reworded.
- \`typescript/tests/replay.test.ts\`: test title + body switched to \`{ unknownFlag: true }\`.

## Verification

    \$ rg -i \"legacy\" python/ typescript/ docs/ CHANGELOG.md -n
    (zero hits)

comment hygiene clean