### PR TITLE
feat(a2a): counterparty_binding helpers (IETF -04 Section 4.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 ## [Unreleased]
 
 ### Added
+- Counterparty acknowledgment helpers (`compute_counterparty_binding`, `verify_counterparty_binding`, `CounterpartyBinding`, `ACKNOWLEDGMENT_RECEIPT_TYPE`) in both Python and TypeScript. Mirrors the cloud's `counterparty_binding` extension field; computes base64 SHA-256 of the originating envelope's canonical bytes and recompares at verify time. `protectmcp:acknowledgment` joins the receipt-type namespace. `verify_compliance_receipt` accepts an optional `originating_envelope` argument and surfaces `counterparty_binding_verified`.
 - `VerificationResponse` exposes `type`, `bitcoinAnchor`, `signatureEnvelope`, `anchors`, `algorithmRegistryVersion` (Python: snake_case). Match the cloud `/verify` response per IETF -03 §8.1.
 - `VerificationDetail` exposes `anchorValidOts`, `anchorValidRfc3161`, `policyDigestResolved`, `duplicateEmissionCandidate`.
 - TypeScript validation-label union includes `agent_revoked_before_issuance`.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,38 @@ console.log(result.agentId, result.chainHash);
 
 Or open the receipt's `verify_url` in a browser. Hashes are reproducible offline from the RFC 8785 (the JSON format spec) payload, so auditors do not need to trust Asqav's servers - the signature speaks for itself.
 
+## Counterparty acknowledgment
+
+When two agents hand off a workflow (A signs an action, B acts on it), the SDK lets B emit a `protectmcp:acknowledgment` receipt that cryptographically binds B's bytes to A's. The bundle carries A's full envelope, B's acknowledgment, and a SHA-256 binding the verifier recomputes offline. A tampered intermediary cannot mutate the bytes without breaking the equality, so a regulator can verify the handoff with one digest comparison.
+
+Python:
+
+```python
+from asqav import compute_counterparty_binding, verify_counterparty_binding
+
+binding = compute_counterparty_binding(originating_envelope)
+b_payload["counterparty_binding"] = binding.to_wire()
+# ... B signs b_payload normally ...
+
+outcome = verify_counterparty_binding(b_envelope, originating_envelope)
+assert outcome.valid, outcome.label
+```
+
+TypeScript:
+
+```ts
+import { computeCounterpartyBinding, verifyCounterpartyBinding } from "@asqav/sdk";
+
+const binding = computeCounterpartyBinding(originatingEnvelope);
+bPayload.counterparty_binding = binding;
+// ... B signs bPayload normally ...
+
+const outcome = verifyCounterpartyBinding(bEnvelope, originatingEnvelope);
+if (!outcome.valid) throw new Error(outcome.label);
+```
+
+The cloud `/verify` endpoint reports the same outcome on the verification response under `counterparty_binding_verified`, and `/audit-pack/export` pulls the originating receipt into the bundle automatically when an acknowledgment in the export window references one outside it.
+
 ## Conformance
 
 The `conformance/` directory contains shared test fixtures both SDKs run against. Adding a new feature means adding a fixture there first, then making both SDKs pass it. CI reruns both matrices whenever `conformance/` changes, even if neither `python/` nor `typescript/` was touched, so cross-language drift is caught at PR time.

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -114,6 +114,13 @@ from .client import (
     verify_signature,
 )
 from .compliance import ComplianceBundle, export_bundle, fetch_audit_pack
+from .counterparty import (
+    ACKNOWLEDGMENT_RECEIPT_TYPE,
+    CounterpartyBinding,
+    CounterpartyBindingVerification,
+    compute_counterparty_binding,
+    verify_counterparty_binding,
+)
 from .decorators import async_session, session, sign
 from .hooks import clear_hooks, register_after, register_before
 from .keys import (
@@ -281,6 +288,12 @@ __all__ = [
     "SKEW_BOUND_SECONDS",
     "ComplianceReceiptVerification",
     "verify_compliance_receipt",
+    # Counterparty acknowledgment binding (IETF -04 counterparty_binding extension)
+    "ACKNOWLEDGMENT_RECEIPT_TYPE",
+    "CounterpartyBinding",
+    "CounterpartyBindingVerification",
+    "compute_counterparty_binding",
+    "verify_counterparty_binding",
     # DORA RTS JC 2024-33 Annex II vocabulary
     "DORA_INCIDENT_CLASS_NAMESPACE",
     # Algorithm agility

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -196,6 +196,7 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
         "protectmcp:decision",
         "protectmcp:restraint",
         "protectmcp:lifecycle",
+        "protectmcp:acknowledgment",
     }
 )
 
@@ -2322,6 +2323,10 @@ class ComplianceReceiptVerification:
     `errors` carries a per-clause failure code so a CLI / dashboard can
     show the user which clause failed. Codes mirror the cloud's
     `validation_label` vocabulary in `routes/verify.py`.
+
+    `counterparty_binding_verified` is None when the receipt carries no
+    ``counterparty_binding`` field; True/False when the originating
+    envelope was supplied and the recomputed digest was compared.
     """
 
     valid: bool
@@ -2330,12 +2335,14 @@ class ComplianceReceiptVerification:
     skew_within_bound: bool
     chain_link_rederives: bool
     errors: list[str]
+    counterparty_binding_verified: bool | None = None
 
 
 def verify_compliance_receipt(
     envelope: dict[str, Any],
     *,
     predecessor_envelope: dict[str, Any] | None = None,
+    originating_envelope: dict[str, Any] | None = None,
     now: float | None = None,
 ) -> ComplianceReceiptVerification:
     """Local-side sanity-check on a Compliance Receipt envelope.
@@ -2352,6 +2359,13 @@ def verify_compliance_receipt(
        first on its chain (`previousReceiptHash == "0" * 64`) the
        rederivation step is skipped.
 
+    A fifth check fires when the receipt carries a
+    ``counterparty_binding`` object and the caller supplies the
+    originating envelope: the SHA-256 digest of the canonical bytes is
+    recomputed and compared to ``envelope_hash``, and (when present)
+    ``expect_ack_from`` is cross-checked against the acknowledging
+    receipt's ``signature.kid``.
+
     The cloud is authoritative for cryptographic signature checks,
     policy_digest resolution against the Audit Pack, and anchor
     verification. This helper is a convenience.
@@ -2361,6 +2375,10 @@ def verify_compliance_receipt(
         predecessor_envelope: Optional predecessor envelope. When
             provided, the chain-link is rederived and compared to
             ``envelope["previousReceiptHash"]``.
+        originating_envelope: Optional originating envelope referenced by
+            ``payload.counterparty_binding.receipt_ref`` on an
+            acknowledgment receipt. When provided, the binding's
+            ``envelope_hash`` is recomputed and compared.
         now: Optional override for the verifier wall clock (UNIX
             seconds). Defaults to ``time.time()``.
 
@@ -2425,11 +2443,26 @@ def verify_compliance_receipt(
             errors.append("chain_link_mismatch")
     # No predecessor supplied: leave chain_link_rederives=True (unchecked is not failed).
 
+    counterparty_binding_verified: bool | None = None
+    payload_obj = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else envelope
+    has_binding = isinstance(payload_obj, dict) and isinstance(
+        payload_obj.get("counterparty_binding"), dict
+    )
+    if has_binding and originating_envelope is not None:
+        from .counterparty import verify_counterparty_binding
+
+        ack_env = envelope if "payload" in envelope else {"payload": payload_obj}
+        outcome = verify_counterparty_binding(ack_env, originating_envelope)
+        counterparty_binding_verified = outcome.valid
+        if not outcome.valid:
+            errors.append(f"counterparty_binding_{outcome.label}")
+
     valid = (
         fields_present
         and receipt_type_in_namespace
         and skew_within_bound
         and chain_link_rederives
+        and (counterparty_binding_verified is not False)
     )
     return ComplianceReceiptVerification(
         valid=valid,
@@ -2438,6 +2471,7 @@ def verify_compliance_receipt(
         skew_within_bound=skew_within_bound,
         chain_link_rederives=chain_link_rederives,
         errors=errors,
+        counterparty_binding_verified=counterparty_binding_verified,
     )
 
 

--- a/python/src/asqav/counterparty.py
+++ b/python/src/asqav/counterparty.py
@@ -1,0 +1,189 @@
+"""Counterparty acknowledgment binding helpers for the IETF Compliance Receipts profile.
+
+Public surface:
+
+* :class:`CounterpartyBinding` - dataclass mirror of the cloud's
+  ``core.envelope.CounterpartyBinding`` Pydantic model.
+* :func:`compute_counterparty_binding` - builds the binding object from
+  an originating envelope; computes the base64 SHA-256 over its
+  canonical bytes.
+* :func:`verify_counterparty_binding` - re-derives the digest from the
+  originating envelope and reports the per-axis outcome.
+
+The acknowledging receipt's ``receipt_type`` is
+``protectmcp:acknowledgment``; the binding object travels on the signed
+payload of B's receipt and gates verification per the staged IETF -04
+revision (Sections 4.6 and 4.6.1).
+
+See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+from ._jcs import canonical_json
+
+__all__ = [
+    "ACKNOWLEDGMENT_RECEIPT_TYPE",
+    "CounterpartyBinding",
+    "compute_counterparty_binding",
+    "verify_counterparty_binding",
+]
+
+#: Receipt type emitted by an acknowledging agent (B) over an originating receipt.
+ACKNOWLEDGMENT_RECEIPT_TYPE: str = "protectmcp:acknowledgment"
+
+
+@dataclass
+class CounterpartyBinding:
+    """Acknowledger's cross-agent byte-equality binding to an originating receipt.
+
+    ``envelope_hash`` is the base64-encoded SHA-256 digest over the
+    originating receipt's full canonical signed envelope (signature
+    bytes included). ``receipt_ref`` is the opaque resolvable locator
+    the verifier uses to fetch A's envelope from the Audit Pack or a
+    Deployer-published index. ``expect_ack_from`` is an OPTIONAL
+    cross-check on the acknowledging receipt's signature ``kid``;
+    ``transport_label`` is operational only and MUST NOT be used to
+    derive trust.
+    """
+
+    envelope_hash: str = field(
+        metadata={"description": "base64 SHA-256 of originating envelope JCS bytes."}
+    )
+    receipt_ref: str = field(
+        metadata={"description": "Opaque resolvable id for the originating receipt."}
+    )
+    expect_ack_from: str | None = field(
+        default=None,
+        metadata={"description": "Expected acknowledger kid/issuer_id."},
+    )
+    transport_label: str | None = field(
+        default=None,
+        metadata={"description": "Operational transport hint (mcp|bus|http)."},
+    )
+
+    def to_wire(self) -> dict[str, Any]:
+        """Return the wire-shape dict suitable for placement on the signed payload.
+
+        Drops keys whose value is ``None`` so omitted OPTIONAL fields do
+        not appear in the canonical bytes; this keeps the JCS output
+        byte-identical to the cloud's emit path.
+        """
+        out: dict[str, Any] = {
+            "envelope_hash": self.envelope_hash,
+            "receipt_ref": self.receipt_ref,
+        }
+        if self.expect_ack_from is not None:
+            out["expect_ack_from"] = self.expect_ack_from
+        if self.transport_label is not None:
+            out["transport_label"] = self.transport_label
+        return out
+
+
+def compute_envelope_hash(envelope: dict[str, Any]) -> str:
+    """Base64 of SHA-256 over the originating envelope's full JCS bytes.
+
+    Mirrors the cloud's ``core.envelope.compute_envelope_hash`` so the
+    acknowledger and the verifier produce byte-identical digests across
+    Python and TypeScript SDKs and the cloud emit path.
+    """
+    return base64.b64encode(hashlib.sha256(canonical_json(envelope)).digest()).decode()
+
+
+def compute_counterparty_binding(
+    originating_envelope: dict[str, Any],
+    *,
+    receipt_ref: str | None = None,
+    expect_ack_from: str | None = None,
+    transport_label: str | None = None,
+) -> CounterpartyBinding:
+    """Build a :class:`CounterpartyBinding` for the originating envelope.
+
+    Args:
+        originating_envelope: Full signed envelope (``{payload, signature, anchors?}``)
+            of A's receipt. The digest is computed over the canonical bytes of
+            the dict as-passed; callers MUST pass the bytes B actually received,
+            not a re-canonicalization, so intermediary tampering is detectable.
+        receipt_ref: Resolvable locator for A's receipt. Defaults to
+            ``originating_envelope["payload"]["action_id"]`` when present so the
+            common case can be a one-liner; callers SHOULD pass an explicit
+            value when their Audit Pack production layer uses a different
+            identifier scheme.
+        expect_ack_from: Optional declared acknowledger identifier; the verifier
+            cross-checks the acknowledging receipt's ``signature.kid`` against
+            this value when present.
+        transport_label: Optional operational transport hint.
+
+    Returns:
+        A :class:`CounterpartyBinding` ready to place on the acknowledgment
+        receipt's signed payload via :meth:`CounterpartyBinding.to_wire`.
+    """
+    if receipt_ref is None:
+        payload = originating_envelope.get("payload")
+        if isinstance(payload, dict):
+            ref = payload.get("action_id") or payload.get("signature_id")
+            if isinstance(ref, str):
+                receipt_ref = ref
+    if receipt_ref is None:
+        raise ValueError(
+            "receipt_ref is required: originating_envelope.payload has no action_id"
+        )
+    return CounterpartyBinding(
+        envelope_hash=compute_envelope_hash(originating_envelope),
+        receipt_ref=receipt_ref,
+        expect_ack_from=expect_ack_from,
+        transport_label=transport_label,
+    )
+
+
+@dataclass
+class CounterpartyBindingVerification:
+    """Outcome of the SDK-side counterparty-binding sanity check.
+
+    ``valid`` is the AND of all populated booleans. Per-axis labels mirror
+    the cloud's ``counterparty_binding_verified`` vocabulary in
+    ``api/routes/verify.py``.
+    """
+
+    valid: bool
+    envelope_hash_matches: bool
+    kid_matches: bool | None
+    label: str
+
+
+def verify_counterparty_binding(
+    acknowledgment_envelope: dict[str, Any],
+    originating_envelope: dict[str, Any],
+) -> CounterpartyBindingVerification:
+    """Re-derive and compare the binding's ``envelope_hash``.
+
+    Returns ``label`` in {``matches``, ``mismatch``, ``unresolved``,
+    ``kid_mismatch``} so callers can distinguish a tampered handoff from
+    a missing originator. ``kid_matches`` is None when
+    ``expect_ack_from`` was not declared on the binding.
+    """
+    payload = acknowledgment_envelope.get("payload")
+    if not isinstance(payload, dict):
+        return CounterpartyBindingVerification(False, False, None, "unresolved")
+    binding = payload.get("counterparty_binding")
+    if not isinstance(binding, dict):
+        return CounterpartyBindingVerification(False, False, None, "unresolved")
+    expected_hash = binding.get("envelope_hash")
+    actual_hash = compute_envelope_hash(originating_envelope)
+    envelope_hash_matches = expected_hash == actual_hash
+    expect_ack_from = binding.get("expect_ack_from")
+    kid_matches: bool | None = None
+    if isinstance(expect_ack_from, str):
+        sig = acknowledgment_envelope.get("signature")
+        ack_kid = sig.get("kid") if isinstance(sig, dict) else None
+        kid_matches = ack_kid == expect_ack_from
+    if not envelope_hash_matches:
+        return CounterpartyBindingVerification(False, False, kid_matches, "mismatch")
+    if kid_matches is False:
+        return CounterpartyBindingVerification(False, True, False, "kid_mismatch")
+    return CounterpartyBindingVerification(True, True, kid_matches, "matches")

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -76,6 +76,7 @@ def test_receipt_type_namespace_constant() -> None:
             "protectmcp:decision",
             "protectmcp:restraint",
             "protectmcp:lifecycle",
+            "protectmcp:acknowledgment",
         }
     )
 

--- a/python/tests/test_counterparty_binding.py
+++ b/python/tests/test_counterparty_binding.py
@@ -1,0 +1,204 @@
+"""SDK-side tests for the counterparty acknowledgment binding (IETF -04).
+
+Covers:
+
+* envelope_hash byte-stability (matches the cloud's compute_envelope_hash).
+* compute_counterparty_binding default and explicit-locator paths.
+* verify_counterparty_binding matches / mismatch / kid-mismatch / unresolved labels.
+* verify_compliance_receipt fifth check fires only when originating_envelope is supplied.
+
+The cloud is the authoritative verifier; these tests pin the SDK's local
+sanity-check semantics so customer-side reproduction stays byte-stable.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav._jcs import canonical_json
+from asqav.client import verify_compliance_receipt
+from asqav.counterparty import (
+    ACKNOWLEDGMENT_RECEIPT_TYPE,
+    CounterpartyBinding,
+    compute_counterparty_binding,
+    verify_counterparty_binding,
+)
+
+
+def _orig_envelope() -> dict:
+    payload = {
+        "v": 1,
+        "action_id": "act_abc",
+        "agent_id": "agt_A",
+        "org_id": "org_1",
+        "type": "protectmcp:decision",
+        "issuer_id": "00000000000000000010",
+        "action_ref": "sha256:" + "a" * 64,
+        "payload_digest": {"hash": "sha256:" + "b" * 64, "size": 7},
+        "policy_digest": "sha256:" + "c" * 64,
+        "previousReceiptHash": "0" * 64,
+        "issued_at": "2026-05-11T00:00:00Z",
+        "decision": "allow",
+        "mode": "payload",
+        "action_type": "api:call",
+        "context": {"model": "gpt-4"},
+        "timestamp": "2026-05-11T00:00:00Z",
+    }
+    return {
+        "payload": payload,
+        "signature": {"alg": "ml-dsa-65", "kid": "kid-A", "sig": "AAAA"},
+        "anchors": [],
+    }
+
+
+def test_envelope_hash_is_base64_sha256_of_jcs():
+    env = _orig_envelope()
+    binding = compute_counterparty_binding(env)
+    expected = base64.b64encode(hashlib.sha256(canonical_json(env)).digest()).decode()
+    assert binding.envelope_hash == expected
+
+
+def test_compute_counterparty_binding_defaults_receipt_ref_to_action_id():
+    env = _orig_envelope()
+    binding = compute_counterparty_binding(env)
+    assert binding.receipt_ref == "act_abc"
+    assert binding.expect_ack_from is None
+    assert binding.transport_label is None
+
+
+def test_compute_counterparty_binding_explicit_receipt_ref():
+    env = _orig_envelope()
+    binding = compute_counterparty_binding(
+        env,
+        receipt_ref="asqav-receipt://org/1/agent_A/seq/42",
+        expect_ack_from="00000000000000000099",
+        transport_label="mcp",
+    )
+    assert binding.receipt_ref == "asqav-receipt://org/1/agent_A/seq/42"
+    assert binding.expect_ack_from == "00000000000000000099"
+    assert binding.transport_label == "mcp"
+
+
+def test_to_wire_drops_none_optional_fields():
+    binding = CounterpartyBinding(envelope_hash="h", receipt_ref="r")
+    wire = binding.to_wire()
+    assert wire == {"envelope_hash": "h", "receipt_ref": "r"}
+
+
+def test_to_wire_keeps_optional_fields_when_set():
+    binding = CounterpartyBinding(
+        envelope_hash="h",
+        receipt_ref="r",
+        expect_ack_from="kid-B",
+        transport_label="bus",
+    )
+    wire = binding.to_wire()
+    assert wire == {
+        "envelope_hash": "h",
+        "receipt_ref": "r",
+        "expect_ack_from": "kid-B",
+        "transport_label": "bus",
+    }
+
+
+def _ack_envelope(
+    orig_env: dict,
+    *,
+    expect_ack_from: str | None = None,
+    ack_kid: str = "kid-B",
+) -> dict:
+    binding = compute_counterparty_binding(orig_env, expect_ack_from=expect_ack_from)
+    return {
+        "payload": {
+            "v": 1,
+            "type": ACKNOWLEDGMENT_RECEIPT_TYPE,
+            "issuer_id": "00000000000000000020",
+            "action_ref": orig_env["payload"]["action_ref"],
+            "payload_digest": {"hash": "sha256:" + "d" * 64, "size": 0},
+            "policy_digest": "sha256:" + "e" * 64,
+            "previousReceiptHash": "0" * 64,
+            "issued_at": "2026-05-11T00:00:01Z",
+            "decision": "allow",
+            "counterparty_binding": binding.to_wire(),
+        },
+        "signature": {"alg": "ml-dsa-65", "kid": ack_kid, "sig": "BBBB"},
+        "anchors": [],
+    }
+
+
+def test_verify_counterparty_binding_honest_pair_matches():
+    orig = _orig_envelope()
+    ack = _ack_envelope(orig)
+    outcome = verify_counterparty_binding(ack, orig)
+    assert outcome.valid is True
+    assert outcome.label == "matches"
+    assert outcome.envelope_hash_matches is True
+    assert outcome.kid_matches is None
+
+
+def test_verify_counterparty_binding_payload_flip_mismatch():
+    orig = _orig_envelope()
+    ack = _ack_envelope(orig)
+    tampered = _orig_envelope()
+    tampered["payload"]["context"] = {"model": "gpt-5"}
+    outcome = verify_counterparty_binding(ack, tampered)
+    assert outcome.valid is False
+    assert outcome.label == "mismatch"
+
+
+def test_verify_counterparty_binding_kid_mismatch():
+    orig = _orig_envelope()
+    ack = _ack_envelope(orig, expect_ack_from="kid-B", ack_kid="kid-attacker")
+    outcome = verify_counterparty_binding(ack, orig)
+    assert outcome.valid is False
+    assert outcome.label == "kid_mismatch"
+    assert outcome.kid_matches is False
+
+
+def test_verify_counterparty_binding_unresolved_no_binding_field():
+    orig = _orig_envelope()
+    ack = {"payload": dict(orig["payload"]), "signature": {"kid": "x"}}
+    outcome = verify_counterparty_binding(ack, orig)
+    assert outcome.valid is False
+    assert outcome.label == "unresolved"
+
+
+def test_verify_compliance_receipt_fifth_check_fires_with_originating_envelope():
+    orig = _orig_envelope()
+    ack = _ack_envelope(orig)
+    result = verify_compliance_receipt(
+        ack["payload"],
+        originating_envelope=orig,
+    )
+    assert result.counterparty_binding_verified is True
+
+
+def test_verify_compliance_receipt_skips_binding_when_no_originating_envelope():
+    orig = _orig_envelope()
+    ack = _ack_envelope(orig)
+    result = verify_compliance_receipt(ack["payload"])
+    assert result.counterparty_binding_verified is None
+
+
+def test_verify_compliance_receipt_binding_mismatch_marks_invalid():
+    orig = _orig_envelope()
+    ack = _ack_envelope(orig)
+    tampered = _orig_envelope()
+    tampered["payload"]["decision"] = "deny"
+    result = verify_compliance_receipt(
+        ack["payload"],
+        originating_envelope=tampered,
+    )
+    assert result.counterparty_binding_verified is False
+    assert any(e.startswith("counterparty_binding_") for e in result.errors)
+
+
+def test_acknowledgment_receipt_type_in_namespace():
+    from asqav.client import RECEIPT_TYPE_NAMESPACE
+
+    assert ACKNOWLEDGMENT_RECEIPT_TYPE in RECEIPT_TYPE_NAMESPACE

--- a/typescript/src/counterparty.ts
+++ b/typescript/src/counterparty.ts
@@ -1,0 +1,156 @@
+/**
+ * Counterparty acknowledgment binding helpers for the IETF Compliance Receipts profile.
+ *
+ * The acknowledging receipt's `receipt_type` is `protectmcp:acknowledgment`;
+ * the binding object travels on the signed payload of B's receipt and
+ * gates verification per the staged IETF -04 revision.
+ *
+ * See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
+ */
+
+import { createHash } from "node:crypto";
+
+import { canonicalJson } from "./jcs.js";
+
+/** Cross-agent byte-equality binding to an originating receipt.
+ *
+ * `envelope_hash` is the base64-encoded SHA-256 digest over the
+ * originating receipt's full canonical signed envelope (signature bytes
+ * included). `receipt_ref` is the opaque resolvable locator the
+ * verifier uses to fetch A's envelope from the Audit Pack or a
+ * Deployer-published index. `expect_ack_from` is an OPTIONAL
+ * cross-check on the acknowledging receipt's signature `kid`;
+ * `transport_label` is operational only and MUST NOT be used to derive
+ * trust.
+ */
+export interface CounterpartyBinding {
+  envelope_hash: string;
+  receipt_ref: string;
+  expect_ack_from?: string;
+  transport_label?: string;
+}
+
+/** Per-axis outcome of the SDK-side counterparty-binding sanity check.
+ *
+ * `label` vocabulary: `matches` | `mismatch` | `unresolved` |
+ * `kid_mismatch`. Mirrors the cloud's `counterparty_binding_verified`
+ * axis in `api/routes/verify.py`.
+ */
+export interface CounterpartyBindingVerification {
+  valid: boolean;
+  envelopeHashMatches: boolean;
+  kidMatches: boolean | null;
+  label: "matches" | "mismatch" | "unresolved" | "kid_mismatch";
+}
+
+/** Base64 SHA-256 of the originating envelope's full JCS bytes.
+ *
+ * Mirrors the cloud's `core.envelope.compute_envelope_hash` so the
+ * acknowledger and the verifier produce byte-identical digests across
+ * SDKs and the cloud emit path.
+ */
+export function computeEnvelopeHash(
+  envelope: Record<string, unknown>,
+): string {
+  return createHash("sha256").update(canonicalJson(envelope)).digest("base64");
+}
+
+/** Options for {@link computeCounterpartyBinding}. */
+export interface ComputeCounterpartyBindingOptions {
+  /** Resolvable locator for A's receipt. Defaults to
+   * `originatingEnvelope.payload.action_id` (then `signature_id`); pass
+   * an explicit value when the Audit Pack production layer uses a
+   * different identifier scheme. */
+  receiptRef?: string;
+  /** Optional declared acknowledger identifier; the verifier cross-checks
+   * the acknowledging receipt's `signature.kid` against this value. */
+  expectAckFrom?: string;
+  /** Optional operational transport hint (`mcp` | `bus` | `http`). */
+  transportLabel?: string;
+}
+
+/** Build a {@link CounterpartyBinding} for the originating envelope.
+ *
+ * The digest is computed over the canonical bytes of the dict as-passed;
+ * callers MUST pass the bytes B actually received, not a
+ * re-canonicalization, so intermediary tampering is detectable.
+ *
+ * @throws Error if `receiptRef` was not supplied and the originating
+ *   envelope's payload has no `action_id` to default to.
+ */
+export function computeCounterpartyBinding(
+  originatingEnvelope: Record<string, unknown>,
+  options: ComputeCounterpartyBindingOptions = {},
+): CounterpartyBinding {
+  let receiptRef = options.receiptRef;
+  if (receiptRef === undefined) {
+    const payload = originatingEnvelope.payload;
+    if (payload && typeof payload === "object") {
+      const p = payload as Record<string, unknown>;
+      const candidate = p.action_id ?? p.signature_id;
+      if (typeof candidate === "string") {
+        receiptRef = candidate;
+      }
+    }
+  }
+  if (receiptRef === undefined) {
+    throw new Error(
+      "receipt_ref is required: originating envelope payload has no action_id",
+    );
+  }
+  const binding: CounterpartyBinding = {
+    envelope_hash: computeEnvelopeHash(originatingEnvelope),
+    receipt_ref: receiptRef,
+  };
+  if (options.expectAckFrom !== undefined) {
+    binding.expect_ack_from = options.expectAckFrom;
+  }
+  if (options.transportLabel !== undefined) {
+    binding.transport_label = options.transportLabel;
+  }
+  return binding;
+}
+
+/** Re-derive and compare the binding's `envelope_hash`.
+ *
+ * Returns `label` in {`matches`, `mismatch`, `unresolved`,
+ * `kid_mismatch`} so callers can distinguish a tampered handoff from
+ * a missing originator. `kidMatches` is `null` when `expect_ack_from`
+ * was not declared on the binding.
+ */
+export function verifyCounterpartyBinding(
+  acknowledgmentEnvelope: Record<string, unknown>,
+  originatingEnvelope: Record<string, unknown>,
+): CounterpartyBindingVerification {
+  const payload = acknowledgmentEnvelope.payload;
+  if (!payload || typeof payload !== "object") {
+    return { valid: false, envelopeHashMatches: false, kidMatches: null, label: "unresolved" };
+  }
+  const binding = (payload as Record<string, unknown>).counterparty_binding;
+  if (!binding || typeof binding !== "object") {
+    return { valid: false, envelopeHashMatches: false, kidMatches: null, label: "unresolved" };
+  }
+  const b = binding as Record<string, unknown>;
+  const expectedHash = typeof b.envelope_hash === "string" ? b.envelope_hash : undefined;
+  const actualHash = computeEnvelopeHash(originatingEnvelope);
+  const envelopeHashMatches = expectedHash === actualHash;
+
+  const expectAckFrom = typeof b.expect_ack_from === "string" ? b.expect_ack_from : undefined;
+  let kidMatches: boolean | null = null;
+  if (expectAckFrom !== undefined) {
+    const sig = acknowledgmentEnvelope.signature;
+    const ackKid =
+      sig && typeof sig === "object"
+        ? ((sig as Record<string, unknown>).kid as unknown)
+        : undefined;
+    kidMatches = ackKid === expectAckFrom;
+  }
+
+  if (!envelopeHashMatches) {
+    return { valid: false, envelopeHashMatches: false, kidMatches, label: "mismatch" };
+  }
+  if (kidMatches === false) {
+    return { valid: false, envelopeHashMatches: true, kidMatches: false, label: "kid_mismatch" };
+  }
+  return { valid: true, envelopeHashMatches: true, kidMatches, label: "matches" };
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -27,8 +27,13 @@ export const RECEIPT_TYPE_NAMESPACE = [
   "protectmcp:decision",
   "protectmcp:restraint",
   "protectmcp:lifecycle",
+  "protectmcp:acknowledgment",
 ] as const;
 export type ReceiptType = (typeof RECEIPT_TYPE_NAMESPACE)[number];
+
+/** Receipt type emitted by an acknowledging agent (B) over an originating
+ * receipt; the binding object travels on B's signed payload. */
+export const ACKNOWLEDGMENT_RECEIPT_TYPE = "protectmcp:acknowledgment" as const;
 
 /** DORA RTS JC 2024-33 Annex II field 3.23 canonical incident classification.
  *
@@ -116,6 +121,16 @@ export {
   type AnchorEntry,
   type ProjectableResponse,
 } from "./ietfProjection.js";
+
+// Counterparty acknowledgment binding (IETF -04 counterparty_binding extension).
+export {
+  computeCounterpartyBinding,
+  computeEnvelopeHash,
+  verifyCounterpartyBinding,
+  type CounterpartyBinding,
+  type CounterpartyBindingVerification,
+  type ComputeCounterpartyBindingOptions,
+} from "./counterparty.js";
 
 import {
   signatureEnvelopeFromResponse as _signatureEnvelopeFromResponse,

--- a/typescript/tests/counterparty.test.ts
+++ b/typescript/tests/counterparty.test.ts
@@ -1,0 +1,163 @@
+/**
+ * SDK-side tests for the counterparty acknowledgment binding (IETF -04).
+ *
+ * Covers envelope_hash byte-stability, default vs explicit receipt_ref,
+ * verifyCounterpartyBinding matches / mismatch / kid_mismatch / unresolved
+ * labels, and cross-SDK byte-stability with the Python helper (vector pin).
+ */
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { canonicalJson } from "../src/jcs.js";
+import {
+  ACKNOWLEDGMENT_RECEIPT_TYPE,
+  RECEIPT_TYPE_NAMESPACE,
+} from "../src/index.js";
+import {
+  computeCounterpartyBinding,
+  computeEnvelopeHash,
+  verifyCounterpartyBinding,
+  type CounterpartyBinding,
+} from "../src/counterparty.js";
+
+function origEnvelope(): Record<string, unknown> {
+  return {
+    payload: {
+      v: 1,
+      action_id: "act_abc",
+      agent_id: "agt_A",
+      org_id: "org_1",
+      type: "protectmcp:decision",
+      issuer_id: "00000000000000000010",
+      action_ref: `sha256:${"a".repeat(64)}`,
+      payload_digest: { hash: `sha256:${"b".repeat(64)}`, size: 7 },
+      policy_digest: `sha256:${"c".repeat(64)}`,
+      previousReceiptHash: "0".repeat(64),
+      issued_at: "2026-05-11T00:00:00Z",
+      decision: "allow",
+      mode: "payload",
+      action_type: "api:call",
+      context: { model: "gpt-4" },
+      timestamp: "2026-05-11T00:00:00Z",
+    },
+    signature: { alg: "ml-dsa-65", kid: "kid-A", sig: "AAAA" },
+    anchors: [],
+  };
+}
+
+function ackEnvelope(
+  orig: Record<string, unknown>,
+  opts: { expectAckFrom?: string; ackKid?: string } = {},
+): Record<string, unknown> {
+  const binding = computeCounterpartyBinding(orig, {
+    expectAckFrom: opts.expectAckFrom,
+  });
+  const ackPayload = orig.payload as Record<string, unknown>;
+  return {
+    payload: {
+      v: 1,
+      type: ACKNOWLEDGMENT_RECEIPT_TYPE,
+      issuer_id: "00000000000000000020",
+      action_ref: ackPayload.action_ref,
+      payload_digest: { hash: `sha256:${"d".repeat(64)}`, size: 0 },
+      policy_digest: `sha256:${"e".repeat(64)}`,
+      previousReceiptHash: "0".repeat(64),
+      issued_at: "2026-05-11T00:00:01Z",
+      decision: "allow",
+      counterparty_binding: binding,
+    },
+    signature: { alg: "ml-dsa-65", kid: opts.ackKid ?? "kid-B", sig: "BBBB" },
+    anchors: [],
+  };
+}
+
+describe("computeEnvelopeHash", () => {
+  it("returns base64 SHA-256 of the JCS bytes", () => {
+    const env = origEnvelope();
+    const expected = createHash("sha256")
+      .update(canonicalJson(env))
+      .digest("base64");
+    expect(computeEnvelopeHash(env)).toBe(expected);
+  });
+});
+
+describe("computeCounterpartyBinding", () => {
+  it("defaults receipt_ref to payload.action_id", () => {
+    const binding = computeCounterpartyBinding(origEnvelope());
+    expect(binding.receipt_ref).toBe("act_abc");
+    expect(binding.expect_ack_from).toBeUndefined();
+    expect(binding.transport_label).toBeUndefined();
+  });
+
+  it("honors explicit receipt_ref, expect_ack_from, and transport_label", () => {
+    const binding = computeCounterpartyBinding(origEnvelope(), {
+      receiptRef: "asqav-receipt://org/1/agent_A/seq/42",
+      expectAckFrom: "kid-B",
+      transportLabel: "mcp",
+    });
+    expect(binding.receipt_ref).toBe("asqav-receipt://org/1/agent_A/seq/42");
+    expect(binding.expect_ack_from).toBe("kid-B");
+    expect(binding.transport_label).toBe("mcp");
+  });
+
+  it("throws when no receipt_ref and no action_id is resolvable", () => {
+    expect(() =>
+      computeCounterpartyBinding({ payload: { foo: "bar" } }),
+    ).toThrow(/receipt_ref is required/);
+  });
+});
+
+describe("verifyCounterpartyBinding", () => {
+  it("returns matches on the honest pair", () => {
+    const orig = origEnvelope();
+    const ack = ackEnvelope(orig);
+    const outcome = verifyCounterpartyBinding(ack, orig);
+    expect(outcome.valid).toBe(true);
+    expect(outcome.label).toBe("matches");
+  });
+
+  it("flags mismatch when the originating envelope is tampered", () => {
+    const orig = origEnvelope();
+    const ack = ackEnvelope(orig);
+    const tampered = origEnvelope();
+    (tampered.payload as Record<string, unknown>).context = { model: "gpt-5" };
+    const outcome = verifyCounterpartyBinding(ack, tampered);
+    expect(outcome.valid).toBe(false);
+    expect(outcome.label).toBe("mismatch");
+  });
+
+  it("flags kid_mismatch when expect_ack_from disagrees with signature.kid", () => {
+    const orig = origEnvelope();
+    const ack = ackEnvelope(orig, { expectAckFrom: "kid-B", ackKid: "kid-attacker" });
+    const outcome = verifyCounterpartyBinding(ack, orig);
+    expect(outcome.valid).toBe(false);
+    expect(outcome.label).toBe("kid_mismatch");
+    expect(outcome.kidMatches).toBe(false);
+  });
+
+  it("returns unresolved when no counterparty_binding present", () => {
+    const orig = origEnvelope();
+    const ack = { payload: { ...(orig.payload as object) }, signature: { kid: "x" } };
+    const outcome = verifyCounterpartyBinding(ack, orig);
+    expect(outcome.valid).toBe(false);
+    expect(outcome.label).toBe("unresolved");
+  });
+});
+
+describe("namespace", () => {
+  it("includes protectmcp:acknowledgment", () => {
+    expect((RECEIPT_TYPE_NAMESPACE as readonly string[]).includes(ACKNOWLEDGMENT_RECEIPT_TYPE)).toBe(true);
+  });
+});
+
+describe("cross-sdk byte-stability", () => {
+  it("pins envelope_hash for a frozen JCS input", () => {
+    const env = origEnvelope();
+    const binding: CounterpartyBinding = computeCounterpartyBinding(env);
+    const recomputed = createHash("sha256")
+      .update(canonicalJson(env))
+      .digest("base64");
+    expect(binding.envelope_hash).toBe(recomputed);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the cloud's `counterparty_binding` extension in both language SDKs. An acknowledging agent (B) builds the binding from A's full signed envelope via `compute_counterparty_binding`; a verifier offline recomputes the SHA-256 over the canonical bytes and compares it to `envelope_hash`. The bundle pattern is the staged IETF -04 revision.

## Changes

- **Python** (`python/src/asqav/counterparty.py`): `CounterpartyBinding` dataclass, `compute_counterparty_binding`, `verify_counterparty_binding`, `ACKNOWLEDGMENT_RECEIPT_TYPE` constant, `compute_envelope_hash` helper. Re-exported from `asqav.__init__`.
- **Python** (`client.py`): `protectmcp:acknowledgment` added to `RECEIPT_TYPE_NAMESPACE`. `verify_compliance_receipt` accepts `originating_envelope` and surfaces `counterparty_binding_verified` on `ComplianceReceiptVerification`.
- **TypeScript** (`typescript/src/counterparty.ts`): `computeCounterpartyBinding`, `verifyCounterpartyBinding`, `computeEnvelopeHash`, `CounterpartyBinding`, `CounterpartyBindingVerification`, `ACKNOWLEDGMENT_RECEIPT_TYPE`. Wired through `index.ts`.
- **Tests**: 13 Python + 10 TypeScript covering honest pair, payload-flip mismatch, kid mismatch, unresolved, and envelope_hash byte-stability against the SDK's JCS module. All existing tests stay green (635 Py / 197 TS).
- **README**: new "Counterparty acknowledgment" section with Python and TypeScript snippets.
- **CHANGELOG**: `[Unreleased]` one-line entry.

## LOC

~395 prod + ~370 tests across Python and TypeScript.

## Backwards compatibility

Additive. `counterparty_binding_verified` is None on receipts that carry no binding or when callers do not pass `originating_envelope`. Callers signing the existing `protectmcp:decision` / `restraint` / `lifecycle` receipt types see no behaviour change.

## Tests

- Python: `python/tests/test_counterparty_binding.py` (13 tests). Full suite: 635 passed.
- TypeScript: `typescript/tests/counterparty.test.ts` (10 tests). Full suite: 197 passed.

comment hygiene clean