### PR TITLE
fix(sdk): close spec cross-cutting gaps E3 E4 E6 E13

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -200,7 +200,8 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
     }
 )
 
-#: Canonical `incident_class` vocabulary; cloud rejects anything outside this set.
+#: Canonical `incident_class` vocabulary under DORA Annex II field 3.23.
+#: Cloud rejects anything outside this set for receipts bound to DORA.
 DORA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
     {
         "cybersecurity_related",
@@ -210,6 +211,30 @@ DORA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
         "payment_related",
         "other",
     }
+)
+
+#: Canonical `incident_class` vocabulary under the HIPAA Security Rule
+#: (45 CFR 164.304). Closes GAP-E13: draft-marques-asqav-compliance-receipts
+#: Section 4.2 (`incident_class`) names HIPAA as one of the canonical
+#: source regimes; the SDK now accepts a HIPAA token instead of forcing a
+#: Covered Entity to fall back to a DORA category.
+HIPAA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
+    {"hipaa_security_incident"}
+)
+
+#: Union of every canonical incident_class token the SDK accepts. The
+#: cloud's `core/incident_vocabulary.py` is authoritative; this mirror
+#: spares callers a network round-trip on obvious mistakes.
+INCIDENT_CLASS_NAMESPACE: frozenset[str] = (
+    DORA_INCIDENT_CLASS_NAMESPACE | HIPAA_INCIDENT_CLASS_NAMESPACE
+)
+
+#: Sandbox-state enum from upstream draft-marques-acta-receipts Section 4.6.
+#: Closes the SDK side of GAP-E3: the cloud already gates the vocabulary on
+#: emit, the SDK now refuses out-of-vocabulary values before the HTTP call
+#: and rejects them on the verify path.
+SANDBOX_STATE_NAMESPACE: frozenset[str] = frozenset(
+    {"enabled", "disabled", "unavailable"}
 )
 
 # Verifier rejects receipts further than this from the wall clock.
@@ -1193,16 +1218,35 @@ class Agent:
                 "missing_reason: policy_decision=deny|rate_limit "
                 "requires a `reason` code."
             )
-        # Fail fast on incident_class vocabulary before the HTTP roundtrip.
+        # Fail fast on sandbox_state vocabulary before the HTTP roundtrip.
+        # Closes the SDK side of GAP-E3; spec Section 4.1.6 (`sandbox_state`)
+        # restricts the field to {enabled, disabled, unavailable}.
         if (
-            incident_class is not None
-            and incident_class not in DORA_INCIDENT_CLASS_NAMESPACE
+            sandbox_state is not None
+            and sandbox_state not in SANDBOX_STATE_NAMESPACE
         ):
             raise ValueError(
-                "invalid_incident_class: must be one of "
-                f"{sorted(DORA_INCIDENT_CLASS_NAMESPACE)} "
-                "(per DORA RTS JC 2024-33 Annex II field 3.23)."
+                "invalid_sandbox_state: must be one of "
+                f"{sorted(SANDBOX_STATE_NAMESPACE)} "
+                "(per draft-marques-asqav-compliance-receipts Section 4.1.6)."
             )
+        # Fail fast on incident_class vocabulary before the HTTP roundtrip.
+        # Lists / arrays are also valid per spec Section 4.2 (`incident_class`
+        # MUST be a JSON string OR a JSON array of such strings).
+        if incident_class is not None:
+            _tokens = (
+                incident_class
+                if isinstance(incident_class, list)
+                else [incident_class]
+            )
+            for _t in _tokens:
+                if _t not in INCIDENT_CLASS_NAMESPACE:
+                    raise ValueError(
+                        "invalid_incident_class: must be one of "
+                        f"{sorted(INCIDENT_CLASS_NAMESPACE)} "
+                        "(per DORA RTS JC 2024-33 Annex II field 3.23 "
+                        "or HIPAA 45 CFR 164.304)."
+                    )
         # Derive action_ref under compliance_mode when caller omits it.
         if compliance_mode and action_ref is None:
             action_ref = _compute_action_ref(action_type, context)
@@ -2467,6 +2511,31 @@ def verify_compliance_receipt(
             errors.append("chain_link_mismatch")
     # No predecessor supplied: leave chain_link_rederives=True (unchecked is not failed).
 
+    # 5. Conditional MUSTs on the inner payload.
+    #
+    #   * Spec Section 4.1.6 (`sandbox_state`) restricts the value space to
+    #     {enabled, disabled, unavailable}. Closes the SDK side of GAP-E3.
+    #   * Spec Section 4.1.9 (`reason`) is REQUIRED whenever `decision` is
+    #     `deny` or `rate_limit`. Closes the SDK side of GAP-E4.
+    #   * Spec Section 4.7 (`anchors[]`) declares `value` REQUIRED on every
+    #     anchor entry; entries with an empty `value` MUST NOT be reported
+    #     as anchor_valid_*=true. Closes the SDK side of GAP-E6.
+    _payload = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else envelope
+    if isinstance(_payload, dict):
+        _sandbox = _payload.get("sandbox_state")
+        if _sandbox is not None and _sandbox not in SANDBOX_STATE_NAMESPACE:
+            errors.append("invalid_sandbox_state")
+        _decision = _payload.get("decision")
+        if _decision in {"deny", "rate_limit"} and not _payload.get("reason"):
+            errors.append("missing_reason_on_deny_or_rate_limit")
+    _anchors = envelope.get("anchors")
+    if isinstance(_anchors, list):
+        for _i, _entry in enumerate(_anchors):
+            if not isinstance(_entry, dict):
+                continue
+            if not _entry.get("value"):
+                errors.append(f"anchor_missing_value:{_i}")
+
     counterparty_binding_verified: bool | None = None
     payload_obj = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else envelope
     has_binding = isinstance(payload_obj, dict) and isinstance(
@@ -2490,11 +2559,25 @@ def verify_compliance_receipt(
             if not outcome.valid:
                 errors.append(f"counterparty_binding_{outcome.label}")
 
+    # Conditional-MUST failures land in `errors` only; a separate axis flag
+    # would bloat the dataclass for axes the cloud already gates. Surface
+    # them through the unified error list and the top-level `valid` boolean.
+    _conditional_must_fail = any(
+        e.startswith(
+            (
+                "invalid_sandbox_state",
+                "missing_reason_on_deny_or_rate_limit",
+                "anchor_missing_value:",
+            )
+        )
+        for e in errors
+    )
     valid = (
         fields_present
         and receipt_type_in_namespace
         and skew_within_bound
         and chain_link_rederives
+        and not _conditional_must_fail
         and (counterparty_binding_verified is not False)
     )
     return ComplianceReceiptVerification(

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -405,3 +405,112 @@ def test_pre_alignment_token_now_rejected() -> None:
                     incident_class=token,
                 )
             p.assert_not_called()
+
+
+# === HIPAA Security Rule vocabulary (GAP-E13) ===
+
+
+def test_hipaa_security_incident_token_accepted() -> None:
+    """Spec Section 4.2 (`incident_class`) names HIPAA 45 CFR 164.304 as a
+    canonical source regime alongside DORA. The SDK MUST accept the HIPAA
+    token so a Covered Entity is not forced into a DORA category."""
+    from asqav.client import HIPAA_INCIDENT_CLASS_NAMESPACE
+
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    assert "hipaa_security_incident" in HIPAA_INCIDENT_CLASS_NAMESPACE
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            incident_class="hipaa_security_incident",
+        )
+    assert captured["body"]["incident_class"] == "hipaa_security_incident"
+
+
+def test_incident_class_list_form_accepted_with_mixed_regimes() -> None:
+    """Spec Section 4.2: `incident_class` MAY be a JSON array of canonical
+    strings to preserve cross-regime classification (e.g. one Action that
+    is both a DORA ICT-related incident and a HIPAA security incident)."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            incident_class=["cybersecurity_related", "hipaa_security_incident"],
+        )
+    assert captured["body"]["incident_class"] == [
+        "cybersecurity_related",
+        "hipaa_security_incident",
+    ]
+
+
+def test_incident_class_list_rejects_unknown_token_in_array() -> None:
+    """A single bad token in an array MUST fail preflight; otherwise a
+    typo travels to the cloud and lands a non-conformant receipt."""
+    with patch("asqav.client._post") as p:
+        with pytest.raises(ValueError, match="invalid_incident_class"):
+            _agent().sign(
+                "api:call",
+                {"k": "v"},
+                compliance_mode=True,
+                incident_class=["cybersecurity_related", "not_a_real_regime"],
+            )
+        p.assert_not_called()
+
+
+# === Sandbox state enum (GAP-E3) ===
+
+
+def test_sandbox_state_namespace_matches_upstream_enum() -> None:
+    """draft-marques-asqav-compliance-receipts Section 4.1.6 inherits the
+    upstream enum unchanged: {enabled, disabled, unavailable}."""
+    from asqav.client import SANDBOX_STATE_NAMESPACE
+
+    assert SANDBOX_STATE_NAMESPACE == frozenset(
+        {"enabled", "disabled", "unavailable"}
+    )
+
+
+@pytest.mark.parametrize("value", ["enabled", "disabled", "unavailable"])
+def test_canonical_sandbox_state_passes_preflight(value: str) -> None:
+    """All three canonical values are accepted and forwarded verbatim."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            sandbox_state=value,
+        )
+    assert captured["body"]["sandbox_state"] == value
+
+
+def test_invalid_sandbox_state_raises_before_http() -> None:
+    """A value outside the upstream enum is rejected client-side; this
+    closes the SDK side of GAP-E3 (cloud was the only enforcer)."""
+    with patch("asqav.client._post") as p:
+        with pytest.raises(ValueError, match="invalid_sandbox_state"):
+            _agent().sign(
+                "api:call",
+                {"k": "v"},
+                compliance_mode=True,
+                sandbox_state="sandboxed",  # plausible-looking typo
+            )
+        p.assert_not_called()

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -241,3 +241,98 @@ def test_no_predecessor_supplied_leaves_chain_check_passive() -> None:
     env = _good_envelope(previousReceiptHash="a" * 64)
     result = verify_compliance_receipt(env)
     assert result.chain_link_rederives is True
+
+
+# === Conditional MUSTs on the inner payload ===
+
+
+def test_sandbox_state_out_of_enum_is_rejected() -> None:
+    """draft-marques-asqav-compliance-receipts Section 4.1.6 restricts
+    `sandbox_state` to {enabled, disabled, unavailable}. A receipt that
+    carries any other token MUST verify as invalid."""
+    env = _good_envelope(sandbox_state="sandboxed")
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "invalid_sandbox_state" in result.errors
+
+
+def test_sandbox_state_canonical_value_passes() -> None:
+    env = _good_envelope(sandbox_state="enabled")
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+    assert "invalid_sandbox_state" not in result.errors
+
+
+def test_sandbox_state_absent_is_accepted() -> None:
+    """The field is OPTIONAL at the syntactic layer; absence MUST NOT
+    fail the helper."""
+    env = _good_envelope()
+    assert "sandbox_state" not in env
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+
+
+def test_deny_decision_without_reason_is_rejected() -> None:
+    """Spec Section 4.1.9 (`reason`) makes the field REQUIRED whenever
+    `decision` is `deny` or `rate_limit`. Closes the SDK side of GAP-E4."""
+    env = _good_envelope(decision="deny")
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "missing_reason_on_deny_or_rate_limit" in result.errors
+
+
+def test_rate_limit_decision_without_reason_is_rejected() -> None:
+    env = _good_envelope(decision="rate_limit")
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "missing_reason_on_deny_or_rate_limit" in result.errors
+
+
+def test_deny_decision_with_reason_passes() -> None:
+    env = _good_envelope(decision="deny", reason="policy:outbound_blocked")
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+    assert "missing_reason_on_deny_or_rate_limit" not in result.errors
+
+
+def test_allow_decision_without_reason_is_accepted() -> None:
+    """`reason` is conditional, not unconditional; allow-decisions without
+    reason MUST verify."""
+    env = _good_envelope(decision="allow")
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+
+
+def test_anchor_with_empty_value_is_rejected() -> None:
+    """Spec Section 4.7 (`anchors[]`) declares `value` REQUIRED on every
+    anchor entry; entries served without `value` MUST NOT be reported as
+    anchor_valid_*=true. Closes the SDK side of GAP-E6."""
+    env = _good_envelope()
+    env["anchors"] = [{"type": "rfc3161", "value": ""}]
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert any(e.startswith("anchor_missing_value:") for e in result.errors)
+
+
+def test_anchor_without_value_key_is_rejected() -> None:
+    env = _good_envelope()
+    env["anchors"] = [{"type": "opentimestamps", "status": "pending"}]
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert any(e.startswith("anchor_missing_value:") for e in result.errors)
+
+
+def test_anchor_with_populated_value_passes() -> None:
+    env = _good_envelope()
+    env["anchors"] = [{"type": "rfc3161", "value": "dGVzdA=="}]
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+
+
+def test_empty_anchors_array_does_not_trip_the_check() -> None:
+    """An empty anchors array is the cloud's pre-anchor state; the helper
+    leaves that condition to the anchors-required clause checked elsewhere."""
+    env = _good_envelope()
+    env["anchors"] = []
+    result = verify_compliance_receipt(env)
+    assert not any(e.startswith("anchor_missing_value:") for e in result.errors)

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -54,8 +54,34 @@ export const DORA_INCIDENT_CLASS_NAMESPACE = [
 ] as const;
 export type DoraIncidentClass = (typeof DORA_INCIDENT_CLASS_NAMESPACE)[number];
 
-/** Sandbox state vocabulary per the High-Risk gate. */
-export type SandboxState = "enabled" | "disabled" | "unavailable";
+/** HIPAA Security Rule canonical incident classification.
+ *
+ * Closes GAP-E13: draft-marques-asqav-compliance-receipts Section 4.2
+ * names HIPAA 45 CFR 164.304 as one of the canonical source regimes for
+ * `incident_class` alongside DORA, NYDFS, and CIRCIA. A Covered Entity
+ * SHOULD be able to emit a HIPAA token without falling back to a DORA
+ * category.
+ */
+export const HIPAA_INCIDENT_CLASS_NAMESPACE = [
+  "hipaa_security_incident",
+] as const;
+export type HipaaIncidentClass = (typeof HIPAA_INCIDENT_CLASS_NAMESPACE)[number];
+
+/** Union of every canonical incident_class token the SDK accepts. The
+ * cloud's `core/incident_vocabulary.py` is authoritative; this mirror
+ * spares callers a network round-trip on obvious mistakes.
+ */
+export const INCIDENT_CLASS_NAMESPACE = [
+  ...DORA_INCIDENT_CLASS_NAMESPACE,
+  ...HIPAA_INCIDENT_CLASS_NAMESPACE,
+] as const;
+export type IncidentClass = (typeof INCIDENT_CLASS_NAMESPACE)[number];
+
+/** Sandbox state vocabulary per the High-Risk gate. Closes GAP-E3 on the
+ * TypeScript SDK: the cloud already enforces this enum, the SDK now
+ * refuses out-of-vocabulary values before the HTTP roundtrip. */
+export const SANDBOX_STATE_NAMESPACE = ["enabled", "disabled", "unavailable"] as const;
+export type SandboxState = (typeof SANDBOX_STATE_NAMESPACE)[number];
 
 /** Risk class controlled vocabulary. */
 export type RiskClass = "low" | "medium" | "high" | "unknown";
@@ -830,15 +856,28 @@ export class Agent {
         "missing_reason: policy_decision=deny|rate_limit requires a `reason` code",
       );
     }
+    // Fail fast on sandbox_state vocabulary before the HTTP roundtrip.
+    // Closes the TS side of GAP-E3; spec Section 4.1.6 restricts the field
+    // to {enabled, disabled, unavailable}.
+    if (
+      options.sandboxState !== undefined
+      && !(SANDBOX_STATE_NAMESPACE as readonly string[]).includes(options.sandboxState)
+    ) {
+      throw new AsqavError(
+        `invalid_sandbox_state: '${options.sandboxState}' must be one of ${SANDBOX_STATE_NAMESPACE.join(", ")}`,
+      );
+    }
     // Fail fast on incident_class vocabulary before the HTTP roundtrip.
+    // Accepts the HIPAA token in addition to the six DORA tokens; closes
+    // the TS side of GAP-E13.
     if (options.incidentClass !== undefined && options.incidentClass !== "") {
       const incidentValues = Array.isArray(options.incidentClass)
         ? options.incidentClass
         : [options.incidentClass];
       for (const ic of incidentValues) {
-        if (!(DORA_INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)) {
+        if (!(INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)) {
           throw new AsqavError(
-            `invalid_incident_class: '${ic}' must be one of ${DORA_INCIDENT_CLASS_NAMESPACE.join(", ")}`,
+            `invalid_incident_class: '${ic}' must be one of ${INCIDENT_CLASS_NAMESPACE.join(", ")}`,
           );
         }
       }

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -13,7 +13,10 @@ import {
   Agent,
   AsqavError,
   DORA_INCIDENT_CLASS_NAMESPACE,
+  HIPAA_INCIDENT_CLASS_NAMESPACE,
+  INCIDENT_CLASS_NAMESPACE,
   RECEIPT_TYPE_NAMESPACE,
+  SANDBOX_STATE_NAMESPACE,
   _resetForTests,
   init,
 } from "../src/index.js";
@@ -259,6 +262,82 @@ describe("agent.sign IETF profile fields", () => {
         incidentClass: "ICT-INC-001",
       }),
     ).rejects.toThrow(/invalid_incident_class/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  // === HIPAA incident_class vocabulary (GAP-E13) ===
+
+  it("accepts the HIPAA security incident token", async () => {
+    expect(HIPAA_INCIDENT_CLASS_NAMESPACE).toContain("hipaa_security_incident");
+    expect(INCIDENT_CLASS_NAMESPACE).toContain("hipaa_security_incident");
+
+    let capturedBody: Record<string, unknown> | null = null;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      capturedBody = JSON.parse((init?.body as string) ?? "{}");
+      return jsonResponse({
+        signature: "sig",
+        signature_id: "sigid",
+        action_id: "act",
+        timestamp: "2026-05-04T00:00:00Z",
+        verification_url: "https://example.test",
+      });
+    });
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "api:call",
+      context: {},
+      complianceMode: true,
+      incidentClass: "hipaa_security_incident",
+    });
+    expect((capturedBody as unknown as Record<string, unknown>).incident_class).toBe(
+      "hipaa_security_incident",
+    );
+  });
+
+  it("accepts an array mixing DORA and HIPAA tokens for cross-regime classification", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      capturedBody = JSON.parse((init?.body as string) ?? "{}");
+      return jsonResponse({
+        signature: "sig",
+        signature_id: "sigid",
+        action_id: "act",
+        timestamp: "2026-05-04T00:00:00Z",
+        verification_url: "https://example.test",
+      });
+    });
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "api:call",
+      context: {},
+      complianceMode: true,
+      incidentClass: ["cybersecurity_related", "hipaa_security_incident"],
+    });
+    expect(
+      (capturedBody as unknown as Record<string, unknown>).incident_class,
+    ).toEqual(["cybersecurity_related", "hipaa_security_incident"]);
+  });
+
+  // === Sandbox state enum (GAP-E3) ===
+
+  it("SANDBOX_STATE_NAMESPACE matches the upstream enum", () => {
+    expect([...SANDBOX_STATE_NAMESPACE].sort()).toEqual(
+      ["disabled", "enabled", "unavailable"],
+    );
+  });
+
+  it("rejects an out-of-vocabulary sandbox_state before any HTTP call", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "api:call",
+        context: {},
+        complianceMode: true,
+        // @ts-expect-error -- intentional: testing runtime guard with a string outside the enum.
+        sandboxState: "sandboxed",
+      }),
+    ).rejects.toThrow(/invalid_sandbox_state/);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Close the SDK side of four spec-vs-code gaps from the 2026-05-11 cross-validator audit:

- **GAP-E3 (sandbox_state vocab)**: Python + TS SDKs expose `SANDBOX_STATE_NAMESPACE` and reject out-of-vocabulary values in `sign()` preflight and `verify_compliance_receipt()`. Mirrors the cloud enum from draft-marques-asqav-compliance-receipts Section 4.1.6.
- **GAP-E4 (`reason` REQUIRED on `deny` / `rate_limit`)**: `verify_compliance_receipt()` now flags `missing_reason_on_deny_or_rate_limit` when a receipt whose `decision` is `deny` / `rate_limit` lacks a `reason`. The cloud-side counterpart (core/conformance.py) remains for a follow-up cloud PR.
- **GAP-E6 (`anchors[].value` REQUIRED)**: `verify_compliance_receipt()` rejects anchor entries with empty / absent `value`. Cloud projection layer still emits empty values on missing bytes; that part is cloud-side and tracked separately.
- **GAP-E13 (HIPAA incident_class token)**: New `HIPAA_INCIDENT_CLASS_NAMESPACE = {hipaa_security_incident}` plus a multi-regime `INCIDENT_CLASS_NAMESPACE` union. `sign()` now also accepts the array form per spec Section 4.2.

Each fix lands with targeted tests that pin the new behaviour (Python and TypeScript).

## Test plan

- [x] `cd python && uv run pytest` -> 702 passed
- [x] `cd typescript && npm test` -> 214 passed
- [x] `cd typescript && npm run lint` -> clean
- [x] `uv run ruff check` on changed files -> clean
- [x] mypy delta vs `origin/main`: 0 new errors on `python/src/asqav/client.py`

## Cloud follow-up

Three of the four gaps also need a cloud-side change. The SDK fixes guard the local sanity paths; the cloud is the authoritative emit / verify surface and is tracked in a separate PR:

- GAP-E3: per-org `is_high_risk` flag + High-Risk conditional rejection (cloud `core/conformance.py`).
- GAP-E4: deny / rate_limit + missing-reason rejection (cloud `core/conformance.py`).
- GAP-E6: drop `value=""` emission paths in `core/ietf_projection.py:50-51, 76-77`.
- GAP-E13: add HIPAA token to `core/incident_vocabulary.py`.