### PR TITLE
fix(client): surface real API error detail in APIError

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -2030,9 +2030,18 @@ def _handle_response(response: Any) -> None:
         raise RateLimitError("Rate limit exceeded. Upgrade at asqav.com/pricing")
     elif response.status_code >= 400:
         try:
-            error = response.json().get("error", "Unknown error")
+            body = response.json()
+            error = body.get("detail") or body.get("error") or response.text or "Unknown error"
+            if isinstance(error, list):
+                error = "; ".join(
+                    f"{e.get('loc', ['?'])[-1]}: {e.get('msg', '')}".strip(": ")
+                    for e in error
+                    if isinstance(e, dict)
+                ) or str(error)
+            elif not isinstance(error, str):
+                error = str(error)
         except Exception:
-            error = response.text
+            error = response.text or "Unknown error"
         raise APIError(error, response.status_code)
 
 


### PR DESCRIPTION
## Summary

- `_handle_response` was reading `response.json().get("error", ...)` but the cloud returns FastAPI's `{"detail": ...}` shape, so every API error collapsed to `Unknown error` with the real message hidden.
- Fix reads `detail` first (FastAPI standard), falls back to `error` (legacy/non-FastAPI surfaces), then `response.text`. FastAPI 422 validation lists are flattened to `field: msg; field: msg` one-liners.
- Backwards-compat: old `{"error": ...}` responses still surface identically.

## Test plan

Smoke-tested against five shapes, all surface the real message:

- `{"detail": "bad reason"}` -> APIError("bad reason")
- `{"detail": [{"loc":["body","reason"],"msg":"must match pattern"}]}` -> APIError("reason: must match pattern")
- `{"error": "server boom"}` -> APIError("server boom")
- non-JSON body with text "gateway down" -> APIError("gateway down")
- empty body -> APIError("Unknown error")

comment hygiene clean