### PR TITLE
chore(cleanup): drop unused JsonValue exports

### DIFF
--- a/typescript/src/canonicalize.ts
+++ b/typescript/src/canonicalize.ts
@@ -16,7 +16,7 @@
 
 import { createHash, createHmac } from "node:crypto";
 
-export type JsonValue =
+type JsonValue =
   | null
   | boolean
   | number

--- a/typescript/src/jcs.ts
+++ b/typescript/src/jcs.ts
@@ -29,7 +29,7 @@
  * is the named landing for the IETF profile callers.
  */
 
-export type JsonValue =
+type JsonValue =
   | null
   | boolean
   | number


### PR DESCRIPTION
Knip flagged `JsonValue` as exported-but-unused in `canonicalize.ts` + `jcs.ts`. Zero external consumers; drop the `export` keyword. Examples files (knip's other findings) are reference documentation; left in place.

comment hygiene clean