### PR TITLE
refactor(typescript-extras): wire raiseMissingPeer helper into 3 adapters

### DIFF
--- a/typescript/src/extras/_base.ts
+++ b/typescript/src/extras/_base.ts
@@ -140,11 +140,21 @@ function defaultOnError(err: unknown, ctx: { actionType: string }): void {
 }
 
 /**
- * Helper that frameworks call when their host package is missing. Mirrors
- * the Python ``ImportError`` thrown at module import time.
+ * Throw the canonical missing-peer error for an Asqav framework adapter.
+ * Mirrors the Python ``ImportError`` contract. Optional ``cause`` keeps
+ * the underlying module-resolution error (ERR_MODULE_NOT_FOUND, ESM/CJS
+ * interop, version mismatch, native binding crash) visible to the user.
  */
-export function raiseMissingPeer(peer: string, install: string): never {
+export function raiseMissingPeer(
+  framework: string,
+  peer: string,
+  install: string,
+  cause?: unknown,
+): never {
+  const suffix = cause
+    ? ` (import error: ${cause instanceof Error ? cause.message : String(cause)})`
+    : "";
   throw new Error(
-    `${peer} is required for this Asqav adapter. Install with: ${install}`,
+    `${framework} integration requires ${peer}. Install with: ${install}.${suffix}`,
   );
 }

--- a/typescript/src/extras/index.ts
+++ b/typescript/src/extras/index.ts
@@ -7,7 +7,7 @@
  * import everything from a single specifier.
  */
 
-export { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+export { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
 export { AsqavCallbackHandler } from "./langchain.js";
 export type { AsqavCallbackHandlerOptions } from "./langchain.js";
 export { AsqavMastraHook } from "./mastra.js";

--- a/typescript/src/extras/langchain.ts
+++ b/typescript/src/extras/langchain.ts
@@ -16,7 +16,7 @@
  * ``BaseCallbackHandler`` from ``@langchain/core/callbacks/base``.
  */
 
-import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+import { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
 
 // Local LangChain.js types so this module compiles even when the peer
 // package is not installed. The actual base class is loaded lazily.
@@ -72,10 +72,11 @@ async function loadBase(): Promise<BaseCallbackHandlerCtor> {
     }
     return ctor;
   } catch (err) {
-    throw new Error(
-      "LangChain.js integration requires @langchain/core. "
-      + "Install with: npm install @langchain/core. "
-      + `(import error: ${err instanceof Error ? err.message : String(err)})`,
+    raiseMissingPeer(
+      "LangChain.js",
+      "@langchain/core",
+      "npm install @langchain/core",
+      err,
     );
   }
 }

--- a/typescript/src/extras/mastra.ts
+++ b/typescript/src/extras/mastra.ts
@@ -17,7 +17,7 @@
  * Mastra instance is present.
  */
 
-import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+import { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
 
 const MAX_PREVIEW = 200;
 
@@ -76,10 +76,11 @@ export class AsqavMastraHook extends AsqavAdapter {
       // @ts-ignore optional peer dependency
       return (await import("@mastra/core")) as unknown;
     } catch (err) {
-      throw new Error(
-        "Mastra integration requires @mastra/core. "
-        + "Install with: npm install @mastra/core. "
-        + `(import error: ${err instanceof Error ? err.message : String(err)})`,
+      raiseMissingPeer(
+        "Mastra",
+        "@mastra/core",
+        "npm install @mastra/core",
+        err,
       );
     }
   }

--- a/typescript/src/extras/openai-agents.ts
+++ b/typescript/src/extras/openai-agents.ts
@@ -17,7 +17,7 @@
  * runs. Operates fail-open so governance never breaks the agent loop.
  */
 
-import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+import { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
 
 const MAX_PREVIEW = 200;
 
@@ -61,10 +61,11 @@ export class AsqavOpenAIAgentsAdapter extends AsqavAdapter {
       // @ts-ignore optional peer dependency
       return (await import("@openai/agents")) as unknown;
     } catch (err) {
-      throw new Error(
-        "OpenAI Agents JS integration requires @openai/agents. "
-        + "Install with: npm install @openai/agents. "
-        + `(import error: ${err instanceof Error ? err.message : String(err)})`,
+      raiseMissingPeer(
+        "OpenAI Agents JS",
+        "@openai/agents",
+        "npm install @openai/agents",
+        err,
       );
     }
   }


### PR DESCRIPTION
## What

The 3 TS adapters (\`langchain.ts\`, \`mastra.ts\`, \`openai-agents.ts\`) each emit the same 9-line try/catch block to wrap their optional peer's dynamic import. CLAUDE.md modularity rule 1 calls for extracting any 3+ line block shared across call sites.

The helper at \`extras/_base.ts:146\` was already documented as the Python-ImportError parity surface but was unreachable - not in the barrel, not called by any adapter, and its signature lost the underlying \`(import error: ...)\` context the inline pattern preserves.

## Changes

1. **\`_base.ts\`**: \`raiseMissingPeer(peer, install)\` -> \`raiseMissingPeer(framework, peer, install, cause?)\`. The optional \`cause\` preserves the \`(import error: ...)\` suffix the inline pattern emits, so \`ERR_MODULE_NOT_FOUND\`, ESM/CJS interop, version-mismatch, and native-binding-crash details stay visible to the user.
2. **\`extras/index.ts\`**: re-export \`raiseMissingPeer\` so downstream extras authors get the same helper.
3. **\`langchain.ts\` / \`mastra.ts\` / \`openai-agents.ts\`**: replace inline missing-peer throws with a single \`raiseMissingPeer(...)\` call.

\`vercel-ai.ts\` is not wired - it receives the agent instance from the caller and has no optional-peer dynamic import.

## Decision rationale

Internal debate (DROP vs WIRE):
- DROP argued: dead code per CLAUDE.md, inline pattern emits richer errors, public API surface cost.
- WIRE argued: 27 lines of duplication today across 3 adapters, Python-parity contract documented but not enforced, onboarding cost compounds, signature upgrade neutralises DROP's error-context objection.

WIRE wins because the signature upgrade fully addresses DROP's only real technical objection, and the duplication is already a larger surface than the helper + 3 callsites.

## Test plan

- [x] \`npm run build\` clean (tsup esm + cjs + dts).
- [x] \`npm test\`: 256/256 vitest pass.
- [x] Error message wording preserved verbatim (regex check via \`/@langchain\\/core/\`, \`/@mastra\\/core/\`, \`/@openai\\/agents/\` in adapter tests).
- [x] Diff: 5 files, +33 -20.

comment hygiene clean