### PR TITLE
chore: collapse multi-sentence docstrings (wide slop sweep)

### DIFF
--- a/python/src/asqav/_jcs.py
+++ b/python/src/asqav/_jcs.py
@@ -1,37 +1,8 @@
-"""JCS canonicalization helper for the IETF Compliance Receipts profile.
+"""JCS canonicalization for the IETF Compliance Receipts profile.
 
-Public surface: :func:`canonical_json` returning ``bytes``. The output
-is the exact bytes the cloud's ``core/canonical.py:canonical_json``
-produces and the bytes the chain hashes over.
-
-See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
-
-This module is a named landing for the IETF Compliance Receipts profile
-so callers can ``from asqav._jcs import canonical_json`` to get the same
-function under the spec-mandated name.
-``asqav.canonicalize.canonicalize`` is kept as a public alias for
-backwards compatibility; the two are byte-identical for the JSON value
-types the profile actually signs (objects whose leaves are strings,
-booleans, null, integers, and nested arrays / objects).
-
-Implementation notes:
-
-  - Lexicographic ordering of object keys (UTF-16 code unit order, which
-    Python ``sort_keys=True`` produces for the ASCII / BMP keys this
-    codebase uses).
-  - No insignificant whitespace; ``,`` and ``:`` separators only.
-  - UTF-8 byte output with no BOM. Non-ASCII passes through verbatim.
-  - ``NaN`` / ``Infinity`` rejected.
-  - String escapes follow standard JSON rules (``\\``, ``\"``, ``\b``,
-    ``\f``, ``\n``, ``\r``, ``\t``, plus ``\\u00xx`` for control chars
-    U+0000..U+001F). All other characters pass through, matching
-    ECMAScript ``JSON.stringify``.
-
-Float caveat: Python ``json.dumps`` and ECMAScript ``Number.toString``
-agree byte-for-byte on integer values within the IEEE-754 safe range,
-which is what the Compliance Receipts profile signs. Floats are not
-covered by the conformance vectors and SHOULD NOT appear in signed
-envelopes.
+Byte-identical to the cloud's ``core/canonical.py:canonical_json``; see
+draft-marques-asqav-compliance-receipts. ``asqav.canonicalize.canonicalize`` is
+the back-compat alias.
 """
 
 from __future__ import annotations
@@ -43,15 +14,7 @@ __all__ = ["canonical_json"]
 
 
 def canonical_json(obj: Any) -> bytes:
-    """Return canonical JCS bytes for ``obj``.
-
-    Same function as :func:`asqav.canonicalize.canonicalize`; exposed
-    under the spec-mandated name so IETF profile code reads naturally.
-
-    Identical bytes to the cloud's ``core/canonical.py:canonical_json``
-    so customer-side digests reproduce the bytes the server signs over
-    and the chain hashes over.
-    """
+    """Return canonical JCS bytes for ``obj``, byte-identical to the cloud."""
     return json.dumps(
         obj,
         sort_keys=True,

--- a/python/src/asqav/_mode.py
+++ b/python/src/asqav/_mode.py
@@ -1,23 +1,7 @@
 """Mode resolver for hash-only vs full-payload signing.
 
-The Asqav SDK supports two signing wire formats:
-
-* ``"full-payload"``: send the raw ``context`` dict to the server. This is
-  the default for self-hosted deployments where the server already
-  holds the data.
-* ``"hash-only"``: hash the canonical ``{action_type, context}`` locally
-  and send only the hash plus a small whitelisted metadata bag. This is
-  the GDPR data-minimization mode used by the Asqav cloud (api.asqav.com).
-
-Resolution precedence (highest first):
-
-1. Explicit constructor / init kwarg (``mode="hash-only"``).
-2. Environment variable ``ASQAV_MODE``.
-3. Auto-detection from ``api_base_url``: hostnames matching the Asqav
-   cloud (``api.asqav.com`` or any ``*.asqav.com`` API host) default to
-   hash-only. Anything else (localhost, custom domains, ``myasqav.com``,
-   subdomain attacks like ``asqav.com.evil.com``) defaults to
-   full-payload.
+Resolution order: explicit kwarg, ``ASQAV_MODE`` env, then hostname auto-detection
+(``*.asqav.com`` -> hash-only, else full-payload).
 """
 
 from __future__ import annotations
@@ -31,13 +15,7 @@ _VALID_ENV = {"hash-only", "full-payload"}
 
 
 def _is_asqav_cloud_host(hostname: str | None) -> bool:
-    """True if ``hostname`` is the Asqav cloud API.
-
-    Matches ``api.asqav.com`` exactly, or any subdomain of ``asqav.com``
-    (e.g. ``staging.asqav.com``). Rejects look-alikes such as
-    ``myasqav.com`` (different domain) and ``asqav.com.evil.com``
-    (subdomain attack: the registrable domain is ``evil.com``).
-    """
+    """True if ``hostname`` is ``api.asqav.com`` or any ``*.asqav.com`` subdomain."""
     if not hostname:
         return False
     h = hostname.lower().strip().rstrip(".")
@@ -51,21 +29,7 @@ def _resolve_mode(
     env: str | None,
     explicit: str | None = "auto",
 ) -> Mode:
-    """Resolve the wire mode for a client.
-
-    Args:
-        api_base_url: The configured API URL (may be ``None``).
-        env: Value of the ``ASQAV_MODE`` environment variable, or ``None``.
-        explicit: Explicit mode passed by the caller. ``"auto"`` (the
-            default) defers to env then auto-detection.
-
-    Returns:
-        Either ``"hash-only"`` or ``"full-payload"``.
-
-    Raises:
-        ValueError: If ``explicit`` is not one of ``auto``, ``hash-only``,
-            ``full-payload``.
-    """
+    """Resolve the wire mode; ``explicit`` wins, then ``env``, then host auto-detection."""
     if explicit is None:
         explicit = "auto"
     if explicit not in _VALID_EXPLICIT:

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -1,17 +1,4 @@
-"""Async API Client for the Asqav SDK.
-
-Provides AsyncAgent, an async mirror of the sync Agent class.
-Uses httpx.AsyncClient for non-blocking HTTP calls.
-
-Example:
-    import asqav
-    from asqav.async_client import AsyncAgent
-
-    asqav.init(api_key="sk_...")
-
-    agent = await AsyncAgent.create("my-agent")
-    sig = await agent.sign("api:call", {"model": "gpt-4"})
-"""
+"""Async API client; :class:`AsyncAgent` mirrors :class:`Agent` over ``httpx.AsyncClient``."""
 
 from __future__ import annotations
 
@@ -59,11 +46,7 @@ def _ensure_initialized() -> None:
 
 
 def _get_config() -> tuple[str, str]:
-    """Get current API configuration from client module.
-
-    Returns:
-        Tuple of (api_base, api_key).
-    """
+    """Get the current ``(api_base, api_key)`` tuple from the client module."""
 
     if not _api_key:
         raise AuthenticationError("Call asqav.init() first. Get your API key at asqav.com")
@@ -140,24 +123,7 @@ async def _async_patch(path: str, data: dict[str, Any]) -> dict[str, Any]:
 
 @dataclass
 class AsyncAgent:
-    """Async agent representation from Asqav Cloud.
-
-    Mirrors the sync Agent class but uses async HTTP calls.
-    All ML-DSA cryptography happens server-side.
-
-    Example:
-        import asqav
-        from asqav.async_client import AsyncAgent
-
-        asqav.init(api_key="sk_...")
-
-        agent = await AsyncAgent.create("my-agent")
-        sig = await agent.sign("api:call", {"model": "gpt-4"})
-
-        session = await agent.start_session()
-        await agent.sign("read:data", {"file": "config.json"})
-        await agent.end_session()
-    """
+    """Async agent representation; mirrors the sync :class:`Agent` over async HTTP."""
 
     agent_id: str
     name: str
@@ -175,16 +141,7 @@ class AsyncAgent:
         algorithm: str = "ml-dsa-65",
         capabilities: list[str] | None = None,
     ) -> AsyncAgent:
-        """Create a new agent via Asqav Cloud.
-
-        Args:
-            name: Human-readable name for the agent.
-            algorithm: ML-DSA level (ml-dsa-44, ml-dsa-65, ml-dsa-87).
-            capabilities: List of capabilities/permissions.
-
-        Returns:
-            An AsyncAgent instance.
-        """
+        """Create a new agent via Asqav Cloud; ``algorithm`` is ml-dsa-44/65/87."""
         data = await _async_post(
             "/agents/create",
             {
@@ -206,14 +163,7 @@ class AsyncAgent:
 
     @classmethod
     async def get(cls, agent_id: str) -> AsyncAgent:
-        """Get an existing agent by ID.
-
-        Args:
-            agent_id: The agent ID to retrieve.
-
-        Returns:
-            An AsyncAgent instance.
-        """
+        """Get an existing agent by ID."""
         data = await _async_get(f"/agents/{agent_id}")
 
         return cls(
@@ -237,21 +187,7 @@ class AsyncAgent:
         co_signers: list[str] | None = None,
         user_intent: dict[str, Any] | None = None,
     ) -> SignatureResponse:
-        """Sign an action cryptographically (async).
-
-        Args:
-            action_type: Type of action (e.g., "read:data", "api:call").
-            context: Additional context for the action.
-            tool_name: Optional tool name when this action is a tool call.
-            model_name: Optional model name when this action is an LLM call.
-            parent_id: Optional parent action ID for the agent graph view.
-            co_signers: Optional list of agent_ids in the same org expected
-                to countersign this record. The other agents fetch the
-                record by id and call ``agent.countersign(signature_id)``.
-
-        Returns:
-            SignatureResponse with the signature.
-        """
+        """Sign an action cryptographically (async); ``co_signers`` lists countersigner agents."""
         from .client import _build_sign_body
 
         if tool_name or model_name or parent_id:
@@ -296,16 +232,7 @@ class AsyncAgent:
         )
 
     async def countersign(self, signature_id: str) -> SignatureResponse:
-        """Countersign an existing signature record (async).
-
-        Args:
-            signature_id: The ``sig_...`` id returned by the original
-                ``sign(co_signers=[...])`` call.
-
-        Returns:
-            SignatureResponse with the updated record (including this
-            agent's signature appended to ``co_signatures``).
-        """
+        """Countersign an existing signature record (async); appends to ``co_signatures``."""
         data = await _async_post(
             f"/agents/{self.agent_id}/countersign/{signature_id}",
             {},
@@ -331,11 +258,7 @@ class AsyncAgent:
         )
 
     async def start_session(self) -> SessionResponse:
-        """Start a new session (async).
-
-        Returns:
-            SessionResponse with session details.
-        """
+        """Start a new session (async)."""
         data = await _async_post("/sessions/", {"agent_id": self.agent_id})
 
         self._session_id = data["session_id"]
@@ -348,14 +271,7 @@ class AsyncAgent:
         )
 
     async def end_session(self, status: str = "completed") -> SessionResponse:
-        """End the current session (async).
-
-        Args:
-            status: Final status (completed, error, timeout).
-
-        Returns:
-            SessionResponse with final details.
-        """
+        """End the current session (async); ``status`` is completed/error/timeout."""
         if not self._session_id:
             raise AsqavError("No active session")
 
@@ -376,22 +292,7 @@ class AsyncAgent:
         )
 
     async def preflight(self, action_type: str) -> PreflightResult:
-        """Pre-flight check combining revocation, suspension, and policy status (async).
-
-        Returns a single result indicating whether the agent is cleared to
-        perform the given action type. Combines:
-        - Agent status (not revoked, not suspended)
-        - Policy check (action allowed by org policies)
-
-        Fail-open: if any individual check errors out, the agent is not
-        blocked. A warning is added to reasons instead.
-
-        Args:
-            action_type: The action to check (e.g., "data:read", "api:call").
-
-        Returns:
-            PreflightResult with combined check outcome.
-        """
+        """Pre-flight check (async): revocation + suspension + policy; fail-open on errors."""
         agent_active = True
         policy_allowed = True
         reasons: list[str] = []
@@ -431,14 +332,7 @@ class AsyncAgent:
         )
 
     async def verify(self, signature_id: str) -> VerificationResponse:
-        """Publicly verify a signature by ID (async).
-
-        Args:
-            signature_id: The signature ID to verify.
-
-        Returns:
-            VerificationResponse with verification details.
-        """
+        """Publicly verify a signature by ID (async)."""
         _ensure_httpx()
         api_base, _ = _get_config()
         url = f"{api_base}/verify/{signature_id}"

--- a/python/src/asqav/canonicalize.py
+++ b/python/src/asqav/canonicalize.py
@@ -1,28 +1,7 @@
-"""Fingerprint helpers for the Asqav SDK.
+"""Fingerprint helpers producing the bytes the Asqav backend signs.
 
-This module produces the bytes the Asqav backend signs (and, in
-hash-only mode, the bytes the SDK hashes locally before sending to the
-cloud).
-
-Three helpers are provided:
-
-* :func:`canonicalize` returns standard JSON bytes for any
-  JSON-serializable Python value, following the conventions in
-  ``conformance/vectors.json`` (JCS subset: keys sorted, no whitespace,
-  raw UTF-8, no trailing newline).
-* :func:`canonicalize_tool_args` is a user-facing pre-validator over
-  ``tool_args`` payloads that rejects floats with a JSON-pointer-locating
-  error before delegating to :func:`canonicalize`. The Compliance
-  Receipts profile excludes floats from the signed canonical scope
-  because canonical JSON only fixes byte-stable numeric output for
-  safe-range integers; floats drift across runtimes.
-* :func:`hash_action` returns a self-describing hash string of the form
-  ``"sha256:<64hex>"`` built from a ``{action_type, context}`` dict. An
-  optional ``salt`` switches it to HMAC-SHA-256 for organizations that
-  use a per-org keyed hash.
-
-Customers without the Asqav SDK can reproduce these helpers in a few lines
-of stdlib Python (see ``docs/fingerprint-spec.md``).
+In hash-only mode the SDK hashes these same bytes locally. See
+``docs/fingerprint-spec.md`` for canonical-form rules.
 """
 
 from __future__ import annotations
@@ -49,30 +28,7 @@ def canonicalize_action(
 
 
 def canonicalize(obj: Any) -> bytes:
-    """Return standard JSON bytes for ``obj``.
-
-    Implementation: ``json.dumps`` with ``sort_keys=True``,
-    ``separators=(",", ":")`` and ``ensure_ascii=False``. This is a
-    faithful JCS subset for the value types the Asqav cloud actually
-    accepts (``dict``, ``list``, ``str``, ``int``, ``float``, ``bool``,
-    ``None``). The conformance vectors at
-    ``conformance/vectors.json`` are generated with the exact same
-    rules so SDKs written against this helper agree with the backend
-    byte-for-byte.
-
-    Notes:
-        * Object keys are sorted lexicographically (Python ``sorted``).
-        * No whitespace anywhere.
-        * Unicode characters above U+001F are emitted as raw UTF-8.
-        * ``NaN`` / ``Infinity`` are not legal JSON; ``json.dumps`` will
-          raise unless the caller pre-filtered them.
-
-    Args:
-        obj: Any JSON-serializable value.
-
-    Returns:
-        UTF-8 encoded JSON bytes in standard form.
-    """
+    """Return JCS-subset JSON bytes for ``obj``; matches the conformance vectors byte-for-byte."""
     return json.dumps(
         obj,
         sort_keys=True,
@@ -83,12 +39,7 @@ def canonicalize(obj: Any) -> bytes:
 
 
 def _find_float_pointer(value: Any, pointer: str) -> str | None:
-    """Return JSON pointer to the first float found in ``value``, else None.
-
-    Walks dicts and lists depth-first in insertion order so the reported
-    pointer is stable for a given input. ``bool`` is excluded because
-    Python's ``isinstance(True, int)`` is True and ``bool`` is JCS-safe.
-    """
+    """Return JSON pointer to the first float in ``value`` (depth-first); ``bool`` is JCS-safe."""
     if isinstance(value, bool):
         return None
     if isinstance(value, float):
@@ -110,27 +61,8 @@ def _find_float_pointer(value: Any, pointer: str) -> str | None:
 
 
 def canonicalize_tool_args(args: dict[str, Any] | list[Any]) -> bytes:
-    """Return JCS-canonical bytes of ``tool_args``, rejecting floats.
-
-    Floats are not byte-stable across runtimes, so the Compliance Receipts
-    profile keeps them out of the signed canonical scope. Serialize
-    numerics as strings (``"1.5"``) or integer-rational pairs before
-    calling this helper. Booleans and integers (including arbitrarily
-    large ``int``) are accepted because JCS pins their byte form.
-    See ``docs/fingerprint-spec.md`` for the canonical-form rules.
-
-    Args:
-        args: A dict or list of tool arguments. Leaves may be ``str``,
-            ``int``, ``bool``, ``None``, ``dict``, or ``list``. ``float``
-            is rejected.
-
-    Returns:
-        UTF-8 encoded JCS-canonical bytes.
-
-    Raises:
-        ValueError: If any leaf is a ``float``. The message includes the
-            JSON pointer to the offending value so the caller can fix
-            the input.
+    """Return JCS-canonical bytes of ``tool_args``; raises ``ValueError`` (with JSON
+    pointer) on any float leaf since floats aren't byte-stable across runtimes.
     """
     pointer = _find_float_pointer(args, "")
     if pointer is not None:
@@ -147,22 +79,8 @@ def hash_action(
     context: dict[str, Any] | None = None,
     salt: bytes | None = None,
 ) -> str:
-    """Return ``"sha256:<hex>"`` for the fingerprint bytes of an action.
-
-    The hashed object is ``{"action_type": action_type, "context": context}``
-    formatted via :func:`canonicalize`. This matches the conformance
-    vectors and the backend's hash-only ingestion shape.
-
-    With ``salt`` set, returns HMAC-SHA-256 instead of plain SHA-256.
-    Use the per-organization salt fetched from the Asqav dashboard.
-
-    Args:
-        action_type: The action type string (e.g. ``"api:call"``).
-        context: The action's context dict (any JSON-serializable shape).
-        salt: Optional 32-byte per-org salt for keyed hashing.
-
-    Returns:
-        Self-describing hash string ``"sha256:<64 hex chars>"``.
+    """Return ``"sha256:<hex>"`` of canonicalized ``{action_type, context}``; with
+    ``salt`` set, uses HMAC-SHA-256 (per-org keyed hash) instead of plain SHA-256.
     """
     canonical = canonicalize_action(action_type, context)
     if salt is not None:

--- a/python/src/asqav/compliance.py
+++ b/python/src/asqav/compliance.py
@@ -1,17 +1,7 @@
 """Compliance bundle export for offline audit verification.
 
-Two flows:
-
-- ``export_bundle()`` packages an in-memory list of receipts client-side
-  with a Merkle root. Useful when the caller already has the signed
-  receipts and wants a portable file to hand to an auditor.
-- ``fetch_audit_pack()`` calls the cloud's signed Audit Pack endpoint
-  (POST /api/v1/audit-pack/export). The cloud signs the bundle digest
-  with the same key family as the receipts and includes the regime
-  mapping defined by the IETF Compliance Receipts profile.
-
-Pick ``fetch_audit_pack`` when the auditor wants the cloud's signed
-manifest; pick ``export_bundle`` for fully-offline / air-gapped flows.
+:func:`export_bundle` packages receipts client-side with a Merkle root;
+:func:`fetch_audit_pack` calls the cloud's signed ``/audit-pack/export``.
 """
 
 import hashlib
@@ -74,11 +64,7 @@ FRAMEWORKS = {
 }
 
 def _compute_merkle_root(hashes: list[str]) -> str:
-    """Compute Merkle root from a list of hex hashes.
-
-    Standard binary Merkle tree. Odd-length levels duplicate the last hash.
-    Returns the empty-string SHA-256 hash when the list is empty.
-    """
+    """Compute Merkle root from hex hashes (binary tree, odd levels duplicate the tail)."""
     if not hashes:
         return hashlib.sha256(b"").hexdigest()
 
@@ -166,17 +152,9 @@ def export_bundle(
     signatures: list,
     framework: str = "eu_ai_act",
 ) -> ComplianceBundle:
-    """Package signatures into a compliance bundle with Merkle root.
+    """Package signatures into a :class:`ComplianceBundle` with a Merkle root.
 
-    Args:
-        signatures: List of SignatureResponse, SignedActionResponse, or dicts.
-        framework: Key from FRAMEWORKS dict identifying the compliance standard.
-
-    Returns:
-        A ComplianceBundle ready for export.
-
-    Raises:
-        ValueError: If the framework key is not recognized.
+    Raises ``ValueError`` for unknown framework keys.
     """
     if framework not in FRAMEWORKS:
         raise ValueError(
@@ -212,23 +190,10 @@ def fetch_audit_pack(
     agent_id: str | None = None,
     only_compliance: bool = True,
 ) -> dict[str, Any]:
-    """Fetch the cloud-signed Audit Pack for a window.
+    """Fetch the cloud-signed Audit Pack for a window via ``POST /audit-pack/export``.
 
-    Wraps POST /api/v1/audit-pack/export. Returns the cloud response as a
-    dict including bundle_digest, bundle_signature, bundle_public_key,
-    receipts, regime_mapping, revocation_manifest, and
-    algorithm_registry_version.
-
-    Args:
-        start: ISO-8601 UTC window start (inclusive).
-        end: ISO-8601 UTC window end (exclusive).
-        agent_id: Optional agent_id to scope the export.
-        only_compliance: When True (default), only Compliance Receipts are
-            included. False also includes pre-compliance-mode receipts.
-
-    Raises:
-        RuntimeError: If asqav.init() has not been called.
-        httpx.HTTPStatusError: On cloud error responses (4xx / 5xx).
+    Returns the cloud response dict (bundle_digest, bundle_signature, receipts,
+    regime_mapping, revocation_manifest, algorithm_registry_version).
     """
     from . import client as _client
 

--- a/python/src/asqav/counterparty.py
+++ b/python/src/asqav/counterparty.py
@@ -1,21 +1,8 @@
 """Counterparty acknowledgment binding helpers for the IETF Compliance Receipts profile.
 
-Public surface:
-
-* :class:`CounterpartyBinding` - dataclass mirror of the cloud's
-  ``core.envelope.CounterpartyBinding`` Pydantic model.
-* :func:`compute_counterparty_binding` - builds the binding object from
-  an originating envelope; computes the base64 SHA-256 over its
-  canonical bytes.
-* :func:`verify_counterparty_binding` - re-derives the digest from the
-  originating envelope and reports the per-axis outcome.
-
-The acknowledging receipt's ``receipt_type`` is
-``protectmcp:acknowledgment``; the binding object travels on the signed
-payload of B's receipt and gates verification per the staged IETF -04
-revision (Sections 4.6 and 4.6.1).
-
-See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
+Builds and verifies the ``protectmcp:acknowledgment`` binding that ties B's
+receipt to A's originating envelope via a base64 SHA-256 over A's canonical
+bytes (see draft-marques-asqav-compliance-receipts Sections 4.6 and 4.6.1).
 """
 
 from __future__ import annotations
@@ -42,14 +29,8 @@ ACKNOWLEDGMENT_RECEIPT_TYPE: str = "protectmcp:acknowledgment"
 class CounterpartyBinding:
     """Acknowledger's cross-agent byte-equality binding to an originating receipt.
 
-    ``envelope_hash`` is the base64-encoded SHA-256 digest over the
-    originating receipt's full canonical signed envelope (signature
-    bytes included). ``receipt_ref`` is the opaque resolvable locator
-    the verifier uses to fetch A's envelope from the Audit Pack or a
-    Deployer-published index. ``expect_ack_from`` is an OPTIONAL
-    cross-check on the acknowledging receipt's signature ``kid``;
-    ``transport_label`` is operational only and MUST NOT serve as a
-    basis for trust derivation.
+    ``transport_label`` is operational only and MUST NOT serve as a basis for
+    trust derivation.
     """
 
     envelope_hash: str = field(
@@ -68,12 +49,7 @@ class CounterpartyBinding:
     )
 
     def to_wire(self) -> dict[str, Any]:
-        """Return the wire-shape dict suitable for placement on the signed payload.
-
-        Drops keys whose value is ``None`` so omitted OPTIONAL fields do
-        not appear in the canonical bytes; this keeps the JCS output
-        byte-identical to the cloud's emit path.
-        """
+        """Return the wire-shape dict; drops ``None`` keys to match cloud JCS."""
         out: dict[str, Any] = {
             "envelope_hash": self.envelope_hash,
             "receipt_ref": self.receipt_ref,
@@ -86,12 +62,7 @@ class CounterpartyBinding:
 
 
 def compute_envelope_hash(envelope: dict[str, Any]) -> str:
-    """Base64 of SHA-256 over the originating envelope's full JCS bytes.
-
-    Mirrors the cloud's ``core.envelope.compute_envelope_hash`` so the
-    acknowledger and the verifier produce byte-identical digests across
-    Python and TypeScript SDKs and the cloud emit path.
-    """
+    """Base64 SHA-256 over the envelope's JCS bytes."""
     return base64.b64encode(hashlib.sha256(canonical_json(envelope)).digest()).decode()
 
 
@@ -104,24 +75,9 @@ def compute_counterparty_binding(
 ) -> CounterpartyBinding:
     """Build a :class:`CounterpartyBinding` for the originating envelope.
 
-    Args:
-        originating_envelope: Full signed envelope (``{payload, signature, anchors?}``)
-            of A's receipt. The digest is computed over the canonical bytes of
-            the dict as-passed; callers MUST pass the bytes B actually received,
-            not a re-canonicalization, so intermediary tampering is detectable.
-        receipt_ref: Resolvable locator for A's receipt. Defaults to
-            ``originating_envelope["payload"]["action_id"]`` when present so the
-            common case can be a one-liner; callers SHOULD pass an explicit
-            value when their Audit Pack production layer uses a different
-            identifier scheme.
-        expect_ack_from: Optional declared acknowledger identifier; the verifier
-            cross-checks the acknowledging receipt's ``signature.kid`` against
-            this value when present.
-        transport_label: Optional operational transport hint.
-
-    Returns:
-        A :class:`CounterpartyBinding` ready to place on the acknowledgment
-        receipt's signed payload via :meth:`CounterpartyBinding.to_wire`.
+    Callers MUST pass the bytes B actually received (not a re-canonicalization)
+    so intermediary tampering is detectable. ``receipt_ref`` defaults to
+    ``originating_envelope["payload"]["action_id"]`` when present.
     """
     if receipt_ref is None:
         payload = originating_envelope.get("payload")
@@ -143,12 +99,7 @@ def compute_counterparty_binding(
 
 @dataclass
 class CounterpartyBindingVerification:
-    """Outcome of the SDK-side counterparty-binding sanity check.
-
-    ``valid`` is the AND of all populated booleans. Per-axis labels mirror
-    the cloud's ``counterparty_binding_verified`` vocabulary in
-    ``api/routes/verify.py``.
-    """
+    """Outcome of the counterparty-binding sanity check; ``valid`` ANDs all populated booleans."""
 
     valid: bool
     envelope_hash_matches: bool
@@ -162,10 +113,9 @@ def verify_counterparty_binding(
 ) -> CounterpartyBindingVerification:
     """Re-derive and compare the binding's ``envelope_hash``.
 
-    Returns ``label`` in {``matches``, ``mismatch``, ``unresolved``,
-    ``kid_mismatch``} so callers can distinguish a tampered handoff from
-    a missing originator. ``kid_matches`` is None when
-    ``expect_ack_from`` was not declared on the binding.
+    ``label`` is one of ``matches``, ``mismatch``, ``unresolved``,
+    ``kid_mismatch``. ``kid_matches`` is ``None`` when ``expect_ack_from`` was
+    not declared.
     """
     payload = acknowledgment_envelope.get("payload")
     if not isinstance(payload, dict):

--- a/python/src/asqav/decorators.py
+++ b/python/src/asqav/decorators.py
@@ -1,26 +1,4 @@
-"""Ergonomic signing patterns for the Asqav SDK.
-
-Provides the @asqav.sign decorator and asqav.session() context manager
-for developers who want concise, Pythonic signing without manual Agent calls.
-
-Example - decorator:
-    import asqav
-
-    asqav.init(api_key="sk_...")
-
-    @asqav.sign
-    def process_data(data: dict) -> dict:
-        return {"processed": True}
-
-    @asqav.sign(action_type="deploy:prod")
-    def deploy(env: str) -> None:
-        ...
-
-Example - session context manager:
-    with asqav.session() as s:
-        s.sign("data:read", {"file": "config.json"})
-        s.sign("data:write", {"file": "output.json"})
-"""
+"""Ergonomic signing: ``@asqav.sign`` decorator and ``asqav.session()`` (sync + async)."""
 
 from __future__ import annotations
 
@@ -39,10 +17,7 @@ F = TypeVar("F")
 
 
 class Session:
-    """Groups multiple sign calls under a single session.
-
-    Created by the session() context manager. Do not instantiate directly.
-    """
+    """Groups sign calls under a single session; created by :func:`session`."""
 
     def __init__(self, agent: Agent, session_response: SessionResponse) -> None:
         self._agent = agent
@@ -53,30 +28,13 @@ class Session:
         return self._session_response.session_id
 
     def sign(self, action_type: str, context: dict[str, Any] | None = None) -> SignatureResponse:
-        """Sign an action within this session.
-
-        Args:
-            action_type: Type of action (e.g., "data:read", "api:call").
-            context: Additional context for the action.
-
-        Returns:
-            SignatureResponse with the signature.
-        """
+        """Sign an action within this session."""
         return self._agent.sign(action_type, context)
 
 
 @contextmanager
 def session() -> Generator[Session, None, None]:
-    """Context manager that groups multiple sign calls under a session.
-
-    Usage:
-        with asqav.session() as s:
-            s.sign("data:read", {"file": "config.json"})
-            s.sign("data:write", {"file": "output.json"})
-
-    On enter, starts a session via the API. On exit, ends the session.
-    If an exception occurs, signs an error action before ending with error status.
-    """
+    """Context manager that groups sign calls; signs ``session:error`` on exception."""
     agent = get_agent()
     session_resp = agent.start_session()
     sess = Session(agent, session_resp)
@@ -97,16 +55,7 @@ def session() -> Generator[Session, None, None]:
 
 @asynccontextmanager
 async def async_session() -> AsyncGenerator[Session, None]:
-    """Async context manager that groups multiple sign calls under a session.
-
-    Usage:
-        async with asqav.async_session() as s:
-            s.sign("data:read", {"file": "config.json"})
-            s.sign("data:write", {"file": "output.json"})
-
-    Same lifecycle as the sync version - starts session on enter,
-    ends on exit, signs errors on exception.
-    """
+    """Async counterpart of :func:`session`; signs ``session:error`` on exception."""
     agent = get_agent()
     session_resp = agent.start_session()
     sess = Session(agent, session_resp)
@@ -128,23 +77,9 @@ async def async_session() -> AsyncGenerator[Session, None]:
 
 
 def sign(func: Any = None, *, action_type: str | None = None) -> Any:
-    """Decorator to auto-sign function execution.
+    """Decorator that auto-signs function execution (sync + async, with or without parens).
 
-    Works on both sync and async functions (auto-detects coroutines).
-    Can be used with or without parentheses:
-
-        @asqav.sign
-        def my_func(): ...
-
-        @asqav.sign(action_type="deploy:prod")
-        def my_func(): ...
-
-    Args:
-        func: The function to decorate (when used without parens).
-        action_type: Override the default "function:call" action type.
-
-    Returns:
-        Decorated function that signs calls via asqav.
+    ``action_type`` overrides the default ``"function:call"``.
     """
 
     def decorator(fn: Any) -> Any:

--- a/python/src/asqav/extras/_base.py
+++ b/python/src/asqav/extras/_base.py
@@ -1,9 +1,7 @@
 """Base adapter class for Asqav framework integrations.
 
-All framework-specific adapters (LangChain, CrewAI, LiteLLM, Haystack,
-OpenAI Agents) extend AsqavAdapter. This isolates signing logic from
-framework callback/hook APIs so framework breaking changes only affect
-the thin framework-facing layer.
+Isolates signing logic from framework callback/hook APIs so breaking changes
+affect only the thin framework-facing layer.
 """
 
 from __future__ import annotations
@@ -19,12 +17,7 @@ logger = logging.getLogger("asqav")
 
 
 def _class_name_to_agent_name(cls_name: str) -> str:
-    """Convert CamelCase class name to kebab-case agent name.
-
-    Examples:
-        AsqavCallbackHandler -> asqav-callback-handler
-        AsqavCrewHook -> asqav-crew-hook
-    """
+    """Convert CamelCase class name to kebab-case (e.g. AsqavCrewHook -> asqav-crew-hook)."""
     # Insert hyphen before uppercase letters, then lowercase
     s = re.sub(r"(?<=[a-z0-9])([A-Z])", r"-\1", cls_name)
     s = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1-\2", s)
@@ -34,21 +27,9 @@ def _class_name_to_agent_name(cls_name: str) -> str:
 class AsqavAdapter:
     """Base class for Asqav framework integrations.
 
-    Provides shared helpers for agent initialization, action signing,
-    and optional session grouping. Subclasses implement framework-specific
-    interfaces (callbacks, hooks, guardrails, components) and call
-    ``_sign_action`` to record governance events.
-
-    Args:
-        api_key: Optional API key override (uses asqav.init() default).
-        agent_name: Name for a new agent (calls Agent.create).
-        agent_id: ID of an existing agent (calls Agent.get).
-
-    If neither ``agent_name`` nor ``agent_id`` is provided, the agent name
-    is auto-generated from the subclass class name.
-
-    Raises:
-        AsqavError: If ``asqav.init()`` has not been called.
+    Subclasses call ``_sign_action`` to record governance events. Agent name
+    defaults to a kebab-cased subclass class name when neither ``agent_name``
+    nor ``agent_id`` is provided.
     """
 
     def __init__(
@@ -79,21 +60,10 @@ class AsqavAdapter:
         context: dict | None = None,
         **compliance_kwargs,
     ) -> SignatureResponse | None:
-        """Sign an action via the agent. Returns None on failure (fail-open).
+        """Sign an action via the agent; returns ``None`` on failure (fail-open).
 
-        Governance failures are logged but never raise - the user's AI
-        pipeline must not break because of Asqav availability issues.
-
-        When observe mode is enabled, logs the action that would be signed
-        without making any API calls and returns None.
-
-        IETF Compliance Receipts profile: subclasses MAY pass any of
-        ``compliance_mode``, ``receipt_type``, ``action_ref``,
-        ``payload_digest``, ``issuer_id``, ``iteration_id``,
-        ``sandbox_state``, ``risk_class``, ``incident_class``, ``reason``,
-        ``policy_decision`` via ``**compliance_kwargs``. They forward
-        verbatim to ``Agent.sign``. Unknown kwargs raise TypeError on
-        ``Agent.sign`` and surface as a fail-open warning here.
+        ``compliance_kwargs`` forwards IETF Compliance Receipts fields to
+        ``Agent.sign``.
         """
         if self._observe:
             logger.info(

--- a/python/src/asqav/extras/instructor.py
+++ b/python/src/asqav/extras/instructor.py
@@ -1,26 +1,8 @@
-"""instructor integration for asqav.
+"""instructor integration for asqav (``pip install asqav[instructor]``).
 
-Install: pip install asqav[instructor]
-
-Usage::
-
-    import asqav
-    import instructor
-    from asqav.extras.instructor import AsqavInstructorHook
-
-    asqav.init(api_key="...")
-    client = instructor.from_provider("openai/gpt-4o-mini")
-
-    hook = AsqavInstructorHook(agent_name="my-extractor")
-    hook.attach(client)
-
-    # Every client.chat.completions.create(...) call is now signed via asqav.
-
-instructor's hook system fires four events: ``completion:kwargs`` (request),
-``completion:response`` (success), ``completion:error`` (HTTP / provider
-error), ``parse:error`` (model output failed Pydantic validation). The
-adapter signs each event with a stable ``action_type`` so an auditor can
-distinguish requests, successes, and the two failure modes.
+Signs ``completion:kwargs``, ``completion:response``, ``completion:error``, and
+``parse:error`` events so auditors can distinguish requests, successes, and the
+two failure modes.
 """
 
 from __future__ import annotations
@@ -70,24 +52,7 @@ def _exception_name(exc: BaseException | None) -> str | None:
 
 
 class AsqavInstructorHook(AsqavAdapter):
-    """Asqav adapter for instructor clients.
-
-    Signs ``instructor.completion.start`` on every extraction request,
-    ``instructor.completion.complete`` on each successful response, and
-    ``instructor.completion.error`` / ``instructor.parse.error`` on the two
-    failure paths. Signing is fail-open: if Asqav is unreachable the
-    extraction still runs.
-
-    Args:
-        api_key: Optional API key override (uses ``asqav.init()`` default).
-        agent_name: Name for an Asqav agent (calls ``Agent.create``).
-        agent_id: ID of an existing Asqav agent (calls ``Agent.get``).
-
-    Example:
-        client = instructor.from_provider("openai/gpt-4o-mini")
-        hook = AsqavInstructorHook(agent_name="my-extractor")
-        hook.attach(client)
-    """
+    """Asqav adapter for instructor clients; fail-open (extraction runs even if Asqav is down)."""
 
     def __init__(
         self,
@@ -101,12 +66,7 @@ class AsqavInstructorHook(AsqavAdapter):
     # === Public attachment surface ===
 
     def attach(self, client: Any) -> None:
-        """Register this hook on an instructor client.
-
-        Accepts both sync (``instructor.from_openai`` style) and async
-        (``instructor.from_openai(client, ...)`` with the async OpenAI client)
-        instructor clients. Both expose the same ``.on()`` interface.
-        """
+        """Register this hook on an instructor client (sync or async; both expose ``.on()``)."""
         if not hasattr(client, "on"):
             raise TypeError(
                 "client does not look like an instructor client; "

--- a/python/src/asqav/hooks.py
+++ b/python/src/asqav/hooks.py
@@ -1,26 +1,7 @@
-"""Generic hooks/middleware system for Asqav signing.
+"""Generic before/after hooks around ``Agent.sign(...)``.
 
-Register before/after callbacks that fire around every ``Agent.sign(...)`` call.
-Before-hooks may mutate the context dict; after-hooks observe the response.
-Both are fail-open: if a registered hook raises, it is logged and signing
-continues unaffected.
-
-Pattern matching:
-    - ``"*"`` matches every action_type
-    - ``"strands:*"`` glob-matches any action_type starting with ``strands:``
-    - A compiled ``re.Pattern`` is matched with ``pattern.search(action_type)``
-    - Otherwise the pattern must equal the action_type exactly
-
-Usage::
-
-    import asqav
-
-    def add_request_id(action_type, context):
-        context["request_id"] = "req_abc"
-        return context
-
-    asqav.register_before("*", add_request_id)
-    asqav.register_after("strands:*", lambda resp: print(resp.signature_id))
+Patterns may be glob, regex, ``"*"``, or exact action_type. Both directions
+fail-open: hook exceptions are logged and signing continues.
 """
 
 from __future__ import annotations
@@ -54,23 +35,17 @@ def _matches(pattern: PatternType, action_type: str) -> bool:
 
 
 def register_before(pattern: PatternType, fn: BeforeHook) -> None:
-    """Register ``fn`` to run before signing actions matching ``pattern``.
+    """Register ``fn(action_type, context)`` to run before signing matching actions.
 
-    The hook is called as ``fn(action_type, context)`` and may return a
-    modified context dict; if it returns ``None`` the existing context is
-    kept. Hooks are invoked in registration order.
+    Return a dict to replace the context or ``None`` to keep it. Hooks run in
+    registration order.
     """
     with _lock:
         _before_hooks.append((pattern, fn))
 
 
 def register_after(pattern: PatternType, fn: AfterHook) -> None:
-    """Register ``fn`` to run after signing actions matching ``pattern``.
-
-    The hook is called as ``fn(response)`` where ``response`` is a
-    ``SignatureResponse``. After-hooks are observers; their return value is
-    ignored.
-    """
+    """Register ``fn(response)`` to observe signing for matching actions."""
     with _lock:
         _after_hooks.append((pattern, fn))
 

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -1,11 +1,4 @@
-"""Compliance Receipts wire-shape projection helpers.
-
-Pure helpers for offline analysis of a receipt: extract the spec-shape
-signature envelope `{alg, kid, sig}` and the anchors[] array. The
-cloud emits the three-key envelope directly under compliance_mode; the
-helpers below return the cloud-supplied values and None on flat-shape
-receipts.
-"""
+"""Compliance Receipts wire-shape projection helpers for offline receipt analysis."""
 
 from __future__ import annotations
 
@@ -13,12 +6,7 @@ from typing import Any
 
 
 def signature_envelope_from_response(response: Any) -> dict[str, str] | None:
-    """Return `{alg, kid, sig}` when the response carries it, else None.
-
-    The cloud emits `signature` as the object form under compliance_mode
-    and as a base64 string in flat mode. None on flat-shape receipts so
-    callers can branch cleanly.
-    """
+    """Return ``{alg, kid, sig}`` for compliance-mode receipts, else ``None`` (flat shape)."""
     sig = _get(response, "signature")
     if isinstance(sig, dict):
         keys = set(sig.keys())
@@ -28,11 +16,7 @@ def signature_envelope_from_response(response: Any) -> dict[str, str] | None:
 
 
 def anchors_from_response(response: Any) -> list[dict[str, Any]] | None:
-    """Return the `anchors[]` array when present, else None.
-
-    Cloud emits the array directly under compliance_mode (possibly as
-    []). None on non-compliance receipts.
-    """
+    """Return the ``anchors[]`` array when present, else ``None``."""
     anchors = _get(response, "anchors")
     if isinstance(anchors, list):
         return [dict(e) for e in anchors]

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -1,18 +1,8 @@
-"""Algorithm-agility helpers for the IETF Compliance Receipts profile.
+"""Algorithm-agility helpers for offline keypair generation (Ed25519, ES256).
 
-The Asqav cloud signs receipts server-side; client-side keypair
-generation is only useful for offline scenarios (LocalQueue, air-gapped
-demos, conformance vectors). This module exposes a tiny stable API so
-callers can opt into Ed25519 or ES256 without depending on
-`cryptography` / `pynacl` directly. ML-DSA-65 keypair generation
-happens server-side in the cloud KMS; call
-`asqav.Agent.create(name, algorithm='ml-dsa-65')` for that path.
-
-The module is import-safe even when `cryptography` is not installed:
-the import is deferred to call sites so cloud-only users never see a
-hard dependency. Callers that ask for Ed25519 or ES256 without the
-optional dep get a clear ImportError pointing them at the install
-command.
+ML-DSA-65 is cloud-KMS only via ``Agent.create(algorithm='ml-dsa-65')``.
+``cryptography`` is a deferred optional import so cloud-only callers never see
+a hard dependency.
 """
 
 from __future__ import annotations
@@ -37,11 +27,8 @@ Algorithm = Literal["ed25519", "es256"]
 class LocalKeypair:
     """A locally-generated keypair for offline / air-gapped flows.
 
-    `private_key_pem` is PKCS#8 (Ed25519, ES256) or a raw 32-byte secret
-    for ML-DSA-65. `public_key_pem` is SubjectPublicKeyInfo (Ed25519,
-    ES256) or raw 32-byte public for ML-DSA-65. The SDK intentionally
-    does not retain the private key after the dataclass is returned;
-    storage is the caller's problem.
+    PEM-encoded (PKCS#8 private, SubjectPublicKeyInfo public). The SDK does
+    not retain the private key after return.
     """
 
     algorithm: str
@@ -61,26 +48,10 @@ def _check_algorithm(algorithm: str) -> str:
 
 
 def generate_local_keypair(algorithm: Algorithm = "ed25519") -> LocalKeypair:
-    """Generate a keypair locally for the requested algorithm.
+    """Generate a local Ed25519 or ES256 keypair for offline flows.
 
-    For cloud-signed receipts the cloud generates the keypair; this
-    helper is for offline scenarios (LocalQueue, conformance vector
-    fixtures, air-gapped operator tooling).
-
-    ML-DSA-65 keypair generation is server-side only; call
-    `asqav.Agent.create(name, algorithm='ml-dsa-65')` to mint one via
-    the cloud KMS.
-
-    Args:
-        algorithm: One of `ed25519`, `es256`. Default is `ed25519`.
-
-    Returns:
-        A :class:`LocalKeypair` with PEM-encoded keys.
-
-    Raises:
-        ValueError: If `algorithm` is not in `SUPPORTED_ALGORITHMS`.
-        ImportError: If the optional `cryptography` package is needed
-            but not installed.
+    Raises ``ValueError`` for unsupported algorithms and ``ImportError`` when
+    ``cryptography`` is missing.
     """
     alg = _check_algorithm(algorithm)
     if alg == ALGORITHM_ED25519:

--- a/python/src/asqav/local.py
+++ b/python/src/asqav/local.py
@@ -1,20 +1,4 @@
-"""
-Asqav local mode - Queue actions offline and sync when connectivity returns.
-
-Enables developers to use Asqav in offline or air-gapped environments.
-Actions are queued locally as JSON files and synced to the API later.
-
-Usage:
-    from asqav import LocalQueue, local_sign
-
-    # Queue an action locally
-    item_id = local_sign("agent_123", "api:call", {"model": "gpt-4"})
-
-    # Sync when ready
-    queue = LocalQueue()
-    result = queue.sync()
-    print(f"Synced {result['synced']}/{result['total']} items")
-"""
+"""Asqav local mode: queue actions offline as JSON files and sync to the API later."""
 
 from __future__ import annotations
 

--- a/python/src/asqav/patterns.py
+++ b/python/src/asqav/patterns.py
@@ -1,9 +1,4 @@
-"""Semantic action patterns for asqav.
-
-Maps human-friendly pattern names to glob-style action type strings,
-so users can write agent.sign("sql-destructive", {...}) instead of
-remembering the full action namespace.
-"""
+"""Semantic action patterns mapping human-friendly names to glob action-type strings."""
 
 from __future__ import annotations
 
@@ -24,24 +19,10 @@ PATTERNS: dict[str, str] = {
 
 
 def resolve_pattern(pattern: str) -> str:
-    """Resolve a semantic pattern name to its glob string.
-
-    If the pattern matches a known semantic name, return the corresponding
-    glob. Otherwise return the pattern as-is (passthrough for custom patterns).
-
-    Args:
-        pattern: A semantic name like "sql-read" or a raw action type.
-
-    Returns:
-        The resolved glob pattern string.
-    """
+    """Resolve a semantic pattern name to its glob string; passthrough for unknown patterns."""
     return PATTERNS.get(pattern, pattern)
 
 
 def list_patterns() -> dict[str, str]:
-    """Return all available semantic action patterns.
-
-    Returns:
-        Dict mapping semantic names to their glob patterns.
-    """
+    """Return all available semantic action patterns."""
     return dict(PATTERNS)

--- a/python/src/asqav/pytest_plugin.py
+++ b/python/src/asqav/pytest_plugin.py
@@ -1,16 +1,7 @@
-"""Pytest plugin: sign each test result and produce a compliance bundle.
+"""Pytest plugin that signs each test outcome and emits a ComplianceBundle.
 
-Activates with `pytest --asqav --asqav-agent=test-runner`. Each test result
-(passed/failed/skipped) is signed via agent.sign() and included in a
-ComplianceBundle written at the end of the run.
-
-Both surfaces are exposed:
-
-- CLI: `pytest --asqav` runs the plugin via pytest's entry-point system.
-- API: import `asqav.pytest_plugin` and call `make_bundle_from_report(...)`
-  if you have your own test runner.
-
-Requires `ASQAV_API_KEY` in the environment.
+Activate with ``pytest --asqav --asqav-agent=test-runner``; ``ASQAV_API_KEY``
+must be set.
 """
 
 from __future__ import annotations
@@ -164,12 +155,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
 def make_bundle_from_report(
     signatures: list[Any], *, framework: str = "eu_ai_act"
 ) -> Any:
-    """Build a ComplianceBundle from a list of pre-signed test results.
-
-    Use from a custom test runner that signs results itself and just wants
-    the bundle structure. Returns the same ComplianceBundle the pytest hook
-    writes at end-of-run.
-    """
+    """Build a :class:`ComplianceBundle` from pre-signed test results."""
     from asqav.compliance import export_bundle
 
     return export_bundle(signatures, framework=framework)

--- a/python/src/asqav/reasoning.py
+++ b/python/src/asqav/reasoning.py
@@ -1,13 +1,8 @@
 """Reasoning-trace signing helper.
 
 Captures an LLM action's prompt, reasoning trace, and output as a single
-signed receipt. Only SHA-256 hashes of the three payloads are sent to the
-API by default, so raw prompt text and intermediate chain-of-thought never
-leave the caller unless explicitly opted in via ``store_raw``.
-
-Built on top of ``Agent.sign`` (client.py:799) and the existing context
-fields already understood by the server (``_system_prompt_hash``,
-``_tool_inputs_hash``). No new server surface is required.
+signed receipt. Only SHA-256 hashes are posted by default; raw text never
+leaves the caller unless ``store_raw`` is set.
 """
 
 from __future__ import annotations
@@ -19,12 +14,7 @@ from typing import Any
 
 
 def _sha256(data: Any) -> str:
-    """Return hex SHA-256 of ``data``.
-
-    Dicts and lists are serialized via ``json.dumps(..., sort_keys=True)``
-    so equivalent structures produce equal hashes. Bytes pass through.
-    Everything else is ``str()``-coerced.
-    """
+    """Return hex SHA-256 of ``data`` (dicts/lists JSON-serialized; bytes pass through)."""
     if isinstance(data, bytes):
         payload = data
     elif isinstance(data, str):
@@ -81,32 +71,8 @@ def sign_reasoning(
 ) -> ReasoningReceipt:
     """Sign an LLM action's prompt + reasoning trace + output.
 
-    By default only SHA-256 hashes of the three payloads are posted to the
-    API. The raw text never leaves the caller. Set ``store_raw=True`` to
-    additionally post the raw payloads (subject to ``retention_days`` on
-    the server side).
-
-    Args:
-        agent: An ``Agent`` (or compatible) with a ``.sign(...)`` method.
-        prompt: The user-visible or system prompt. Any JSON-serializable
-            value is accepted; strings and dicts are formatted before
-            hashing.
-        trace: The reasoning trace (chain-of-thought messages, tool calls,
-            intermediate steps). Any JSON-serializable value.
-        output: The final model output.
-        action_type: Action type passed through to ``sign``. Defaults to
-            ``"ai:reasoning"``.
-        context: Extra context merged into the ``sign`` call.
-        trace_id: Optional trace ID for correlation.
-        parent_id: Optional parent signature ID for chaining.
-        store_raw: If True, include the raw prompt/trace/output in the
-            signed context. Default False (hash-only).
-        retention_days: Optional server-side retention window for raw
-            payloads. Only meaningful when ``store_raw=True``.
-
-    Returns:
-        ``ReasoningReceipt`` bundling the underlying signature and the
-        three hashes.
+    Posts only SHA-256 hashes by default; set ``store_raw=True`` to additionally
+    post raw payloads (subject to ``retention_days`` server-side).
     """
     prompt_hash = _sha256(prompt)
     trace_hash = _sha256(trace)

--- a/python/src/asqav/replay.py
+++ b/python/src/asqav/replay.py
@@ -1,18 +1,8 @@
-"""Audit trail replay: reconstruct and verify what any agent did, step by step.
+"""Audit trail replay: reconstruct and verify what an agent did step by step.
 
-Chain shape (IETF Compliance Receipts):
-
-  ``previousReceiptHash = sha256(JCS(predecessor compliance payload))``.
-
-The chain link is over the inner payload bytes only, NOT the full
-``{payload, signature, anchors}`` envelope. This matches the cloud's
-on-chain digest (``sha256(SignatureRecord.message)`` where ``message`` is
-``canonical_json(payload)``). When a step carries the full bundle-shaped
-envelope with a top-level ``payload`` dict, the verifier hashes only that
-sub-dict so the result is byte-identical to the cloud.
-
-The first record's predecessor seed is ``"0" * 64`` (``FIRST_RECEIPT_SEED``).
-See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
+Chain link is ``previousReceiptHash = sha256(JCS(predecessor compliance payload))``
+over the inner payload bytes only (matches the cloud's on-chain digest); first
+record uses ``FIRST_RECEIPT_SEED = "0" * 64``.
 """
 
 from __future__ import annotations
@@ -34,11 +24,8 @@ FIRST_RECEIPT_SEED: str = "0" * 64
 def _payload_bytes_for_chain(envelope: dict[str, Any]) -> bytes:
     """Return the canonical JSON bytes the cloud hashes for the chain link.
 
-    The cloud computes ``sha256(canonical_json(payload))`` where ``payload``
-    is the IETF compliance payload dict. When ``envelope`` is the
-    bundle-shaped ``{payload, signature, anchors, ...}`` wrapper this
-    extracts ``envelope["payload"]``; when it is already the payload dict
-    (no ``signature`` sibling) the dict is hashed as-is.
+    Extracts ``envelope["payload"]`` when bundle-shaped (``signature`` /
+    ``anchors`` sibling present), else hashes the dict as-is.
     """
     inner = envelope.get("payload")
     if isinstance(inner, dict) and ("signature" in envelope or "anchors" in envelope):
@@ -149,18 +136,10 @@ class ReplayTimeline:
         return "\n".join(lines)
 
     def verify_chain(self) -> bool:
-        """Recompute each step's predecessor hash, compare to stored
-        ``prev_chain_hash``. Mismatch = tampering. Steps lacking a stored
-        hash are marked invalid rather than passing silently.
+        """Recompute each step's predecessor hash and compare to stored ``prev_chain_hash``.
 
-        Each step MUST carry `signed_envelope`. The chain hash is computed
-        as ``sha256(JCS(payload))`` over the inner compliance payload so the
-        result matches the cloud's on-chain digest byte-for-byte. When the
-        envelope is bundle-shaped (``{payload, signature, anchors, ...}``)
-        only the ``payload`` sub-dict is hashed; when it is already a
-        payload-shaped dict the whole dict is hashed. Steps without an
-        envelope cannot prove byte-level integrity and drop
-        ``compliance_chain_valid``.
+        Mismatch or missing = tampering. Steps lacking ``signed_envelope`` drop
+        ``compliance_chain_valid`` since byte-level integrity cannot be proven.
         """
         if not self.steps:
             self.chain_integrity = True
@@ -197,10 +176,10 @@ class ReplayTimeline:
 
 
 def _step_chain_hash(step: ReplayStep, prev_hash: str) -> str:
-    """Compute the synthetic chain hash a step contributes when no
-    `signed_envelope` is attached. Internal-consistency only: tampering
-    of fields outside the synthetic shape will NOT be caught. Callers
-    that need byte-level integrity MUST attach `signed_envelope`.
+    """Compute the synthetic chain hash a step contributes when no envelope is attached.
+
+    Internal-consistency only; callers needing byte-level integrity MUST attach
+    ``signed_envelope``.
     """
     envelope = {
         "signature_id": step.signature_id,
@@ -215,18 +194,9 @@ def _step_chain_hash(step: ReplayStep, prev_hash: str) -> str:
 def _verify_hash_chain(signatures: list[dict]) -> list[bool]:
     """Check each signature chains to the previous via SHA-256.
 
-    Returns a list of booleans, one per signature, indicating whether the
-    chain link from the previous entry is valid. Each entry's stored
-    ``previousReceiptHash`` (or snake-case ``previous_receipt_hash``) is
-    compared to the predecessor's derived chain hash; the seed
-    ``FIRST_RECEIPT_SEED`` is expected on the first entry. Entries that
-    omit the link field are treated as unverifiable (``False``) rather
-    than passing silently.
-
-    Note: this synthetic-shape verifier can only catch tampering of the
-    fields it hashes (``signature_id``, ``action_type``, ``payload``,
-    ``signed_at``). Byte-level integrity against the cloud requires the
-    full ``signed_envelope`` path on :meth:`ReplayTimeline.verify_chain`.
+    Returns a per-entry boolean; missing link fields are treated as unverifiable.
+    Byte-level integrity against the cloud requires the ``signed_envelope`` path
+    on :meth:`ReplayTimeline.verify_chain`.
     """
     if not signatures:
         return []
@@ -290,28 +260,13 @@ def _build_explanation(action_type: str, context: dict[str, Any] | None) -> str:
 
 
 def replay(agent_id: str, session_id: str) -> ReplayTimeline:
-    """Fetch signatures for a session and reconstruct the audit trail.
-
-    Args:
-        agent_id: The agent that owns the session.
-        session_id: The session to replay.
-
-    Returns:
-        A ReplayTimeline with ordered steps and chain verification.
-    """
+    """Fetch signatures for a session and reconstruct a :class:`ReplayTimeline`."""
     raw_sigs = get_session_signatures(session_id)
     return _build_timeline(agent_id, session_id, raw_sigs)
 
 
 def replay_from_bundle(bundle: ComplianceBundle) -> ReplayTimeline:
-    """Reconstruct a timeline from a ComplianceBundle offline.
-
-    Args:
-        bundle: A ComplianceBundle export.
-
-    Returns:
-        A ReplayTimeline built from the bundle receipts.
-    """
+    """Reconstruct a :class:`ReplayTimeline` from a :class:`ComplianceBundle` export offline."""
     agent_id = ""
     session_id = ""
     if bundle.receipts:

--- a/python/src/asqav/retry.py
+++ b/python/src/asqav/retry.py
@@ -1,17 +1,7 @@
-"""Retry logic with exponential backoff for the Asqav SDK.
+"""Retry decorators with exponential backoff + jitter for sync and async functions.
 
-Provides decorators for automatic retry of transient API errors
-with exponential backoff and jitter. Works with both sync and async functions.
-
-Retries on:
-    - RateLimitError (429)
-    - APIError with 5xx status codes
-    - ConnectionError
-    - TimeoutError
-
-Does NOT retry:
-    - AuthenticationError (401/403)
-    - APIError with 4xx status codes (except 429)
+Retries 429, 5xx, ``ConnectionError``, and ``TimeoutError``; never retries
+4xx except 429 or :class:`AuthenticationError`.
 """
 
 from __future__ import annotations
@@ -27,21 +17,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 def _is_retryable(exc: Exception) -> bool:
-    """Determine if an exception is retryable.
-
-    Uses lazy imports to avoid circular dependency with client.py.
-
-    Returns True for:
-        - RateLimitError
-        - APIError with 5xx status code
-        - ConnectionError
-        - TimeoutError
-
-    Returns False for:
-        - AuthenticationError
-        - APIError with 4xx status code (except 429, which is RateLimitError)
-        - Any other exception
-    """
+    """Return True for retryable exceptions: rate-limit, 5xx, connection, timeout."""
     from .client import APIError, AuthenticationError, RateLimitError
 
     if isinstance(exc, AuthenticationError):
@@ -67,17 +43,7 @@ def _calculate_delay(
     max_delay: float,
     jitter: bool,
 ) -> float:
-    """Calculate delay for a given retry attempt using exponential backoff.
-
-    Args:
-        attempt: Zero-based attempt number.
-        base_delay: Base delay in seconds.
-        max_delay: Maximum delay cap in seconds.
-        jitter: Whether to add random jitter.
-
-    Returns:
-        Delay in seconds.
-    """
+    """Exponential backoff delay in seconds for ``attempt`` (zero-based)."""
     delay = min(base_delay * (2 ** attempt), max_delay)
     if jitter:
         delay = random.uniform(0, delay)
@@ -90,22 +56,7 @@ def with_retry(
     max_delay: float = 30.0,
     jitter: bool = True,
 ) -> Callable[[F], F]:
-    """Decorator for retrying sync functions with exponential backoff.
-
-    Args:
-        max_retries: Maximum number of retry attempts (default 3).
-        base_delay: Initial delay in seconds (default 0.5).
-        max_delay: Maximum delay cap in seconds (default 30.0).
-        jitter: Add random jitter to delay (default True).
-
-    Returns:
-        Decorated function with retry logic.
-
-    Example:
-        @with_retry(max_retries=5, base_delay=1.0)
-        def call_api():
-            return _post("/endpoint", data)
-    """
+    """Decorator that retries sync functions with exponential backoff + optional jitter."""
 
     def decorator(func: F) -> F:
         @functools.wraps(func)
@@ -133,22 +84,7 @@ def with_async_retry(
     max_delay: float = 30.0,
     jitter: bool = True,
 ) -> Callable[[F], F]:
-    """Decorator for retrying async functions with exponential backoff.
-
-    Args:
-        max_retries: Maximum number of retry attempts (default 3).
-        base_delay: Initial delay in seconds (default 0.5).
-        max_delay: Maximum delay cap in seconds (default 30.0).
-        jitter: Add random jitter to delay (default True).
-
-    Returns:
-        Decorated async function with retry logic.
-
-    Example:
-        @with_async_retry(max_retries=5, base_delay=1.0)
-        async def call_api():
-            return await _async_post("/endpoint", data)
-    """
+    """Decorator that retries async functions with exponential backoff + optional jitter."""
 
     def decorator(func: F) -> F:
         @functools.wraps(func)

--- a/python/src/asqav/scope.py
+++ b/python/src/asqav/scope.py
@@ -1,13 +1,7 @@
 """Portable scope tokens for cross-org agent verification.
 
-Thin wrapper around the existing SD-JWT token API. Scope tokens let an
-agent carry proof of what it can do into external services, so the
-receiving side can verify permissions without calling back to your org.
-
-All cryptography happens server-side via issue_sd_token(). This module
-just adds a convenient ScopeToken envelope with helpers for attaching
-the token to HTTP requests, checking expiry, and selecting which scopes
-to reveal.
+Thin wrapper around ``issue_sd_token`` adding an envelope with helpers for
+HTTP attachment, expiry, and selective-disclosure presentation.
 """
 
 from __future__ import annotations
@@ -25,11 +19,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class ScopeToken:
-    """A portable proof of agent permissions.
-
-    Wraps an SDTokenResponse with convenience methods for carrying the
-    token across service boundaries.
-    """
+    """A portable proof of agent permissions; wraps an SDTokenResponse."""
 
     token: str
     jwt: str
@@ -43,15 +33,7 @@ class ScopeToken:
     # -- helpers --------------------------------------------------------------
 
     def to_header(self, disclose: list[str] | None = None) -> dict[str, str]:
-        """Return an Authorization header dict for HTTP requests.
-
-        Args:
-            disclose: Specific scope claims to reveal. When None the full
-                token (all disclosures) is used.
-
-        Returns:
-            Dict suitable for ``requests.get(url, headers=token.to_header())``.
-        """
+        """Return an ``Authorization`` header dict; ``disclose=None`` includes all disclosures."""
         if disclose is not None:
             parts = [self.jwt]
             for name in disclose:
@@ -63,16 +45,7 @@ class ScopeToken:
         return {"Authorization": f"Bearer {value}"}
 
     def present(self, disclose: list[str]) -> str:
-        """Create a selective-disclosure presentation.
-
-        Delegates to the same logic as SDTokenResponse.present().
-
-        Args:
-            disclose: Claim names to reveal.
-
-        Returns:
-            SD-JWT string with only the listed disclosures.
-        """
+        """Return an SD-JWT string with only the listed disclosures revealed."""
         parts = [self.jwt]
         for name in disclose:
             if name in self.disclosures:
@@ -98,7 +71,7 @@ class ScopeToken:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ScopeToken:
-        """Reconstruct a ScopeToken from a dict (e.g. after deserialization)."""
+        """Reconstruct a :class:`ScopeToken` from a dict."""
         return cls(
             token=data["token"],
             jwt=data["jwt"],
@@ -120,21 +93,7 @@ def create_scope_token(
     ttl: int = 3600,
     metadata: dict[str, Any] | None = None,
 ) -> ScopeToken:
-    """Issue a portable scope token for an agent.
-
-    Resolves semantic action patterns, builds the SD-JWT claims via the
-    existing ``agent.issue_sd_token()`` call, and wraps the response in
-    a ScopeToken.
-
-    Args:
-        agent: The Agent instance to issue the token for.
-        actions: Action patterns (semantic names or raw globs).
-        ttl: Token time-to-live in seconds.
-        metadata: Optional extra claims to embed.
-
-    Returns:
-        A ScopeToken ready to attach to outbound requests.
-    """
+    """Issue a portable :class:`ScopeToken` for an agent over the given action patterns."""
     resolved = [resolve_pattern(a) for a in actions]
     nonce = uuid.uuid4().hex
 
@@ -170,17 +129,7 @@ def create_scope_token(
 
 
 def verify_scope_token(signature_id: str) -> dict[str, Any]:
-    """Verify a scope token via the public verification endpoint.
-
-    Delegates to the existing ``verify_signature()`` function - no new
-    crypto, just a convenience alias that returns a dict.
-
-    Args:
-        signature_id: The signature or token ID to verify.
-
-    Returns:
-        Dict with verification result including ``verified`` bool.
-    """
+    """Verify a scope token via :func:`verify_signature`; returns a result dict."""
     from .client import verify_signature
 
     resp = verify_signature(signature_id)


### PR DESCRIPTION
## Summary
Collapses multi-sentence docstrings across 19 files in python/src/asqav/ to the CLAUDE.md rule-10 budget (1-2 sentences max). No source logic touched.

## Why
Cycle 18 deep slop hunt (~/.company/cycles/c18/scans/SLOP-DEEP.md) found heavy paragraph-shaped docstrings across the asqav-sdk Python source: client.py (25), cli.py (15), replay.py (4+ egregious), canonicalize.py (3+), keys.py (2+), async_client.py (10+ multi-sentence), counterparty.py (5+), and more. AI agents skim; long descriptions hurt navigation.

Files in other open PRs are skipped: client.py (#200), extras/{crewai,letta,litellm,smolagents,dspy,haystack,langchain,llamaindex,openai_agents,strands}.py (#196, #198), cli.py (#198), demo.py (#196).

## Files touched (19)
_jcs.py, _mode.py, async_client.py, canonicalize.py, compliance.py, counterparty.py, decorators.py, extras/_base.py, extras/instructor.py, hooks.py, ietf_projection.py, keys.py, local.py, patterns.py, pytest_plugin.py, reasoning.py, replay.py, retry.py, scope.py.

## Test plan
- [x] uv run ruff check src passes.
- [x] uv run pytest tests/ green (747/747).
- [ ] CI green on this PR.

comment hygiene clean