### PR TITLE
fix(sdk-ts): README uses real init() not phantom Asqav class; cli compliance_mode default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,17 @@ print(sig.signature_id, sig.verify_url)
 TypeScript:
 
 ```ts
-import { Asqav } from "@asqav/sdk";
+import { init, Agent } from "@asqav/sdk";
 
-const asqav = new Asqav({ apiKey: "sk_..." });
+init({ apiKey: "sk_..." });
 
-const agent = await asqav.Agent.create("my-agent");
-const sig = await agent.sign("api:call", { model: "gpt-4" });
+const agent = await Agent.create({ name: "my-agent" });
+const sig = await agent.sign({
+  actionType: "api:call",
+  context: { model: "gpt-4" },
+});
 
-console.log(sig.signatureId, sig.verifyUrl);
+console.log(sig.signatureId, sig.verificationUrl);
 ```
 
 Each signed action returns a receipt like:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -16,8 +16,9 @@ The package ships an `asqav` binary mirroring the Python CLI surface. Set `ASQAV
 asqav --version
 asqav verify <signature_id> [--output text|json]           # IETF axes when present
 asqav sign --agent-id ID --action-type T --action-json action.json \
-           --compliance-mode --receipt-type protectmcp:decision \
+           --receipt-type protectmcp:decision \
            --risk-class high --issuer-id legal:Acme
+           # add --no-compliance-mode to opt out of the IETF profile (default is on)
 asqav agents list / create / revoke
 asqav sessions list / end <session_id>
 asqav replay <agent_id> <session_id> [--json]              # Pro
@@ -37,7 +38,7 @@ asqav migrate run v3-20|v3-21|v3-22                        # X-Maintenance-Key r
 
 Pro/Business commands are gated client-side via `GET /account` so a free-tier key gets a clean upgrade message instead of a mid-pipeline 402. The server is the source of truth; older self-hosted deployments without `/account` skip the gate.
 
-The IETF Compliance Receipts profile commands (`sign --compliance-mode`, `audit-pack export`, `audit-pack policy`, `payloads erase`, `replay-verify --strict`, `org set-compliance-strict`) match the SDK options on `agent.sign(...)`. Wire keys are snake_case (`compliance_mode`, `policy_decision`, `action_ref`) per the [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) profile; the CLI accepts the kebab-case equivalents.
+The IETF Compliance Receipts profile commands (`sign` defaults to the profile; pass `--no-compliance-mode` to opt out, `audit-pack export`, `audit-pack policy`, `payloads erase`, `replay-verify --strict`, `org set-compliance-strict`) match the SDK options on `agent.sign(...)`. Wire keys are snake_case (`compliance_mode`, `policy_decision`, `action_ref`) per the [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) profile; the CLI accepts the kebab-case equivalents.
 
 ## Quick start
 

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -407,9 +407,12 @@ async function cmdSign(args: string[]): Promise<void> {
   const agentId = parseFlag(args, "agent-id");
   const actionType = parseFlag(args, "action-type");
   if (!agentId || !actionType) {
-    die("Usage: asqav sign --agent-id ID --action-type T [--compliance-mode] [--action-json PATH]");
+    die("Usage: asqav sign --agent-id ID --action-type T [--no-compliance-mode] [--action-json PATH]");
   }
-  const complianceMode = hasFlag(args, "compliance-mode");
+  // Compliance Receipts default to compliance_mode=true to match the SDK
+  // constructor default (typescript/src/index.ts) and the Python SDK. Pass
+  // --no-compliance-mode to opt out for the rare non-profile receipt.
+  const complianceMode = !hasFlag(args, "no-compliance-mode");
   const actionRef = parseFlag(args, "action-ref");
   const actionJson = parseFlag(args, "action-json");
   const sandboxState = parseFlag(args, "sandbox-state");
@@ -761,7 +764,7 @@ function printHelp(): void {
 Usage:
   asqav --version
   asqav verify <signature_id> [--output text|json]
-  asqav sign --agent-id ID --action-type T [--compliance-mode] [--action-json PATH|-]
+  asqav sign --agent-id ID --action-type T [--no-compliance-mode] [--action-json PATH|-]
              [--receipt-type protectmcp:decision|...] [--risk-class low|medium|high|unknown]
              [--sandbox-state enabled|disabled|unavailable] [--iteration-id ID]
              [--issuer-id LEGAL] [--policy-decision permit|deny|rate_limit]

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -4,7 +4,7 @@
  * Thin TypeScript SDK for asqav.com. All ML-DSA cryptography happens server-side.
  *
  * Quick start:
- *   import { init, Agent } from "asqav";
+ *   import { init, Agent } from "@asqav/sdk";
  *
  *   init({ apiKey: "sk_..." });
  *   const agent = await Agent.create({ name: "my-agent" });


### PR DESCRIPTION
## Summary

Fixes two audit findings (H14 and H15) in the TypeScript SDK.

**H14: top-level README TypeScript snippet did not compile.**
- The snippet imported a non-existent `Asqav` class and called `new Asqav({...})`. The SDK exports `init`, `Agent`, `AsqavError`, etc., never a default class. Any TypeScript user copy-pasting hit a compile error.
- Replaced with the real surface: `init({apiKey})`, `Agent.create({name})`, `agent.sign({actionType, context})`, plus the correct response fields (`signatureId`, `verificationUrl`).
- Also fixed `typescript/src/index.ts:7` JSDoc which said `from "asqav"` instead of the published package name `@asqav/sdk` (per `typescript/package.json`).

**H15: CLI `compliance_mode` default disagreed with the library.**
- `typescript/src/cli.ts:412` defaulted `compliance_mode=false` via `hasFlag(args, "compliance-mode")`, contradicting `typescript/src/index.ts:817` (`options.complianceMode !== false`, default true) and the Python SDK.
- Per CLAUDE.md ("Compliance Receipts default to compliance_mode=True in the SDK (Python and TypeScript)") the CLI must match.
- Flipped to `!hasFlag(args, "no-compliance-mode")`: default true, opt out via `--no-compliance-mode`. Old `--compliance-mode` invocations remain valid as a no-op (mode stays true), so existing scripts do not break.
- Updated help text and `typescript/README.md` to drop the now-redundant flag and document the opt-out.

No existing test asserted the old default, so no test changes were needed.

## Test plan

- [x] `npm test` in `typescript/` passes (208/208)
- [x] `npm run lint` (`tsc --noEmit`) clean
- [x] TS snippet in top-level README typechecks against the actual exports
- [x] CLI `--no-compliance-mode` opts out; absence of any flag yields `complianceMode=true`
- [x] Backward compatibility: existing scripts passing `--compliance-mode` still produce compliance receipts

comment hygiene clean