### PR TITLE
feat(typescript): parity for LangChain.js + Mastra + OpenAI Agents JS adapters

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -19,6 +19,22 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "*",
+        "@mastra/core": "*",
+        "@openai/agents": "*"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "@mastra/core": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -36,10 +36,30 @@
       "import": "./dist/cli.mjs",
       "require": "./dist/cli.js"
     },
+    "./extras": {
+      "types": "./dist/extras/index.d.ts",
+      "import": "./dist/extras/index.mjs",
+      "require": "./dist/extras/index.js"
+    },
     "./extras/vercel-ai": {
       "types": "./dist/extras/vercel-ai.d.ts",
       "import": "./dist/extras/vercel-ai.mjs",
       "require": "./dist/extras/vercel-ai.js"
+    },
+    "./extras/langchain": {
+      "types": "./dist/extras/langchain.d.ts",
+      "import": "./dist/extras/langchain.mjs",
+      "require": "./dist/extras/langchain.js"
+    },
+    "./extras/mastra": {
+      "types": "./dist/extras/mastra.d.ts",
+      "import": "./dist/extras/mastra.mjs",
+      "require": "./dist/extras/mastra.js"
+    },
+    "./extras/openai-agents": {
+      "types": "./dist/extras/openai-agents.d.ts",
+      "import": "./dist/extras/openai-agents.mjs",
+      "require": "./dist/extras/openai-agents.js"
     }
   },
   "files": [
@@ -48,13 +68,29 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/cli.ts src/extras/vercel-ai.ts --format cjs,esm --dts --clean",
+    "build": "tsup src/index.ts src/cli.ts src/extras/index.ts src/extras/vercel-ai.ts src/extras/langchain.ts src/extras/mastra.ts src/extras/openai-agents.ts --format cjs,esm --dts --clean",
     "test": "vitest run",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
   "engines": {
     "node": ">=18"
+  },
+  "peerDependencies": {
+    "@langchain/core": "*",
+    "@mastra/core": "*",
+    "@openai/agents": "*"
+  },
+  "peerDependenciesMeta": {
+    "@langchain/core": {
+      "optional": true
+    },
+    "@mastra/core": {
+      "optional": true
+    },
+    "@openai/agents": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/typescript/src/extras/_base.ts
+++ b/typescript/src/extras/_base.ts
@@ -1,0 +1,150 @@
+/**
+ * Base adapter for Asqav framework integrations.
+ *
+ * Mirrors the Python ``asqav.extras._base.AsqavAdapter`` surface so the
+ * documentation can cross-link the two SDKs. Framework-specific adapters
+ * (LangChain.js, Mastra, OpenAI Agents JS, etc.) compose this class via
+ * an internal field rather than multiple inheritance because TypeScript
+ * does not support multi-class inheritance.
+ *
+ * Responsibilities:
+ *   - Resolve an Asqav ``Agent`` from either a pre-built instance,
+ *     ``agentId`` (calls ``Agent.get``), or ``agentName`` (calls
+ *     ``Agent.create``).
+ *   - Provide a shared ``signAction`` helper that is fail-open: signing
+ *     errors are routed to the caller-supplied ``onError`` handler and
+ *     never raise into the host pipeline.
+ *   - Provide a stable place to attach future cross-cutting features
+ *     (observe mode, session grouping) without touching every adapter.
+ */
+
+import { Agent } from "../index.js";
+
+/**
+ * Options accepted by every Asqav adapter constructor.
+ *
+ * Exactly one of ``agent``, ``agentId``, or ``agentName`` should be
+ * provided. When ``agent`` is set the adapter signs against it directly.
+ * When ``agentId`` is set the adapter calls ``Agent.get`` lazily on the
+ * first event. When ``agentName`` is set the adapter calls
+ * ``Agent.create`` lazily on the first event.
+ */
+export interface AsqavAdapterOptions {
+  /** Pre-built Asqav Agent. Takes precedence over agentId/agentName. */
+  agent?: Agent;
+  /** ID of an existing Asqav agent. Resolved lazily via Agent.get. */
+  agentId?: string;
+  /** Name for a new Asqav agent. Resolved lazily via Agent.create. */
+  agentName?: string;
+  /**
+   * Optional error sink. Defaults to ``console.warn``. The adapter never
+   * throws into the host AI pipeline; governance must fail-open.
+   */
+  onError?: (err: unknown, context: { actionType: string }) => void;
+  /**
+   * When true, the adapter logs what it would sign but skips the network
+   * call. Useful for local development and snapshot testing.
+   */
+  observe?: boolean;
+}
+
+export interface SignActionInput {
+  actionType: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Shared base for the framework adapters in this folder.
+ *
+ * Subclasses call ``protected signAction`` on every framework callback.
+ * They MUST NOT call the Asqav SDK directly so the fail-open contract is
+ * preserved at one place.
+ */
+export class AsqavAdapter {
+  protected readonly options: AsqavAdapterOptions;
+  protected agent: Agent | null;
+  private agentPromise: Promise<Agent> | null = null;
+
+  constructor(options: AsqavAdapterOptions) {
+    if (!options.agent && !options.agentId && !options.agentName) {
+      throw new Error(
+        "AsqavAdapter requires one of { agent, agentId, agentName }. "
+        + "Call asqav.init() first and supply an Agent or identifier.",
+      );
+    }
+    this.options = options;
+    this.agent = options.agent ?? null;
+  }
+
+  /** Resolve the Asqav agent, creating or fetching lazily if needed. */
+  protected async resolveAgent(): Promise<Agent> {
+    if (this.agent) return this.agent;
+    if (this.agentPromise) return this.agentPromise;
+
+    const promise = (async (): Promise<Agent> => {
+      if (this.options.agentId) {
+        return Agent.get(this.options.agentId);
+      }
+      if (this.options.agentName) {
+        return Agent.create({ name: this.options.agentName });
+      }
+      throw new Error("AsqavAdapter: no agent identifier available");
+    })();
+
+    this.agentPromise = promise;
+    const resolved = await promise;
+    this.agent = resolved;
+    return resolved;
+  }
+
+  /**
+   * Sign a governance action. Fire-and-forget by default; errors route
+   * through ``options.onError``. This method MUST NOT throw.
+   */
+  protected signAction(input: SignActionInput): void {
+    const onError = this.options.onError ?? defaultOnError;
+
+    if (this.options.observe) {
+      // observe mode mirrors Python ``AsqavAdapter._observe``.
+      // eslint-disable-next-line no-console
+      console.info(
+        `[asqav] OBSERVE: would sign ${input.actionType}`,
+        input.context ?? {},
+      );
+      return;
+    }
+
+    // Fire-and-forget; never await so callbacks stay synchronous for
+    // host frameworks that expect synchronous return values.
+    void (async () => {
+      try {
+        const agent = await this.resolveAgent();
+        await agent.sign({
+          actionType: input.actionType,
+          context: input.context,
+        });
+      } catch (err) {
+        try {
+          onError(err, { actionType: input.actionType });
+        } catch {
+          // Swallow secondary errors from the user-supplied handler.
+        }
+      }
+    })();
+  }
+}
+
+function defaultOnError(err: unknown, ctx: { actionType: string }): void {
+  // eslint-disable-next-line no-console
+  console.warn(`[asqav] sign failed for ${ctx.actionType}:`, err);
+}
+
+/**
+ * Helper that frameworks call when their host package is missing. Mirrors
+ * the Python ``ImportError`` thrown at module import time.
+ */
+export function raiseMissingPeer(peer: string, install: string): never {
+  throw new Error(
+    `${peer} is required for this Asqav adapter. Install with: ${install}`,
+  );
+}

--- a/typescript/src/extras/index.ts
+++ b/typescript/src/extras/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Barrel for Asqav framework adapters.
+ *
+ * Each adapter is also published as a discrete subpath export
+ * (``@asqav/sdk/extras/<framework>``) so peers stay tree-shakable. This
+ * barrel exists so callers who already depend on multiple peers can
+ * import everything from a single specifier.
+ */
+
+export { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+export { AsqavCallbackHandler } from "./langchain.js";
+export type { AsqavCallbackHandlerOptions } from "./langchain.js";
+export { AsqavMastraHook } from "./mastra.js";
+export type { AsqavMastraHookOptions } from "./mastra.js";
+export { AsqavOpenAIAgentsAdapter } from "./openai-agents.js";
+export type {
+  AsqavOpenAIAgentsAdapterOptions,
+  OpenAIAgentsToolLike,
+} from "./openai-agents.js";
+export { createAsqavExporter, mapSpanNameToActionType } from "./vercel-ai.js";

--- a/typescript/src/extras/langchain.ts
+++ b/typescript/src/extras/langchain.ts
@@ -1,0 +1,212 @@
+/**
+ * LangChain.js integration for Asqav.
+ *
+ * Install (peer dependency):
+ *   npm install @langchain/core
+ *
+ * Usage:
+ *   import { init } from "@asqav/sdk";
+ *   import { AsqavCallbackHandler } from "@asqav/sdk/extras/langchain";
+ *   init({ apiKey: process.env.ASQAV_API_KEY! });
+ *   const handler = await AsqavCallbackHandler.create({ agentName: "my-chain" });
+ *   await chain.invoke(input, { callbacks: [handler] });
+ *
+ * Mirrors the Python ``asqav.extras.langchain.AsqavCallbackHandler``
+ * (chain/tool/LLM lifecycle signing) using the LangChain.js
+ * ``BaseCallbackHandler`` from ``@langchain/core/callbacks/base``.
+ */
+
+import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+
+// Local LangChain.js types so this module compiles even when the peer
+// package is not installed. The actual base class is loaded lazily.
+
+interface LCSerialized {
+  id?: string[];
+  name?: string;
+  [key: string]: unknown;
+}
+
+interface LCGeneration {
+  text?: string;
+  [key: string]: unknown;
+}
+
+interface LCLLMResult {
+  generations: LCGeneration[][];
+  llmOutput?: Record<string, unknown> | null;
+}
+
+interface BaseCallbackHandlerLike {
+  // The LangChain.js base class declares many optional handlers. We only
+  // need ours to type-check; consumers receive a real subclass instance.
+  name?: string;
+}
+
+type BaseCallbackHandlerCtor = new (...args: unknown[]) => BaseCallbackHandlerLike;
+
+const MAX_PREVIEW = 200;
+
+function truncate(s: string, max = MAX_PREVIEW): string {
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+/**
+ * Lazily import ``BaseCallbackHandler`` from ``@langchain/core``.
+ *
+ * The Python ImportError contract is preserved by re-throwing a clear
+ * error when the peer is missing. Callers normally invoke
+ * ``AsqavCallbackHandler.create`` which forwards through this.
+ */
+async function loadBase(): Promise<BaseCallbackHandlerCtor> {
+  try {
+    // Dynamic specifier: the peer is optional, declared in package.json
+    // peerDependenciesMeta. ts-ignore avoids hard-failing the type-check
+    // for installs without @langchain/core.
+    // @ts-ignore optional peer dependency
+    const mod = (await import("@langchain/core/callbacks/base")) as unknown;
+    const ctor = (mod as { BaseCallbackHandler?: BaseCallbackHandlerCtor })
+      .BaseCallbackHandler;
+    if (!ctor) {
+      throw new Error("BaseCallbackHandler not exported from @langchain/core/callbacks/base");
+    }
+    return ctor;
+  } catch (err) {
+    throw new Error(
+      "LangChain.js integration requires @langchain/core. "
+      + "Install with: npm install @langchain/core. "
+      + `(import error: ${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+}
+
+export interface AsqavCallbackHandlerOptions extends AsqavAdapterOptions {
+  /** Optional callback handler name; defaults to "asqav-callback-handler". */
+  name?: string;
+}
+
+/**
+ * LangChain.js callback handler that signs chain, tool, and LLM events
+ * via the Asqav governance pipeline. Use
+ * ``AsqavCallbackHandler.create()`` since the parent class is loaded
+ * asynchronously.
+ */
+export class AsqavCallbackHandler extends AsqavAdapter {
+  /** Friendly name surfaced to LangChain's tracing UI. */
+  public readonly name: string = "asqav-callback-handler";
+
+  /**
+   * Build the handler. The factory is async because LangChain.js's
+   * ``BaseCallbackHandler`` is the constructor we extend at runtime via
+   * a returned subclass (so this class itself stays usable without the
+   * peer installed).
+   */
+  static async create(
+    opts: AsqavCallbackHandlerOptions,
+  ): Promise<AsqavCallbackHandler & BaseCallbackHandlerLike> {
+    const Base = await loadBase();
+
+    class _AsqavCallbackHandlerImpl extends (Base as unknown as new () => object) {
+      public readonly name: string;
+      private readonly _asqav: AsqavCallbackHandler;
+
+      constructor(asqav: AsqavCallbackHandler, name: string) {
+        super();
+        this._asqav = asqav;
+        this.name = name;
+      }
+
+      handleChainStart(
+        serialized: LCSerialized,
+        inputs: Record<string, unknown>,
+      ): void {
+        const fallbackName = (serialized.id ?? ["unknown"]).slice(-1)[0];
+        this._asqav._emit("chain:start", {
+          chain: String(serialized.name ?? fallbackName),
+          input_keys: Object.keys(inputs ?? {}),
+        });
+      }
+
+      handleChainEnd(outputs: Record<string, unknown>): void {
+        this._asqav._emit("chain:end", {
+          output_keys: Object.keys(outputs ?? {}),
+        });
+      }
+
+      handleChainError(err: Error): void {
+        this._asqav._emit("chain:error", {
+          error_type: err?.name ?? "Error",
+          error: truncate(String(err?.message ?? err)),
+        });
+      }
+
+      handleToolStart(serialized: LCSerialized, input: string): void {
+        const fallbackName = (serialized.id ?? ["unknown"]).slice(-1)[0];
+        this._asqav._emit("tool:start", {
+          tool: String(serialized.name ?? fallbackName),
+          input: truncate(String(input ?? "")),
+        });
+      }
+
+      handleToolEnd(output: unknown): void {
+        const outStr = typeof output === "string" ? output : JSON.stringify(output);
+        this._asqav._emit("tool:end", {
+          output_type: typeof output,
+          output_length: outStr?.length ?? 0,
+        });
+      }
+
+      handleToolError(err: Error): void {
+        this._asqav._emit("tool:error", {
+          error_type: err?.name ?? "Error",
+          error: truncate(String(err?.message ?? err)),
+        });
+      }
+
+      handleLLMStart(serialized: LCSerialized, prompts: string[]): void {
+        const fallbackName = (serialized.id ?? ["unknown"]).slice(-1)[0];
+        this._asqav._emit("llm:start", {
+          model: String(serialized.name ?? fallbackName),
+          prompt_count: Array.isArray(prompts) ? prompts.length : 0,
+        });
+      }
+
+      handleLLMEnd(result: LCLLMResult): void {
+        const generationCount = (result?.generations ?? []).reduce(
+          (acc, gens) => acc + (gens?.length ?? 0),
+          0,
+        );
+        const ctx: Record<string, unknown> = { generation_count: generationCount };
+        const usage = result?.llmOutput?.tokenUsage ?? result?.llmOutput?.token_usage;
+        if (usage && typeof usage === "object") {
+          ctx.token_usage = Object.fromEntries(
+            Object.entries(usage as Record<string, unknown>).filter(
+              ([, v]) => typeof v === "number",
+            ),
+          );
+        }
+        this._asqav._emit("llm:end", ctx);
+      }
+
+      handleLLMError(err: Error): void {
+        this._asqav._emit("llm:error", {
+          error_type: err?.name ?? "Error",
+          error: truncate(String(err?.message ?? err)),
+        });
+      }
+    }
+
+    const wrapper = new AsqavCallbackHandler(opts);
+    const impl = new _AsqavCallbackHandlerImpl(
+      wrapper,
+      opts.name ?? "asqav-callback-handler",
+    );
+    // Make the underlying signAction reachable through the wrapper.
+    return impl as unknown as AsqavCallbackHandler & BaseCallbackHandlerLike;
+  }
+
+  /** Internal hook used by the inner LangChain subclass. */
+  public _emit(actionType: string, context: Record<string, unknown>): void {
+    this.signAction({ actionType, context });
+  }
+}

--- a/typescript/src/extras/mastra.ts
+++ b/typescript/src/extras/mastra.ts
@@ -1,0 +1,182 @@
+/**
+ * Mastra integration for Asqav.
+ *
+ * Install (peer dependency):
+ *   npm install @mastra/core
+ *
+ * Usage:
+ *   import { init } from "@asqav/sdk";
+ *   import { AsqavMastraHook } from "@asqav/sdk/extras/mastra";
+ *   init({ apiKey: process.env.ASQAV_API_KEY! });
+ *   const hook = new AsqavMastraHook({ agentName: "my-mastra-agent" });
+ *   await hook.attach(mastraAgent);
+ *
+ * Signs Mastra agent step ``before`` and ``after`` events so every tool
+ * call, LLM call, and workflow step is captured as an Asqav receipt.
+ * Falls back to a direct ``before``/``after`` API for tests when no
+ * Mastra instance is present.
+ */
+
+import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+
+const MAX_PREVIEW = 200;
+
+function truncate(s: string, max = MAX_PREVIEW): string {
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+/**
+ * Shape of the minimum surface we touch on a Mastra agent. We avoid
+ * importing ``@mastra/core`` at the top level so the SDK installs
+ * cleanly without it.
+ */
+interface MastraAgentLike {
+  readonly name?: string;
+  on?: (event: string, listener: (...args: unknown[]) => void) => unknown;
+  use?: (middleware: unknown) => unknown;
+}
+
+interface MastraStepEvent {
+  /** The Mastra step identifier (tool name, LLM call, sub-workflow). */
+  stepId?: string;
+  stepType?: string;
+  input?: unknown;
+  output?: unknown;
+  error?: unknown;
+  agentName?: string;
+}
+
+export interface AsqavMastraHookOptions extends AsqavAdapterOptions {
+  /** Optional agent display name; defaults to "asqav-mastra-hook". */
+  name?: string;
+}
+
+/**
+ * Mastra hook that signs agent step lifecycle events through Asqav.
+ *
+ * The class composes with Asqav's shared adapter base. ``before`` and
+ * ``after`` are public so callers can wire them into custom Mastra
+ * middleware or invoke them directly from tests.
+ */
+export class AsqavMastraHook extends AsqavAdapter {
+  public readonly name: string;
+
+  constructor(options: AsqavMastraHookOptions) {
+    super(options);
+    this.name = options.name ?? "asqav-mastra-hook";
+  }
+
+  /**
+   * Verify the Mastra peer is installed and return its module. Throws a
+   * clear error matching the Python ImportError contract when missing.
+   */
+  static async loadPeer(): Promise<unknown> {
+    try {
+      // Optional peer; not declared in normal dependencies.
+      // @ts-ignore optional peer dependency
+      return (await import("@mastra/core")) as unknown;
+    } catch (err) {
+      throw new Error(
+        "Mastra integration requires @mastra/core. "
+        + "Install with: npm install @mastra/core. "
+        + `(import error: ${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+  }
+
+  /**
+   * Attach to a Mastra agent. Subscribes to ``step:before`` and
+   * ``step:after`` if the agent exposes an event emitter; otherwise
+   * registers a middleware that wraps each step.
+   */
+  async attach(agent: MastraAgentLike): Promise<void> {
+    // Validate the peer is available so attach() fails fast with a
+    // helpful message rather than at first event time.
+    await AsqavMastraHook.loadPeer();
+
+    if (typeof agent.on === "function") {
+      agent.on("step:before", (evt: unknown) => {
+        this.before((evt ?? {}) as MastraStepEvent);
+      });
+      agent.on("step:after", (evt: unknown) => {
+        this.after((evt ?? {}) as MastraStepEvent);
+      });
+      agent.on("step:error", (evt: unknown) => {
+        this.onError((evt ?? {}) as MastraStepEvent);
+      });
+      return;
+    }
+
+    if (typeof agent.use === "function") {
+      const self = this;
+      agent.use({
+        async wrap(
+          ctx: MastraStepEvent,
+          next: () => Promise<unknown>,
+        ): Promise<unknown> {
+          self.before(ctx);
+          try {
+            const out = await next();
+            self.after({ ...ctx, output: out });
+            return out;
+          } catch (err) {
+            self.onError({ ...ctx, error: err });
+            throw err;
+          }
+        },
+      });
+      return;
+    }
+
+    throw new Error(
+      "AsqavMastraHook.attach: agent exposes neither .on() nor .use(); "
+      + "wire .before/.after manually instead.",
+    );
+  }
+
+  /** Sign the start of a Mastra step. Safe to call directly from tests. */
+  public before(evt: MastraStepEvent): void {
+    const ctx: Record<string, unknown> = {
+      step_id: String(evt.stepId ?? "unknown"),
+      step_type: String(evt.stepType ?? "step"),
+      agent_name: evt.agentName ?? this.name,
+    };
+    if (evt.input !== undefined) {
+      const inputStr = typeof evt.input === "string"
+        ? evt.input
+        : JSON.stringify(evt.input);
+      ctx.input_preview = truncate(inputStr);
+    }
+    this.signAction({ actionType: "step:before", context: ctx });
+  }
+
+  /** Sign the successful end of a Mastra step. */
+  public after(evt: MastraStepEvent): void {
+    const ctx: Record<string, unknown> = {
+      step_id: String(evt.stepId ?? "unknown"),
+      step_type: String(evt.stepType ?? "step"),
+      agent_name: evt.agentName ?? this.name,
+    };
+    if (evt.output !== undefined) {
+      const outputStr = typeof evt.output === "string"
+        ? evt.output
+        : JSON.stringify(evt.output);
+      ctx.output_preview = truncate(outputStr);
+      ctx.output_length = outputStr?.length ?? 0;
+    }
+    this.signAction({ actionType: "step:after", context: ctx });
+  }
+
+  /** Sign an error event from a Mastra step. */
+  public onError(evt: MastraStepEvent): void {
+    const err = evt.error;
+    const ctx: Record<string, unknown> = {
+      step_id: String(evt.stepId ?? "unknown"),
+      step_type: String(evt.stepType ?? "step"),
+      agent_name: evt.agentName ?? this.name,
+      error_type: err instanceof Error ? err.name : typeof err,
+      error: truncate(err instanceof Error ? err.message : String(err)),
+    };
+    this.signAction({ actionType: "step:error", context: ctx });
+  }
+}

--- a/typescript/src/extras/openai-agents.ts
+++ b/typescript/src/extras/openai-agents.ts
@@ -1,0 +1,150 @@
+/**
+ * OpenAI Agents JS integration for Asqav.
+ *
+ * Install (peer dependency):
+ *   npm install @openai/agents
+ *
+ * Usage:
+ *   import { init } from "@asqav/sdk";
+ *   import { AsqavOpenAIAgentsAdapter } from "@asqav/sdk/extras/openai-agents";
+ *   init({ apiKey: process.env.ASQAV_API_KEY! });
+ *   const adapter = new AsqavOpenAIAgentsAdapter({ agentName: "my-agent" });
+ *   adapter.wrapTool(myTool);
+ *
+ * Mirrors the Python ``asqav.extras.openai_agents.AsqavGuardrail`` /
+ * ``AsqavTracingProcessor`` adapter: signs ``agent:input`` /
+ * ``agent:output`` / ``tool:start`` / ``tool:end`` events as the agent
+ * runs. Operates fail-open so governance never breaks the agent loop.
+ */
+
+import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+
+const MAX_PREVIEW = 200;
+
+function truncate(s: string, max = MAX_PREVIEW): string {
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+/**
+ * Minimal surface of an OpenAI Agents JS ``tool``. We accept any object
+ * with ``name`` and ``execute`` so we never bind to a specific SDK
+ * version.
+ */
+export interface OpenAIAgentsToolLike<I = unknown, O = unknown> {
+  name?: string;
+  description?: string;
+  execute?: (input: I, ...rest: unknown[]) => Promise<O> | O;
+}
+
+export interface AsqavOpenAIAgentsAdapterOptions extends AsqavAdapterOptions {
+  /** Optional adapter display name. */
+  name?: string;
+}
+
+/**
+ * Wraps OpenAI Agents JS tools and run-loop callbacks so every
+ * tool-call lifecycle event flows through Asqav. Mirrors the Python
+ * ``AsqavGuardrail`` and ``AsqavTracingProcessor``.
+ */
+export class AsqavOpenAIAgentsAdapter extends AsqavAdapter {
+  public readonly name: string;
+
+  constructor(options: AsqavOpenAIAgentsAdapterOptions) {
+    super(options);
+    this.name = options.name ?? "asqav-openai-agents-adapter";
+  }
+
+  /** Verify ``@openai/agents`` is installed; throw a clear error if not. */
+  static async loadPeer(): Promise<unknown> {
+    try {
+      // Optional peer; not declared in normal dependencies.
+      // @ts-ignore optional peer dependency
+      return (await import("@openai/agents")) as unknown;
+    } catch (err) {
+      throw new Error(
+        "OpenAI Agents JS integration requires @openai/agents. "
+        + "Install with: npm install @openai/agents. "
+        + `(import error: ${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+  }
+
+  /**
+   * Wrap an OpenAI Agents tool so each invocation signs
+   * ``tool:start`` and ``tool:end`` (or ``tool:error``). Returns a new
+   * tool object with the same ``name``/``description`` and a wrapped
+   * ``execute``.
+   */
+  wrapTool<I, O>(tool: OpenAIAgentsToolLike<I, O>): OpenAIAgentsToolLike<I, O> {
+    if (typeof tool.execute !== "function") {
+      throw new Error("wrapTool: tool.execute must be a function");
+    }
+    const original = tool.execute.bind(tool);
+    const self = this;
+    const toolName = tool.name ?? "unknown";
+
+    const execute = async (input: I, ...rest: unknown[]): Promise<O> => {
+      const inputStr = typeof input === "string" ? input : JSON.stringify(input);
+      self.signAction({
+        actionType: "tool:start",
+        context: {
+          tool: String(toolName),
+          input_preview: truncate(inputStr ?? ""),
+        },
+      });
+      try {
+        const out = await original(input, ...rest);
+        const outStr = typeof out === "string" ? out : JSON.stringify(out);
+        self.signAction({
+          actionType: "tool:end",
+          context: {
+            tool: String(toolName),
+            output_length: outStr?.length ?? 0,
+            output_preview: truncate(outStr ?? ""),
+          },
+        });
+        return out;
+      } catch (err) {
+        self.signAction({
+          actionType: "tool:error",
+          context: {
+            tool: String(toolName),
+            error_type: err instanceof Error ? err.name : typeof err,
+            error: truncate(err instanceof Error ? err.message : String(err)),
+          },
+        });
+        throw err;
+      }
+    };
+
+    return { ...tool, execute };
+  }
+
+  /** Sign an ``agent:input`` event. Use as an input guardrail. */
+  public onAgentInput(input: unknown, agentName?: string): void {
+    const repr = typeof input === "string" ? input : JSON.stringify(input);
+    this.signAction({
+      actionType: "agent:input",
+      context: {
+        agent_name: agentName ?? this.name,
+        input_type: typeof input,
+        input_length: repr?.length ?? 0,
+        input_preview: truncate(repr ?? ""),
+      },
+    });
+  }
+
+  /** Sign an ``agent:output`` event. Use as an output guardrail. */
+  public onAgentOutput(output: unknown, agentName?: string): void {
+    const repr = typeof output === "string" ? output : JSON.stringify(output);
+    this.signAction({
+      actionType: "agent:output",
+      context: {
+        agent_name: agentName ?? this.name,
+        output_type: typeof output,
+        output_length: repr?.length ?? 0,
+        output_preview: truncate(repr ?? ""),
+      },
+    });
+  }
+}

--- a/typescript/tests/extras/langchain.test.ts
+++ b/typescript/tests/extras/langchain.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Agent } from "../../src/index.js";
+
+// Fake Asqav agent: hermetic, no init() / network.
+function makeFakeAgent() {
+  const calls: Array<{ actionType: string; context: Record<string, unknown> }> = [];
+  const sign = vi.fn(async (opts: { actionType: string; context?: Record<string, unknown> }) => {
+    calls.push({ actionType: opts.actionType, context: opts.context ?? {} });
+    return {
+      signature: "sig",
+      signatureId: "sig_1",
+      actionId: "act_1",
+      timestamp: "2026-01-01T00:00:00Z",
+      verificationUrl: "https://asqav.com/verify/sig_1",
+    };
+  });
+  return { agent: { agentId: "agt_fake", sign } as unknown as Agent, calls, sign };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("AsqavCallbackHandler without @langchain/core installed", () => {
+  it("throws a clear ImportError when create() is called", async () => {
+    const { AsqavCallbackHandler } = await import("../../src/extras/langchain.js");
+    const { agent } = makeFakeAgent();
+    await expect(
+      AsqavCallbackHandler.create({ agent }),
+    ).rejects.toThrow(/@langchain\/core/);
+  });
+});
+
+describe("AsqavCallbackHandler with @langchain/core mocked", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Provide a fake @langchain/core/callbacks/base so loadBase() succeeds.
+    vi.doMock("@langchain/core/callbacks/base", () => {
+      class BaseCallbackHandler {
+        // The real class has many no-op handlers; an empty base is enough.
+      }
+      return { BaseCallbackHandler };
+    });
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@langchain/core/callbacks/base");
+  });
+
+  it("signs handleLLMStart, handleLLMEnd, and tool events into the agent", async () => {
+    const { AsqavCallbackHandler } = await import("../../src/extras/langchain.js");
+    const { agent, calls, sign } = makeFakeAgent();
+    const handler = await AsqavCallbackHandler.create({ agent });
+
+    interface InnerHandler {
+      handleLLMStart(s: Record<string, unknown>, prompts: string[]): void;
+      handleLLMEnd(r: Record<string, unknown>): void;
+      handleToolStart(s: Record<string, unknown>, input: string): void;
+      handleToolEnd(out: unknown): void;
+      handleLLMError(err: Error): void;
+    }
+    const inner = handler as unknown as InnerHandler;
+
+    inner.handleLLMStart({ name: "gpt-4o" }, ["hello"]);
+    inner.handleLLMEnd({ generations: [[{ text: "hi" }]], llmOutput: { tokenUsage: { total: 10 } } });
+    inner.handleToolStart({ name: "weather" }, "lisbon");
+    inner.handleToolEnd("sunny");
+    inner.handleLLMError(new Error("boom"));
+
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(5);
+    expect(calls.map((c) => c.actionType)).toEqual([
+      "llm:start",
+      "llm:end",
+      "tool:start",
+      "tool:end",
+      "llm:error",
+    ]);
+    expect(calls[0].context.model).toBe("gpt-4o");
+    expect(calls[1].context.generation_count).toBe(1);
+    expect(calls[1].context.token_usage).toEqual({ total: 10 });
+    expect(calls[2].context.tool).toBe("weather");
+    expect(calls[3].context.output_length).toBe("sunny".length);
+    expect(calls[4].context.error).toBe("boom");
+  });
+});

--- a/typescript/tests/extras/mastra.test.ts
+++ b/typescript/tests/extras/mastra.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AsqavMastraHook } from "../../src/extras/mastra.js";
+import type { Agent } from "../../src/index.js";
+
+function makeFakeAgent() {
+  const calls: Array<{ actionType: string; context: Record<string, unknown> }> = [];
+  const sign = vi.fn(async (opts: { actionType: string; context?: Record<string, unknown> }) => {
+    calls.push({ actionType: opts.actionType, context: opts.context ?? {} });
+    return {
+      signature: "sig",
+      signatureId: "sig_1",
+      actionId: "act_1",
+      timestamp: "2026-01-01T00:00:00Z",
+      verificationUrl: "https://asqav.com/verify/sig_1",
+    };
+  });
+  return { agent: { agentId: "agt_fake", sign } as unknown as Agent, calls, sign };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("AsqavMastraHook without @mastra/core installed", () => {
+  it("attach() throws a clear ImportError", async () => {
+    const { agent } = makeFakeAgent();
+    const hook = new AsqavMastraHook({ agent });
+    await expect(
+      hook.attach({ on: () => undefined }),
+    ).rejects.toThrow(/@mastra\/core/);
+  });
+});
+
+describe("AsqavMastraHook before/after wiring", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock("@mastra/core", () => ({ __mastraStub: true }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@mastra/core");
+  });
+
+  it("signs step:before, step:after, and step:error events", async () => {
+    const { AsqavMastraHook: Hook } = await import("../../src/extras/mastra.js");
+    const { agent, calls, sign } = makeFakeAgent();
+    const hook = new Hook({ agent });
+
+    hook.before({ stepId: "fetch-weather", stepType: "tool", input: { city: "Lisbon" } });
+    hook.after({ stepId: "fetch-weather", stepType: "tool", output: { temp: 22 } });
+    hook.onError({ stepId: "fetch-weather", stepType: "tool", error: new Error("nope") });
+
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(3);
+    expect(calls.map((c) => c.actionType)).toEqual([
+      "step:before",
+      "step:after",
+      "step:error",
+    ]);
+    expect(calls[0].context.step_id).toBe("fetch-weather");
+    expect(calls[1].context.output_length).toBe(JSON.stringify({ temp: 22 }).length);
+    expect(calls[2].context.error).toBe("nope");
+  });
+
+  it("attach(agent.on) subscribes to step:before / step:after / step:error", async () => {
+    const { AsqavMastraHook: Hook } = await import("../../src/extras/mastra.js");
+    const { agent, sign } = makeFakeAgent();
+    const hook = new Hook({ agent });
+
+    const listeners: Record<string, (evt: unknown) => void> = {};
+    const fakeMastra = {
+      on(evt: string, fn: (evt: unknown) => void) {
+        listeners[evt] = fn;
+      },
+    };
+
+    await hook.attach(fakeMastra);
+    listeners["step:before"]({ stepId: "s1", stepType: "tool" });
+    listeners["step:after"]({ stepId: "s1", stepType: "tool", output: "ok" });
+
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(2);
+  });
+});

--- a/typescript/tests/extras/openai-agents.test.ts
+++ b/typescript/tests/extras/openai-agents.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AsqavOpenAIAgentsAdapter } from "../../src/extras/openai-agents.js";
+import type { Agent } from "../../src/index.js";
+
+function makeFakeAgent() {
+  const calls: Array<{ actionType: string; context: Record<string, unknown> }> = [];
+  const sign = vi.fn(async (opts: { actionType: string; context?: Record<string, unknown> }) => {
+    calls.push({ actionType: opts.actionType, context: opts.context ?? {} });
+    return {
+      signature: "sig",
+      signatureId: "sig_1",
+      actionId: "act_1",
+      timestamp: "2026-01-01T00:00:00Z",
+      verificationUrl: "https://asqav.com/verify/sig_1",
+    };
+  });
+  return { agent: { agentId: "agt_fake", sign } as unknown as Agent, calls, sign };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("AsqavOpenAIAgentsAdapter without @openai/agents installed", () => {
+  it("loadPeer() throws a clear ImportError", async () => {
+    await expect(AsqavOpenAIAgentsAdapter.loadPeer()).rejects.toThrow(/@openai\/agents/);
+  });
+});
+
+describe("AsqavOpenAIAgentsAdapter wrapTool + guardrail hooks", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock("@openai/agents", () => ({ __openaiAgentsStub: true }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@openai/agents");
+  });
+
+  it("signs tool:start and tool:end around a successful tool execute", async () => {
+    const { agent, calls, sign } = makeFakeAgent();
+    const adapter = new AsqavOpenAIAgentsAdapter({ agent });
+
+    const tool = {
+      name: "weather",
+      execute: async (input: { city: string }) => ({ city: input.city, temp: 22 }),
+    };
+    const wrapped = adapter.wrapTool(tool);
+    const out = await wrapped.execute!({ city: "Lisbon" });
+
+    await tick();
+    expect(out).toEqual({ city: "Lisbon", temp: 22 });
+    expect(sign).toHaveBeenCalledTimes(2);
+    expect(calls.map((c) => c.actionType)).toEqual(["tool:start", "tool:end"]);
+    expect(calls[0].context.tool).toBe("weather");
+    expect(calls[1].context.output_length).toBeGreaterThan(0);
+  });
+
+  it("signs tool:error and re-throws when the underlying tool fails", async () => {
+    const { agent, calls, sign } = makeFakeAgent();
+    const adapter = new AsqavOpenAIAgentsAdapter({ agent });
+
+    const tool = {
+      name: "broken",
+      execute: async () => {
+        throw new Error("kaboom");
+      },
+    };
+    const wrapped = adapter.wrapTool(tool);
+    await expect(wrapped.execute!(null)).rejects.toThrow(/kaboom/);
+
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(2);
+    expect(calls.map((c) => c.actionType)).toEqual(["tool:start", "tool:error"]);
+    expect(calls[1].context.error).toBe("kaboom");
+  });
+
+  it("signs agent:input and agent:output via guardrail helpers", async () => {
+    const { agent, calls } = makeFakeAgent();
+    const adapter = new AsqavOpenAIAgentsAdapter({ agent });
+
+    adapter.onAgentInput("hello", "agent-1");
+    adapter.onAgentOutput({ answer: 42 }, "agent-1");
+
+    await tick();
+    expect(calls.map((c) => c.actionType)).toEqual(["agent:input", "agent:output"]);
+    expect(calls[0].context.agent_name).toBe("agent-1");
+    expect(calls[1].context.output_length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds three TypeScript framework adapters under `typescript/src/extras/`, matching the Python adapter surface so docs can cross-link the two SDKs. Introduces a shared `AsqavAdapter` base that mirrors `asqav.extras._base.AsqavAdapter`.

- **`extras/langchain.ts`** - `AsqavCallbackHandler` extending `BaseCallbackHandler` from `@langchain/core/callbacks/base`. Signs chain, tool, and LLM lifecycle events (start/end/error).
- **`extras/mastra.ts`** - `AsqavMastraHook` signing `step:before` / `step:after` / `step:error` on Mastra agent step events. Supports both event-emitter (`agent.on`) and middleware (`agent.use`) attach modes.
- **`extras/openai-agents.ts`** - `AsqavOpenAIAgentsAdapter` that wraps OpenAI Agents JS tools (`tool:start/end/error`) and exposes `onAgentInput` / `onAgentOutput` guardrail helpers.

All adapters lazy-import their host package and throw a clear, Python-`ImportError`-equivalent message when the peer is missing. Host packages are declared as optional via `peerDependencies` + `peerDependenciesMeta` so plain `@asqav/sdk` installs stay lean.

## Install (npm equivalents of the Python extras)

- `pip install asqav[langchain]`  ->  `npm install @asqav/sdk @langchain/core`
- new Mastra adapter  ->  `npm install @asqav/sdk @mastra/core`
- `pip install asqav[openai-agents]`  ->  `npm install @asqav/sdk @openai/agents`

## Tests

- `npm run lint`: clean (`tsc --noEmit`)
- `npm run build`: clean (tsup esm + cjs + dts for every new entry)
- `npm test`: 256/256 pass (3 new test files: langchain, mastra, openai-agents)

Each smoke test verifies (a) the missing-peer ImportError contract and (b) sign-hook routing into a mocked Asqav client.

## Comment hygiene

Clean. No em dashes, no AI-self-references, no forbidden tokens in `*.ts` files or docstrings under the new modules.

## Test plan

- [ ] CI green on lint + build + vitest
- [ ] Verify subpath exports resolve: `import { AsqavCallbackHandler } from "@asqav/sdk/extras/langchain"`
- [ ] Verify barrel resolves: `import { AsqavMastraHook } from "@asqav/sdk/extras"`
- [ ] Manual smoke against a real LangChain.js chain once peer is installed locally