### PR TITLE
docs(security): enumerate four accepted dependabot residuals

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,3 +19,16 @@ Do not open public issues for security vulnerabilities.
 - Key storage: Server-side, never exposed to SDK
 - Timestamps: RFC 3161 compliant
 - All cryptography runs server-side via liboqs
+
+## Known dependency advisories
+
+These advisories are surfaced by Dependabot against `python/uv.lock` but are not exploitable in the default `pip install asqav` install path. The vulnerable packages live in `python/pyproject.toml` `optional-dependencies` extras and only enter the dependency graph when a caller installs that extra explicitly.
+
+- `GHSA-jxgv-6j54-wwc7` (smolagents, low). Gated by the `[smolagents]` extra. Not installed by default.
+- `GHSA-54fq-v6x8-244g` (smolagents, low). Gated by the `[smolagents]` extra. Not installed by default.
+- `GHSA-w8v5-vhqr-4h9v` (diskcache, medium). Transitive of `dspy`; gated by the `[dspy]` extra. Not installed by default.
+- `GHSA-vvw2-h478-xwr3` (dspy, medium). Gated by the `[dspy]` extra. Not installed by default.
+
+Trivy and pip-audit against `python/uv.lock` both report 0 vulnerabilities in the default install path because their uv scanners treat marker-gated extras as not-installed-by-default. Dependabot remains stricter and flags them regardless.
+
+If you install any of the affected extras (`pip install "asqav[smolagents]"`, `pip install "asqav[dspy]"`, or `pip install "asqav[all]"`) you opt in to the upstream advisory surface for those packages. Review the GHSAs above before pinning those extras in a production deployment.


### PR DESCRIPTION
## Summary

Adds a `## Known dependency advisories` section to `SECURITY.md` enumerating the four GHSAs that Dependabot still surfaces against `python/uv.lock` after the cycle-12 cleanup pass:

- `GHSA-jxgv-6j54-wwc7` (smolagents, low) - gated by `[smolagents]`
- `GHSA-54fq-v6x8-244g` (smolagents, low) - gated by `[smolagents]`
- `GHSA-w8v5-vhqr-4h9v` (diskcache, medium) - transitive of `dspy`, gated by `[dspy]`
- `GHSA-vvw2-h478-xwr3` (dspy, medium) - gated by `[dspy]`

All four live in `python/pyproject.toml` `optional-dependencies` extras and only enter the dependency graph when a caller installs that extra explicitly. Trivy and pip-audit both report 0 vulnerabilities in the default install path because their uv scanners treat marker-gated extras as not-installed-by-default. The advisory section spells out the trade-off so callers who opt in to `[smolagents]`, `[dspy]`, or `[all]` know what they are taking on.

## Why now

Cycle-12 NEXT.md asked for a documented home for these residuals. The cycle-12 STATUS.md captured them but the SDK repo itself had no enumeration. `SECURITY.md` is the canonical home and surfaces them to anyone running their own audit.

## Test plan

- [ ] CI ci-ok green
- [ ] markdown renders cleanly on github.com

comment hygiene clean