### PR TITLE
fix(sdk): use spec wire 'type' field; past skew allowed; sync README pins; fix dead roadmap link

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -164,7 +164,7 @@ Frameworks shipped today: `eu_ai_act_art12`, `eu_ai_act_art14`, `dora_ict`,
 ## Tips
 
 - Pin `asqav` to a specific version once your governance setup is stable
-  (`pip install asqav==0.4.3`). Lockstep upgrades catch breaking changes early.
+  (`pip install asqav==0.4.4`). Lockstep upgrades catch breaking changes early.
 - The `asqav doctor` step reads only environment variables and the public API,
   so it is safe to run on forks. The bundle export touches your API key and
   produces an artifact, so guard it with

--- a/python/README.md
+++ b/python/README.md
@@ -115,7 +115,6 @@ Algorithm agility per profile section 10.8 is exposed via `asqav.SUPPORTED_ALGOR
 
 - Repository: <https://github.com/jagmarques/asqav-sdk>
 - Full docs: <https://asqav.com/docs>
-- Roadmap: <https://asqav.com/roadmap>
 
 ## License
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -234,8 +234,12 @@ def _map_policy_decision_to_decision(policy_decision: str | None) -> str:
     return DECISION_MAP.get((policy_decision or "").lower(), "deny")
 
 # REQUIRED fields on a Compliance Receipt envelope; used by `verify_compliance_receipt`.
+# Field names match the wire form defined in
+# draft-marques-asqav-compliance-receipts (Section 2.1, worked example); the
+# top-level discriminator is ``type``, not the SDK's internal ``receipt_type``
+# attribute. Conformant emitters MUST translate to ``type`` on emission.
 _COMPLIANCE_REQUIRED_FIELDS: tuple[str, ...] = (
-    "receipt_type",
+    "type",
     "issuer_id",
     "agent_id",
     "action_ref",
@@ -2351,9 +2355,11 @@ def verify_compliance_receipt(
     to the cloud:
 
     1. All REQUIRED fields are present.
-    2. ``receipt_type`` is in the `protectmcp:*` namespace.
-    3. ``signed_at`` (or ``issued_at``) is within
-       ``SKEW_BOUND_SECONDS`` of ``now``.
+    2. ``type`` is in the `protectmcp:*` namespace.
+    3. ``issued_at`` is not more than ``SKEW_BOUND_SECONDS`` ahead of
+       ``now``. Past skew is bounded by the retention floor, not by
+       freshness, so historical receipts within retention verify on the
+       same path as fresh ones (spec Section 2.1, ``issued_at``).
     4. ``previousReceiptHash`` rederives over the predecessor's inner
        compliance payload under JCS, when one is supplied. The cloud
        hashes ``canonical_json(payload)`` only, not the bundle wrapper,
@@ -2403,8 +2409,10 @@ def verify_compliance_receipt(
     if missing:
         errors.append(f"missing_fields:{','.join(missing)}")
 
-    # 2. receipt_type namespace.
-    rt = envelope.get("receipt_type") or envelope.get("type")
+    # 2. ``type`` namespace. Spec wire field is ``type``; the legacy
+    # ``receipt_type`` attribute is still accepted on input for callers
+    # that have not yet migrated their emitter to the wire form.
+    rt = envelope.get("type") or envelope.get("receipt_type")
     receipt_type_in_namespace = rt in RECEIPT_TYPE_NAMESPACE
     if not receipt_type_in_namespace:
         errors.append("invalid_receipt_type")
@@ -2423,7 +2431,12 @@ def verify_compliance_receipt(
                 s = str(issued_at).replace("Z", "+00:00")
                 ts = datetime.fromisoformat(s).timestamp()
             wall = now if now is not None else time.time()
-            skew = abs(ts - wall)
+            # Spec (draft-marques-asqav-compliance-receipts Section 2.1,
+            # issued_at): verifiers MUST reject receipts whose ``issued_at``
+            # is more than SKEW_BOUND_SECONDS ahead of the verifier clock and
+            # MUST NOT reject solely because ``issued_at`` lies in the past.
+            # Past skew is bounded by the retention floor, not freshness.
+            skew = ts - wall
             skew_within_bound = skew <= SKEW_BOUND_SECONDS
             if not skew_within_bound:
                 errors.append("signed_at_skew")

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -22,10 +22,13 @@ from asqav.replay import FIRST_RECEIPT_SEED
 
 
 def _good_envelope(**overrides) -> dict:
-    """A receipt envelope that passes every check by default."""
+    """A receipt envelope that passes every check by default.
+
+    Uses the spec wire form ``type`` (draft-marques-asqav-compliance-receipts
+    Section 2.1) rather than the SDK-internal ``receipt_type`` attribute.
+    """
     base = {
         "type": "protectmcp:decision",
-        "receipt_type": "protectmcp:decision",
         "issued_at": datetime.now(timezone.utc).isoformat(),
         "issuer_id": "legal:Acme GmbH",
         "agent_id": "agent_001",
@@ -94,7 +97,7 @@ def test_multiple_missing_fields_all_reported() -> None:
 
 
 def test_receipt_type_outside_namespace_rejected() -> None:
-    env = _good_envelope(receipt_type="custom:weird", type="custom:weird")
+    env = _good_envelope(type="custom:weird")
     result = verify_compliance_receipt(env)
     assert result.receipt_type_in_namespace is False
     assert result.valid is False
@@ -107,9 +110,26 @@ def test_all_three_namespace_values_accepted() -> None:
         "protectmcp:restraint",
         "protectmcp:lifecycle",
     ):
-        env = _good_envelope(receipt_type=rt, type=rt)
+        env = _good_envelope(type=rt)
         result = verify_compliance_receipt(env)
         assert result.receipt_type_in_namespace is True, rt
+
+
+def test_legacy_receipt_type_attribute_still_accepted_for_namespace() -> None:
+    """Callers that have not yet migrated their emitter to the wire form
+    may still ship a ``receipt_type`` attribute; the namespace check
+    falls back to it. The REQUIRED-fields check, however, demands the
+    wire ``type``."""
+    env = _good_envelope()
+    env["receipt_type"] = env.pop("type")
+    result = verify_compliance_receipt(env)
+    # Namespace fallback succeeds.
+    assert result.receipt_type_in_namespace is True
+    # But REQUIRED-fields check insists on the wire ``type``.
+    assert result.fields_present is False
+    assert any(
+        e.startswith("missing_fields:") and "type" in e for e in result.errors
+    )
 
 
 # === 300-second skew bound ===
@@ -127,11 +147,28 @@ def test_skew_well_within_boundary_is_accepted() -> None:
     assert result.valid is True
 
 
-def test_skew_just_over_boundary_is_rejected() -> None:
-    """A receipt 305s old (just past the 300s bound) is rejected."""
+def test_skew_just_over_past_boundary_is_accepted() -> None:
+    """Spec Section 2.1 issued_at: verifiers MUST NOT reject a receipt
+    solely because ``issued_at`` lies in the past. A receipt 305s old is
+    therefore accepted by the freshness check; retention is enforced
+    elsewhere."""
     now = time.time()
     issued = datetime.fromtimestamp(
         now - SKEW_BOUND_SECONDS - 5, tz=timezone.utc
+    ).isoformat()
+    env = _good_envelope(issued_at=issued)
+    result = verify_compliance_receipt(env, now=now)
+    assert result.skew_within_bound is True
+    assert "signed_at_skew" not in result.errors
+
+
+def test_skew_in_future_is_rejected() -> None:
+    """Spec Section 2.1 issued_at: verifiers MUST reject when
+    ``issued_at`` is more than SKEW_BOUND_SECONDS ahead of the
+    verifier's own clock."""
+    now = time.time()
+    issued = datetime.fromtimestamp(
+        now + SKEW_BOUND_SECONDS + 5, tz=timezone.utc
     ).isoformat()
     env = _good_envelope(issued_at=issued)
     result = verify_compliance_receipt(env, now=now)
@@ -140,14 +177,26 @@ def test_skew_just_over_boundary_is_rejected() -> None:
     assert "signed_at_skew" in result.errors
 
 
-def test_skew_in_future_is_also_rejected() -> None:
+def test_skew_one_hour_in_past_is_accepted() -> None:
+    """M4 audit fix: an hour-old receipt (skew = -3600s) MUST verify."""
     now = time.time()
-    issued = datetime.fromtimestamp(
-        now + SKEW_BOUND_SECONDS + 5, tz=timezone.utc
-    ).isoformat()
+    issued = datetime.fromtimestamp(now - 3600, tz=timezone.utc).isoformat()
+    env = _good_envelope(issued_at=issued)
+    result = verify_compliance_receipt(env, now=now)
+    assert result.skew_within_bound is True
+    assert result.valid is True
+
+
+def test_skew_one_hour_in_future_is_rejected() -> None:
+    """M4 audit fix: a receipt timestamped an hour ahead (skew = +3600s)
+    is outside the 300s bound and MUST reject."""
+    now = time.time()
+    issued = datetime.fromtimestamp(now + 3600, tz=timezone.utc).isoformat()
     env = _good_envelope(issued_at=issued)
     result = verify_compliance_receipt(env, now=now)
     assert result.skew_within_bound is False
+    assert result.valid is False
+    assert "signed_at_skew" in result.errors
 
 
 def test_skew_accepts_unix_seconds_too() -> None:


### PR DESCRIPTION
## Summary

Audit findings M3, M4, M13, M22 in one PR.

- **M3** `_COMPLIANCE_REQUIRED_FIELDS` (`python/src/asqav/client.py:237`) listed the SDK-internal attribute `receipt_type` instead of the spec wire field `type` (draft-marques-asqav-compliance-receipts Section 2.1, worked example). The local verifier therefore reported every conformant receipt as `missing_fields:receipt_type`. The REQUIRED-fields tuple is now `type`; the namespace check still falls back to `receipt_type` for callers mid-migration.
- **M4** `verify_compliance_receipt` used `abs(skew)`, rejecting both past and future skew. Spec Section 2.1 (`issued_at`) forbids rejecting past skew on freshness grounds; past skew is bounded by the retention floor. Switch to signed skew; reject only when `issued_at` is ahead of the verifier clock. Two new tests pin the contract: hour-old receipt verifies, hour-future receipt rejects.
- **M13** `docs/github-actions.md` pinned `asqav==0.4.3` in a CI example. Current published version is 0.4.4 (PyPI + `pyproject.toml`). Bumped.
- **M22** `python/README.md:118` linked to `asqav.com/roadmap`, which 404s after the www redirect. No roadmap page exists; the README already carries an inline roadmap section above the link, so the dead line is removed.

## Test plan

- [x] pytest python/tests/test_verify_compliance_receipt.py (17 passed, including new past-vs-future skew tests)
- [x] pytest python/tests/ (678 passed)
- [x] grep "receipt_type" python/src/asqav/client.py shows only SDK-internal callsites; _COMPLIANCE_REQUIRED_FIELDS no longer contains it
- [x] grep "abs(skew)" python/src/asqav/client.py returns zero
- [x] grep "==0.4.3" python/README.md docs/github-actions.md returns zero
- [x] curl -sSL asqav.com/roadmap returns 404; link removed
- [ ] CI green on the PR

comment hygiene clean