### PR TITLE
docs(sdk): name LangChain.js + Mastra + OpenAI Agents JS adapters in TS README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ The TypeScript SDK focuses on the core API and `Agent` surface for Node 20+ runt
 
 - The `user_intent` envelope on `agent.sign(...)`.
 - A Vercel AI SDK adapter at `@asqav/sdk/extras/vercel-ai` that plugs into `experimental_telemetry: { tracer }` and signs every span the AI SDK opens.
-
-Other framework integrations are tracked on the roadmap.
+- A LangChain.js callback handler `AsqavCallbackHandler` at `@asqav/sdk/extras/langchain` that signs each chain step.
+- A Mastra hook `AsqavMastraHook` at `@asqav/sdk/extras/mastra` that signs each step the Mastra agent emits.
+- An OpenAI Agents JS adapter `AsqavOpenAIAgentsAdapter` at `@asqav/sdk/extras/openai-agents` that signs tool calls on the agent runner.
 
 If a feature exists in one SDK but not the other, the language README will mark it explicitly.
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -180,6 +180,18 @@ const result = await generateText({
 
 Span names are mapped to Asqav action types: `ai.generateText` -> `ai:completion`, `ai.streamText` -> `ai:completion_stream`, `ai.toolCall` -> `ai:tool_call`, errors -> `ai:error`. Signing is fire-and-forget and never blocks generation; failures log a warning instead of throwing.
 
+### LangChain.js
+
+`AsqavCallbackHandler` at `@asqav/sdk/extras/langchain` plugs into LangChain.js's `callbacks` array and signs each chain, tool, and LLM lifecycle event. Construct it via the async factory: `const handler = await AsqavCallbackHandler.create({ agent });` then pass to a chain or model `callbacks: [handler]`. Requires `@langchain/core` as a peer dep.
+
+### Mastra
+
+`AsqavMastraHook` at `@asqav/sdk/extras/mastra` attaches to a Mastra agent and signs each step lifecycle event: `await new AsqavMastraHook({ agent }).attach(mastraAgent)`. Requires `@mastra/core` as a peer dep.
+
+### OpenAI Agents JS
+
+`AsqavOpenAIAgentsAdapter` at `@asqav/sdk/extras/openai-agents` wraps individual tools so each invocation signs `tool:start` / `tool:end` / `tool:error`. Use `const wrapped = new AsqavOpenAIAgentsAdapter({ agent }).wrapTool(tool)` and pass the wrapped tool into your `@openai/agents` runner. Requires `@openai/agents` as a peer dep.
+
 ## Compliance receipts (IETF profile)
 
 Set `complianceMode: true` on `agent.sign(...)` to opt the receipt into the IETF [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) profile. The cloud then emits a conformant chain link, content-addressed `policy_digest`, fail-closed anchoring, and the raised retention floor.


### PR DESCRIPTION
## Summary

PR #190 shipped three TypeScript adapters that the cross-SDK README understated. This corrects the wording from "Other framework integrations are tracked on the roadmap" to a full list of the four adapters that exist in `typescript/src/extras/`, and adds a short per-adapter section to `typescript/README.md` with the real construction surface verified against the source.

## Cold-verified surface

| Adapter | Source | Construction |
|---------|--------|--------------|
| Vercel AI | `typescript/src/extras/vercel-ai.ts` | `createAsqavExporter({ agent })` |
| LangChain.js | `typescript/src/extras/langchain.ts:95` | `await AsqavCallbackHandler.create({ agent })` async factory; pass into `callbacks: [...]` |
| Mastra | `typescript/src/extras/mastra.ts:61` | `await new AsqavMastraHook({ agent }).attach(mastraAgent)` |
| OpenAI Agents JS | `typescript/src/extras/openai-agents.ts:49` | `new AsqavOpenAIAgentsAdapter({ agent }).wrapTool(tool)` returns a wrapped tool |

All four are exported from `typescript/src/extras/index.ts` and each ships its own subpath in `package.json` `exports` (`@asqav/sdk/extras/<name>`).

## Test plan

- [x] No code changes; docs only.
- [x] No em dashes; no forbidden tokens; capital-A "Asqav" in prose.
- [x] Surface claims cold-validated against typescript/src/extras/*.ts before drafting.

comment hygiene clean