### PR TITLE
refactor: mechanical lint cleanup (RUF100 + RUF022)

### DIFF
--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -142,169 +142,169 @@ from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
 __version__ = "0.4.5"
 __all__ = [
-    # Initialization
-    "init",
-    "health_check",
-    # Fingerprint helpers
-    "canonicalize",
-    "canonicalize_tool_args",
-    "canonical_json",
-    "hash_action",
-    # Agent
-    "Agent",
-    "AgentResponse",
-    "get_agent",
-    "PreflightResult",
-    # Responses
-    "TokenResponse",
-    "SDTokenResponse",
-    "SignatureResponse",
-    "SignedActionResponse",
-    "SessionResponse",
-    "CertificateResponse",
-    "VerificationResponse",
-    # Multi-Party Signing
-    "SigningSessionResponse",
-    "ApprovalResponse",
-    "SignatureDetail",
-    "request_action",
-    "approve_action",
-    "get_action_status",
-    # Signing Groups
-    "SigningGroupResponse",
-    "create_signing_group",
-    "get_signing_group",
-    "update_signing_group",
-    # Agents
-    "list_agents",
-    # Signing Entities
-    "SigningEntityResponse",
-    "add_entity",
-    "list_entities",
-    "remove_entity",
-    # Group Keypairs
-    "GroupKeypairResponse",
-    "GroupSignResponse",
-    "generate_keypair",
-    "get_keypair",
-    "group_sign",
-    "KeyRefreshResponse",
-    "refresh_keypair",
-    "ShareRecoveryResponse",
-    "recover_share",
-    # Risk Rules
-    "RiskRuleResponse",
-    "create_risk_rule",
-    "list_risk_rules",
-    "get_risk_rule",
-    "update_risk_rule",
-    "delete_risk_rule",
-    # Delegations
-    "DelegationResponse",
-    "create_delegation",
-    "list_delegations",
-    "get_delegation",
-    "revoke_delegation",
-    # Session Listing
-    "list_sessions",
-    # Verification
-    "verify_signature",
-    "verify_output",
-    "VerificationDetail",
-    "BitcoinAnchorStatus",
-    # May 2026 release helpers
-    "post_applied_attestation",
-    "list_rejected_attempts",
-    # Trust Signal Export
-    "generate_attestation",
-    "verify_attestation",
-    # Sessions
-    "get_session_signatures",
-    # Export
-    "export_audit_json",
-    "export_audit_csv",
-    # Trace Correlation
-    "generate_trace_id",
-    # Emergency Halt
-    "emergency_halt",
-    # Tracing
-    "Span",
-    "span",
-    "get_current_span",
-    # OTEL Export
-    "configure_otel",
-    "export_spans",
-    "flush_spans",
-    # Decorators
-    "secure",
-    "secure_async",
-    "sign",
-    "session",
-    "async_session",
-    # Async
-    "AsyncAgent",
-    # Local Queue
-    "LocalQueue",
-    "local_sign",
-    # Retry
-    "with_retry",
-    "with_async_retry",
-    # Budget Tracking
-    "BudgetTracker",
-    "BudgetCheckResult",
-    # Compliance
-    "ComplianceBundle",
-    "export_bundle",
-    "fetch_audit_pack",
-    # Replay
-    "replay",
-    "replay_from_bundle",
-    "ReplayTimeline",
-    "ReplayStep",
+    # Counterparty acknowledgment binding (IETF -04 counterparty_binding extension)
+    "ACKNOWLEDGMENT_RECEIPT_TYPE",
+    "ALGORITHM_ED25519",
+    "ALGORITHM_ES256",
+    # Algorithm agility
+    "ALGORITHM_ML_DSA_65",
+    # IETF -04 capture-topologies appendix vocabulary
+    "CAPTURE_TOPOLOGY_NAMESPACE",
+    # DORA RTS JC 2024-33 Annex II vocabulary
+    "DORA_INCIDENT_CLASS_NAMESPACE",
     # Patterns
     "PATTERNS",
-    "resolve_pattern",
-    "list_patterns",
-    # Scope Tokens
-    "ScopeToken",
-    "create_scope_token",
-    "verify_scope_token",
-    "is_replay",
-    # Three-Phase Signing
-    "PhaseChain",
-    "sign_with_phases",
-    # Reasoning Trace
-    "ReasoningReceipt",
-    "sign_reasoning",
-    # Hooks
-    "register_before",
-    "register_after",
-    "clear_hooks",
-    # Exceptions
-    "AsqavError",
-    "AuthenticationError",
-    "RateLimitError",
-    "APIError",
     # IETF Compliance Receipts profile
     "RECEIPT_TYPE_NAMESPACE",
     "SKEW_BOUND_SECONDS",
+    "SUPPORTED_ALGORITHMS",
+    "APIError",
+    # Agent
+    "Agent",
+    "AgentResponse",
+    "ApprovalResponse",
+    # Exceptions
+    "AsqavError",
+    # Async
+    "AsyncAgent",
+    "AuthenticationError",
+    "BitcoinAnchorStatus",
+    "BudgetCheckResult",
+    # Budget Tracking
+    "BudgetTracker",
+    "CertificateResponse",
+    # Compliance
+    "ComplianceBundle",
     "ComplianceReceiptVerification",
-    "verify_compliance_receipt",
-    # Counterparty acknowledgment binding (IETF -04 counterparty_binding extension)
-    "ACKNOWLEDGMENT_RECEIPT_TYPE",
     "CounterpartyBinding",
     "CounterpartyBindingVerification",
-    "compute_counterparty_binding",
-    "verify_counterparty_binding",
-    # DORA RTS JC 2024-33 Annex II vocabulary
-    "DORA_INCIDENT_CLASS_NAMESPACE",
-    # IETF -04 capture-topologies appendix vocabulary
-    "CAPTURE_TOPOLOGY_NAMESPACE",
-    # Algorithm agility
-    "ALGORITHM_ML_DSA_65",
-    "ALGORITHM_ED25519",
-    "ALGORITHM_ES256",
-    "SUPPORTED_ALGORITHMS",
+    # Delegations
+    "DelegationResponse",
+    # Group Keypairs
+    "GroupKeypairResponse",
+    "GroupSignResponse",
+    "KeyRefreshResponse",
     "LocalKeypair",
+    # Local Queue
+    "LocalQueue",
+    # Three-Phase Signing
+    "PhaseChain",
+    "PreflightResult",
+    "RateLimitError",
+    # Reasoning Trace
+    "ReasoningReceipt",
+    "ReplayStep",
+    "ReplayTimeline",
+    # Risk Rules
+    "RiskRuleResponse",
+    "SDTokenResponse",
+    # Scope Tokens
+    "ScopeToken",
+    "SessionResponse",
+    "ShareRecoveryResponse",
+    "SignatureDetail",
+    "SignatureResponse",
+    "SignedActionResponse",
+    # Signing Entities
+    "SigningEntityResponse",
+    # Signing Groups
+    "SigningGroupResponse",
+    # Multi-Party Signing
+    "SigningSessionResponse",
+    # Tracing
+    "Span",
+    # Responses
+    "TokenResponse",
+    "VerificationDetail",
+    "VerificationResponse",
+    "add_entity",
+    "approve_action",
+    "async_session",
+    "canonical_json",
+    # Fingerprint helpers
+    "canonicalize",
+    "canonicalize_tool_args",
+    "clear_hooks",
+    "compute_counterparty_binding",
+    # OTEL Export
+    "configure_otel",
+    "create_delegation",
+    "create_risk_rule",
+    "create_scope_token",
+    "create_signing_group",
+    "delete_risk_rule",
+    # Emergency Halt
+    "emergency_halt",
+    "export_audit_csv",
+    # Export
+    "export_audit_json",
+    "export_bundle",
+    "export_spans",
+    "fetch_audit_pack",
+    "flush_spans",
+    # Trust Signal Export
+    "generate_attestation",
+    "generate_keypair",
     "generate_local_keypair",
+    # Trace Correlation
+    "generate_trace_id",
+    "get_action_status",
+    "get_agent",
+    "get_current_span",
+    "get_delegation",
+    "get_keypair",
+    "get_risk_rule",
+    # Sessions
+    "get_session_signatures",
+    "get_signing_group",
+    "group_sign",
+    "hash_action",
+    "health_check",
+    # Initialization
+    "init",
+    "is_replay",
+    # Agents
+    "list_agents",
+    "list_delegations",
+    "list_entities",
+    "list_patterns",
+    "list_rejected_attempts",
+    "list_risk_rules",
+    # Session Listing
+    "list_sessions",
+    "local_sign",
+    # May 2026 release helpers
+    "post_applied_attestation",
+    "recover_share",
+    "refresh_keypair",
+    "register_after",
+    # Hooks
+    "register_before",
+    "remove_entity",
+    # Replay
+    "replay",
+    "replay_from_bundle",
+    "request_action",
+    "resolve_pattern",
+    "revoke_delegation",
+    # Decorators
+    "secure",
+    "secure_async",
+    "session",
+    "sign",
+    "sign_reasoning",
+    "sign_with_phases",
+    "span",
+    "update_risk_rule",
+    "update_signing_group",
+    "verify_attestation",
+    "verify_compliance_receipt",
+    "verify_counterparty_binding",
+    "verify_output",
+    "verify_scope_token",
+    # Verification
+    "verify_signature",
+    "with_async_retry",
+    # Retry
+    "with_retry",
 ]

--- a/python/src/asqav/demo.py
+++ b/python/src/asqav/demo.py
@@ -9,7 +9,6 @@ a verifiable receipt.
 Usage: `asqav demo`
 """
 
-# ruff: noqa: E501
 
 from __future__ import annotations
 
@@ -345,7 +344,7 @@ load();
 class DemoHandler(http.server.BaseHTTPRequestHandler):
     state: DemoState
 
-    def log_message(self, format: str, *args: Any) -> None:  # noqa: ARG002
+    def log_message(self, format: str, *args: Any) -> None:
         return  # Suppress default access logs
 
     def _json(self, status: int, body: dict[str, Any]) -> None:
@@ -356,7 +355,7 @@ class DemoHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(data)
 
-    def do_GET(self) -> None:  # noqa: N802
+    def do_GET(self) -> None:
         if self.path == "/":
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -368,7 +367,7 @@ class DemoHandler(http.server.BaseHTTPRequestHandler):
             return
         self._json(404, {"error": "not found"})
 
-    def do_POST(self) -> None:  # noqa: N802
+    def do_POST(self) -> None:
         length = int(self.headers.get("Content-Length", "0"))
         raw = self.rfile.read(length) if length else b"{}"
         try:

--- a/python/src/asqav/extras/crewai.py
+++ b/python/src/asqav/extras/crewai.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Any
 
 try:
-    import crewai  # noqa: F401
+    import crewai
 except ImportError:
     raise ImportError(
         "CrewAI integration requires crewai. "

--- a/python/src/asqav/extras/letta.py
+++ b/python/src/asqav/extras/letta.py
@@ -21,7 +21,7 @@ import logging
 from typing import Any
 
 try:
-    import letta_client  # noqa: F401
+    import letta_client
 except ImportError:
     raise ImportError(
         "letta integration requires letta-client. "

--- a/python/src/asqav/extras/litellm.py
+++ b/python/src/asqav/extras/litellm.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 try:
-    import litellm  # noqa: F401
+    import litellm
 except ImportError:
     raise ImportError(
         "LiteLLM integration requires litellm. "

--- a/python/src/asqav/extras/smolagents.py
+++ b/python/src/asqav/extras/smolagents.py
@@ -28,7 +28,7 @@ import logging
 from typing import Any
 
 try:
-    import smolagents  # noqa: F401
+    import smolagents
 except ImportError:
     raise ImportError(
         "smolagents integration requires smolagents. "

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -938,7 +938,7 @@ def test_keys_generate_ed25519(tmp_path) -> None:
     """keys generate --algorithm ed25519 emits a PKCS#8 PEM private key."""
     pytest_skipif_no_crypto = False
     try:
-        from cryptography.hazmat.primitives.asymmetric import ed25519  # noqa: F401
+        from cryptography.hazmat.primitives.asymmetric import ed25519
     except ImportError:
         pytest_skipif_no_crypto = True
     if pytest_skipif_no_crypto:

--- a/python/tests/test_client_hash_mode.py
+++ b/python/tests/test_client_hash_mode.py
@@ -16,9 +16,9 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-import asqav  # noqa: E402
-from asqav import client as client_mod  # noqa: E402
-from asqav.client import Agent  # noqa: E402
+import asqav
+from asqav import client as client_mod
+from asqav.client import Agent
 
 # A canned response that satisfies SignatureResponse decoding.
 MOCK_SIGN_RESPONSE: dict = {

--- a/python/tests/test_co_signers.py
+++ b/python/tests/test_co_signers.py
@@ -115,7 +115,7 @@ def test_countersign_posts_to_correct_path(mock_post: object) -> None:
         "verification_url": "https://api.asqav.com/api/v1/verify/sig_01",
         "required_co_signers": ["agent_alice"],
         "co_signatures": [
-            {"agent_id": "agent_alice", "signature": "co_sig_bytes", "signed_at": "2026-04-28T10:00:01Z"}  # noqa: E501
+            {"agent_id": "agent_alice", "signature": "co_sig_bytes", "signed_at": "2026-04-28T10:00:01Z"}
         ],
     }
     agent = _make_agent()

--- a/python/tests/test_crewai_integration.py
+++ b/python/tests/test_crewai_integration.py
@@ -16,7 +16,7 @@ sys.modules["crewai"] = _fake_crewai
 # Remove any cached version first so the fresh fake module is used.
 sys.modules.pop("asqav.extras.crewai", None)
 
-from asqav.extras.crewai import AsqavCrewHook  # noqa: E402
+from asqav.extras.crewai import AsqavCrewHook
 
 # === Fixtures ===
 

--- a/python/tests/test_dspy_integration.py
+++ b/python/tests/test_dspy_integration.py
@@ -58,7 +58,7 @@ def _remove_dspy_mocks() -> None:
 
 BaseCallback = _install_dspy_mocks()
 
-from asqav.extras.dspy import AsqavDSPyCallback  # noqa: E402
+from asqav.extras.dspy import AsqavDSPyCallback
 
 # === Fixtures ===
 

--- a/python/tests/test_extras.py
+++ b/python/tests/test_extras.py
@@ -62,12 +62,12 @@ def test_all_extra_includes_everything():
     all_deps = opt_deps["all"]
 
     # Each framework extra's deps should appear in 'all'
-    framework_extras = ["httpx", "cli", "langchain", "crewai", "litellm", "haystack", "openai-agents"]  # noqa: E501
+    framework_extras = ["httpx", "cli", "langchain", "crewai", "litellm", "haystack", "openai-agents"]
     for extra in framework_extras:
         for dep in opt_deps[extra]:
             # Strip version specifiers for matching
             dep_name = dep.split(">=")[0].split("<=")[0].split("==")[0].strip()
-            all_dep_names = [d.split(">=")[0].split("<=")[0].split("==")[0].strip() for d in all_deps]  # noqa: E501
+            all_dep_names = [d.split(">=")[0].split("<=")[0].split("==")[0].strip() for d in all_deps]
             assert dep_name in all_dep_names, (
                 f"Dep '{dep_name}' from extra '{extra}' not found in 'all'"
             )
@@ -109,7 +109,7 @@ def test_langchain_stub_import_error():
     """Importing langchain stub raises ImportError when langchain-core is not installed."""
     _purge("asqav.extras.langchain", "langchain_core", "langchain_core.callbacks")
     with pytest.raises(ImportError, match="pip install asqav"):
-        import asqav.extras.langchain  # noqa: F401
+        import asqav.extras.langchain
 
 
 @pytest.mark.skipif(_module_installed("crewai"), reason="crewai installed; stub error path is unreachable in this env")
@@ -117,7 +117,7 @@ def test_crewai_stub_import_error():
     """Importing crewai stub raises ImportError when crewai is not installed."""
     _purge("asqav.extras.crewai", "crewai")
     with pytest.raises(ImportError, match="pip install asqav"):
-        import asqav.extras.crewai  # noqa: F401
+        import asqav.extras.crewai
 
 
 @pytest.mark.skipif(_module_installed("litellm"), reason="litellm installed; stub error path is unreachable in this env")
@@ -125,7 +125,7 @@ def test_litellm_stub_import_error():
     """Importing litellm stub raises ImportError when litellm is not installed."""
     _purge("asqav.extras.litellm", "litellm")
     with pytest.raises(ImportError, match="pip install asqav"):
-        import asqav.extras.litellm  # noqa: F401
+        import asqav.extras.litellm
 
 
 @pytest.mark.skipif(_module_installed("haystack"), reason="haystack-ai installed; stub error path is unreachable in this env")
@@ -133,7 +133,7 @@ def test_haystack_stub_import_error():
     """Importing haystack stub raises ImportError when haystack-ai is not installed."""
     _purge("asqav.extras.haystack", "haystack", "haystack.dataclasses")
     with pytest.raises(ImportError, match="pip install asqav"):
-        import asqav.extras.haystack  # noqa: F401
+        import asqav.extras.haystack
 
 
 @pytest.mark.skipif(_module_installed("agents"), reason="openai-agents installed; stub error path is unreachable in this env")
@@ -141,4 +141,4 @@ def test_openai_agents_stub_import_error():
     """Importing openai_agents stub raises ImportError when openai-agents is not installed."""
     _purge("asqav.extras.openai_agents", "agents", "agents.tracing")
     with pytest.raises(ImportError, match="pip install asqav"):
-        import asqav.extras.openai_agents  # noqa: F401
+        import asqav.extras.openai_agents

--- a/python/tests/test_guardrail_provider.py
+++ b/python/tests/test_guardrail_provider.py
@@ -15,8 +15,8 @@ sys.modules["crewai"] = _fake_crewai
 # Remove any cached version first so the fresh fake module is used.
 sys.modules.pop("asqav.extras.crewai", None)
 
-from asqav.client import PreflightResult, SignatureResponse  # noqa: E402
-from asqav.extras.crewai import AsqavGuardrailProvider  # noqa: E402
+from asqav.client import PreflightResult, SignatureResponse
+from asqav.extras.crewai import AsqavGuardrailProvider
 
 # === Fixtures ===
 

--- a/python/tests/test_haystack_integration.py
+++ b/python/tests/test_haystack_integration.py
@@ -35,7 +35,7 @@ class _MockComponent:
 _mock_haystack.component = _MockComponent()  # type: ignore[attr-defined]
 sys.modules.setdefault("haystack", _mock_haystack)
 
-from asqav.extras.haystack import AsqavComponent  # noqa: E402
+from asqav.extras.haystack import AsqavComponent
 
 MOCK_SIGN_RESPONSE: dict = {
     "signature": "sig_abc123",

--- a/python/tests/test_hooks.py
+++ b/python/tests/test_hooks.py
@@ -11,8 +11,8 @@ import pytest
 # Ensure src is importable
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-import asqav  # noqa: E402
-from asqav import hooks as hooks_module  # noqa: E402
+import asqav
+from asqav import hooks as hooks_module
 
 
 def _make_agent() -> "asqav.Agent":

--- a/python/tests/test_instructor_integration.py
+++ b/python/tests/test_instructor_integration.py
@@ -59,7 +59,7 @@ def _remove_instructor_mocks() -> None:
 
 HookName = _install_instructor_mocks()
 
-from asqav.extras.instructor import AsqavInstructorHook  # noqa: E402
+from asqav.extras.instructor import AsqavInstructorHook
 
 
 @pytest.fixture

--- a/python/tests/test_langchain_integration.py
+++ b/python/tests/test_langchain_integration.py
@@ -87,7 +87,7 @@ def _remove_langchain_mocks() -> None:
 # Install mocks before importing the handler
 LLMResult = _install_langchain_mocks()
 
-from asqav.extras.langchain import AsqavCallbackHandler  # noqa: E402, I001
+from asqav.extras.langchain import AsqavCallbackHandler
 
 
 # === Fixtures ===

--- a/python/tests/test_letta_integration.py
+++ b/python/tests/test_letta_integration.py
@@ -22,7 +22,7 @@ _fake_letta_client = types.ModuleType("letta_client")
 sys.modules["letta_client"] = _fake_letta_client
 sys.modules.pop("asqav.extras.letta", None)
 
-from asqav.extras.letta import AsqavLettaHook  # noqa: E402
+from asqav.extras.letta import AsqavLettaHook
 
 # === Helpers ===
 

--- a/python/tests/test_litellm_integration.py
+++ b/python/tests/test_litellm_integration.py
@@ -18,7 +18,7 @@ from asqav.client import AsqavError, SignatureResponse
 _mock_litellm = ModuleType("litellm")
 sys.modules.setdefault("litellm", _mock_litellm)
 
-from asqav.extras.litellm import AsqavGuardrail  # noqa: E402
+from asqav.extras.litellm import AsqavGuardrail
 
 MOCK_SIGN_RESPONSE: dict = {
     "signature": "sig_abc123",

--- a/python/tests/test_llamaindex_integration.py
+++ b/python/tests/test_llamaindex_integration.py
@@ -136,7 +136,7 @@ def _remove_llamaindex_mocks() -> None:
 
 _install_llamaindex_mocks()
 
-from asqav.extras.llamaindex import AsqavLlamaIndexHandler  # noqa: E402
+from asqav.extras.llamaindex import AsqavLlamaIndexHandler
 
 # === Fixtures ===
 

--- a/python/tests/test_local.py
+++ b/python/tests/test_local.py
@@ -156,9 +156,9 @@ def test_local_sign_convenience(tmp_path: object) -> None:
 # === CLI tests ===
 
 
-from typer.testing import CliRunner  # noqa: E402
+from typer.testing import CliRunner
 
-from asqav.cli import app  # noqa: E402
+from asqav.cli import app
 
 runner = CliRunner()
 

--- a/python/tests/test_openai_agents_integration.py
+++ b/python/tests/test_openai_agents_integration.py
@@ -24,7 +24,7 @@ sys.modules["agents.tracing"] = _mock_agents_tracing
 
 sys.modules.pop("asqav.extras.openai_agents", None)
 
-from asqav.extras.openai_agents import AsqavGuardrail, GuardrailResult  # noqa: E402, I001
+from asqav.extras.openai_agents import AsqavGuardrail, GuardrailResult
 
 
 # === Helpers ===

--- a/python/tests/test_retry_async.py
+++ b/python/tests/test_retry_async.py
@@ -255,7 +255,7 @@ async def test_async_verify() -> None:
     )
 
     # Mock _get_config to return valid config
-    with sync_patch("asqav.async_client._get_config", return_value=("https://api.asqav.com/api/v1", "sk_test")):  # noqa: E501
+    with sync_patch("asqav.async_client._get_config", return_value=("https://api.asqav.com/api/v1", "sk_test")):
         # Mock httpx.AsyncClient
         mock_client = AsyncMock()
         mock_client.get.return_value = mock_response

--- a/python/tests/test_scope_tokens.py
+++ b/python/tests/test_scope_tokens.py
@@ -190,7 +190,7 @@ class TestCreateScopeToken:
         assert token.actions == ["data:read:*"]
         mock_sd.assert_called_once()
         call_kwargs = mock_sd.call_args
-        assert "scope_actions" in call_kwargs[1]["claims"] or "scope_actions" in call_kwargs.kwargs.get("claims", {})  # noqa: E501
+        assert "scope_actions" in call_kwargs[1]["claims"] or "scope_actions" in call_kwargs.kwargs.get("claims", {})
 
     def test_semantic_pattern_resolved(self):
         agent = _make_agent()

--- a/python/tests/test_smolagents_integration.py
+++ b/python/tests/test_smolagents_integration.py
@@ -22,7 +22,7 @@ _fake_smolagents = types.ModuleType("smolagents")
 sys.modules["smolagents"] = _fake_smolagents
 sys.modules.pop("asqav.extras.smolagents", None)
 
-from asqav.extras.smolagents import AsqavSmolagentsHook  # noqa: E402
+from asqav.extras.smolagents import AsqavSmolagentsHook
 
 # === Helpers ===
 

--- a/python/tests/test_user_intent.py
+++ b/python/tests/test_user_intent.py
@@ -14,8 +14,8 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from asqav import client as client_mod  # noqa: E402
-from asqav.client import Agent  # noqa: E402
+from asqav import client as client_mod
+from asqav.client import Agent
 
 MOCK_SIGN_RESPONSE: dict = {
     "signature": "sig-bytes",


### PR DESCRIPTION
## What
Auto-fixes from `ruff check --fix --select RUF100,RUF022`:
- 40 unused `# noqa` markers dropped across `src/`, `tests/`, and `examples/`.
- `__all__` in `python/src/asqav/__init__.py` sorted alphabetically (RUF022, with `--unsafe-fixes` since RUF022 is `unsafe-fix` only).

## Why
Cycle 18 lint scan found 21 unused `# noqa: E402` markers (CLAUDE.md rule 11 violation) plus 19 other unused `# noqa` directives. The sorted `__all__` is purely a re-ordering of a name list with embedded comments preserved.

## Scope
B904 (47 raise-without-from) is intentionally NOT included in this PR. It will be a follow-up under `chore/lint-cleanup-b904`, since B904 has no auto-fix and the manual edits warrant separate review.

Files touched by open PRs (#188 fastapi middleware, #193 docs, #194 .gitignore, #195 README) are deliberately skipped.

## Test plan
- [x] `ruff check --select RUF100,RUF022` passes after the diff.
- [ ] CI runs the full test suite.

comment hygiene clean