### PR TITLE
feat(examples): vendor CrewAI / LangChain / Manifest examples

### DIFF
--- a/python/examples/crewai_example.py
+++ b/python/examples/crewai_example.py
@@ -1,0 +1,89 @@
+"""CrewAI integration example for asqav.
+
+Demonstrates how to wire AsqavCrewHook into a CrewAI ``Crew`` so every step
+and task is signed and recorded in the audit trail. Context is hashed
+client-side when ``base_url`` points at *.asqav.com.
+
+Requirements:
+    pip install asqav crewai python-dotenv
+
+Usage:
+    ASQAV_API_KEY=sk_... python examples/crewai_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+from asqav.extras.crewai import AsqavCrewHook
+
+try:
+    from crewai import Agent, Crew, Process, Task
+except ImportError as err:
+    raise SystemExit(
+        "crewai is required for this example.\n"
+        "Install with: pip install crewai"
+    ) from err
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+api_key = os.environ.get("ASQAV_API_KEY", "")
+if not api_key:
+    raise SystemExit(
+        "Set the ASQAV_API_KEY environment variable before running this example.\n"
+        "Get your key at https://asqav.com"
+    )
+
+hook = AsqavCrewHook(agent_name="crewai-demo")
+
+researcher = Agent(
+    role="Researcher",
+    goal="Find accurate, recent information on the given topic",
+    backstory="You are a thorough researcher who finds reliable sources.",
+    verbose=True,
+)
+
+writer = Agent(
+    role="Writer",
+    goal="Turn research into clear, concise summaries",
+    backstory="You are a technical writer who explains complex topics simply.",
+    verbose=True,
+)
+
+research_task = Task(
+    description=(
+        "Research the current state of AI governance frameworks worldwide. "
+        "Focus on the EU AI Act and recent US executive orders."
+    ),
+    expected_output="A list of key frameworks with brief descriptions.",
+    agent=researcher,
+)
+
+summary_task = Task(
+    description=(
+        "Take the research and write a 3-paragraph summary suitable for a "
+        "developer audience."
+    ),
+    expected_output="A clear, jargon-free summary of AI governance frameworks.",
+    agent=writer,
+)
+
+crew = Crew(
+    agents=[researcher, writer],
+    tasks=[research_task, summary_task],
+    process=Process.sequential,
+    verbose=True,
+    step_callback=hook.step_callback,
+    task_callback=hook.task_callback,
+)
+
+result = crew.kickoff()
+
+print("\nResult:")
+print(result)
+print("\nView the signed audit trail at https://asqav.com/dashboard")

--- a/python/examples/langchain_example.py
+++ b/python/examples/langchain_example.py
@@ -1,0 +1,71 @@
+"""LangChain integration example for asqav.
+
+Demonstrates how to attach AsqavCallbackHandler to a LangChain agent so every
+LLM call, tool invocation, and chain step is signed and recorded in the audit
+trail.
+
+Requirements:
+    pip install asqav langchain langchain-openai langchain-community python-dotenv
+
+Usage:
+    ASQAV_API_KEY=sk_... OPENAI_API_KEY=sk-... python examples/langchain_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+from asqav.extras.langchain import AsqavCallbackHandler
+
+try:
+    from langchain.agents import AgentExecutor, create_react_agent
+    from langchain_community.tools import WikipediaQueryRun
+    from langchain_community.utilities import WikipediaAPIWrapper
+    from langchain_core.prompts import PromptTemplate
+    from langchain_openai import ChatOpenAI
+except ImportError as err:
+    raise SystemExit(
+        "langchain is required for this example.\n"
+        "Install with: pip install langchain langchain-openai langchain-community"
+    ) from err
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+api_key = os.environ.get("ASQAV_API_KEY", "")
+if not api_key:
+    raise SystemExit(
+        "Set the ASQAV_API_KEY environment variable before running this example.\n"
+        "Get your key at https://asqav.com"
+    )
+
+handler = AsqavCallbackHandler(agent_name="langchain-demo")
+
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+tools = [WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper(top_k_results=1))]
+
+prompt = PromptTemplate.from_template(
+    """Answer the question using available tools.
+
+Tools: {tools}
+Tool names: {tool_names}
+
+Question: {input}
+{agent_scratchpad}"""
+)
+
+agent = create_react_agent(llm, tools, prompt)
+executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
+
+result = executor.invoke(
+    {"input": "What is Python and who created it?"},
+    config={"callbacks": [handler]},
+)
+
+print("\nResult:")
+print(result["output"])
+print("\nView the signed audit trail at https://asqav.com/dashboard")

--- a/python/examples/manifest_example.py
+++ b/python/examples/manifest_example.py
@@ -1,0 +1,89 @@
+"""Manifest + Asqav two-SDK example.
+
+Demonstrates a minimal flow where Manifest routes the LLM call and asqav
+signs the resulting agent action with ML-DSA-65 (Compliance Receipt):
+
+    prompt
+      -> Manifest /v1/chat/completions (picks the model)
+      -> agent decides on an action
+      -> asqav signs the action
+      -> public verify URL anyone can audit
+
+Requirements:
+    pip install asqav openai
+
+Usage:
+    ASQAV_API_KEY=sk_... python examples/manifest_example.py \\
+        "Wire 1500 EUR to vendor INV-2026-04-12"
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import asqav
+
+try:
+    from openai import OpenAI
+except ImportError as err:
+    raise SystemExit(
+        "openai is required for this example.\n"
+        "Install with: pip install openai"
+    ) from err
+
+
+def main() -> int:
+    prompt = sys.argv[1] if len(sys.argv) > 1 else "noop"
+
+    api_key = os.environ.get("ASQAV_API_KEY", "")
+    if not api_key:
+        raise SystemExit(
+            "Set the ASQAV_API_KEY environment variable before running.\n"
+            "Get your key at https://asqav.com"
+        )
+
+    manifest = OpenAI(
+        base_url=os.environ.get("MANIFEST_BASE_URL", "http://localhost:2099/v1"),
+        api_key=os.environ.get("MANIFEST_API_KEY", "dev-api-key-12345"),
+    )
+
+    asqav.init(api_key=api_key)
+    agent = asqav.Agent.create("finance-bot", capabilities=["wire_transfer"])
+
+    resp = manifest.chat.completions.create(
+        model="auto",
+        messages=[
+            {
+                "role": "system",
+                "content": "Extract structured wire-transfer details from the user request.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+    )
+    model = resp.model
+    text = resp.choices[0].message.content or ""
+    tokens = resp.usage.total_tokens if resp.usage else 0
+    cost = float(tokens) * 0.000002  # placeholder unit price
+
+    sig = agent.sign(
+        "wire_transfer",
+        context={
+            "prompt": prompt,
+            "extracted": text,
+            "model": model,
+            "cost_usd": cost,
+        },
+        receipt_type="protectmcp:decision",
+        risk_class="high",
+        model_name=model,
+    )
+
+    print(f"Manifest routed to: {model}  cost: ${cost:.4f}")
+    print(f"Asqav signature:    {sig.signature_id}")
+    print(f"Verify:             {sig.verification_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Vendors three standalone example repos into this SDK's `python/examples/` directory. Each example is now next to the SDK it demos, discoverable via the SDK README, and one less repo to maintain.

| Source repo | Target |
|---|---|
| `asqav-crewai-example/main.py` | `python/examples/crewai_example.py` |
| `asqav-langchain-example/main.py` | `python/examples/langchain_example.py` |
| `asqav-manifest-example/agent.py` | `python/examples/manifest_example.py` |

Each file matches the style of the existing examples (`autogen_integration.py`, `dspy_example.py`, `smolagents_example.py`):
- Terse docstring with `Requirements:` + `Usage:` lines (no separate `requirements.txt`)
- Explicit import guards so users get a clear install hint
- `ASQAV_API_KEY` env check
- Pointer to the dashboard at the end

The CrewAI example also fixes a stale API: the source repo used `hook.on_step` / `hook.on_task`, which do not exist; the SDK's actual API is `hook.step_callback` / `hook.task_callback`.

## Why
Cycle 18 audit found zero GitHub stars, zero external contributors, and no download signal for the standalone `asqav-<framework>-example` repos. Vendoring cuts the maintenance footprint from 12 repos to 9.

## Test plan
- [x] All three files parse (`python3 -m py_compile`)
- [x] `uv run ruff check examples/{crewai,langchain,manifest}_example.py` passes
- [x] Imports resolve against this SDK's module layout (`asqav.extras.crewai.AsqavCrewHook`, `asqav.extras.langchain.AsqavCallbackHandler`, `asqav.Agent.create`)
- [ ] `pip install asqav <framework>; python examples/<example>.py` runs (manual, not CI-gated)
- [ ] Source repo archival is a separate maintainer step, NOT in this PR

comment hygiene clean