### PR TITLE
refactor(typescript): decompose sign and cmdSign to drop CC below threshold

### DIFF
--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -30,6 +30,7 @@ import {
   verifyChain,
   verifySignature,
   type LocalSigningAlgorithm,
+  type SignatureResponse,
 } from "./index.js";
 
 export const CLI_VERSION = "0.3.5";
@@ -403,110 +404,188 @@ async function readJsonInput(value: string): Promise<unknown> {
   return JSON.parse(text);
 }
 
-async function cmdSign(args: string[]): Promise<void> {
-  const agentId = parseFlag(args, "agent-id");
-  const actionType = parseFlag(args, "action-type");
-  if (!agentId || !actionType) {
-    die("Usage: asqav sign --agent-id ID --action-type T [--no-compliance-mode] [--action-json PATH]");
-  }
-  // Compliance Receipts default to compliance_mode=true; pass --no-compliance-mode to opt out.
-  const complianceMode = !hasFlag(args, "no-compliance-mode");
-  const actionRef = parseFlag(args, "action-ref");
-  const actionJson = parseFlag(args, "action-json");
-  const sandboxState = parseFlag(args, "sandbox-state");
-  const iterationId = parseFlag(args, "iteration-id");
-  const riskClass = parseFlag(args, "risk-class");
-  const incidentClass = parseFlag(args, "incident-class");
-  const issuerId = parseFlag(args, "issuer-id");
-  const receiptType = parseFlag(args, "receipt-type") ?? "protectmcp:decision";
-  const reason = parseFlag(args, "reason");
-  // --decision (allow|deny|rate_limit) takes precedence over --policy-decision.
+/** Parsed shape of `asqav sign` flags; bundles raw strings without
+ * applying any type casts (those happen in `buildSignCallArgs`). */
+interface SignCliFlags {
+  agentId: string | undefined;
+  actionType: string | undefined;
+  complianceMode: boolean;
+  actionRef: string | undefined;
+  actionJson: string | undefined;
+  actionId: string | undefined;
+  sandboxState: string | undefined;
+  iterationId: string | undefined;
+  riskClass: string | undefined;
+  incidentClass: string | undefined;
+  issuerId: string | undefined;
+  receiptType: string;
+  reason: string | undefined;
+  policyDecision: string;
+  sessionId: string | undefined;
+  validSecondsStr: string | undefined;
+  policyArtefactPath: string | undefined;
+  output: string;
+}
+
+/** Resolve `--decision` (allow|deny|rate_limit) into a policy_decision
+ * token; `--decision` wins over `--policy-decision`. Defaults to permit. */
+function resolvePolicyDecision(args: string[]): string {
   const decisionFlag = parseFlag(args, "decision");
   const decisionMap: Record<string, string> = {
     allow: "permit",
     deny: "deny",
     rate_limit: "rate_limit",
   };
-  const policyDecision =
-    (decisionFlag !== undefined ? decisionMap[decisionFlag] : undefined)
-    ?? parseFlag(args, "policy-decision")
-    ?? "permit";
-  const sessionId = parseFlag(args, "session-id");
-  const validSecondsStr = parseFlag(args, "valid-seconds");
-  const policyArtefactPath = parseFlag(args, "policy-artefact");
-  const output = parseFlag(args, "output") ?? "text";
+  const fromDecision = decisionFlag !== undefined ? decisionMap[decisionFlag] : undefined;
+  return fromDecision ?? parseFlag(args, "policy-decision") ?? "permit";
+}
 
-  if ((policyDecision === "deny" || policyDecision === "rate_limit") && !reason) {
+/** Pull every `asqav sign` flag into a strongly-typed bag. No
+ * validation, no fs reads, no type narrowing yet. */
+function parseSignFlags(args: string[]): SignCliFlags {
+  return {
+    agentId: parseFlag(args, "agent-id"),
+    actionType: parseFlag(args, "action-type"),
+    complianceMode: !hasFlag(args, "no-compliance-mode"),
+    actionRef: parseFlag(args, "action-ref"),
+    actionJson: parseFlag(args, "action-json"),
+    actionId: parseFlag(args, "action-id"),
+    sandboxState: parseFlag(args, "sandbox-state"),
+    iterationId: parseFlag(args, "iteration-id"),
+    riskClass: parseFlag(args, "risk-class"),
+    incidentClass: parseFlag(args, "incident-class"),
+    issuerId: parseFlag(args, "issuer-id"),
+    receiptType: parseFlag(args, "receipt-type") ?? "protectmcp:decision",
+    reason: parseFlag(args, "reason"),
+    policyDecision: resolvePolicyDecision(args),
+    sessionId: parseFlag(args, "session-id"),
+    validSecondsStr: parseFlag(args, "valid-seconds"),
+    policyArtefactPath: parseFlag(args, "policy-artefact"),
+    output: parseFlag(args, "output") ?? "text",
+  };
+}
+
+/** Pre-flight validation that exits the process on a usage error. */
+function validateSignFlags(flags: SignCliFlags): void {
+  if (!flags.agentId || !flags.actionType) {
+    die("Usage: asqav sign --agent-id ID --action-type T [--no-compliance-mode] [--action-json PATH]");
+  }
+  if (
+    (flags.policyDecision === "deny" || flags.policyDecision === "rate_limit")
+    && !flags.reason
+  ) {
     die("Error: --reason is required when --policy-decision is deny or rate_limit.");
   }
+}
 
-  ensureApiKey();
+/** Assemble the call-time `context` map by reading the optional JSON
+ * file, layering the optional policy artefact under a sentinel key, and
+ * stamping the `_action_id` sentinel when supplied. */
+async function loadSignContext(
+  flags: SignCliFlags,
+): Promise<Record<string, unknown> | undefined> {
   let context: Record<string, unknown> | undefined;
-  if (actionJson) {
+  if (flags.actionJson) {
     try {
-      context = (await readJsonInput(actionJson)) as Record<string, unknown>;
+      context = (await readJsonInput(flags.actionJson)) as Record<string, unknown>;
     } catch (err) {
       die(`Error reading action JSON: ${(err as Error).message}`);
     }
   }
-  if (policyArtefactPath) {
+  if (flags.policyArtefactPath) {
     try {
-      const artefact = await readJsonInput(policyArtefactPath);
+      const artefact = await readJsonInput(flags.policyArtefactPath);
       context = { ...(context ?? {}), _policy_artefact: artefact };
     } catch (err) {
       die(`Error reading policy artefact: ${(err as Error).message}`);
     }
   }
-  const actionId = parseFlag(args, "action-id");
-  if (actionId) {
-    context = { ...(context ?? {}), _action_id: actionId };
+  if (flags.actionId) {
+    context = { ...(context ?? {}), _action_id: flags.actionId };
   }
+  return context;
+}
+
+/** Project the CLI-shape flags into the SDK's `SignOptions` shape with
+ * the narrow casts the SDK accepts. Pure: no IO. */
+function buildSignCallOptions(
+  flags: SignCliFlags,
+  context: Record<string, unknown> | undefined,
+): Parameters<Agent["sign"]>[0] {
+  return {
+    actionType: flags.actionType as string,
+    context,
+    complianceMode: flags.complianceMode,
+    actionRef: flags.actionRef,
+    sandboxState: flags.sandboxState as
+      | "enabled"
+      | "disabled"
+      | "unavailable"
+      | undefined,
+    iterationId: flags.iterationId,
+    riskClass: flags.riskClass as
+      | "low"
+      | "medium"
+      | "high"
+      | "unknown"
+      | undefined,
+    incidentClass: flags.incidentClass,
+    issuerId: flags.issuerId,
+    receiptType: flags.receiptType as
+      | "protectmcp:decision"
+      | "protectmcp:restraint"
+      | "protectmcp:lifecycle",
+    reason: flags.reason,
+    policyDecision: flags.policyDecision as "permit" | "deny" | "rate_limit",
+    validSeconds: flags.validSecondsStr ? Number(flags.validSecondsStr) : undefined,
+  };
+}
+
+/** Print the human-readable sign output. JSON output is handled by the
+ * caller because it is a single line. */
+function printSignTextOutput(sig: SignatureResponse): void {
+  process.stdout.write(`signature_id: ${sig.signatureId}\n`);
+  process.stdout.write(`action_id:    ${sig.actionId}\n`);
+  process.stdout.write(`algorithm:    ${sig.algorithm ?? "?"}\n`);
+  process.stdout.write(`signed_at:    ${sig.timestamp}\n`);
+  if (sig.policyDigest) process.stdout.write(`policy_digest: ${sig.policyDigest}\n`);
+  if (sig.complianceMode) printSignComplianceFields(sig);
+  process.stdout.write(`verify_url:   ${sig.verificationUrl}\n`);
+}
+
+/** Print the IETF Compliance Receipts profile fields. Split out so
+ * `printSignTextOutput` stays a flat decision tree. */
+function printSignComplianceFields(sig: SignatureResponse): void {
+  process.stdout.write(`compliance_mode: true\n`);
+  if (sig.receiptType) process.stdout.write(`receipt_type:  ${sig.receiptType}\n`);
+  if (sig.actionRef) process.stdout.write(`action_ref:    ${sig.actionRef}\n`);
+  if (sig.previousReceiptHash) {
+    process.stdout.write(`previous_receipt_hash: ${sig.previousReceiptHash}\n`);
+  }
+  if (sig.decision) {
+    process.stdout.write(`decision:      ${sig.decision}\n`);
+  }
+}
+
+async function cmdSign(args: string[]): Promise<void> {
+  const flags = parseSignFlags(args);
+  validateSignFlags(flags);
+
+  ensureApiKey();
+  const context = await loadSignContext(flags);
 
   try {
-    const agent = await Agent.get(agentId);
-    if (sessionId) {
+    const agent = await Agent.get(flags.agentId as string);
+    if (flags.sessionId) {
       // Internal field used by buildSignBody when the session is bound.
-      (agent as unknown as { sessionId: string }).sessionId = sessionId;
+      (agent as unknown as { sessionId: string }).sessionId = flags.sessionId;
     }
-    const sig = await agent.sign({
-      actionType: actionType,
-      context,
-      complianceMode,
-      actionRef,
-      sandboxState: sandboxState as "enabled" | "disabled" | "unavailable" | undefined,
-      iterationId,
-      riskClass: riskClass as "low" | "medium" | "high" | "unknown" | undefined,
-      incidentClass,
-      issuerId,
-      receiptType: receiptType as
-        | "protectmcp:decision"
-        | "protectmcp:restraint"
-        | "protectmcp:lifecycle",
-      reason,
-      policyDecision: policyDecision as "permit" | "deny" | "rate_limit",
-      validSeconds: validSecondsStr ? Number(validSecondsStr) : undefined,
-    });
-    if (output === "json") {
+    const sig = await agent.sign(buildSignCallOptions(flags, context));
+    if (flags.output === "json") {
       process.stdout.write(`${JSON.stringify(sig, null, 2)}\n`);
       return;
     }
-    process.stdout.write(`signature_id: ${sig.signatureId}\n`);
-    process.stdout.write(`action_id:    ${sig.actionId}\n`);
-    process.stdout.write(`algorithm:    ${sig.algorithm ?? "?"}\n`);
-    process.stdout.write(`signed_at:    ${sig.timestamp}\n`);
-    if (sig.policyDigest) process.stdout.write(`policy_digest: ${sig.policyDigest}\n`);
-    if (sig.complianceMode) {
-      process.stdout.write(`compliance_mode: true\n`);
-      if (sig.receiptType) process.stdout.write(`receipt_type:  ${sig.receiptType}\n`);
-      if (sig.actionRef) process.stdout.write(`action_ref:    ${sig.actionRef}\n`);
-      if (sig.previousReceiptHash) {
-        process.stdout.write(`previous_receipt_hash: ${sig.previousReceiptHash}\n`);
-      }
-      if (sig.decision) {
-        process.stdout.write(`decision:      ${sig.decision}\n`);
-      }
-    }
-    process.stdout.write(`verify_url:   ${sig.verificationUrl}\n`);
+    printSignTextOutput(sig);
   } catch (err) {
     die(`Error signing: ${(err as Error).message}`);
   }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -738,6 +738,253 @@ export async function request<T = unknown>(
 
 // === Sign body builder (mode-aware) ===
 
+/**
+ * Merge explicit kwargs (`toolName`, `modelName`, `parentId`) into the
+ * caller-supplied context as underscored sentinel keys so the hash-only
+ * metadata builder picks them up. Returns a fresh object only when one
+ * of the kwargs was present; otherwise returns the original ref. Mirrors
+ * the Python SDK's surface-into-context behaviour.
+ */
+function surfaceKwargsIntoContext(options: SignOptions): Record<string, unknown> {
+  const initial = options.context ?? {};
+  if (
+    options.toolName === undefined
+    && options.modelName === undefined
+    && options.parentId === undefined
+  ) {
+    return initial;
+  }
+  const merged: Record<string, unknown> = { ...initial };
+  if (options.toolName !== undefined) merged._tool_name = options.toolName;
+  if (options.modelName !== undefined) merged._model_name = options.modelName;
+  if (options.parentId !== undefined) merged._parent_id = options.parentId;
+  return merged;
+}
+
+/**
+ * Fail-fast vocabulary checks on caller input before the HTTP roundtrip.
+ * The cloud remains source of truth; these mirror the canonical sets so
+ * obvious mistakes do not consume a network call. Throws AsqavError on
+ * the first offending field.
+ */
+function validateSignOptions(options: SignOptions): void {
+  if (
+    options.receiptType !== undefined
+    && !(RECEIPT_TYPE_NAMESPACE as readonly string[]).includes(options.receiptType)
+  ) {
+    throw new AsqavError(
+      `invalid_receipt_type: must be one of ${RECEIPT_TYPE_NAMESPACE.join(", ")}`,
+    );
+  }
+  if (
+    (options.policyDecision === "deny" || options.policyDecision === "rate_limit")
+    && !options.reason
+  ) {
+    throw new AsqavError(
+      "missing_reason: policy_decision=deny|rate_limit requires a `reason` code",
+    );
+  }
+  if (
+    options.sandboxState !== undefined
+    && !(SANDBOX_STATE_NAMESPACE as readonly string[]).includes(options.sandboxState)
+  ) {
+    throw new AsqavError(
+      `invalid_sandbox_state: '${options.sandboxState}' must be one of ${SANDBOX_STATE_NAMESPACE.join(", ")}`,
+    );
+  }
+  if (
+    options.captureTopology !== undefined
+    && !(CAPTURE_TOPOLOGY_NAMESPACE as readonly string[]).includes(options.captureTopology)
+  ) {
+    throw new AsqavError(
+      `invalid_capture_topology: '${options.captureTopology}' must be one of ${CAPTURE_TOPOLOGY_NAMESPACE.join(", ")}`,
+    );
+  }
+  validateIncidentClass(options.incidentClass);
+}
+
+/**
+ * Reject `incident_class` values outside the canonical union (HIPAA
+ * token plus the six DORA tokens). Accepts a single value, an array,
+ * or undefined / empty string (skip).
+ */
+function validateIncidentClass(value: string | string[] | undefined): void {
+  if (value === undefined || value === "") return;
+  const values = Array.isArray(value) ? value : [value];
+  for (const ic of values) {
+    if (!(INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)) {
+      throw new AsqavError(
+        `invalid_incident_class: '${ic}' must be one of ${INCIDENT_CLASS_NAMESPACE.join(", ")}`,
+      );
+    }
+  }
+}
+
+/**
+ * Derive `action_ref` locally when omitted under compliance mode; matches
+ * the cloud's `hash_action` shape (`sha256:<hex>` over canonical JSON of
+ * `{action_type, context}`). Returns the caller's value verbatim when
+ * compliance mode is off or `actionRef` is already set.
+ */
+function deriveActionRef(
+  complianceMode: boolean,
+  actionRef: string | undefined,
+  actionType: string,
+  context: Record<string, unknown>,
+): string | undefined {
+  if (!complianceMode || actionRef !== undefined) return actionRef;
+  const action = { action_type: actionType, context };
+  const hex = createHash("sha256").update(canonicalJson(action)).digest("hex");
+  return `sha256:${hex}`;
+}
+
+/**
+ * Tack the optional non-IETF wire fields (`co_signers`, `nonce`,
+ * `valid_seconds`, `expected_executor_pubkey_b64`) onto the body when
+ * the caller supplied them. Mutates `body` in place for parity with the
+ * inline original.
+ */
+function applyOptionalWireFields(
+  body: Record<string, unknown>,
+  options: SignOptions,
+): void {
+  if (options.coSigners && options.coSigners.length > 0) {
+    body.co_signers = [...options.coSigners];
+  }
+  if (options.nonce !== undefined) body.nonce = options.nonce;
+  if (options.validSeconds !== undefined) body.valid_seconds = options.validSeconds;
+  if (options.expectedExecutorPubkeyB64 !== undefined) {
+    body.expected_executor_pubkey_b64 = options.expectedExecutorPubkeyB64;
+  }
+}
+
+/** Snake_case wire-key projection of the optional IETF profile fields
+ * that do not depend on `complianceMode`. Defined as a const table so
+ * the `applyComplianceFields` loop stays single-pass. */
+const IETF_OPTIONAL_FIELD_MAP: ReadonlyArray<{
+  wire: string;
+  read: (o: SignOptions) => unknown;
+}> = [
+  { wire: "sandbox_state", read: (o) => o.sandboxState },
+  { wire: "iteration_id", read: (o) => o.iterationId },
+  { wire: "risk_class", read: (o) => o.riskClass },
+  { wire: "incident_class", read: (o) => o.incidentClass },
+  { wire: "issuer_id", read: (o) => o.issuerId },
+  { wire: "payload_digest", read: (o) => o.payloadDigest },
+  { wire: "receipt_type", read: (o) => o.receiptType },
+  { wire: "reason", read: (o) => o.reason },
+];
+
+/**
+ * Project IETF Compliance Receipts profile fields onto the request body
+ * using snake_case wire keys. Adds `compliance_mode`, `action_ref`, the
+ * non-conditional optional fields (`sandbox_state`, `iteration_id`,
+ * `risk_class`, `incident_class`, `issuer_id`, `payload_digest`,
+ * `receipt_type`, `reason`), then the decision / topology fields that
+ * depend on `complianceMode`.
+ */
+function applyComplianceFields(
+  body: Record<string, unknown>,
+  options: SignOptions,
+  complianceMode: boolean,
+  actionRef: string | undefined,
+): void {
+  if (complianceMode) body.compliance_mode = true;
+  if (actionRef !== undefined) body.action_ref = actionRef;
+  for (const { wire, read } of IETF_OPTIONAL_FIELD_MAP) {
+    const value = read(options);
+    if (value !== undefined) body[wire] = value;
+  }
+  applyDecisionFields(body, options, complianceMode);
+}
+
+/** Attach `policy_decision`, the spec-shape `decision` mirror, and the
+ * compliance-only `capture_topology` to the body. Split out so
+ * `applyComplianceFields` stays a flat loop plus one helper call. */
+function applyDecisionFields(
+  body: Record<string, unknown>,
+  options: SignOptions,
+  complianceMode: boolean,
+): void {
+  if (options.policyDecision !== undefined) {
+    body.policy_decision = options.policyDecision;
+    if (complianceMode) {
+      body.decision = mapPolicyDecisionToDecision(options.policyDecision);
+    }
+  }
+  if (complianceMode && options.captureTopology !== undefined) {
+    body.capture_topology = options.captureTopology;
+  }
+}
+
+/** Wire shape returned by `POST /agents/:id/sign`. Defined once so the
+ * response-shaping helper can be reused and type-checked. */
+interface SignWireResponse {
+  signature: string;
+  signature_id: string;
+  action_id: string;
+  timestamp: string;
+  verification_url: string;
+  algorithm?: string;
+  chain_hash?: string;
+  record_hash?: string;
+  required_co_signers?: string[];
+  co_signatures?: Array<{ agent_id: string; signature: string; signed_at: string }>;
+  countersign_url?: string;
+  user_intent_verified?: boolean;
+  compliance_mode?: boolean;
+  previousReceiptHash?: string;
+  previous_receipt_hash?: string;
+  action_ref?: string;
+  policy_digest?: string;
+  receipt_type?: string;
+  issuer_id?: string;
+  policy_decision?: string;
+  decision?: string;
+  payload?: Record<string, unknown>;
+  anchors?: AnchorEntry[];
+}
+
+/**
+ * Shape the snake_case wire response into the camelCase
+ * `SignatureResponse` returned to callers. Prefers cloud-supplied
+ * `decision`; maps from `policy_decision` for older clouds under
+ * compliance_mode. Accepts either casing on `previous_receipt_hash`.
+ */
+function mapSignWireToResponse(data: SignWireResponse): SignatureResponse {
+  return {
+    signature: data.signature,
+    signatureId: data.signature_id,
+    actionId: data.action_id,
+    timestamp: data.timestamp,
+    verificationUrl: data.verification_url,
+    algorithm: data.algorithm,
+    chainHash: data.chain_hash ?? data.record_hash,
+    requiredCoSigners: data.required_co_signers,
+    coSignatures: data.co_signatures?.map((s) => ({
+      agentId: s.agent_id,
+      signature: s.signature,
+      signedAt: s.signed_at,
+    })),
+    countersignUrl: data.countersign_url,
+    userIntentVerified: data.user_intent_verified,
+    complianceMode: data.compliance_mode,
+    previousReceiptHash: data.previousReceiptHash ?? data.previous_receipt_hash,
+    actionRef: data.action_ref,
+    policyDigest: data.policy_digest,
+    receiptType: data.receipt_type,
+    issuerId: data.issuer_id,
+    policyDecision: data.policy_decision as PolicyDecision | undefined,
+    decision: (data.decision as Decision | undefined) ?? (
+      data.compliance_mode
+        ? mapPolicyDecisionToDecision(data.policy_decision)
+        : undefined
+    ),
+    payload: data.payload,
+    anchors: data.anchors,
+  };
+}
+
 interface BuildSignBodyArgs {
   actionType: string;
   context: Record<string, unknown>;
@@ -847,78 +1094,18 @@ export class Agent {
   }
 
   async sign(options: SignOptions): Promise<SignatureResponse> {
-    let initialContext = options.context ?? {};
-    // Surface explicit kwargs into the underscored sentinel keys so the
-    // hash-only metadata builder picks them up. Mirrors the Python SDK.
-    if (
-      options.toolName !== undefined
-      || options.modelName !== undefined
-      || options.parentId !== undefined
-    ) {
-      initialContext = { ...initialContext };
-      if (options.toolName !== undefined) initialContext._tool_name = options.toolName;
-      if (options.modelName !== undefined) initialContext._model_name = options.modelName;
-      if (options.parentId !== undefined) initialContext._parent_id = options.parentId;
-    }
+    const initialContext = surfaceKwargsIntoContext(options);
     const finalContext = _dispatchBefore(options.actionType, initialContext);
-
     const complianceMode = options.complianceMode !== false;
 
-    // Fail fast on receipt_type before the HTTP roundtrip; cloud remains source of truth.
-    if (options.receiptType !== undefined
-      && !(RECEIPT_TYPE_NAMESPACE as readonly string[]).includes(options.receiptType)) {
-      throw new AsqavError(
-        `invalid_receipt_type: must be one of ${RECEIPT_TYPE_NAMESPACE.join(", ")}`,
-      );
-    }
-    if (options.policyDecision === "deny" || options.policyDecision === "rate_limit") {
-      if (!options.reason) {
-        throw new AsqavError(
-          "missing_reason: policy_decision=deny|rate_limit requires a `reason` code",
-        );
-      }
-    }
-    // Fail fast on sandbox_state vocabulary (restricted to {enabled, disabled, unavailable}) before the HTTP roundtrip.
-    if (
-      options.sandboxState !== undefined
-      && !(SANDBOX_STATE_NAMESPACE as readonly string[]).includes(options.sandboxState)
-    ) {
-      throw new AsqavError(
-        `invalid_sandbox_state: '${options.sandboxState}' must be one of ${SANDBOX_STATE_NAMESPACE.join(", ")}`,
-      );
-    }
-    // Fail fast on capture_topology vocabulary (5 values) before the HTTP roundtrip.
-    if (
-      options.captureTopology !== undefined
-      && !(CAPTURE_TOPOLOGY_NAMESPACE as readonly string[]).includes(options.captureTopology)
-    ) {
-      throw new AsqavError(
-        `invalid_capture_topology: '${options.captureTopology}' must be one of ${CAPTURE_TOPOLOGY_NAMESPACE.join(", ")}`,
-      );
-    }
-    // Fail fast on incident_class vocabulary (HIPAA token plus the six DORA tokens) before the HTTP roundtrip.
-    if (options.incidentClass !== undefined && options.incidentClass !== "") {
-      const incidentValues = Array.isArray(options.incidentClass)
-        ? options.incidentClass
-        : [options.incidentClass];
-      for (const ic of incidentValues) {
-        if (!(INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)) {
-          throw new AsqavError(
-            `invalid_incident_class: '${ic}' must be one of ${INCIDENT_CLASS_NAMESPACE.join(", ")}`,
-          );
-        }
-      }
-    }
+    validateSignOptions(options);
 
-    // Derive action_ref locally when omitted under compliance mode; matches cloud hash_action shape.
-    let actionRef = options.actionRef;
-    if (complianceMode && actionRef === undefined) {
-      const action = { action_type: options.actionType, context: finalContext };
-      const hex = createHash("sha256")
-        .update(canonicalJson(action))
-        .digest("hex");
-      actionRef = `sha256:${hex}`;
-    }
+    const actionRef = deriveActionRef(
+      complianceMode,
+      options.actionRef,
+      options.actionType,
+      finalContext,
+    );
 
     const body = await buildSignBody({
       actionType: options.actionType,
@@ -927,103 +1114,15 @@ export class Agent {
       agentId: this.agentId,
       userIntent: options.userIntent,
     });
-    if (options.coSigners && options.coSigners.length > 0) {
-      body.co_signers = [...options.coSigners];
-    }
-    if (options.nonce !== undefined) {
-      body.nonce = options.nonce;
-    }
-    if (options.validSeconds !== undefined) {
-      body.valid_seconds = options.validSeconds;
-    }
-    if (options.expectedExecutorPubkeyB64 !== undefined) {
-      body.expected_executor_pubkey_b64 = options.expectedExecutorPubkeyB64;
-    }
+    applyOptionalWireFields(body, options);
+    applyComplianceFields(body, options, complianceMode, actionRef);
 
-    // IETF Compliance Receipts profile fields ride along as snake_case wire keys.
-    if (complianceMode) body.compliance_mode = true;
-    if (actionRef !== undefined) body.action_ref = actionRef;
-    if (options.sandboxState !== undefined) body.sandbox_state = options.sandboxState;
-    if (options.iterationId !== undefined) body.iteration_id = options.iterationId;
-    if (options.riskClass !== undefined) body.risk_class = options.riskClass;
-    if (options.incidentClass !== undefined) body.incident_class = options.incidentClass;
-    if (options.issuerId !== undefined) body.issuer_id = options.issuerId;
-    if (options.payloadDigest !== undefined) body.payload_digest = options.payloadDigest;
-    if (options.receiptType !== undefined) body.receipt_type = options.receiptType;
-    if (options.reason !== undefined) body.reason = options.reason;
-    if (options.policyDecision !== undefined) {
-      body.policy_decision = options.policyDecision;
-      // Send spec-shape `decision` under compliance_mode; older clouds ignore.
-      if (complianceMode) {
-        body.decision = mapPolicyDecisionToDecision(options.policyDecision);
-      }
-    }
-    // Producer-side topology; only meaningful under compliance_mode (manifest projection).
-    if (complianceMode && options.captureTopology !== undefined) {
-      body.capture_topology = options.captureTopology;
-    }
-
-    const data = await request<{
-      signature: string;
-      signature_id: string;
-      action_id: string;
-      timestamp: string;
-      verification_url: string;
-      algorithm?: string;
-      chain_hash?: string;
-      record_hash?: string;
-      required_co_signers?: string[];
-      co_signatures?: Array<{ agent_id: string; signature: string; signed_at: string }>;
-      countersign_url?: string;
-      user_intent_verified?: boolean;
-      compliance_mode?: boolean;
-      previousReceiptHash?: string;
-      previous_receipt_hash?: string;
-      action_ref?: string;
-      policy_digest?: string;
-      receipt_type?: string;
-      issuer_id?: string;
-      policy_decision?: string;
-      decision?: string;
-      payload?: Record<string, unknown>;
-      anchors?: AnchorEntry[];
-    }>("POST", `/agents/${this.agentId}/sign`, body);
-
-    const response: SignatureResponse = {
-      signature: data.signature,
-      signatureId: data.signature_id,
-      actionId: data.action_id,
-      timestamp: data.timestamp,
-      verificationUrl: data.verification_url,
-      algorithm: data.algorithm,
-      chainHash: data.chain_hash ?? data.record_hash,
-      requiredCoSigners: data.required_co_signers,
-      coSignatures: data.co_signatures?.map((s) => ({
-        agentId: s.agent_id,
-        signature: s.signature,
-        signedAt: s.signed_at,
-      })),
-      countersignUrl: data.countersign_url,
-      userIntentVerified: data.user_intent_verified,
-      complianceMode: data.compliance_mode,
-      // Accept either camelCase (per the IETF profile JSON wire) or
-      // snake_case (alias for one release).
-      previousReceiptHash: data.previousReceiptHash ?? data.previous_receipt_hash,
-      actionRef: data.action_ref,
-      policyDigest: data.policy_digest,
-      receiptType: data.receipt_type,
-      issuerId: data.issuer_id,
-      policyDecision: data.policy_decision as PolicyDecision | undefined,
-      // Prefer cloud-emitted `decision`; map locally for older clouds.
-      decision: (data.decision as Decision | undefined) ?? (
-        data.compliance_mode
-          ? mapPolicyDecisionToDecision(data.policy_decision)
-          : undefined
-      ),
-      payload: data.payload,
-      anchors: data.anchors,
-    };
-
+    const data = await request<SignWireResponse>(
+      "POST",
+      `/agents/${this.agentId}/sign`,
+      body,
+    );
+    const response = mapSignWireToResponse(data);
     _dispatchAfter(options.actionType, response);
     return response;
   }

--- a/typescript/tests/cli.test.ts
+++ b/typescript/tests/cli.test.ts
@@ -235,6 +235,99 @@ describe("asqav CLI (TypeScript)", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
+  it("sign exits with usage when --agent-id missing", async () => {
+    try {
+      await runCli(["sign", "--action-type", "x.y"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("Usage: asqav sign");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("sign prints text output and surfaces compliance fields", async () => {
+    vi.spyOn(globalThis, "fetch")
+      // Agent.get
+      .mockResolvedValueOnce(
+        jsonResponse({
+          agent_id: "agt_x",
+          name: "n",
+          public_key: "pk",
+          key_id: "kid",
+          algorithm: "ml-dsa-65",
+          capabilities: [],
+          created_at: "2026-01-01T00:00:00Z",
+        }),
+      )
+      // /agents/{id}/sign
+      .mockResolvedValueOnce(
+        jsonResponse({
+          signature: "sig_b64",
+          signature_id: "sig_1",
+          action_id: "act_1",
+          timestamp: "2026-05-04T00:00:00Z",
+          verification_url: "https://verify.example/sig_1",
+          algorithm: "ml-dsa-65",
+          policy_digest: "sha256:abc",
+          compliance_mode: true,
+          receipt_type: "protectmcp:decision",
+          action_ref: "sha256:def",
+          previous_receipt_hash: "0".repeat(64),
+          decision: "allow",
+        }),
+      );
+    await runCli([
+      "sign",
+      "--agent-id", "agt_x",
+      "--action-type", "x.y",
+      "--session-id", "sess_1",
+    ]);
+    const out = output();
+    expect(out).toContain("signature_id: sig_1");
+    expect(out).toContain("compliance_mode: true");
+    expect(out).toContain("receipt_type:  protectmcp:decision");
+    expect(out).toContain("action_ref:    sha256:def");
+    expect(out).toContain("decision:      allow");
+    expect(out).toContain("policy_digest: sha256:abc");
+    expect(out).toContain("verify_url:   https://verify.example/sig_1");
+  });
+
+  it("sign --output json emits the camelCase payload", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          agent_id: "agt_y",
+          name: "n",
+          public_key: "pk",
+          key_id: "kid",
+          algorithm: "ed25519",
+          capabilities: [],
+          created_at: "2026-01-01T00:00:00Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          signature: "sig_b64",
+          signature_id: "sig_2",
+          action_id: "act_2",
+          timestamp: "2026-05-04T00:00:00Z",
+          verification_url: "https://verify.example/sig_2",
+          algorithm: "ed25519",
+        }),
+      );
+    await runCli([
+      "sign",
+      "--agent-id", "agt_y",
+      "--action-type", "x.y",
+      "--no-compliance-mode",
+      "--output", "json",
+      "--decision", "allow",
+    ]);
+    const parsed = JSON.parse(output());
+    expect(parsed.signatureId).toBe("sig_2");
+    expect(parsed.algorithm).toBe("ed25519");
+  });
+
   it("audit-pack policy normalizes a bare 64-hex digest", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       jsonResponse({


### PR DESCRIPTION
## Summary

CRAP report targeted two TypeScript SDK hotspots:

- **src/index.ts:849 Agent.sign** (CC=74, cov=94%)
- **src/cli.ts:404 cmdSign** (CC=40, cov=39%, CRAP=16,335)

This PR decomposes both into single-purpose helpers, dropping CC well below 15 on each entry point, and lifts cli.ts coverage with three new tests.

### sign decomposition

Eight new private helpers, all CC <= 12:

- `surfaceKwargsIntoContext` - merge `toolName` / `modelName` / `parentId` into the underscored sentinel keys
- `validateSignOptions` - fail-fast vocabulary checks before the HTTP roundtrip
- `validateIncidentClass` - canonical HIPAA + DORA token enforcement
- `deriveActionRef` - client-side `action_ref` hash under compliance_mode
- `applyOptionalWireFields` - `co_signers`, `nonce`, `valid_seconds`, `expected_executor_pubkey_b64`
- `applyComplianceFields` - IETF profile snake_case projection (uses a const field-map table to stay a flat loop)
- `applyDecisionFields` - `policy_decision` + `decision` mirror + `capture_topology` split
- `mapSignWireToResponse` - wire snake_case to camelCase `SignatureResponse`

`sign` body drops from **CC ~74 to CC=2** (the only branching token is `!== false`).

### cmdSign decomposition

Seven new helpers, all CC <= 9:

- `parseSignFlags` + `resolvePolicyDecision` - flag parsing + `--decision` to `policy_decision` map
- `validateSignFlags` - usage + reason-required exit checks
- `loadSignContext` - read `--action-json` + `--policy-artefact`, stamp `_action_id`
- `buildSignCallOptions` - CLI shape to `SignOptions`
- `printSignTextOutput` + `printSignComplianceFields` - text output writers

`cmdSign` body drops from **CC ~40 to CC=4**.

### Coverage delta

Both files moved up thanks to three new cli tests (usage exit, text output happy path, JSON output happy path):

| File | Lines | Branches | Functions |
|---|---|---|---|
| index.ts | 72.22 -> 73.54 | 69.34 -> 69.61 | 59.45 -> 65.90 |
| cli.ts | 49.22 -> 54.05 | 39.89 -> 45.10 | 62.85 -> 69.04 |

Test count 268 -> 271, all passing.

## Test plan

- [x] vitest run: 271 passing (was 268)
- [x] vitest run --coverage: lines and branches up on both files
- [x] npm run lint (tsc --noEmit) clean
- [x] npm run build (tsup) emits both ESM and CJS bundles