### PR TITLE
fix(readme): drop 404 asqav.com URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://asqav.com">Website</a> |
   <a href="https://asqav.com/docs">Docs</a> |
   <a href="https://asqav.com/docs/sdk">SDK Guide</a> |
-  <a href="https://asqav.com/compliance">Compliance</a>
+  <a href="https://www.asqav.com/docs">Compliance</a>
 </p>
 
 # Asqav SDK - Python + TypeScript
@@ -353,7 +353,6 @@ Machine-readable service descriptor at [`https://asqav.com/.well-known/governanc
 
 - Docs: <https://asqav.com/docs>
 - Repo: <https://github.com/jagmarques/asqav-sdk>
-- Integration docs: <https://asqav.com/docs/integrations>
 - Blog: <https://dev.to/jagmarques>
 - Dashboard: <https://asqav.com/dashboard>
 


### PR DESCRIPTION
## What
Two README links pointed at dead pages:
- https://asqav.com/compliance returned 404. Replaced with https://www.asqav.com/docs (verified 200).
- https://asqav.com/docs/integrations returned 404. Dropped the bullet.

## Why
Cycle 17 cold-link audit found these URLs dead.

comment hygiene clean