### PR TITLE
feat(sdk): canonicalize_tool_args helper rejects float inputs per IETF -04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 ## [Unreleased]
 
 ### Added
+- `canonicalize_tool_args` (Python) and `canonicalizeToolArgs` (TypeScript) pre-validate `tool_args` payloads and reject float leaves with a JSON-pointer-locating error before delegating to JCS canonicalization, surfacing the rule that floats are not byte-stable across runtimes.
 - Counterparty acknowledgment helpers (`compute_counterparty_binding`, `verify_counterparty_binding`, `CounterpartyBinding`, `ACKNOWLEDGMENT_RECEIPT_TYPE`) in both Python and TypeScript. Mirrors the cloud's `counterparty_binding` extension field; computes base64 SHA-256 of the originating envelope's canonical bytes and recompares at verify time. `protectmcp:acknowledgment` joins the receipt-type namespace. `verify_compliance_receipt` accepts an optional `originating_envelope` argument and surfaces `counterparty_binding_verified`.
 - `VerificationResponse` exposes `type`, `bitcoinAnchor`, `signatureEnvelope`, `anchors`, `algorithmRegistryVersion` (Python: snake_case). Match the cloud `/verify` response per IETF -03 §8.1.
 - `VerificationDetail` exposes `anchorValidOts`, `anchorValidRfc3161`, `policyDigestResolved`, `duplicateEmissionCandidate`.

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -29,7 +29,7 @@ Get your API key at asqav.com
 
 from ._jcs import canonical_json
 from .async_client import AsyncAgent
-from .canonicalize import canonicalize, hash_action
+from .canonicalize import canonicalize, canonicalize_tool_args, hash_action
 from .client import (
     DORA_INCIDENT_CLASS_NAMESPACE,
     RECEIPT_TYPE_NAMESPACE,
@@ -146,6 +146,7 @@ __all__ = [
     "health_check",
     # Fingerprint helpers
     "canonicalize",
+    "canonicalize_tool_args",
     "canonical_json",
     "hash_action",
     # Agent

--- a/python/src/asqav/canonicalize.py
+++ b/python/src/asqav/canonicalize.py
@@ -4,12 +4,18 @@ This module produces the bytes the asqav backend signs (and, in
 hash-only mode, the bytes the SDK hashes locally before sending to the
 cloud).
 
-Two helpers are provided:
+Three helpers are provided:
 
 * :func:`canonicalize` returns standard JSON bytes for any
   JSON-serializable Python value, following the conventions in
   ``conformance/vectors.json`` (JCS subset: keys sorted, no whitespace,
   raw UTF-8, no trailing newline).
+* :func:`canonicalize_tool_args` is a user-facing pre-validator over
+  ``tool_args`` payloads that rejects floats with a JSON-pointer-locating
+  error before delegating to :func:`canonicalize`. The Compliance
+  Receipts profile excludes floats from the signed canonical scope
+  because RFC 8785 section 3.2.2 only fixes byte-stable numeric output
+  for safe-range integers; floats drift across runtimes.
 * :func:`hash_action` returns a self-describing hash string of the form
   ``"sha256:<64hex>"`` built from a ``{action_type, context}`` dict. An
   optional ``salt`` switches it to HMAC-SHA-256 for organizations that
@@ -26,7 +32,12 @@ import hmac
 import json
 from typing import Any
 
-__all__ = ["canonicalize", "canonicalize_action", "hash_action"]
+__all__ = [
+    "canonicalize",
+    "canonicalize_action",
+    "canonicalize_tool_args",
+    "hash_action",
+]
 
 
 def canonicalize_action(
@@ -69,6 +80,66 @@ def canonicalize(obj: Any) -> bytes:
         ensure_ascii=False,
         allow_nan=False,
     ).encode("utf-8")
+
+
+def _find_float_pointer(value: Any, pointer: str) -> str | None:
+    """Return JSON pointer to the first float found in ``value``, else None.
+
+    Walks dicts and lists depth-first in insertion order so the reported
+    pointer is stable for a given input. ``bool`` is excluded because
+    Python's ``isinstance(True, int)`` is True and ``bool`` is JCS-safe.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, float):
+        return pointer
+    if isinstance(value, dict):
+        for key, sub in value.items():
+            token = str(key).replace("~", "~0").replace("/", "~1")
+            hit = _find_float_pointer(sub, f"{pointer}/{token}")
+            if hit is not None:
+                return hit
+        return None
+    if isinstance(value, list):
+        for idx, sub in enumerate(value):
+            hit = _find_float_pointer(sub, f"{pointer}/{idx}")
+            if hit is not None:
+                return hit
+        return None
+    return None
+
+
+def canonicalize_tool_args(args: dict[str, Any] | list[Any]) -> bytes:
+    """Return JCS-canonical bytes of ``tool_args``, rejecting floats.
+
+    Floats are not byte-stable across runtimes per RFC 8785 section 3.2.2,
+    so the Compliance Receipts profile keeps them out of the signed
+    canonical scope. Serialize numerics as strings (``"1.5"``) or
+    integer-rational pairs before calling this helper. Booleans and
+    integers (including arbitrarily large ``int``) are accepted because
+    JCS pins their byte form.
+
+    Args:
+        args: A dict or list of tool arguments. Leaves may be ``str``,
+            ``int``, ``bool``, ``None``, ``dict``, or ``list``. ``float``
+            is rejected.
+
+    Returns:
+        UTF-8 encoded JCS-canonical bytes.
+
+    Raises:
+        ValueError: If any leaf is a ``float``. The message includes the
+            JSON pointer to the offending value so the caller can fix
+            the input.
+    """
+    pointer = _find_float_pointer(args, "")
+    if pointer is not None:
+        raise ValueError(
+            f"tool_args float at {pointer or '/'}: floats are not byte-stable "
+            "across runtimes per RFC 8785 section 3.2.2; serialize numerics "
+            "as strings or rationals before passing to canonicalize_tool_args"
+        )
+    return canonicalize(args)
 
 
 def hash_action(

--- a/python/tests/test_canonicalize_tool_args.py
+++ b/python/tests/test_canonicalize_tool_args.py
@@ -1,0 +1,125 @@
+"""Tests for :func:`asqav.canonicalize_tool_args`.
+
+The helper pre-validates ``tool_args`` payloads against the
+Compliance Receipts canonicalization rule: no floats in the signed
+canonical scope, because RFC 8785 section 3.2.2 only fixes byte-stable
+numeric output for safe-range integers. Floats drift across runtimes
+and break verifier equality.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+
+import pytest
+
+from asqav import canonicalize, canonicalize_tool_args
+
+
+def test_happy_path_dict_with_int_str_bool_nested_dict_and_list() -> None:
+    args = {
+        "tool": "database.query",
+        "limit": 100,
+        "dry_run": True,
+        "filters": {"status": "active", "tags": ["a", "b"]},
+        "nullable": None,
+    }
+    out = canonicalize_tool_args(args)
+    assert out == canonicalize(args)
+    # Sort-stable JCS keeps the digest fixed across runs.
+    assert hashlib.sha256(out).hexdigest() == hashlib.sha256(canonicalize(args)).hexdigest()
+
+
+def test_rejects_bare_float_with_rfc_pointer() -> None:
+    with pytest.raises(ValueError) as exc:
+        canonicalize_tool_args({"x": 1.5})
+    msg = str(exc.value)
+    assert "tool_args float at /x" in msg
+    assert "RFC 8785 section 3.2.2" in msg
+
+
+def test_rejects_nested_float_and_reports_json_pointer() -> None:
+    with pytest.raises(ValueError) as exc:
+        canonicalize_tool_args({"a": {"b": [1, 2.0]}})
+    msg = str(exc.value)
+    assert "/a/b/1" in msg
+
+
+def test_rejects_nan() -> None:
+    with pytest.raises(ValueError) as exc:
+        canonicalize_tool_args({"x": math.nan})
+    assert "tool_args float at /x" in str(exc.value)
+
+
+def test_rejects_infinity() -> None:
+    with pytest.raises(ValueError) as exc:
+        canonicalize_tool_args({"x": math.inf})
+    assert "tool_args float at /x" in str(exc.value)
+
+
+def test_accepts_decimal_as_string() -> None:
+    out = canonicalize_tool_args({"x": "1.5"})
+    assert out == b'{"x":"1.5"}'
+
+
+def test_accepts_bool_and_does_not_misclassify_as_float() -> None:
+    out = canonicalize_tool_args({"flag": True, "count": 0})
+    assert out == b'{"count":0,"flag":true}'
+
+
+def test_accepts_list_root() -> None:
+    out = canonicalize_tool_args([{"a": 1}, {"b": 2}])
+    assert out == b'[{"a":1},{"b":2}]'
+
+
+def test_json_pointer_escapes_slash_and_tilde() -> None:
+    with pytest.raises(ValueError) as exc:
+        canonicalize_tool_args({"a/b": 1.5})
+    assert "/a~1b" in str(exc.value)
+    with pytest.raises(ValueError) as exc:
+        canonicalize_tool_args({"a~b": 1.5})
+    assert "/a~0b" in str(exc.value)
+
+
+def test_first_float_wins_for_pointer() -> None:
+    with pytest.raises(ValueError) as exc:
+        canonicalize_tool_args({"a": 1.5, "b": 2.5})
+    msg = str(exc.value)
+    # dict iteration is insertion-ordered in Python 3.7+, so /a comes first.
+    assert "/a" in msg
+
+
+# === Negative conformance: receipt fixture with float in payload.tool_args ===
+
+
+def test_receipt_fixture_float_in_tool_args_is_rejected() -> None:
+    """Receipt-shaped fixture: float under ``payload.tool_args`` must fail.
+
+    Mirrors the wire shape a caller would feed when computing the
+    canonical bytes for ``tool_args`` before signing.
+    """
+    receipt = {
+        "payload": {
+            "action_type": "tool:call",
+            "tool_args": {"price": 1.5},
+        }
+    }
+    with pytest.raises(ValueError) as exc:
+        canonicalize_tool_args(receipt["payload"]["tool_args"])
+    msg = str(exc.value)
+    assert "/price" in msg
+    assert "RFC 8785 section 3.2.2" in msg
+
+
+def test_receipt_fixture_stringified_float_canonicalizes_cleanly() -> None:
+    """Same fixture with the float stringified produces stable bytes."""
+    receipt = {
+        "payload": {
+            "action_type": "tool:call",
+            "tool_args": {"price": "1.5"},
+        }
+    }
+    out = canonicalize_tool_args(receipt["payload"]["tool_args"])
+    assert out == b'{"price":"1.5"}'
+    assert hashlib.sha256(out).hexdigest() == hashlib.sha256(b'{"price":"1.5"}').hexdigest()

--- a/typescript/src/canonicalize.ts
+++ b/typescript/src/canonicalize.ts
@@ -118,6 +118,61 @@ export function canonicalizeAction(
   return canonicalize({ action_type: actionType, context });
 }
 
+function escapeJsonPointerToken(token: string): string {
+  return token.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function findFloatPointer(value: unknown, pointer: string): string | null {
+  if (typeof value === "number" && !Number.isInteger(value)) {
+    return pointer;
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return pointer;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const hit = findFloatPointer(value[i], `${pointer}/${i}`);
+      if (hit !== null) return hit;
+    }
+    return null;
+  }
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    for (const key of Object.keys(obj)) {
+      const hit = findFloatPointer(obj[key], `${pointer}/${escapeJsonPointerToken(key)}`);
+      if (hit !== null) return hit;
+    }
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Pre-validate ``tool_args`` and return JCS-canonical bytes.
+ *
+ * Floats are not byte-stable across runtimes per RFC 8785 section 3.2.2,
+ * so the Compliance Receipts profile keeps them out of the signed
+ * canonical scope. Serialize numerics as strings (``"1.5"``) or
+ * integer-rational pairs before calling this helper. Integers (including
+ * any value where ``Number.isInteger`` is true) and booleans pass through.
+ *
+ * @throws Error When any leaf is a non-integer or non-finite number; the
+ *   message includes the JSON pointer to the offending value so the
+ *   caller can fix the input.
+ */
+export function canonicalizeToolArgs(args: unknown): Uint8Array {
+  const pointer = findFloatPointer(args, "");
+  if (pointer !== null) {
+    const where = pointer === "" ? "/" : pointer;
+    throw new Error(
+      `tool_args float at ${where}: floats are not byte-stable across runtimes `
+      + "per RFC 8785 section 3.2.2; serialize numerics as strings or rationals "
+      + "before passing to canonicalizeToolArgs",
+    );
+  }
+  return canonicalize(args);
+}
+
 /**
  * Self-describing hash for an action: `sha256:<hex>`.
  * With `salt` set, uses HMAC-SHA-256.

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -86,7 +86,12 @@ export function mapPolicyDecisionToDecision(
 
 export { clearHooks, registerAfter, registerBefore } from "./hooks.js";
 export type { AfterHook, BeforeHook } from "./hooks.js";
-export { canonicalize, canonicalizeAction, hashAction } from "./canonicalize.js";
+export {
+  canonicalize,
+  canonicalizeAction,
+  canonicalizeToolArgs,
+  hashAction,
+} from "./canonicalize.js";
 export { canonicalJson } from "./jcs.js";
 export {
   verifyChain,

--- a/typescript/tests/canonicalize-tool-args.test.ts
+++ b/typescript/tests/canonicalize-tool-args.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for `canonicalizeToolArgs`.
+ *
+ * The helper pre-validates `tool_args` payloads against the Compliance
+ * Receipts canonicalization rule: no floats in the signed canonical
+ * scope, because RFC 8785 section 3.2.2 only fixes byte-stable numeric
+ * output for safe-range integers. Floats drift across runtimes and
+ * break verifier equality.
+ */
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { canonicalize, canonicalizeToolArgs } from "../src/canonicalize.js";
+
+describe("canonicalizeToolArgs() happy path", () => {
+  it("returns JCS bytes for dict with int + str + bool + nested dict + list", () => {
+    const args = {
+      tool: "database.query",
+      limit: 100,
+      dry_run: true,
+      filters: { status: "active", tags: ["a", "b"] },
+      nullable: null,
+    };
+    const out = canonicalizeToolArgs(args);
+    expect(out).toEqual(canonicalize(args));
+    const left = createHash("sha256").update(out).digest("hex");
+    const right = createHash("sha256").update(canonicalize(args)).digest("hex");
+    expect(left).toBe(right);
+  });
+
+  it("accepts a list at root", () => {
+    const out = canonicalizeToolArgs([{ a: 1 }, { b: 2 }]);
+    expect(new TextDecoder().decode(out)).toBe('[{"a":1},{"b":2}]');
+  });
+
+  it("accepts a decimal-as-string", () => {
+    const out = canonicalizeToolArgs({ x: "1.5" });
+    expect(new TextDecoder().decode(out)).toBe('{"x":"1.5"}');
+  });
+
+  it("does not misclassify booleans as floats", () => {
+    const out = canonicalizeToolArgs({ flag: true, count: 0 });
+    expect(new TextDecoder().decode(out)).toBe('{"count":0,"flag":true}');
+  });
+});
+
+describe("canonicalizeToolArgs() rejects floats", () => {
+  it("rejects a bare float with the RFC pointer in the message", () => {
+    expect(() => canonicalizeToolArgs({ x: 1.5 })).toThrow(/tool_args float at \/x/);
+    expect(() => canonicalizeToolArgs({ x: 1.5 })).toThrow(/RFC 8785 section 3\.2\.2/);
+  });
+
+  it("reports the JSON pointer for a nested float", () => {
+    expect(() => canonicalizeToolArgs({ a: { b: [1, 2.5] } })).toThrow(/\/a\/b\/1/);
+  });
+
+  it("rejects NaN", () => {
+    expect(() => canonicalizeToolArgs({ x: Number.NaN })).toThrow(/tool_args float at \/x/);
+  });
+
+  it("rejects Infinity", () => {
+    expect(() => canonicalizeToolArgs({ x: Number.POSITIVE_INFINITY })).toThrow(
+      /tool_args float at \/x/,
+    );
+  });
+
+  it("escapes slash and tilde in JSON pointer tokens", () => {
+    expect(() => canonicalizeToolArgs({ "a/b": 1.5 })).toThrow(/\/a~1b/);
+    expect(() => canonicalizeToolArgs({ "a~b": 1.5 })).toThrow(/\/a~0b/);
+  });
+});
+
+describe("canonicalizeToolArgs() negative conformance fixture", () => {
+  it("receipt payload.tool_args with a float fails canonicalization", () => {
+    const receipt = {
+      payload: {
+        action_type: "tool:call",
+        tool_args: { price: 1.5 },
+      },
+    };
+    expect(() => canonicalizeToolArgs(receipt.payload.tool_args)).toThrow(
+      /tool_args float at \/price/,
+    );
+    expect(() => canonicalizeToolArgs(receipt.payload.tool_args)).toThrow(
+      /RFC 8785 section 3\.2\.2/,
+    );
+  });
+
+  it("same fixture with the float stringified canonicalizes cleanly", () => {
+    const receipt = {
+      payload: {
+        action_type: "tool:call",
+        tool_args: { price: "1.5" },
+      },
+    };
+    const out = canonicalizeToolArgs(receipt.payload.tool_args);
+    expect(new TextDecoder().decode(out)).toBe('{"price":"1.5"}');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `canonicalize_tool_args` (Python) and `canonicalizeToolArgs` (TypeScript) as user-facing helpers that pre-validate `tool_args` against the IETF -04 canonicalization rule: no floats in the signed canonical scope, because JCS only fixes byte-stable numeric output for safe-range integers.
- Helper walks the value tree, raises on the first float (or non-finite number) with a JSON-pointer-locating error pointing to RFC 8785 section 3.2.2, otherwise delegates to the existing JCS canonicalize.
- Negative conformance test mirrors a receipt fixture (`payload.tool_args` with a float) and asserts both the rejection and that the stringified-float variant canonicalizes cleanly.

## Test plan

- [x] `cd python && python -m pytest -x` (675 passed)
- [x] `cd typescript && npm test` (208 passed, 11 new)
- [x] `cd typescript && npm run lint` (clean)
- [x] `python -m ruff check` on touched python files (clean)
- [x] Comment hygiene sweep on touched files (rules 1-10 of CLAUDE.md): no `RFC ` / `Section ` / `spec §` tokens inside `# ...` or `// ...`; references live in docstrings / JSDoc / error messages.

comment hygiene clean