### PR TITLE
chore(gitignore): cover AI dev tool dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,14 @@ COMPANY.md
 .cursor/
 COMPANY.md
 CLAUDE.md
+
+# AI dev tool artefacts (not tracked, may contain session data)
+.gemini/
+.codex/
+.copilot/
+.github_token
+
+# Environment files (never commit secrets)
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
Adds .gemini/, .codex/, .copilot/, .github_token, and .env/.env.* (with !.env.example allowlist) to .gitignore. Brings parity with asqav-compliance #56 + asqav-pydantic #17. comment hygiene clean