### PR TITLE
chore(conformance): exercise capture_topology vocabulary in conformance vectors

### DIFF
--- a/conformance/vectors.json
+++ b/conformance/vectors.json
@@ -138,6 +138,90 @@
       "sha256": "9d62c8f11b8d3922e838edfecd866eae20e4865b38cdd58092e8b592aa789c30",
       "expected_verify": false,
       "reason": "Because card_version is inside the signed payload, any attempt to rewrite it post-signing changes the canonical bytes and breaks the signature."
+    },
+    {
+      "name": "capture_topology_in_process_sdk",
+      "description": "Audit Pack manifest entry stamped with capture_topology=in_process_sdk. Producer-side metadata; lives in `manifest`, never in the signed payload.",
+      "input": {
+        "action_type": "api:call",
+        "context": {"tool": "database.query"},
+        "manifest": {"capture_topology": "in_process_sdk"}
+      },
+      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"in_process_sdk\"}}",
+      "sha256": "f4b6da748f7720f15450cf61fa2c4cf8c3e9148fc15ab6b6cd15d8d3f3fd341e",
+      "capture_topology": "in_process_sdk",
+      "expected_verify": true,
+      "reason": "Closed-vocabulary value; manifest-only placement preserves signed-payload bytes."
+    },
+    {
+      "name": "capture_topology_network_proxy",
+      "description": "Audit Pack manifest entry stamped with capture_topology=network_proxy. Producer-side metadata; lives in `manifest`, never in the signed payload.",
+      "input": {
+        "action_type": "api:call",
+        "context": {"tool": "database.query"},
+        "manifest": {"capture_topology": "network_proxy"}
+      },
+      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"network_proxy\"}}",
+      "sha256": "de100ddcb08a1aadf3ade136a42ce554d38004ba06bbc4f0cecdc2235d46bd9d",
+      "capture_topology": "network_proxy",
+      "expected_verify": true,
+      "reason": "Closed-vocabulary value; manifest-only placement preserves signed-payload bytes."
+    },
+    {
+      "name": "capture_topology_browser_extension",
+      "description": "Audit Pack manifest entry stamped with capture_topology=browser_extension. Producer-side metadata; lives in `manifest`, never in the signed payload.",
+      "input": {
+        "action_type": "api:call",
+        "context": {"tool": "database.query"},
+        "manifest": {"capture_topology": "browser_extension"}
+      },
+      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"browser_extension\"}}",
+      "sha256": "9375a5437440101f386da4f6af0b2b64b1ed1f53fa3bdd5334363f15a173bd15",
+      "capture_topology": "browser_extension",
+      "expected_verify": true,
+      "reason": "Closed-vocabulary value; manifest-only placement preserves signed-payload bytes."
+    },
+    {
+      "name": "capture_topology_ebpf_observer",
+      "description": "Audit Pack manifest entry stamped with capture_topology=ebpf_observer. Producer-side metadata; lives in `manifest`, never in the signed payload.",
+      "input": {
+        "action_type": "api:call",
+        "context": {"tool": "database.query"},
+        "manifest": {"capture_topology": "ebpf_observer"}
+      },
+      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"ebpf_observer\"}}",
+      "sha256": "57d912d39dd720ea6ceb3bfbf7103c45f74519e5a4e9583211cf24fda0d33491",
+      "capture_topology": "ebpf_observer",
+      "expected_verify": true,
+      "reason": "Closed-vocabulary value; manifest-only placement preserves signed-payload bytes."
+    },
+    {
+      "name": "capture_topology_mcp_proxy",
+      "description": "Audit Pack manifest entry stamped with capture_topology=mcp_proxy. Producer-side metadata; lives in `manifest`, never in the signed payload.",
+      "input": {
+        "action_type": "api:call",
+        "context": {"tool": "database.query"},
+        "manifest": {"capture_topology": "mcp_proxy"}
+      },
+      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"mcp_proxy\"}}",
+      "sha256": "4731cae72f4a30b5c10a688541faf8759873af7d78b8fe999069e112217b82c7",
+      "capture_topology": "mcp_proxy",
+      "expected_verify": true,
+      "reason": "Closed-vocabulary value; manifest-only placement preserves signed-payload bytes."
+    },
+    {
+      "name": "capture_topology_unknown_value_rejected",
+      "description": "An unknown capture_topology value MUST be rejected by a conformant SDK before the HTTP roundtrip. Canonical bytes are still defined so implementers can verify rejection without depending on hash drift.",
+      "input": {
+        "action_type": "api:call",
+        "context": {"tool": "database.query"},
+        "manifest": {"capture_topology": "rootkit"}
+      },
+      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"rootkit\"}}",
+      "sha256": "d2a306e1c437b467c431b7d1b4a70c1190aec10642e43ac002c55bb84dd3e617",
+      "capture_topology": "rootkit",
+      "expected_verify": false,
+      "reason": "capture_topology is a closed Literal of {in_process_sdk, network_proxy, browser_extension, ebpf_observer, mcp_proxy}; any other value is rejected client-side."
     }
   ]
 }

--- a/python/tests/test_conformance_vectors.py
+++ b/python/tests/test_conformance_vectors.py
@@ -11,7 +11,20 @@ import hashlib
 import json
 from pathlib import Path
 
+import pytest
+
 VECTORS_PATH = Path(__file__).parent.parent.parent / "conformance" / "vectors.json"
+
+# Closed Literal mirrored from the cloud SignRequest and IETF draft -04 appendix.
+CAPTURE_TOPOLOGY_VOCABULARY: frozenset[str] = frozenset(
+    {
+        "in_process_sdk",
+        "network_proxy",
+        "browser_extension",
+        "ebpf_observer",
+        "mcp_proxy",
+    }
+)
 
 
 def _jcs(obj: object) -> str:
@@ -79,3 +92,56 @@ def test_nonce_mismatch_vector_has_peer_sent_nonce() -> None:
     v = next(x for x in d["vectors"] if x["name"] == "nonce_mismatch")
     assert "peer_sent_nonce" in v
     assert v["input"].get("client_nonce") != v["peer_sent_nonce"]
+
+
+# === capture_topology vocabulary parity (IETF -04 appendix + cloud SignRequest) ===
+
+
+def _capture_vectors() -> list[dict]:
+    """Return all conformance vectors that exercise the capture_topology field."""
+    d = json.loads(VECTORS_PATH.read_text())
+    return [v for v in d["vectors"] if v["name"].startswith("capture_topology_")]
+
+
+def test_capture_topology_covers_full_closed_vocabulary() -> None:
+    """All five IETF -04 capture topologies must appear as accepted vectors."""
+    accepted = {
+        v["capture_topology"]
+        for v in _capture_vectors()
+        if v.get("expected_verify") is True
+    }
+    assert accepted == CAPTURE_TOPOLOGY_VOCABULARY, (
+        f"capture_topology vector coverage drift: {accepted ^ CAPTURE_TOPOLOGY_VOCABULARY}"
+    )
+
+
+@pytest.mark.parametrize("value", sorted(CAPTURE_TOPOLOGY_VOCABULARY))
+def test_capture_topology_value_round_trips_via_manifest(value: str) -> None:
+    """Each accepted vector stamps capture_topology on the manifest entry.
+
+    The token must never appear inside the signed payload bytes.
+    """
+    matching = [
+        v
+        for v in _capture_vectors()
+        if v.get("capture_topology") == value and v.get("expected_verify") is True
+    ]
+    assert len(matching) == 1, f"expected exactly one accepted vector for {value}"
+    v = matching[0]
+    assert "manifest" in v["input"], f"{v['name']}: capture_topology must live in `manifest`"
+    assert v["input"]["manifest"]["capture_topology"] == value
+    assert "capture_topology" not in v["input"].get("context", {}), (
+        f"{v['name']}: capture_topology MUST NOT appear inside the signed payload"
+    )
+
+
+def test_capture_topology_unknown_value_is_a_failure_vector() -> None:
+    """An out-of-vocabulary capture_topology token is a rejected conformance vector."""
+    rejected = [
+        v
+        for v in _capture_vectors()
+        if v.get("expected_verify") is False
+    ]
+    assert rejected, "missing the unknown-value rejection vector"
+    v = rejected[0]
+    assert v["capture_topology"] not in CAPTURE_TOPOLOGY_VOCABULARY

--- a/typescript/tests/canonicalize.test.ts
+++ b/typescript/tests/canonicalize.test.ts
@@ -16,12 +16,23 @@ interface Vector {
   input: unknown;
   canonical: string;
   sha256: string;
+  capture_topology?: string;
+  expected_verify?: boolean;
 }
 
 const vectorsPath = resolve(__dirname, "..", "..", "conformance", "vectors.json");
 const { vectors } = JSON.parse(readFileSync(vectorsPath, "utf8")) as {
   vectors: Vector[];
 };
+
+// Closed Literal mirrored from the cloud SignRequest and IETF draft -04 appendix.
+const CAPTURE_TOPOLOGY_VOCABULARY = new Set([
+  "in_process_sdk",
+  "network_proxy",
+  "browser_extension",
+  "ebpf_observer",
+  "mcp_proxy",
+]);
 
 describe("canonicalize() against conformance vectors", () => {
   for (const v of vectors) {
@@ -62,6 +73,45 @@ describe("hashAction()", () => {
     expect(plain).not.toBe(keyed);
     expect(keyed.startsWith("sha256:")).toBe(true);
     expect(keyed.length).toBe("sha256:".length + 64);
+  });
+});
+
+describe("capture_topology conformance vectors (IETF -04 appendix)", () => {
+  const captureVectors = vectors.filter((v) =>
+    v.name.startsWith("capture_topology_"),
+  );
+
+  it("covers all five values in the closed vocabulary", () => {
+    const accepted = new Set(
+      captureVectors
+        .filter((v) => v.expected_verify === true)
+        .map((v) => v.capture_topology),
+    );
+    expect(accepted).toEqual(CAPTURE_TOPOLOGY_VOCABULARY);
+  });
+
+  for (const value of [...CAPTURE_TOPOLOGY_VOCABULARY]) {
+    it(`stamps capture_topology=${value} on the manifest, not the signed payload`, () => {
+      const matching = captureVectors.filter(
+        (v) => v.capture_topology === value && v.expected_verify === true,
+      );
+      expect(matching).toHaveLength(1);
+      const v = matching[0];
+      const input = v.input as {
+        manifest?: { capture_topology?: string };
+        context?: Record<string, unknown>;
+      };
+      expect(input.manifest?.capture_topology).toBe(value);
+      expect(input.context).toBeDefined();
+      expect((input.context ?? {}).capture_topology).toBeUndefined();
+    });
+  }
+
+  it("ships an unknown-value rejection vector", () => {
+    const rejected = captureVectors.filter((v) => v.expected_verify === false);
+    expect(rejected.length).toBeGreaterThan(0);
+    const v = rejected[0];
+    expect(CAPTURE_TOPOLOGY_VOCABULARY.has(v.capture_topology ?? "")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the SDK leg of the three-place atomic landing rule (CLAUDE.md recurring engineering lesson 1) for the cycle-13 `capture_topology` wire token. The token landed in cloud Pydantic `SignRequest` (`src/asqav_cloud/api/routes/agents.py:1276` Literal), IETF draft -04 appendix (capture-topologies and capture-vocabulary-registry sections), and SDK runtime in PR #186 (`Agent.sign(capture_topology=...)`, `CAPTURE_TOPOLOGY_NAMESPACE`). The fourth landing site, the cross-language conformance vectors, was missing - flagged in the cycle 14 honest cross-PR audit (`top three gaps to act on`, item 1).

This PR adds the missing conformance coverage.

## What changed

`conformance/vectors.json` gains 7 vectors:

- `capture_topology_in_process_sdk`
- `capture_topology_network_proxy`
- `capture_topology_browser_extension`
- `capture_topology_ebpf_observer`
- `capture_topology_mcp_proxy`
- `capture_topology_unknown_value_rejected` (expected_verify=false)

Each accepted vector stamps `capture_topology` on the Audit Pack manifest entry (`input.manifest.capture_topology`), never on the signed payload (`input.context`), mirroring the IETF -04 appendix invariant that producer-side topology metadata MUST NOT alter signed bytes.

`python/tests/test_conformance_vectors.py` adds three new tests:

- `test_capture_topology_covers_full_closed_vocabulary` - asserts the accepted set equals the 5-value frozenset.
- `test_capture_topology_value_round_trips_via_manifest` - parametrised across the 5 values, asserts manifest placement and forbids leakage into the signed payload.
- `test_capture_topology_unknown_value_is_a_failure_vector` - asserts an out-of-vocabulary token is a rejection vector.

`typescript/tests/canonicalize.test.ts` mirrors the three Python assertions inside a new `capture_topology conformance vectors` describe block; the existing dynamic for-loop over `vectors` auto-picks up the canonical-bytes and SHA-256 invariants for the 7 new vectors.

## Why this matters

CLAUDE.md recurring engineering lesson 1 (Wire-vocabulary change = three-place atomic landing) names the consumer conformance test as the third mandatory landing place for any new wire token. Cloud commit (PR #384 cycle 13), IETF -04 draft, and SDK runtime (PR #186) all shipped this token; the conformance vectors did not. Until this PR lands, a third-party ACTA-RECEIPTS implementation has no fixture to validate its capture_topology handling against.

## Cross-references

- Cloud Pydantic Literal: `src/asqav_cloud/api/routes/agents.py:1276` (5-value closed Literal)
- IETF draft -04: appendix Capture Topologies and appendix capture_topology Vocabulary and Considerations for a Future IANA Registry (5 sub-sections, one per topology)
- SDK runtime: PR #186 feat(sdk): vocabulary parity with cloud (observation + capture_topology) (CAPTURE_TOPOLOGY_NAMESPACE, Agent.sign kwarg, preflight ValueError)
- MCP proxy: jagmarques/asqav-mcp#40 (emits capture_topology=mcp_proxy on every forwarded/ack receipt)

## Test plan

- [x] `cd python && pytest tests/test_conformance_vectors.py -v` - 14/14 pass (7 baseline + 7 new).
- [x] `cd python && pytest` - 735/735 full suite green.
- [x] `cd python && ruff check tests/test_conformance_vectors.py` - clean.
- [x] `cd typescript && npm test` - 247/247 pass (240 baseline + 7 new).
- [x] `cd typescript && npm run lint` - tsc --noEmit clean.
- [x] Forbidden-token sweep on diff: clean (RFC 8785 JCS hits are pre-existing canonicalization-spec literals).

comment hygiene clean