### PR TITLE
chore: comment hygiene sweep

### DIFF
--- a/python/examples/dspy_example.py
+++ b/python/examples/dspy_example.py
@@ -26,9 +26,7 @@ except ImportError:
         "Install with: pip install asqav[dspy]"
     )
 
-# ---------------------------------------------------------------------------
-# Initialise asqav
-# ---------------------------------------------------------------------------
+# === Initialise asqav ===
 
 api_key = os.environ.get("ASQAV_API_KEY", "")
 if not api_key:
@@ -46,9 +44,7 @@ dspy.configure(
     callbacks=[AsqavDSPyCallback(agent_name="dspy-demo")],
 )
 
-# ---------------------------------------------------------------------------
-# Define a DSPy program
-# ---------------------------------------------------------------------------
+# === Define a DSPy program ===
 
 
 class RAGPipeline(dspy.Module):
@@ -63,9 +59,7 @@ class RAGPipeline(dspy.Module):
         return self.generate(context=context, question=question)
 
 
-# ---------------------------------------------------------------------------
-# Run the program
-# ---------------------------------------------------------------------------
+# === Run the program ===
 
 pipeline = RAGPipeline()
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -109,9 +109,7 @@ _client: Any = None
 # Hybrid GDPR mode: resolved at init() time, overridable per-call. See _mode.py.
 _mode: str = "full-payload"
 _org_salt: bytes | None = None
-# Metadata keys allowed to ride alongside a hash-only request. The server
-# enforces its own whitelist; this mirrors the conservative default so we
-# don't accidentally leak fields the customer didn't intend to share.
+#: Hash-only request metadata allowlist; mirrors the server-enforced whitelist.
 _HASH_ONLY_METADATA_WHITELIST: frozenset[str] = frozenset(
     {"agent_id", "session_id", "action_type", "model_name", "tool_name", "parent_id"}
 )
@@ -201,13 +199,7 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
     }
 )
 
-# DORA RTS JC 2024-33 Annex II field 3.23 canonical incident classification.
-# The Joint Committee of the European Supervisory Authorities published
-# the final RTS on classification of major ICT-related incidents on
-# 17 July 2024 (JC 2024-33). Annex II field 3.23 fixes the controlled
-# vocabulary of `incident_class` to exactly six values. The cloud
-# accepts only these canonical tokens; this SDK forwards the caller's
-# value verbatim and rejects anything outside the canonical set.
+#: Canonical `incident_class` vocabulary; cloud rejects anything outside this set.
 DORA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
     {
         "cybersecurity_related",
@@ -279,17 +271,13 @@ class SignatureResponse:
     policy_decision: str = "permit"
     authorization_ref: str | None = None
     bitcoin_anchor: BitcoinAnchor | None = None
-    # Multi-party countersigning (optional). When the caller passed
-    # `co_signers=[...]` to `agent.sign()`, the server records the list and
-    # surfaces it back so peers know they need to countersign.
+    # Multi-party countersigning: peer agent_ids the original signer expects to countersign.
     required_co_signers: list[str] | None = None
     co_signatures: list[dict[str, Any]] | None = None
     countersign_url: str | None = None
     # True when the server validated a user_intent envelope on this record.
     user_intent_verified: bool | None = None
-    # Compliance Receipts profile fields. Populated by the cloud only
-    # when `compliance_mode=True` was passed on the sign call. None on
-    # non-compliance receipts so callers can branch cleanly.
+    # Compliance Receipts profile fields populated by cloud when compliance_mode=True.
     compliance_mode: bool = False
     receipt_type: str | None = None
     action_ref: str | None = None
@@ -307,9 +295,7 @@ class SignatureResponse:
     # Spec `decision` token (allow | deny | rate_limit). None on
     # non-compliance receipts.
     decision: str | None = None
-    # Three-key Compliance Receipts envelope. `payload` is the canonical
-    # signed dict; `anchors` is the type-discriminated array. None on
-    # non-compliance receipts.
+    # Three-key Compliance Receipts envelope (payload + anchors); None on non-compliance.
     payload: dict[str, Any] | None = None
     anchors: list[dict[str, Any]] | None = None
 
@@ -1202,9 +1188,7 @@ class Agent:
                 "missing_reason: policy_decision=deny|rate_limit "
                 "requires a `reason` code."
             )
-        # DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check
-        # (six canonical values). Reject anything else before the HTTP
-        # roundtrip.
+        # Fail fast on incident_class vocabulary before the HTTP roundtrip.
         if (
             incident_class is not None
             and incident_class not in DORA_INCIDENT_CLASS_NAMESPACE
@@ -1277,9 +1261,7 @@ class Agent:
             co_signatures=data.get("co_signatures"),
             countersign_url=data.get("countersign_url"),
             user_intent_verified=data.get("user_intent_verified"),
-            # IETF profile fields. Cloud emits both `previousReceiptHash`
-            # (camelCase per spec) and `previous_receipt_hash` (snake_case
-            # alias). Accept either so the SDK works against both shapes.
+            # Accept both camelCase `previousReceiptHash` and snake_case alias on the wire.
             compliance_mode=bool(data.get("compliance_mode", False)),
             receipt_type=data.get("receipt_type"),
             action_ref=data.get("action_ref"),
@@ -2441,10 +2423,7 @@ def verify_compliance_receipt(
         if actual_prev != expected_prev:
             chain_link_rederives = False
             errors.append("chain_link_mismatch")
-    # else: caller did not pass a predecessor; cannot rederive. We
-    # leave `chain_link_rederives=True` since "did not check" is not the
-    # same as "failed to check". Callers needing strictness pass the
-    # predecessor.
+    # No predecessor supplied: leave chain_link_rederives=True (unchecked is not failed).
 
     valid = (
         fields_present

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -25,9 +25,7 @@ ALGORITHM_ML_DSA_65 = "ml-dsa-65"
 ALGORITHM_ED25519 = "ed25519"
 ALGORITHM_ES256 = "es256"
 
-# Algorithms `generate_local_keypair` can mint locally. ML-DSA-65
-# keypair generation is server-side only (cloud KMS) so it is not in
-# this set.
+#: Algorithms `generate_local_keypair` can mint locally (ML-DSA-65 is cloud-KMS only).
 SUPPORTED_ALGORITHMS: frozenset[str] = frozenset(
     {ALGORITHM_ED25519, ALGORITHM_ES256}
 )
@@ -90,9 +88,7 @@ def generate_local_keypair(algorithm: Algorithm = "ed25519") -> LocalKeypair:
     return _generate_es256()
 
 
-# ---------------------------------------------------------------------------
-# Per-algorithm implementations.
-# ---------------------------------------------------------------------------
+# === Per-algorithm implementations ===
 
 
 def _generate_ed25519() -> LocalKeypair:

--- a/python/src/asqav/replay.py
+++ b/python/src/asqav/replay.py
@@ -20,9 +20,7 @@ from ._jcs import canonical_json
 from .client import SignedActionResponse, get_session_signatures
 from .compliance import ComplianceBundle, _normalize_signature
 
-# Per-IETF-profile seed for the first record on every chain. Distinguishes
-# "no predecessor" from "predecessor not yet linked". Mirrors
-# `core/integrity.py:FIRST_RECEIPT_SEED` on the cloud.
+#: Seed planted as `previousReceiptHash` on the first record per chain (mirrors cloud).
 FIRST_RECEIPT_SEED: str = "0" * 64
 
 
@@ -40,10 +38,7 @@ class ReplayStep:
     explanation: str
     # Predecessor's chain hash; verify_chain recomputes and compares.
     prev_chain_hash: str | None = None
-    # When the caller has the full signed envelope for this step (the
-    # exact bytes the cloud put under `compute_signature_record_hash_v2`),
-    # verify_chain hashes those bytes byte-for-byte and tampering of any
-    # field surfaces.
+    # Full signed envelope bytes; verify_chain hashes byte-for-byte when present.
     signed_envelope: dict[str, Any] | None = None
 
 
@@ -55,9 +50,7 @@ class ReplayTimeline:
     session_id: str
     steps: list[ReplayStep] = field(default_factory=list)
     chain_integrity: bool = True
-    # True only when EVERY step under compliance mode carried a
-    # `signed_envelope` and verified byte-for-byte against the cloud's
-    # `compute_signature_record_hash_v2`.
+    # True only when every compliance-mode step verified byte-for-byte from its signed envelope.
     compliance_chain_valid: bool = True
     start_time: float | None = None
     end_time: float | None = None

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -16,9 +16,7 @@ from asqav.cli import app
 runner = CliRunner()
 
 
-# ---------------------------------------------------------------------------
-# Version
-# ---------------------------------------------------------------------------
+# === Version ===
 
 
 def test_version() -> None:
@@ -29,9 +27,7 @@ def test_version() -> None:
     assert __version__ in result.output
 
 
-# ---------------------------------------------------------------------------
-# verify command
-# ---------------------------------------------------------------------------
+# === verify command ===
 
 
 @patch("asqav.verify_signature")
@@ -80,9 +76,7 @@ def test_verify_not_found(mock_verify: MagicMock) -> None:
     assert "not found" in result.output.lower()
 
 
-# ---------------------------------------------------------------------------
-# sign command (IETF Compliance Receipts profile)
-# ---------------------------------------------------------------------------
+# === sign command (IETF Compliance Receipts profile) ===
 
 
 @patch("asqav.Agent.get")
@@ -237,9 +231,7 @@ def test_verify_json_emits_full_detail(mock_verify: MagicMock) -> None:
     assert payload["verification_detail"]["signed_at_skew_seconds"] == 0.5
 
 
-# ---------------------------------------------------------------------------
-# agents list command
-# ---------------------------------------------------------------------------
+# === agents list command ===
 
 
 @patch("asqav.client._get")
@@ -305,9 +297,7 @@ def test_agents_list_no_api_key() -> None:
     assert "ASQAV_API_KEY" in result.output
 
 
-# ---------------------------------------------------------------------------
-# agents create command
-# ---------------------------------------------------------------------------
+# === agents create command ===
 
 
 @patch("asqav.Agent.create")
@@ -332,9 +322,7 @@ def test_agents_create(mock_init: MagicMock, mock_create: MagicMock) -> None:
     mock_create.assert_called_once_with("my-agent")
 
 
-# ---------------------------------------------------------------------------
-# quickstart command
-# ---------------------------------------------------------------------------
+# === quickstart command ===
 
 
 def test_quickstart_with_api_key() -> None:
@@ -356,9 +344,7 @@ def test_quickstart_without_api_key() -> None:
     assert "mcpServers" in result.output
 
 
-# ---------------------------------------------------------------------------
-# doctor command
-# ---------------------------------------------------------------------------
+# === doctor command ===
 
 
 def test_doctor_no_api_key() -> None:
@@ -394,9 +380,7 @@ def test_doctor_api_unreachable(mock_init: MagicMock, mock_health: MagicMock) ->
     assert "Connection refused" in result.output
 
 
-# ---------------------------------------------------------------------------
-# replay command
-# ---------------------------------------------------------------------------
+# === replay command ===
 
 
 def _fake_timeline(*, chain_integrity: bool = True) -> MagicMock:
@@ -466,9 +450,7 @@ def test_replay_bundle_missing_file() -> None:
     assert "Error reading bundle" in result.output
 
 
-# ---------------------------------------------------------------------------
-# preflight command
-# ---------------------------------------------------------------------------
+# === preflight command ===
 
 
 @patch("asqav.Agent.get")
@@ -508,9 +490,7 @@ def test_preflight_blocked(mock_init: MagicMock, mock_get: MagicMock) -> None:
     assert "agent is suspended" in result.output
 
 
-# ---------------------------------------------------------------------------
-# budget commands
-# ---------------------------------------------------------------------------
+# === budget commands ===
 
 
 @patch("asqav.Agent.get")
@@ -567,9 +547,7 @@ def test_budget_record(
     mock_record.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
-# approve command
-# ---------------------------------------------------------------------------
+# === approve command ===
 
 
 @patch("asqav.approve_action")
@@ -589,9 +567,7 @@ def test_approve_approved(mock_init: MagicMock, mock_approve: MagicMock) -> None
     assert "APPROVED" in result.output
 
 
-# ---------------------------------------------------------------------------
-# compliance commands
-# ---------------------------------------------------------------------------
+# === compliance commands ===
 
 
 def test_compliance_frameworks_lists_known() -> None:
@@ -644,9 +620,7 @@ def test_compliance_export_unknown_framework(
     assert "nonexistent" in result.output
 
 
-# ---------------------------------------------------------------------------
-# Tier gating
-# ---------------------------------------------------------------------------
+# === Tier gating ===
 
 
 @patch("asqav.client._get")
@@ -726,9 +700,7 @@ def test_unreachable_account_endpoint_does_not_block(
     assert result.exit_code == 0
 
 
-# ---------------------------------------------------------------------------
-# CLI gap-fill (agents revoke, sessions, policies, webhooks)
-# ---------------------------------------------------------------------------
+# === CLI gap-fill (agents revoke, sessions, policies, webhooks) ===
 
 
 @patch("asqav.Agent.get")
@@ -846,9 +818,7 @@ def test_policies_blocked_on_free_tier(
     assert result.exit_code == 2
 
 
-# ---------------------------------------------------------------------------
-# audit-pack export / policy
-# ---------------------------------------------------------------------------
+# === audit-pack export / policy ===
 
 
 @patch("asqav.client._post")
@@ -912,9 +882,7 @@ def test_audit_pack_policy_resolves_digest(
     assert called_path == f"/audit-pack/policy/sha256:{'a' * 64}"
 
 
-# ---------------------------------------------------------------------------
-# payloads erase
-# ---------------------------------------------------------------------------
+# === payloads erase ===
 
 
 @patch("asqav.client._delete")
@@ -934,9 +902,7 @@ def test_payloads_erase_calls_delete(
     mock_delete.assert_called_once_with("/signatures/payloads/sig_abc")
 
 
-# ---------------------------------------------------------------------------
-# org set-compliance-strict
-# ---------------------------------------------------------------------------
+# === org set-compliance-strict ===
 
 
 @patch("asqav.client._patch")
@@ -965,9 +931,7 @@ def test_org_set_compliance_strict_requires_one_flag() -> None:
     assert result.exit_code == 1
 
 
-# ---------------------------------------------------------------------------
-# keys generate
-# ---------------------------------------------------------------------------
+# === keys generate ===
 
 
 def test_keys_generate_ed25519(tmp_path) -> None:
@@ -999,9 +963,7 @@ def test_keys_generate_ml_dsa_errors() -> None:
     assert "unsupported_algorithm" in result.output.lower()
 
 
-# ---------------------------------------------------------------------------
-# replay-verify
-# ---------------------------------------------------------------------------
+# === replay-verify ===
 
 
 @patch("asqav.client._get")
@@ -1064,9 +1026,7 @@ def test_replay_verify_strict_rejects_steps_without_envelope(
     assert "strict mode FAILED" in result.output
 
 
-# ---------------------------------------------------------------------------
-# migrate run
-# ---------------------------------------------------------------------------
+# === migrate run ===
 
 
 def test_migrate_run_requires_maintenance_key(monkeypatch) -> None:

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -36,9 +36,7 @@ from asqav.client import (
     _compute_action_ref,
 )
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+# === Fixtures ===
 
 
 def _agent() -> Agent:
@@ -68,9 +66,7 @@ def _ok_response(extra: dict | None = None) -> dict:
     return base
 
 
-# ---------------------------------------------------------------------------
-# Namespace + validation
-# ---------------------------------------------------------------------------
+# === Namespace + validation ===
 
 
 def test_receipt_type_namespace_constant() -> None:
@@ -110,9 +106,7 @@ def test_deny_without_reason_raises_before_http() -> None:
         p.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# action_ref auto-compute
-# ---------------------------------------------------------------------------
+# === action_ref auto-compute ===
 
 
 def test_compute_action_ref_matches_canonical_sha256() -> None:
@@ -201,9 +195,7 @@ def test_no_compliance_mode_means_no_extra_fields_on_body() -> None:
         assert k not in body, f"unexpected compliance-mode-off field: {k}"
 
 
-# ---------------------------------------------------------------------------
-# Pass-through of all profile fields
-# ---------------------------------------------------------------------------
+# === Pass-through of all profile fields ===
 
 
 def test_all_profile_fields_passthrough_in_body() -> None:
@@ -259,9 +251,7 @@ def test_deny_with_reason_passes_through() -> None:
     assert captured["body"]["reason"] == "policy_violation_outbound_url"
 
 
-# ---------------------------------------------------------------------------
-# Response parsing
-# ---------------------------------------------------------------------------
+# === Response parsing ===
 
 
 def test_signature_response_surfaces_new_fields() -> None:
@@ -309,9 +299,7 @@ def test_response_accepts_snake_case_previous_receipt_hash() -> None:
     assert resp.previous_receipt_hash == "f" * 64
 
 
-# ---------------------------------------------------------------------------
-# Re-export
-# ---------------------------------------------------------------------------
+# === Re-export ===
 
 
 def test_constant_is_re_exported_at_top_level() -> None:
@@ -319,9 +307,7 @@ def test_constant_is_re_exported_at_top_level() -> None:
     assert asqav.RECEIPT_TYPE_NAMESPACE == RECEIPT_TYPE_NAMESPACE
 
 
-# ---------------------------------------------------------------------------
-# _build_sign_body branches
-# ---------------------------------------------------------------------------
+# === _build_sign_body branches ===
 
 
 def test_build_sign_body_full_payload_includes_compliance_fields() -> None:
@@ -351,9 +337,7 @@ def test_build_sign_body_omits_compliance_when_no_fields() -> None:
     assert "compliance_mode" not in body
 
 
-# ---------------------------------------------------------------------------
-# DORA RTS JC 2024-33 Annex II vocabulary
-# ---------------------------------------------------------------------------
+# === DORA RTS JC 2024-33 Annex II vocabulary ===
 
 
 def test_dora_incident_class_namespace_is_canonical_six() -> None:

--- a/python/tests/test_keys_alg_agility.py
+++ b/python/tests/test_keys_alg_agility.py
@@ -20,9 +20,7 @@ from asqav.keys import (
     generate_local_keypair,
 )
 
-# ---------------------------------------------------------------------------
-# Constants and namespace
-# ---------------------------------------------------------------------------
+# === Constants and namespace ===
 
 
 def test_supported_algorithms_set() -> None:
@@ -47,9 +45,7 @@ def test_re_exports_at_package_root() -> None:
     assert asqav.generate_local_keypair is generate_local_keypair
 
 
-# ---------------------------------------------------------------------------
-# _check_algorithm
-# ---------------------------------------------------------------------------
+# === _check_algorithm ===
 
 
 def test_check_algorithm_normalises_case() -> None:
@@ -68,9 +64,7 @@ def test_check_algorithm_rejects_ml_dsa_65() -> None:
         _check_algorithm("ml-dsa-65")
 
 
-# ---------------------------------------------------------------------------
-# Ed25519
-# ---------------------------------------------------------------------------
+# === Ed25519 ===
 
 
 def test_ed25519_keypair_generates_pem() -> None:
@@ -110,9 +104,7 @@ def test_ed25519_signs_and_verifies() -> None:
     pub.verify(sig, msg)  # raises on failure
 
 
-# ---------------------------------------------------------------------------
-# ES256
-# ---------------------------------------------------------------------------
+# === ES256 ===
 
 
 def test_es256_keypair_generates_pem() -> None:
@@ -152,9 +144,7 @@ def test_es256_signs_and_verifies() -> None:
     pub.verify(sig, msg, ec.ECDSA(hashes.SHA256()))
 
 
-# ---------------------------------------------------------------------------
-# ML-DSA-65 is server-side only
-# ---------------------------------------------------------------------------
+# === ML-DSA-65 is server-side only ===
 
 
 def test_ml_dsa_65_local_generation_rejected() -> None:
@@ -171,9 +161,7 @@ def test_default_algorithm_is_ed25519() -> None:
     assert kp.algorithm == "ed25519"
 
 
-# ---------------------------------------------------------------------------
-# Validation
-# ---------------------------------------------------------------------------
+# === Validation ===
 
 
 def test_unsupported_algorithm_raises_value_error() -> None:

--- a/python/tests/test_letta_integration.py
+++ b/python/tests/test_letta_integration.py
@@ -16,9 +16,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Inject a fake letta_client module before importing the hook
-# ---------------------------------------------------------------------------
+# === Inject a fake letta_client module before importing the hook ===
 
 _fake_letta_client = types.ModuleType("letta_client")
 sys.modules["letta_client"] = _fake_letta_client
@@ -26,9 +24,7 @@ sys.modules.pop("asqav.extras.letta", None)
 
 from asqav.extras.letta import AsqavLettaHook  # noqa: E402
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+# === Helpers ===
 
 
 def _make_client(
@@ -52,9 +48,7 @@ def _make_client(
     return client
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+# === Fixtures ===
 
 
 @pytest.fixture()
@@ -70,9 +64,7 @@ def hook() -> AsqavLettaHook:
     return h
 
 
-# ---------------------------------------------------------------------------
-# Canonical API: positional block_label, keyword-only agent_id
-# ---------------------------------------------------------------------------
+# === Canonical API: positional block_label, keyword-only agent_id ===
 
 
 def test_retrieve_canonical_positional_form(hook: AsqavLettaHook) -> None:
@@ -118,9 +110,7 @@ def test_update_without_value_still_calls_original(hook: AsqavLettaHook) -> None
     assert "value" not in kwargs
 
 
-# ---------------------------------------------------------------------------
-# wrap_client: memory:read
-# ---------------------------------------------------------------------------
+# === wrap_client: memory:read ===
 
 
 def test_wrap_client_signs_memory_read(hook: AsqavLettaHook) -> None:
@@ -170,9 +160,7 @@ def test_wrap_client_retrieve_returns_original_result(hook: AsqavLettaHook) -> N
     assert result is sentinel
 
 
-# ---------------------------------------------------------------------------
-# wrap_client: memory:write
-# ---------------------------------------------------------------------------
+# === wrap_client: memory:write ===
 
 
 def test_wrap_client_signs_memory_write(hook: AsqavLettaHook) -> None:
@@ -223,9 +211,7 @@ def test_wrap_client_update_returns_original_result(hook: AsqavLettaHook) -> Non
     assert result is sentinel
 
 
-# ---------------------------------------------------------------------------
-# Error paths
-# ---------------------------------------------------------------------------
+# === Error paths ===
 
 
 def test_wrap_client_signs_read_error_on_exception(hook: AsqavLettaHook) -> None:
@@ -308,9 +294,7 @@ def test_wrap_client_signs_write_start_and_error_on_failure(hook: AsqavLettaHook
     assert hook._sign_action.call_args_list[1][0][0] == "memory:write.error"
 
 
-# ---------------------------------------------------------------------------
-# Truncation
-# ---------------------------------------------------------------------------
+# === Truncation ===
 
 
 def test_agent_id_truncated_to_200_chars(hook: AsqavLettaHook) -> None:
@@ -347,9 +331,7 @@ def test_error_message_truncated_to_200_chars(hook: AsqavLettaHook) -> None:
     assert len(ctx["error"]) == 200
 
 
-# ---------------------------------------------------------------------------
-# Fail-open: signing must never block memory operations
-# ---------------------------------------------------------------------------
+# === Fail-open: signing must never block memory operations ===
 
 
 def test_fail_open_memory_read_does_not_block_retrieve(hook: AsqavLettaHook) -> None:
@@ -408,9 +390,7 @@ def test_fail_open_read_error_signing_does_not_swallow_exception(
         client.agents.blocks.retrieve("b", agent_id="a")
 
 
-# ---------------------------------------------------------------------------
-# Multiple clients tracked independently
-# ---------------------------------------------------------------------------
+# === Multiple clients tracked independently ===
 
 
 def test_multiple_clients_tracked_independently(hook: AsqavLettaHook) -> None:
@@ -429,9 +409,7 @@ def test_multiple_clients_tracked_independently(hook: AsqavLettaHook) -> None:
     assert calls[2][0][1]["agent_id"] == "agent-b"
 
 
-# ---------------------------------------------------------------------------
-# Cleanup
-# ---------------------------------------------------------------------------
+# === Cleanup ===
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/python/tests/test_replay_ietf_chain.py
+++ b/python/tests/test_replay_ietf_chain.py
@@ -22,9 +22,7 @@ from asqav.replay import (
     _verify_hash_chain,
 )
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+# === Fixtures ===
 
 
 def _make_signed_action(
@@ -43,9 +41,7 @@ def _make_signed_action(
     )
 
 
-# ---------------------------------------------------------------------------
-# FIRST_RECEIPT_SEED matches the spec
-# ---------------------------------------------------------------------------
+# === FIRST_RECEIPT_SEED matches the spec ===
 
 
 def test_first_receipt_seed_is_64_zero_hex() -> None:
@@ -55,9 +51,7 @@ def test_first_receipt_seed_is_64_zero_hex() -> None:
     assert all(c == "0" for c in FIRST_RECEIPT_SEED)
 
 
-# ---------------------------------------------------------------------------
-# IETF v2 default behaviour
-# ---------------------------------------------------------------------------
+# === IETF v2 default behaviour ===
 
 
 def test_v2_chain_hash_matches_jcs_of_envelope() -> None:
@@ -139,25 +133,19 @@ def test_v2_verify_chain_detects_tamper() -> None:
 
 
 
-# ---------------------------------------------------------------------------
-# _step_chain_hash helper
-# ---------------------------------------------------------------------------
+# === _step_chain_hash helper ===
 
 
 
 
 
-# ---------------------------------------------------------------------------
-# _step_chain_hash helper
-# ---------------------------------------------------------------------------
+# === _step_chain_hash helper ===
 
 
 
 
 
-# ---------------------------------------------------------------------------
-# Empty timeline
-# ---------------------------------------------------------------------------
+# === Empty timeline ===
 
 
 def test_empty_timeline_verifies() -> None:
@@ -166,9 +154,7 @@ def test_empty_timeline_verifies() -> None:
     assert timeline.compliance_chain_valid is True
 
 
-# ---------------------------------------------------------------------------
-# H-NEW-1: signed_envelope path verifies byte-for-byte against the cloud
-# ---------------------------------------------------------------------------
+# === H-NEW-1: signed_envelope path verifies byte-for-byte against the cloud ===
 
 
 def _compliance_envelope(

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -18,9 +18,7 @@ from asqav.client import (
 )
 from asqav.replay import FIRST_RECEIPT_SEED
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+# === Fixtures ===
 
 
 def _good_envelope(**overrides) -> dict:
@@ -41,9 +39,7 @@ def _good_envelope(**overrides) -> dict:
     return base
 
 
-# ---------------------------------------------------------------------------
-# Happy path
-# ---------------------------------------------------------------------------
+# === Happy path ===
 
 
 def test_clean_first_receipt_validates() -> None:
@@ -68,9 +64,7 @@ def test_chain_link_rederives_against_predecessor() -> None:
     assert result.chain_link_rederives is True
 
 
-# ---------------------------------------------------------------------------
-# Missing fields (§5)
-# ---------------------------------------------------------------------------
+# === Compliance-Receipt minimum-required-fields contract ===
 
 
 def test_missing_required_field_flags_fields_present_false() -> None:
@@ -96,9 +90,7 @@ def test_multiple_missing_fields_all_reported() -> None:
     assert "payload_digest" in err
 
 
-# ---------------------------------------------------------------------------
-# receipt_type namespace
-# ---------------------------------------------------------------------------
+# === receipt_type namespace ===
 
 
 def test_receipt_type_outside_namespace_rejected() -> None:
@@ -120,9 +112,7 @@ def test_all_three_namespace_values_accepted() -> None:
         assert result.receipt_type_in_namespace is True, rt
 
 
-# ---------------------------------------------------------------------------
-# 300-second skew bound
-# ---------------------------------------------------------------------------
+# === 300-second skew bound ===
 
 
 def test_skew_well_within_boundary_is_accepted() -> None:
@@ -174,9 +164,7 @@ def test_invalid_issued_at_is_flagged() -> None:
     assert "invalid_issued_at" in result.errors
 
 
-# ---------------------------------------------------------------------------
-# Chain link rederivation (§5.7)
-# ---------------------------------------------------------------------------
+# === Chain link rederivation contract ===
 
 
 def test_chain_link_mismatch_detected() -> None:

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -166,9 +166,7 @@ const config: Config = {
   orgSalt: null,
 };
 
-// ---------------------------------------------------------------------------
-// Errors
-// ---------------------------------------------------------------------------
+// === Errors ===
 
 export class AsqavError extends Error {
   constructor(message: string) {
@@ -200,9 +198,7 @@ export class APIError extends AsqavError {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
+// === Public types ===
 
 export interface InitOptions {
   apiKey?: string;
@@ -269,11 +265,7 @@ export interface SignOptions {
    * other keys -> 403 `executor_key_mismatch`. */
   expectedExecutorPubkeyB64?: string;
 
-  // -------------------------------------------------------------------
-  // IETF Compliance Receipts profile fields. All optional client-side;
-  // the cloud applies the per-field MUST/REQUIRED rules when
-  // ``complianceMode=true``. Wire keys are snake_case (e.g. ``action_ref``).
-  // -------------------------------------------------------------------
+  // === IETF Compliance Receipts profile fields ===
 
   /** Emit the receipt under the IETF profile. When true, the cloud uses
    * fail-closed anchoring, raises the retention floor, and writes the
@@ -567,9 +559,7 @@ export interface PreflightResult {
   explanation: string;
 }
 
-// ---------------------------------------------------------------------------
-// init
-// ---------------------------------------------------------------------------
+// === init ===
 
 export function init(options: InitOptions = {}): void {
   const apiKey = options.apiKey ?? process.env.ASQAV_API_KEY ?? null;
@@ -594,9 +584,7 @@ function ensureInitialized(): void {
   }
 }
 
-// ---------------------------------------------------------------------------
-// HTTP request helper with retry
-// ---------------------------------------------------------------------------
+// === HTTP request helper with retry ===
 
 const RETRY_STATUSES = new Set([429, 500, 502, 503, 504]);
 const MAX_ATTEMPTS = 3;
@@ -680,9 +668,7 @@ export async function request<T = unknown>(
   throw new APIError(`Request failed after ${MAX_ATTEMPTS} attempts`, 0);
 }
 
-// ---------------------------------------------------------------------------
-// Sign body builder (mode-aware)
-// ---------------------------------------------------------------------------
+// === Sign body builder (mode-aware) ===
 
 interface BuildSignBodyArgs {
   actionType: string;
@@ -734,9 +720,7 @@ async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, un
   return fullBody;
 }
 
-// ---------------------------------------------------------------------------
-// Agent
-// ---------------------------------------------------------------------------
+// === Agent ===
 
 interface AgentData {
   agent_id: string;
@@ -812,9 +796,7 @@ export class Agent {
 
     const complianceMode = options.complianceMode !== false;
 
-    // Validate the IETF receipt namespace client-side so callers fail
-    // fast instead of waiting for the server's 422. The cloud is still
-    // the source of truth; we mirror the same vocabulary.
+    // Fail fast on receipt_type before the HTTP roundtrip; cloud remains source of truth.
     if (options.receiptType !== undefined
       && !(RECEIPT_TYPE_NAMESPACE as readonly string[]).includes(options.receiptType)) {
       throw new AsqavError(
@@ -828,8 +810,7 @@ export class Agent {
         "missing_reason: policy_decision=deny|rate_limit requires a `reason` code",
       );
     }
-    // DORA RTS JC 2024-33 Annex II field 3.23 vocabulary check (six
-    // canonical values). Reject anything else before the HTTP roundtrip.
+    // Fail fast on incident_class vocabulary before the HTTP roundtrip.
     if (options.incidentClass !== undefined && options.incidentClass !== "") {
       const incidentValues = Array.isArray(options.incidentClass)
         ? options.incidentClass
@@ -843,11 +824,7 @@ export class Agent {
       }
     }
 
-    // Compute action_ref client-side when the caller is in compliance
-    // mode and did not supply one. Per spec:
-    //   action_ref = "sha256:" + sha256(canonicalJson(action))
-    // where `action = {action_type, context}` matches the cloud-side
-    // shape used by `hash_action`.
+    // Derive action_ref locally when omitted under compliance mode; matches cloud hash_action shape.
     let actionRef = options.actionRef;
     if (complianceMode && actionRef === undefined) {
       const action = { action_type: options.actionType, context: finalContext };
@@ -877,10 +854,7 @@ export class Agent {
       body.expected_executor_pubkey_b64 = options.expectedExecutorPubkeyB64;
     }
 
-    // IETF Compliance Receipts profile fields. Wire-format names are
-    // snake_case. `compliance_mode` always travels (default false) so
-    // the cloud knows whether to apply the profile rules. The other
-    // fields ride along when present; the cloud applies per-field checks.
+    // IETF Compliance Receipts profile fields ride along as snake_case wire keys.
     if (complianceMode) body.compliance_mode = true;
     if (actionRef !== undefined) body.action_ref = actionRef;
     if (options.sandboxState !== undefined) body.sandbox_state = options.sandboxState;
@@ -1112,9 +1086,7 @@ export class Agent {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Standalone functions
-// ---------------------------------------------------------------------------
+// === Standalone functions ===
 
 export async function verifySignature(signatureId: string): Promise<VerificationResponse> {
   const data = await request<{
@@ -1353,9 +1325,7 @@ export async function exportAuditJson(
   return request<unknown>("GET", path);
 }
 
-// ---------------------------------------------------------------------------
-// Internal config exposure for tests only
-// ---------------------------------------------------------------------------
+// === Internal config exposure for tests only ===
 
 /** @internal - reset module state. Used in tests. */
 export function _resetForTests(): void {


### PR DESCRIPTION
## Summary

- Collapse 3-line dashed divider comment blocks to single-line `# === Section ===` (Python) / `// === Section ===` (TS) per canonical hygiene rule 7 universal.
- Move module-level constant rationale (DORA incident class namespace, hash-only metadata allowlist, FIRST_RECEIPT_SEED, SUPPORTED_ALGORITHMS) into `#:` Sphinx-style doc-comments per rule 7 module-level constant guidance.
- Compress transient WHY blocks inside function bodies to single-line WHY comments per rule 7 transient-WHY guidance.
- Strip spec-clause citation tokens from `test_verify_compliance_receipt.py` section headers; replaced with vocabulary names per rule 3.

## Files touched

- python/tests/test_cli.py
- python/tests/test_letta_integration.py
- python/tests/test_client_ietf_fields.py
- python/tests/test_replay_ietf_chain.py
- python/tests/test_keys_alg_agility.py
- python/tests/test_verify_compliance_receipt.py
- python/examples/dspy_example.py
- python/src/asqav/client.py
- python/src/asqav/replay.py
- python/src/asqav/keys.py
- typescript/src/index.ts

## Test plan

- [x] `awk` multi-line block sweep returns zero on all touched files
- [x] grep for forbidden spec-clause tokens returns zero on touched files
- [x] grep for forbidden version / wave / cycle tokens returns zero on touched files
- [x] `python -m pytest -x`: 648 passed
- [x] `npm test` (vitest): 187 passed

comment hygiene clean