### PR TITLE
fix(a2a): preserve signature kid in payload-only counterparty_binding verify path

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -2451,11 +2451,20 @@ def verify_compliance_receipt(
     if has_binding and originating_envelope is not None:
         from .counterparty import verify_counterparty_binding
 
-        ack_env = envelope if "payload" in envelope else {"payload": payload_obj}
-        outcome = verify_counterparty_binding(ack_env, originating_envelope)
-        counterparty_binding_verified = outcome.valid
-        if not outcome.valid:
-            errors.append(f"counterparty_binding_{outcome.label}")
+        binding_obj = payload_obj["counterparty_binding"]
+        has_full_envelope = "payload" in envelope
+        expects_ack_kid = isinstance(binding_obj.get("expect_ack_from"), str)
+        if expects_ack_kid and not has_full_envelope:
+            # Payload-only input cannot supply ``signature.kid``; surface a
+            # clear outcome instead of a silent kid-axis false negative.
+            counterparty_binding_verified = False
+            errors.append("counterparty_binding_requires_full_envelope")
+        else:
+            ack_env = envelope if has_full_envelope else {"payload": payload_obj}
+            outcome = verify_counterparty_binding(ack_env, originating_envelope)
+            counterparty_binding_verified = outcome.valid
+            if not outcome.valid:
+                errors.append(f"counterparty_binding_{outcome.label}")
 
     valid = (
         fields_present

--- a/python/tests/test_counterparty_binding.py
+++ b/python/tests/test_counterparty_binding.py
@@ -202,3 +202,32 @@ def test_acknowledgment_receipt_type_in_namespace():
     from asqav.client import RECEIPT_TYPE_NAMESPACE
 
     assert ACKNOWLEDGMENT_RECEIPT_TYPE in RECEIPT_TYPE_NAMESPACE
+
+
+def test_verify_compliance_receipt_payload_only_with_expect_ack_from_surfaces_error():
+    """A payload-only caller with expect_ack_from cannot verify the kid axis.
+
+    Regression for the bug where ``{"payload": payload_obj}`` wrapping
+    dropped the signature, leaving ``ack_kid=None`` and producing a
+    silent ``counterparty_binding_kid_mismatch`` false negative against
+    every otherwise-valid acknowledgment.
+    """
+    orig = _orig_envelope()
+    ack = _ack_envelope(orig, expect_ack_from="kid-B", ack_kid="kid-B")
+    result = verify_compliance_receipt(
+        ack["payload"], originating_envelope=orig
+    )
+    assert result.counterparty_binding_verified is False
+    assert "counterparty_binding_requires_full_envelope" in result.errors
+    assert not any(
+        e == "counterparty_binding_kid_mismatch" for e in result.errors
+    )
+
+
+def test_verify_compliance_receipt_payload_only_without_expect_ack_from_still_works():
+    orig = _orig_envelope()
+    ack = _ack_envelope(orig)
+    result = verify_compliance_receipt(
+        ack["payload"], originating_envelope=orig
+    )
+    assert result.counterparty_binding_verified is True


### PR DESCRIPTION
## Summary

Codex flagged a correctness bug on merged PR #170. `verify_compliance_receipt` accepts either a full envelope or a bare payload dict. When `counterparty_binding.expect_ack_from` is present, the payload-only path wrapped the input as `{"payload": payload_obj}`, which drops the outer envelope's `signature`. `verify_counterparty_binding` then saw `ack_kid=None`, returned `kid_mismatch`, and every otherwise-valid acknowledgment came back `valid=False`.

## Fix (Approach B, the conservative path)

Detect the payload-only-plus-`expect_ack_from` case up front and emit `counterparty_binding_requires_full_envelope` so callers re-invoke with the full envelope. This avoids a silent kid-axis false negative; the error label tells the caller exactly what to do. Payload-only callers without `expect_ack_from` keep working unchanged.

Approach A (inject signature into the wrapper) is not feasible here: the signature is not in scope inside `verify_compliance_receipt`, and the function's REQUIRED-field check is already designed for payload-only inputs.

## Files

- `python/src/asqav/client.py`: branch out the payload-only-plus-`expect_ack_from` case with the new error label.
- `python/tests/test_counterparty_binding.py`: regression test for the new outcome, asserts `kid_mismatch` does not appear on the error list, plus a sanity test that payload-only callers without `expect_ack_from` still succeed.

TypeScript was checked. `verifyCounterpartyBinding` already requires a full envelope and there is no TS analog of `verify_compliance_receipt`, so no parallel change is needed.

## Test plan

- [x] `python -m pytest tests/test_counterparty_binding.py -x` (15 passed)
- [x] `python -m pytest -x` full suite (663 passed)

comment hygiene clean