### PR TITLE
refactor(python): decompose cli.sign and cover demo handler

### DIFF
--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -27,6 +27,7 @@ Commands:
 from __future__ import annotations
 
 import sys
+from typing import Any
 
 try:
     import typer
@@ -171,6 +172,134 @@ def verify(
             print(f"Missing fields: {', '.join(detail.missing_fields)}")
 
 
+def _load_json_arg(source: str, label: str) -> dict | None:
+    """Load a JSON arg from a file path, stdin (`-`), or return None when empty.
+
+    Used by `sign` for `--action-json` and `--policy-artefact`. Exits 1 on
+    OSError or JSONDecodeError with a clear `label`-prefixed message so
+    the caller knows which arg failed.
+    """
+    import json as json_mod
+
+    if not source:
+        return None
+    try:
+        if source == "-":
+            return json_mod.loads(sys.stdin.read())
+        with open(source) as f:
+            return json_mod.load(f)
+    except (OSError, json_mod.JSONDecodeError) as exc:
+        print(f"Error reading {label}: {exc}")
+        raise typer.Exit(code=1) from exc
+
+
+def _build_sign_kwargs(
+    *,
+    compliance_mode: bool,
+    policy_decision: str,
+    action_ref: str,
+    sandbox_state: str,
+    iteration_id: str,
+    risk_class: str,
+    incident_class: str,
+    issuer_id: str,
+    receipt_type: str,
+    reason: str,
+    valid_seconds: int,
+) -> dict:
+    """Translate CLI flags into Agent.sign() kwargs.
+
+    Empty-string options are dropped so the SDK falls back to its own
+    defaults; non-empty values pass through 1:1.
+    """
+    kwargs: dict = {
+        "compliance_mode": compliance_mode,
+        "policy_decision": policy_decision,
+    }
+    optional = {
+        "action_ref": action_ref,
+        "sandbox_state": sandbox_state,
+        "iteration_id": iteration_id,
+        "risk_class": risk_class,
+        "incident_class": incident_class,
+        "issuer_id": issuer_id,
+        "receipt_type": receipt_type,
+        "reason": reason,
+    }
+    for key, value in optional.items():
+        if value:
+            kwargs[key] = value
+    if valid_seconds > 0:
+        kwargs["valid_seconds"] = valid_seconds
+    return kwargs
+
+
+def _build_sign_context(
+    action_obj: dict | None,
+    action_id: str,
+    policy_artefact_obj: dict | None,
+) -> dict | None:
+    """Assemble the `context` dict the SDK consumes.
+
+    Returns None when no fields are supplied so the SDK skips the kwarg.
+    `_action_id` and `_policy_artefact` are reserved internal keys the
+    SDK strips before serializing the canonical Action object.
+    """
+    context: dict | None = action_obj or None
+    if action_id:
+        context = {**(context or {}), "_action_id": action_id}
+    if policy_artefact_obj is not None:
+        context = {**(context or {}), "_policy_artefact": policy_artefact_obj}
+    return context
+
+
+def _print_sign_result_json(sig: Any) -> None:
+    """Render the Signature as the documented JSON payload."""
+    import json as json_mod
+
+    payload = {
+        "signature_id": sig.signature_id,
+        "action_id": sig.action_id,
+        "algorithm": sig.algorithm,
+        "verification_url": sig.verification_url,
+        "signed_at": sig.timestamp,
+        "policy_digest": sig.policy_digest,
+        "policy_decision": sig.policy_decision,
+        "compliance_mode": sig.compliance_mode,
+        "receipt_type": sig.receipt_type,
+        "action_ref": sig.action_ref,
+        "issuer_id": sig.issuer_id,
+        "previous_receipt_hash": sig.previous_receipt_hash,
+        "anchor_status": (
+            sig.bitcoin_anchor.status if sig.bitcoin_anchor else None
+        ),
+        "rfc3161_tsa": sig.rfc3161_tsa,
+        "rfc3161_serial": sig.rfc3161_serial,
+    }
+    print(json_mod.dumps(payload, indent=2, default=str))
+
+
+def _print_sign_result_text(sig: Any) -> None:
+    """Render the Signature as human-readable text lines."""
+    print(f"signature_id: {sig.signature_id}")
+    print(f"action_id:    {sig.action_id}")
+    print(f"algorithm:    {sig.algorithm}")
+    print(f"signed_at:    {sig.timestamp}")
+    if sig.policy_digest:
+        print(f"policy_digest: {sig.policy_digest}")
+    if sig.compliance_mode:
+        print("compliance_mode: True")
+        if sig.receipt_type:
+            print(f"receipt_type:  {sig.receipt_type}")
+        if sig.action_ref:
+            print(f"action_ref:    {sig.action_ref}")
+        if sig.previous_receipt_hash:
+            print(f"previous_receipt_hash: {sig.previous_receipt_hash}")
+    if sig.bitcoin_anchor:
+        print(f"anchor:       {sig.bitcoin_anchor.status}")
+    print(f"verify_url:   {sig.verification_url}")
+
+
 @app.command()
 def sign(
     action_type: str = typer.Option(..., "--action-type", help="Action type, e.g. payment.wire_transfer."),
@@ -224,40 +353,12 @@ def sign(
     or stdin when ``-`` is passed; the SDK then computes ``action_ref``
     from the JCS bytes if ``--action-ref`` was not supplied.
     """
-    import json as json_mod
-
     _init_sdk()
     from asqav import Agent, APIError
 
-    # 1. Load action JSON (file, stdin, or empty).
-    action_obj: dict = {}
-    if action_json:
-        try:
-            if action_json == "-":
-                action_obj = json_mod.loads(sys.stdin.read())
-            else:
-                with open(action_json) as f:
-                    action_obj = json_mod.load(f)
-        except (OSError, json_mod.JSONDecodeError) as exc:
-            print(f"Error reading action JSON: {exc}")
-            raise typer.Exit(code=1) from exc
+    action_obj = _load_json_arg(action_json, "action JSON") or {}
+    policy_artefact_obj = _load_json_arg(policy_artefact, "policy artefact")
 
-    # 2. Load policy artefact (sent server-side; the cloud stores it and
-    # stamps `policy_digest` on the receipt).
-    policy_artefact_obj: dict | None = None
-    if policy_artefact:
-        try:
-            if policy_artefact == "-":
-                policy_artefact_obj = json_mod.loads(sys.stdin.read())
-            else:
-                with open(policy_artefact) as f:
-                    policy_artefact_obj = json_mod.load(f)
-        except (OSError, json_mod.JSONDecodeError) as exc:
-            print(f"Error reading policy artefact: {exc}")
-            raise typer.Exit(code=1) from exc
-
-    # 3. Validate policy_decision/reason coupling client-side. The SDK
-    # also validates; this gives a clearer CLI error.
     if policy_decision in {"deny", "rate_limit"} and not reason:
         print(
             "Error: --reason is required when --policy-decision is deny or rate_limit."
@@ -270,40 +371,20 @@ def sign(
         print(f"Error fetching agent: {exc}")
         raise typer.Exit(code=1) from exc
 
-    # 4. Build kwargs. Empty strings -> None so the SDK applies defaults.
-    sign_kwargs: dict = {
-        "compliance_mode": compliance_mode,
-        "policy_decision": policy_decision,
-    }
-    if action_ref:
-        sign_kwargs["action_ref"] = action_ref
-    if sandbox_state:
-        sign_kwargs["sandbox_state"] = sandbox_state
-    if iteration_id:
-        sign_kwargs["iteration_id"] = iteration_id
-    if risk_class:
-        sign_kwargs["risk_class"] = risk_class
-    if incident_class:
-        sign_kwargs["incident_class"] = incident_class
-    if issuer_id:
-        sign_kwargs["issuer_id"] = issuer_id
-    if receipt_type:
-        sign_kwargs["receipt_type"] = receipt_type
-    if reason:
-        sign_kwargs["reason"] = reason
-    if valid_seconds > 0:
-        sign_kwargs["valid_seconds"] = valid_seconds
-
-    context = action_obj or None
-    if action_id and context is not None:
-        context = {**context, "_action_id": action_id}
-    elif action_id:
-        context = {"_action_id": action_id}
-
-    if policy_artefact_obj is not None and context is not None:
-        context = {**context, "_policy_artefact": policy_artefact_obj}
-    elif policy_artefact_obj is not None:
-        context = {"_policy_artefact": policy_artefact_obj}
+    sign_kwargs = _build_sign_kwargs(
+        compliance_mode=compliance_mode,
+        policy_decision=policy_decision,
+        action_ref=action_ref,
+        sandbox_state=sandbox_state,
+        iteration_id=iteration_id,
+        risk_class=risk_class,
+        incident_class=incident_class,
+        issuer_id=issuer_id,
+        receipt_type=receipt_type,
+        reason=reason,
+        valid_seconds=valid_seconds,
+    )
+    context = _build_sign_context(action_obj, action_id, policy_artefact_obj)
 
     if session_id:
         # Internal attribute the SDK consults when building the body.
@@ -323,45 +404,9 @@ def sign(
         raise typer.Exit(code=1) from exc
 
     if output == "json":
-        payload = {
-            "signature_id": sig.signature_id,
-            "action_id": sig.action_id,
-            "algorithm": sig.algorithm,
-            "verification_url": sig.verification_url,
-            "signed_at": sig.timestamp,
-            "policy_digest": sig.policy_digest,
-            "policy_decision": sig.policy_decision,
-            "compliance_mode": sig.compliance_mode,
-            "receipt_type": sig.receipt_type,
-            "action_ref": sig.action_ref,
-            "issuer_id": sig.issuer_id,
-            "previous_receipt_hash": sig.previous_receipt_hash,
-            "anchor_status": (
-                sig.bitcoin_anchor.status if sig.bitcoin_anchor else None
-            ),
-            "rfc3161_tsa": sig.rfc3161_tsa,
-            "rfc3161_serial": sig.rfc3161_serial,
-        }
-        print(json_mod.dumps(payload, indent=2, default=str))
+        _print_sign_result_json(sig)
         return
-
-    print(f"signature_id: {sig.signature_id}")
-    print(f"action_id:    {sig.action_id}")
-    print(f"algorithm:    {sig.algorithm}")
-    print(f"signed_at:    {sig.timestamp}")
-    if sig.policy_digest:
-        print(f"policy_digest: {sig.policy_digest}")
-    if sig.compliance_mode:
-        print("compliance_mode: True")
-        if sig.receipt_type:
-            print(f"receipt_type:  {sig.receipt_type}")
-        if sig.action_ref:
-            print(f"action_ref:    {sig.action_ref}")
-        if sig.previous_receipt_hash:
-            print(f"previous_receipt_hash: {sig.previous_receipt_hash}")
-    if sig.bitcoin_anchor:
-        print(f"anchor:       {sig.bitcoin_anchor.status}")
-    print(f"verify_url:   {sig.verification_url}")
+    _print_sign_result_text(sig)
 
 
 @app.command()

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -160,6 +160,199 @@ def test_sign_deny_without_reason_rejects(
     assert "--reason is required" in result.output
 
 
+# === sign command: previously uncovered branches ===
+
+
+@patch("asqav.init")
+def test_sign_action_json_invalid_exits_1(
+    mock_init: MagicMock, tmp_path
+) -> None:
+    """A malformed --action-json file is reported with a clear error."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    result = runner.invoke(
+        app,
+        [
+            "sign",
+            "--agent-id", "agent_x",
+            "--action-type", "payment.wire_transfer",
+            "--action-json", str(bad),
+        ],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 1
+    assert "Error reading action JSON" in result.output
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.init")
+def test_sign_agent_get_api_error_exits_1(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    """Agent.get APIError surfaces as 'Error fetching agent' and exit 1."""
+    from asqav import APIError
+
+    mock_get.side_effect = APIError("agent revoked", 404)
+    result = runner.invoke(
+        app,
+        [
+            "sign",
+            "--agent-id", "agent_missing",
+            "--action-type", "x.y",
+        ],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 1
+    assert "Error fetching agent" in result.output
+
+
+@patch("asqav.Agent.get")
+@patch("asqav.init")
+def test_sign_json_output_with_policy_artefact_and_algo_mismatch(
+    mock_init: MagicMock, mock_get: MagicMock, tmp_path
+) -> None:
+    """Exercise --output json + --policy-artefact + algorithm mismatch + --session-id.
+
+    Covers: JSON renderer, _load_json_arg file branch, _build_sign_context
+    policy_artefact wiring, the algorithm-mismatch warning, and the
+    --session-id agent attribute injection.
+    """
+    import json
+
+    fake_agent = MagicMock()
+    fake_agent.agent_id = "agent_x"
+    fake_agent.algorithm = "ml-dsa-65"
+    fake_agent.sign.return_value = MagicMock(
+        signature_id="sig_json",
+        action_id="act_json",
+        algorithm="ml-dsa-65",
+        timestamp=1717.0,
+        verification_url="https://verify.example/sig_json",
+        policy_digest="sha256:abc",
+        policy_decision="permit",
+        compliance_mode=False,
+        receipt_type="protectmcp:decision",
+        action_ref=None,
+        issuer_id=None,
+        previous_receipt_hash=None,
+        bitcoin_anchor=MagicMock(status="pending"),
+        rfc3161_tsa="tsa.example",
+        rfc3161_serial="123",
+    )
+    mock_get.return_value = fake_agent
+
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text('{"rule": "deny_over_500k"}')
+
+    result = runner.invoke(
+        app,
+        [
+            "sign",
+            "--agent-id", "agent_x",
+            "--action-type", "payment.wire_transfer",
+            "--policy-artefact", str(policy_path),
+            "--session-id", "sess_bound",
+            "--algorithm", "ed25519",  # mismatch
+            "--output", "json",
+        ],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "Warning: --algorithm=ed25519" in result.output
+    # session_id was threaded onto the agent before sign()
+    assert fake_agent._session_id == "sess_bound"
+    # context wraps the policy artefact under _policy_artefact
+    ctx = fake_agent.sign.call_args.kwargs["context"]
+    assert ctx["_policy_artefact"] == {"rule": "deny_over_500k"}
+    # JSON output is parseable and carries anchor + RFC 3161 fields
+    json_start = result.output.find("{")
+    payload = json.loads(result.output[json_start:])
+    assert payload["signature_id"] == "sig_json"
+    assert payload["anchor_status"] == "pending"
+    assert payload["rfc3161_tsa"] == "tsa.example"
+
+
+# === sign command helpers (unit tests, no CLI runner) ===
+
+
+def test_load_json_arg_empty_returns_none() -> None:
+    from asqav.cli import _load_json_arg
+
+    assert _load_json_arg("", "any") is None
+
+
+def test_build_sign_kwargs_drops_empty_strings() -> None:
+    from asqav.cli import _build_sign_kwargs
+
+    out = _build_sign_kwargs(
+        compliance_mode=True,
+        policy_decision="permit",
+        action_ref="",
+        sandbox_state="enabled",
+        iteration_id="",
+        risk_class="high",
+        incident_class="",
+        issuer_id="",
+        receipt_type="protectmcp:decision",
+        reason="",
+        valid_seconds=0,
+    )
+    assert out == {
+        "compliance_mode": True,
+        "policy_decision": "permit",
+        "sandbox_state": "enabled",
+        "risk_class": "high",
+        "receipt_type": "protectmcp:decision",
+    }
+
+
+def test_build_sign_kwargs_includes_valid_seconds_when_positive() -> None:
+    from asqav.cli import _build_sign_kwargs
+
+    out = _build_sign_kwargs(
+        compliance_mode=False,
+        policy_decision="permit",
+        action_ref="",
+        sandbox_state="",
+        iteration_id="",
+        risk_class="",
+        incident_class="",
+        issuer_id="",
+        receipt_type="",
+        reason="",
+        valid_seconds=60,
+    )
+    assert out["valid_seconds"] == 60
+
+
+def test_build_sign_context_merges_action_id_and_policy() -> None:
+    from asqav.cli import _build_sign_context
+
+    out = _build_sign_context(
+        {"amount": 1000},
+        "act_123",
+        {"rule": "deny"},
+    )
+    assert out == {
+        "amount": 1000,
+        "_action_id": "act_123",
+        "_policy_artefact": {"rule": "deny"},
+    }
+
+
+def test_build_sign_context_returns_none_when_empty() -> None:
+    from asqav.cli import _build_sign_context
+
+    assert _build_sign_context({}, "", None) is None
+
+
+def test_build_sign_context_only_action_id() -> None:
+    """`--action-id` without --action-json produces a context with just the id."""
+    from asqav.cli import _build_sign_context
+
+    assert _build_sign_context({}, "act_only", None) == {"_action_id": "act_only"}
+
+
 @patch("asqav.verify_signature")
 def test_verify_text_shows_ietf_axes(mock_verify: MagicMock) -> None:
     """verify --output text surfaces IETF profile sub-axes when present."""

--- a/python/tests/test_demo_handler.py
+++ b/python/tests/test_demo_handler.py
@@ -1,0 +1,192 @@
+"""Tests for the local demo HTTP handler (`asqav demo`).
+
+Covers `DemoHandler.do_POST`, which is uncovered by default because the
+demo server is launched interactively. The strategy is to instantiate a
+`ThreadingHTTPServer` on an ephemeral port and drive it with `urllib`
+so the real handler runs end-to-end against the real `_sign` / `_verify`
+helpers - no mocks on the demo internals.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socketserver
+import sys
+import threading
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.demo import DemoHandler, DemoState
+
+
+@contextmanager
+def _running_server() -> Iterator[tuple[str, DemoState]]:
+    """Start a DemoHandler on an ephemeral port; yield the base URL + state."""
+    state = DemoState()
+    DemoHandler.state = state
+    httpd = socketserver.ThreadingTCPServer(("127.0.0.1", 0), DemoHandler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}", state
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=2)
+
+
+def _post(url: str, body: dict | None, *, raw: bytes | None = None) -> tuple[int, dict]:
+    """Issue a POST; return (status, decoded JSON body or {} on empty)."""
+    if raw is not None:
+        data = raw
+    else:
+        data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode("utf-8") or "{}"
+        return exc.code, json.loads(body_text)
+
+
+# === Happy path: /api/decide signs a receipt for a known scenario ===
+
+
+def test_do_post_decide_signs_and_records() -> None:
+    """POST /api/decide with valid fields signs and stores the receipt."""
+    with _running_server() as (base, state):
+        status, body = _post(
+            f"{base}/api/decide",
+            {
+                "id": "scenario-rmrf",
+                "decision": "approved",
+                "reason": "user confirmed cleanup is safe",
+            },
+        )
+        assert status == 200
+        assert body["ok"] is True
+        receipt = body["receipt"]
+        # Receipt carries the canonical fields used by the cloud's profile.
+        assert receipt["payload"]["scenario_id"] == "scenario-rmrf"
+        assert receipt["payload"]["policy_decision"] == "permit"
+        assert receipt["signature"].startswith("hmac-sha256:")
+        # State records the approval so the UI can render it.
+        assert state.approvals["scenario-rmrf"]["decision"] == "approved"
+
+
+# === Round trip: a receipt produced by /api/decide verifies via /api/verify ===
+
+
+def test_do_post_verify_round_trip() -> None:
+    """A receipt produced by /api/decide verifies via /api/verify."""
+    with _running_server() as (base, _state):
+        _, decide = _post(
+            f"{base}/api/decide",
+            {
+                "id": "scenario-wire",
+                "decision": "denied",
+                "reason": "amount exceeds the four-eyes policy ceiling",
+            },
+        )
+        receipt = decide["receipt"]
+        # policy_decision mirrors the controlled vocabulary (deny here).
+        assert receipt["payload"]["policy_decision"] == "deny"
+
+        status, body = _post(f"{base}/api/verify", receipt)
+        assert status == 200
+        assert body["valid"] is True
+
+
+# === Error paths ===
+
+
+def test_do_post_invalid_json_returns_400() -> None:
+    """Non-JSON bodies are rejected with 400."""
+    with _running_server() as (base, _state):
+        status, body = _post(f"{base}/api/decide", None, raw=b"{not json")
+        assert status == 400
+        assert "invalid json" in body["error"]
+
+
+def test_do_post_decide_rejects_bad_decision() -> None:
+    """`decision` must be `approved` or `denied`."""
+    with _running_server() as (base, _state):
+        status, body = _post(
+            f"{base}/api/decide",
+            {"id": "scenario-rmrf", "decision": "maybe", "reason": "x" * 20},
+        )
+        assert status == 400
+        assert "approved or denied" in body["error"]
+
+
+def test_do_post_decide_rejects_short_reason() -> None:
+    """Reasons under 10 chars are rejected so the audit trail stays meaningful."""
+    with _running_server() as (base, _state):
+        status, body = _post(
+            f"{base}/api/decide",
+            {"id": "scenario-rmrf", "decision": "approved", "reason": "short"},
+        )
+        assert status == 400
+        assert "at least 10" in body["error"]
+
+
+def test_do_post_decide_unknown_scenario_returns_404() -> None:
+    """Unknown scenario ids surface as a 404."""
+    with _running_server() as (base, _state):
+        status, body = _post(
+            f"{base}/api/decide",
+            {
+                "id": "scenario-ghost",
+                "decision": "approved",
+                "reason": "ten characters at least",
+            },
+        )
+        assert status == 404
+        assert body["error"] == "unknown scenario"
+
+
+def test_do_post_unknown_path_returns_404() -> None:
+    """POSTs to an unknown path return 404."""
+    with _running_server() as (base, _state):
+        status, body = _post(f"{base}/api/nope", {"x": 1})
+        assert status == 404
+
+
+def test_do_post_verify_with_garbage_returns_invalid() -> None:
+    """`/api/verify` returns valid=False for a malformed receipt."""
+    with _running_server() as (base, _state):
+        status, body = _post(
+            f"{base}/api/verify",
+            {"payload": {"scenario_id": "fake"}, "signature": "not-a-real-sig"},
+        )
+        # The handler catches any exception and renders valid=False.
+        assert status == 200
+        assert body["valid"] is False
+
+
+# === Edge case: empty body ===
+
+
+def test_do_post_empty_body_falls_through_to_404() -> None:
+    """Empty body decodes to `{}`; /api/decide path with empty body rejects on decision."""
+    with _running_server() as (base, _state):
+        req = urllib.request.Request(
+            f"{base}/api/decide",
+            data=b"",
+            headers={"Content-Type": "application/json", "Content-Length": "0"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req, timeout=5)
+        assert exc_info.value.code == 400


### PR DESCRIPTION
## Summary

CRAP report targeted two Python SDK hotspots:

- **cli.py:175 sign** (CC=38, cov=64%, CRAP=3,910)
- **demo.py:371 DemoHandler.do_POST** (CC=14, cov=0%, CRAP=2,940)

This PR fixes both.

### cli.sign decomposition

Extracts four helpers, all CC <= 10:

- `_load_json_arg` - file path / stdin / empty branch for `--action-json` and `--policy-artefact`
- `_build_sign_kwargs` - optional CLI flags to `Agent.sign` kwargs
- `_build_sign_context` - merges `action_obj` + `action_id` + `policy_artefact_obj` into the SDK context
- `_print_sign_result_json` / `_print_sign_result_text` - output renderers

`sign` body drops from **CC=38 to CC=10**.

### demo.py do_POST coverage

`asqav demo` ships as a real subcommand (`cli.py:demo` calls `asqav.demo.serve`), so the handler is user-facing - tests rather than `# pragma: no cover`. New `tests/test_demo_handler.py` runs a real `ThreadingTCPServer` on an ephemeral port and drives it with `urllib`:

- happy path (`/api/decide` signs + records)
- round trip (`/api/decide` then `/api/verify` returns valid=true)
- invalid JSON, bad decision, short reason, unknown scenario, unknown path, garbage signature, empty body

### Metrics

- `sign` CC: 38 -> 10
- `do_POST` coverage: 0% -> 100%
- `cli.py` coverage: 70% -> 73%
- `demo.py` coverage: 0% -> 67%
- Test count: 745 -> 763

Remaining `demo.py` uncovered lines are the server lifecycle (`serve`, `_find_free_port`, `main`), not the handler.

## Test plan

- [x] `pytest` 763 passed, 8 skipped (was 745)
- [x] `pytest tests/test_cli.py` 65 passed (was 56)
- [x] `pytest tests/test_demo_handler.py` 9 passed (new)
- [x] `radon cc src/asqav/cli.py` confirms `sign` CC=10, all helpers <= 8
- [x] `ruff check python/src` passes