### PR TITLE
chore: gitignore AI session artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ dist/
 .claude/
 .planning/
 .cursor/
+COMPANY.md
+CLAUDE.md


### PR DESCRIPTION
## What
Adds local-only AI session artefact patterns to `.gitignore`:
- `.claude/`
- `.planning/`
- `.company/`
- `COMPANY.md`
- `CLAUDE.md` (this repo does not track contributor rules; asqav cloud is the canonical home)

## Why
Audit (2026-05-18) found that 11 of 12 Asqav-org repos lack the AI-artefact `.gitignore` patterns. No leak today (all `.claude/` dirs in this repo are empty), but a future session creating a `.claude/settings.json` or `.planning/discuss.md` could accidentally get committed. This closes the gap.

This repo already had `.claude/`, `.planning/`, and `.company/`; this PR adds the missing `COMPANY.md` and `CLAUDE.md` patterns.

## Test plan
- [x] Local: `.gitignore` now lists the five patterns.
- [x] Untracked check: `git status` does not list `.claude/`, `.planning/`, `.company/`, `COMPANY.md`, or `CLAUDE.md` after this PR lands.

comment hygiene clean