### PR TITLE
feat(sdk): vocabulary parity with cloud cycle-12/13 (observation + capture_topology)

### DIFF
--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -31,6 +31,7 @@ from ._jcs import canonical_json
 from .async_client import AsyncAgent
 from .canonicalize import canonicalize, canonicalize_tool_args, hash_action
 from .client import (
+    CAPTURE_TOPOLOGY_NAMESPACE,
     DORA_INCIDENT_CLASS_NAMESPACE,
     RECEIPT_TYPE_NAMESPACE,
     SKEW_BOUND_SECONDS,
@@ -297,6 +298,8 @@ __all__ = [
     "verify_counterparty_binding",
     # DORA RTS JC 2024-33 Annex II vocabulary
     "DORA_INCIDENT_CLASS_NAMESPACE",
+    # IETF -04 capture-topologies appendix vocabulary
+    "CAPTURE_TOPOLOGY_NAMESPACE",
     # Algorithm agility
     "ALGORITHM_ML_DSA_65",
     "ALGORITHM_ED25519",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -32,7 +32,7 @@ import uuid
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 from urllib.parse import urljoin
 
 if TYPE_CHECKING:
@@ -228,16 +228,46 @@ SANDBOX_STATE_NAMESPACE: frozenset[str] = frozenset(
     {"enabled", "disabled", "unavailable"}
 )
 
+#: Producer-side `capture_topology` vocabulary mirrored from the cloud
+#: SignRequest Literal. See docs/capture-topology.md.
+CAPTURE_TOPOLOGY_NAMESPACE: frozenset[str] = frozenset(
+    {
+        "in_process_sdk",
+        "network_proxy",
+        "browser_extension",
+        "ebpf_observer",
+        "mcp_proxy",
+    }
+)
+
+#: Internal `policy_decision` vocabulary; `none` is the lifecycle opt-out
+#: gated to receipt_type startswith `protectmcp:lifecycle`.
+PolicyDecision = Literal["permit", "deny", "rate_limit", "none"]
+
+#: Wire-shape `decision` vocabulary; `observation` is reserved to lifecycle
+#: receipts emitted under `policy_decision="none"`.
+Decision = Literal["allow", "deny", "rate_limit", "observation"]
+
+#: Capture-topology vocabulary as a Literal for callers preferring the type form.
+CaptureTopology = Literal[
+    "in_process_sdk",
+    "network_proxy",
+    "browser_extension",
+    "ebpf_observer",
+    "mcp_proxy",
+]
+
 # Verifier rejects receipts further than this from the wall clock.
 SKEW_BOUND_SECONDS: int = 300
 
-# Spec wire vocabulary {"allow", "deny", "rate_limit"} vs original
-# `policy_decision` {"permit", "deny", "rate_limit"}; unknown -> "deny".
+#: vocabulary | wire `{allow, deny, rate_limit, observation}` keyed by
+#: internal `{permit, allow, deny, rate_limit, none}`. Unknown -> "deny".
 DECISION_MAP: dict[str, str] = {
     "permit": "allow",
     "allow": "allow",
     "deny": "deny",
     "rate_limit": "rate_limit",
+    "none": "observation",
 }
 
 
@@ -1116,6 +1146,7 @@ class Agent:
         incident_class: str | list[str] | None = None,
         reason: str | None = None,
         policy_decision: str = "permit",
+        capture_topology: str | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -1152,6 +1183,10 @@ class Agent:
             model_name: Optional name of the model being called when this
                 action is an LLM call (e.g. "gpt-4", "claude-opus-4-7").
                 Only the name string travels; the prompt does not.
+            capture_topology: Producer-side topology. One of
+                ``in_process_sdk``, ``network_proxy``, ``browser_extension``,
+                ``ebpf_observer``, ``mcp_proxy``. Stamped on the audit-pack
+                manifest entry; never on the signed payload.
 
         Returns:
             SignatureResponse with the signature.
@@ -1215,6 +1250,15 @@ class Agent:
                 "invalid_sandbox_state: must be one of "
                 f"{sorted(SANDBOX_STATE_NAMESPACE)}."
             )
+        # Fail fast on capture_topology vocabulary before the HTTP roundtrip.
+        if (
+            capture_topology is not None
+            and capture_topology not in CAPTURE_TOPOLOGY_NAMESPACE
+        ):
+            raise ValueError(
+                "invalid_capture_topology: must be one of "
+                f"{sorted(CAPTURE_TOPOLOGY_NAMESPACE)}."
+            )
         # Fail fast on incident_class vocabulary before the HTTP roundtrip.
         # The field accepts a JSON string or a JSON array of such strings.
         if incident_class is not None:
@@ -1251,6 +1295,7 @@ class Agent:
                 ("risk_class", risk_class),
                 ("incident_class", incident_class),
                 ("reason", reason),
+                ("capture_topology", capture_topology),
             ):
                 if v is not None:
                     compliance_fields[k] = v

--- a/python/tests/test_client_capture_topology.py
+++ b/python/tests/test_client_capture_topology.py
@@ -1,0 +1,200 @@
+"""SDK parity for `capture_topology` + `observation` decision vocabulary.
+
+Covers the cycle-12/13 cloud + IETF -04 deliverables: the wire `decision`
+vocabulary gains `observation` (paired with internal `policy_decision="none"`
+on `protectmcp:lifecycle` receipts) and the producer-side `capture_topology`
+metadata travels on `SignRequest` as a closed Literal of five values.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav
+from asqav.client import (
+    CAPTURE_TOPOLOGY_NAMESPACE,
+    DECISION_MAP,
+    Agent,
+    _map_policy_decision_to_decision,
+)
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_capture",
+        name="capture-agent",
+        public_key="pk_xxx",
+        key_id="key_capture",
+        algorithm="ML-DSA-65",
+        capabilities=["api:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response(extra: dict | None = None) -> dict:
+    base = {
+        "signature": "sig_b64",
+        "signature_id": "sig_abc",
+        "action_id": "act_abc",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_abc",
+        "algorithm": "ML-DSA-65",
+        "chain_hash": "deadbeef",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+# === observation decision + policy_decision="none" ===
+
+
+def test_decision_map_includes_none_to_observation() -> None:
+    """The lifecycle opt-out token maps to the wire `observation` decision."""
+    assert DECISION_MAP["none"] == "observation"
+
+
+def test_map_policy_decision_translates_none() -> None:
+    """`_map_policy_decision_to_decision('none')` returns `observation`."""
+    assert _map_policy_decision_to_decision("none") == "observation"
+
+
+def test_decision_vocabulary_includes_observation() -> None:
+    """A lifecycle receipt with `policy_decision='none'` ships
+    `decision='observation'` on the outgoing JSON body."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response({
+            "compliance_mode": True,
+            "policy_decision": "none",
+            "decision": "observation",
+        })
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        resp = _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            receipt_type="protectmcp:lifecycle",
+            policy_decision="none",
+        )
+
+    body = captured["body"]
+    assert body["policy_decision"] == "none"
+    assert body["receipt_type"] == "protectmcp:lifecycle"
+    assert resp.decision == "observation"
+
+
+def test_observation_round_trips_on_response_without_cloud_field() -> None:
+    """An older cloud may omit `decision`; the SDK maps `none` locally."""
+    extra = {
+        "compliance_mode": True,
+        "policy_decision": "none",
+        "receipt_type": "protectmcp:lifecycle",
+    }
+    with patch("asqav.client._post", return_value=_ok_response(extra)):
+        resp = _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            receipt_type="protectmcp:lifecycle",
+            policy_decision="none",
+        )
+    assert resp.decision == "observation"
+
+
+# === capture_topology vocabulary ===
+
+
+def test_capture_topology_namespace_matches_cloud_literal() -> None:
+    """SDK namespace mirrors the cloud SignRequest Literal exactly."""
+    assert CAPTURE_TOPOLOGY_NAMESPACE == frozenset(
+        {
+            "in_process_sdk",
+            "network_proxy",
+            "browser_extension",
+            "ebpf_observer",
+            "mcp_proxy",
+        }
+    )
+
+
+def test_capture_topology_is_re_exported_at_top_level() -> None:
+    """`asqav.CAPTURE_TOPOLOGY_NAMESPACE` is part of the public surface."""
+    assert asqav.CAPTURE_TOPOLOGY_NAMESPACE == CAPTURE_TOPOLOGY_NAMESPACE
+
+
+@pytest.mark.parametrize("value", sorted(CAPTURE_TOPOLOGY_NAMESPACE))
+def test_capture_topology_passes_through(value: str) -> None:
+    """All five canonical values are forwarded verbatim on the body."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            capture_topology=value,
+        )
+    assert captured["body"]["capture_topology"] == value
+
+
+def test_capture_topology_invalid_value_rejected() -> None:
+    """A value outside the closed Literal is rejected before the HTTP call."""
+    with patch("asqav.client._post") as p:
+        with pytest.raises(ValueError, match="invalid_capture_topology"):
+            _agent().sign(
+                "api:call",
+                {"k": "v"},
+                compliance_mode=True,
+                capture_topology="rootkit",
+            )
+        p.assert_not_called()
+
+
+def test_capture_topology_absent_when_not_set() -> None:
+    """No body key when the caller does not pass the kwarg."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+        )
+    assert "capture_topology" not in captured["body"]
+
+
+def test_capture_topology_dropped_outside_compliance_mode() -> None:
+    """Compliance-mode-off requests omit `capture_topology` to preserve
+    the non-compliance body shape used in lightweight self-hosted setups."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=False,
+            capture_topology="mcp_proxy",
+        )
+    assert "capture_topology" not in captured["body"]

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -82,21 +82,37 @@ export type IncidentClass = (typeof INCIDENT_CLASS_NAMESPACE)[number];
 export const SANDBOX_STATE_NAMESPACE = ["enabled", "disabled", "unavailable"] as const;
 export type SandboxState = (typeof SANDBOX_STATE_NAMESPACE)[number];
 
+/** Producer-side `capture_topology` vocabulary; mirrors the cloud
+ * SignRequest Literal and the IETF -04 capture-topologies appendix. */
+export const CAPTURE_TOPOLOGY_NAMESPACE = [
+  "in_process_sdk",
+  "network_proxy",
+  "browser_extension",
+  "ebpf_observer",
+  "mcp_proxy",
+] as const;
+export type CaptureTopology = (typeof CAPTURE_TOPOLOGY_NAMESPACE)[number];
+
 /** Risk class controlled vocabulary. */
 export type RiskClass = "low" | "medium" | "high" | "unknown";
 
-/** Policy decision vocabulary; deny / rate_limit require `reason`. */
-export type PolicyDecision = "permit" | "deny" | "rate_limit";
+/** Policy decision vocabulary; deny / rate_limit require `reason`. `none`
+ * is the lifecycle opt-out gated to `protectmcp:lifecycle` receipts. */
+export type PolicyDecision = "permit" | "deny" | "rate_limit" | "none";
 
-/** Spec-shape decision vocabulary; original `policyDecision` uses "permit". */
-export type Decision = "allow" | "deny" | "rate_limit";
+/** Spec-shape decision vocabulary; `observation` is reserved to
+ * lifecycle receipts emitted under `policyDecision="none"` (IETF -04). */
+export type Decision = "allow" | "deny" | "rate_limit" | "observation";
 
-/** Map an original `policyDecision` token to the spec-shape `decision`. */
+/** Map an original `policyDecision` token to the spec-shape `decision`.
+ * The `none -> observation` row is gated to lifecycle receipts by the
+ * no-false-attestation rule on the cloud side. */
 export const DECISION_MAP: Readonly<Record<string, Decision>> = Object.freeze({
   permit: "allow",
   allow: "allow",
   deny: "deny",
   rate_limit: "rate_limit",
+  none: "observation",
 });
 
 /** Translate `policyDecision` to the spec-shape `decision`. Falls back
@@ -357,9 +373,16 @@ export interface SignOptions {
    * source of truth on which codes are accepted. */
   reason?: string;
 
-  /** Policy decision. `permit` (default), `deny`, or `rate_limit`. When
-   * not `permit`, `reason` is required. */
+  /** Policy decision. `permit` (default), `deny`, `rate_limit`, or `none`.
+   * `none` is the lifecycle opt-out and requires `receiptType` in the
+   * `protectmcp:lifecycle` namespace. When `deny` or `rate_limit`,
+   * `reason` is required. */
   policyDecision?: PolicyDecision;
+
+  /** Producer-side topology. One of `in_process_sdk`, `network_proxy`,
+   * `browser_extension`, `ebpf_observer`, `mcp_proxy`. Stamped on the
+   * audit-pack manifest entry; never on the signed payload. */
+  captureTopology?: CaptureTopology;
 }
 
 export interface CoSignature {
@@ -848,12 +871,12 @@ export class Agent {
         `invalid_receipt_type: must be one of ${RECEIPT_TYPE_NAMESPACE.join(", ")}`,
       );
     }
-    if (options.policyDecision !== undefined
-      && options.policyDecision !== "permit"
-      && !options.reason) {
-      throw new AsqavError(
-        "missing_reason: policy_decision=deny|rate_limit requires a `reason` code",
-      );
+    if (options.policyDecision === "deny" || options.policyDecision === "rate_limit") {
+      if (!options.reason) {
+        throw new AsqavError(
+          "missing_reason: policy_decision=deny|rate_limit requires a `reason` code",
+        );
+      }
     }
     // Fail fast on sandbox_state vocabulary (restricted to {enabled, disabled, unavailable}) before the HTTP roundtrip.
     if (
@@ -862,6 +885,15 @@ export class Agent {
     ) {
       throw new AsqavError(
         `invalid_sandbox_state: '${options.sandboxState}' must be one of ${SANDBOX_STATE_NAMESPACE.join(", ")}`,
+      );
+    }
+    // Fail fast on capture_topology vocabulary (5 values) before the HTTP roundtrip.
+    if (
+      options.captureTopology !== undefined
+      && !(CAPTURE_TOPOLOGY_NAMESPACE as readonly string[]).includes(options.captureTopology)
+    ) {
+      throw new AsqavError(
+        `invalid_capture_topology: '${options.captureTopology}' must be one of ${CAPTURE_TOPOLOGY_NAMESPACE.join(", ")}`,
       );
     }
     // Fail fast on incident_class vocabulary (HIPAA token plus the six DORA tokens) before the HTTP roundtrip.
@@ -925,6 +957,10 @@ export class Agent {
       if (complianceMode) {
         body.decision = mapPolicyDecisionToDecision(options.policyDecision);
       }
+    }
+    // Producer-side topology; only meaningful under compliance_mode (manifest projection).
+    if (complianceMode && options.captureTopology !== undefined) {
+      body.capture_topology = options.captureTopology;
     }
 
     const data = await request<{

--- a/typescript/tests/captureTopology.test.ts
+++ b/typescript/tests/captureTopology.test.ts
@@ -1,0 +1,240 @@
+/**
+ * SDK parity for `capture_topology` + `observation` decision vocabulary.
+ *
+ * Mirrors the Python `tests/test_client_capture_topology.py` cases: the
+ * `none -> observation` DECISION_MAP entry, the closed Literal of five
+ * `captureTopology` values, and end-to-end wire-body assertions.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  CAPTURE_TOPOLOGY_NAMESPACE,
+  DECISION_MAP,
+  _resetForTests,
+  init,
+  mapPolicyDecisionToDecision,
+} from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_capture",
+    name: "capture",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-05-15T00:00:00Z",
+  });
+}
+
+describe("DECISION_MAP observation entry", () => {
+  it("maps `none` to `observation` for lifecycle opt-out receipts", () => {
+    expect(DECISION_MAP.none).toBe("observation");
+    expect(mapPolicyDecisionToDecision("none")).toBe("observation");
+  });
+
+  it("keeps the existing alias rows intact", () => {
+    expect(DECISION_MAP.permit).toBe("allow");
+    expect(DECISION_MAP.allow).toBe("allow");
+    expect(DECISION_MAP.deny).toBe("deny");
+    expect(DECISION_MAP.rate_limit).toBe("rate_limit");
+  });
+});
+
+describe("CAPTURE_TOPOLOGY_NAMESPACE", () => {
+  it("matches the cloud SignRequest Literal exactly", () => {
+    expect([...CAPTURE_TOPOLOGY_NAMESPACE].sort()).toEqual(
+      [
+        "browser_extension",
+        "ebpf_observer",
+        "in_process_sdk",
+        "mcp_proxy",
+        "network_proxy",
+      ],
+    );
+  });
+});
+
+describe("agent.sign capture_topology + observation wire fields", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits decision=observation under policyDecision=none + lifecycle receipt", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-15T00:00:00Z",
+        verification_url: "https://verify",
+        compliance_mode: true,
+        policy_decision: "none",
+        decision: "observation",
+        receipt_type: "protectmcp:lifecycle",
+      }),
+    );
+
+    const agent = fakeAgent();
+    const resp = await agent.sign({
+      actionType: "t.lifecycle",
+      complianceMode: true,
+      receiptType: "protectmcp:lifecycle",
+      policyDecision: "none",
+    });
+
+    const init = fetchSpy.mock.calls[0][1];
+    const body = JSON.parse((init?.body as string) ?? "{}");
+    expect(body.policy_decision).toBe("none");
+    expect(body.decision).toBe("observation");
+    expect(body.receipt_type).toBe("protectmcp:lifecycle");
+    expect(resp.decision).toBe("observation");
+  });
+
+  it("client-side maps `none` to `observation` when older cloud omits decision", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-15T00:00:00Z",
+        verification_url: "https://verify",
+        compliance_mode: true,
+        policy_decision: "none",
+        receipt_type: "protectmcp:lifecycle",
+      }),
+    );
+
+    const agent = fakeAgent();
+    const resp = await agent.sign({
+      actionType: "t.lifecycle",
+      complianceMode: true,
+      receiptType: "protectmcp:lifecycle",
+      policyDecision: "none",
+    });
+
+    expect(resp.decision).toBe("observation");
+  });
+
+  it("policyDecision=none does not require a reason", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-15T00:00:00Z",
+        verification_url: "https://verify",
+      }),
+    );
+
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "t.lifecycle",
+        complianceMode: true,
+        receiptType: "protectmcp:lifecycle",
+        policyDecision: "none",
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it.each([
+    "in_process_sdk",
+    "network_proxy",
+    "browser_extension",
+    "ebpf_observer",
+    "mcp_proxy",
+  ] as const)("passes captureTopology=%s through on the outgoing body", async (value) => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-15T00:00:00Z",
+        verification_url: "https://verify",
+      }),
+    );
+
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "t.test",
+      complianceMode: true,
+      captureTopology: value,
+    });
+
+    const init = fetchSpy.mock.calls[0][1];
+    const body = JSON.parse((init?.body as string) ?? "{}");
+    expect(body.capture_topology).toBe(value);
+  });
+
+  it("rejects an out-of-vocabulary captureTopology before the HTTP call", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "t.test",
+        complianceMode: true,
+        // @ts-expect-error - intentionally outside the closed Literal
+        captureTopology: "rootkit",
+      }),
+    ).rejects.toThrow(/invalid_capture_topology/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("omits capture_topology when not supplied", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-15T00:00:00Z",
+        verification_url: "https://verify",
+      }),
+    );
+
+    const agent = fakeAgent();
+    await agent.sign({ actionType: "t.test", complianceMode: true });
+
+    const init = fetchSpy.mock.calls[0][1];
+    const body = JSON.parse((init?.body as string) ?? "{}");
+    expect(body.capture_topology).toBeUndefined();
+  });
+
+  it("drops capture_topology outside compliance mode", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-15T00:00:00Z",
+        verification_url: "https://verify",
+      }),
+    );
+
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "t.test",
+      complianceMode: false,
+      captureTopology: "mcp_proxy",
+    });
+
+    const init = fetchSpy.mock.calls[0][1];
+    const body = JSON.parse((init?.body as string) ?? "{}");
+    expect(body.capture_topology).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Brings the Python and TypeScript SDKs into wire parity with the cloud `SignRequest` and the IETF draft. Two closed-vocabulary gaps were drifting on the SDK leg.

## Gaps closed

- Python `client.py` `PolicyDecision` Literal gains `none` (lifecycle opt-out).
- Python `client.py` `Decision` Literal gains `observation` (wire pair for `none`).
- Python `client.py` `DECISION_MAP` gains the `none -> observation` row.
- Python `Agent.sign` accepts `capture_topology` with a 5-value preflight check mirroring the cloud `SignRequest` Literal.
- Python `CAPTURE_TOPOLOGY_NAMESPACE` exported at package top level.
- TypeScript `index.ts` `PolicyDecision` union gains `none`; `Decision` union gains `observation`.
- TypeScript `DECISION_MAP` gains the `none -> observation` row.
- TypeScript `SignOptions.captureTopology` added with the 5-value Literal; `CAPTURE_TOPOLOGY_NAMESPACE` exported.
- TypeScript `agent.sign` emits `capture_topology` on the body under `complianceMode` and rejects out-of-vocabulary values before the HTTP roundtrip.
- TypeScript `missing_reason` gate narrowed to `deny|rate_limit` so `none` no longer trips it (lifecycle receipts must not require a reason).

## Test coverage added

Python (`python/tests/test_client_capture_topology.py`):
- Parametrised over the 5 capture-topology values, asserts pass-through on the outgoing body.
- Builder accepts `policy_decision="none" + receipt_type="protectmcp:lifecycle"` and emits a body with `decision="observation"`.
- Older cloud omitting `decision` is locally mapped (`none -> observation`).
- Rejects an out-of-vocabulary `capture_topology` (`rootkit`) before the HTTP call.
- `capture_topology` is dropped outside `compliance_mode`.

TypeScript (`typescript/tests/captureTopology.test.ts`):
- Mirror of the Python cases using vitest with a `global.fetch` spy.
- `DECISION_MAP.none === "observation"` and `mapPolicyDecisionToDecision("none") === "observation"`.
- `CAPTURE_TOPOLOGY_NAMESPACE` matches the cloud 5-value set.
- `policyDecision="none"` does not require a `reason`.

## Verification

- 716 Python tests passing (`pytest`).
- 228 TypeScript tests passing (`vitest`).
- `ruff check src/asqav/client.py` clean (pre-existing E501s in unrelated test files left untouched).
- `tsc --noEmit` clean.
- AST parse on touched `.py` files: OK.
- Forbidden-token sweep on the diff: clean.

comment hygiene clean