### PR TITLE
feat(cli): add asqav shadow-ai subcommand group

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -98,6 +98,12 @@ include = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/asqav"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/asqav/templates" = "asqav/templates"
+
+[tool.hatch.build.targets.sdist.force-include]
+"src/asqav/templates" = "src/asqav/templates"
+
 [tool.ruff]
 target-version = "py310"
 line-length = 100

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -21,6 +21,7 @@ Commands:
     asqav sync                                 - Sync local queue to API
     asqav queue list / count / clear           - Manage local queue
     asqav demo / quickstart / doctor           - Onboarding + diagnostics
+    asqav shadow-ai init / up / down / status / logs - Egress signing shim
     asqav --version                            - Show version
 """
 
@@ -1719,3 +1720,277 @@ def compliance_export(
     bundle.to_file(output)
     typer.echo(f"wrote {bundle.receipt_count} receipts to {output}")
     typer.echo(f"merkle_root: {bundle.merkle_root}")
+
+
+# === shadow-ai (egress shim scaffolding + lifecycle) ===
+
+
+shadow_ai_app = typer.Typer(
+    name="shadow-ai",
+    help="Scaffold and run the Asqav shadow-AI egress signing shim.",
+    no_args_is_help=True,
+)
+app.add_typer(shadow_ai_app, name="shadow-ai")
+
+
+_SHADOW_AI_TEMPLATE_FILES = ("docker-compose.yml", ".env.template", "README.md")
+_SHADOW_AI_REQUIRED_ENV_VARS = ("ASQAV_API_KEY", "ASQAV_AGENT_ID", "POSTGRES_PASSWORD")
+
+
+def _shadow_ai_template_dir() -> "object":
+    """Resolve the shipped templates directory as an importlib.resources Traversable."""
+    from importlib.resources import files
+
+    return files("asqav").joinpath("templates", "shadow-ai")
+
+
+def _shadow_ai_copy_templates(dest: "object", force: bool) -> list[str]:
+    """Copy the three template files into dest, returning the written paths."""
+    from pathlib import Path
+
+    dest_path = Path(str(dest))
+    dest_path.mkdir(parents=True, exist_ok=True)
+    src_root = _shadow_ai_template_dir()
+    written: list[str] = []
+    for name in _SHADOW_AI_TEMPLATE_FILES:
+        target = dest_path / name
+        if target.exists() and not force:
+            raise FileExistsError(str(target))
+        data = src_root.joinpath(name).read_bytes()
+        target.write_bytes(data)
+        written.append(str(target))
+    return written
+
+
+def _shadow_ai_parse_env(env_path: "object") -> dict[str, str]:
+    """Return a dict of KEY=VALUE pairs from a dotenv-style file."""
+    from pathlib import Path
+
+    out: dict[str, str] = {}
+    for raw in Path(str(env_path)).read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def _shadow_ai_validate_env(dir_path: "object") -> "object":
+    """Return the .env path if present and required vars are non-empty, else raise."""
+    from pathlib import Path
+
+    base = Path(str(dir_path))
+    env_path = base / ".env"
+    if not env_path.exists():
+        raise FileNotFoundError(
+            f"Missing {env_path}. Copy .env.template to .env and fill in the required values."
+        )
+    parsed = _shadow_ai_parse_env(env_path)
+    missing = [k for k in _SHADOW_AI_REQUIRED_ENV_VARS if not parsed.get(k)]
+    if missing:
+        raise ValueError(
+            "Required environment variables are unset in .env: " + ", ".join(missing)
+        )
+    return env_path
+
+
+@shadow_ai_app.command("init")
+def shadow_ai_init(
+    dir: str = typer.Option(
+        "./shadow-ai",
+        "--dir",
+        help="Target directory the template files are written into.",
+    ),
+    upstream: str = typer.Option(
+        "",
+        "--upstream",
+        help="Override OPENAI_UPSTREAM in the generated .env.template (default upstream is api.openai.com).",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Overwrite existing files in the target directory.",
+    ),
+) -> None:
+    """Scaffold docker-compose.yml, .env.template, and README.md into the target directory."""
+    from pathlib import Path
+
+    target = Path(dir)
+    try:
+        written = _shadow_ai_copy_templates(target, force=force)
+    except FileExistsError as exc:
+        print(
+            f"Refusing to overwrite existing file: {exc}. Re-run with --force to replace."
+        )
+        raise typer.Exit(code=1) from exc
+
+    if upstream:
+        env_template_path = target / ".env.template"
+        text = env_template_path.read_text(encoding="utf-8")
+        text = text.replace(
+            "OPENAI_UPSTREAM=https://api.openai.com",
+            f"OPENAI_UPSTREAM={upstream}",
+        )
+        env_template_path.write_text(text, encoding="utf-8")
+
+    print(f"Scaffolded shadow-AI shim into {target}")
+    for path in written:
+        print(f"  wrote {path}")
+    print("Next: copy .env.template to .env, fill in the values, then `asqav shadow-ai up`.")
+
+
+@shadow_ai_app.command("up")
+def shadow_ai_up(
+    dir: str = typer.Option(
+        "./shadow-ai",
+        "--dir",
+        help="Directory holding docker-compose.yml and .env.",
+    ),
+) -> None:
+    """Start the shim + signer stack via docker compose up -d --build."""
+    import subprocess
+    from pathlib import Path
+
+    base = Path(dir)
+    compose = base / "docker-compose.yml"
+    if not compose.exists():
+        print(f"No docker-compose.yml at {compose}. Run `asqav shadow-ai init --dir {dir}` first.")
+        raise typer.Exit(code=1)
+
+    try:
+        _shadow_ai_validate_env(base)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    cmd = ["docker", "compose", "-f", str(compose), "up", "-d", "--build"]
+    try:
+        result = subprocess.run(cmd, cwd=str(base), check=False)
+    except FileNotFoundError as exc:
+        print("Error: docker CLI not found on PATH.")
+        raise typer.Exit(code=1) from exc
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)
+
+
+@shadow_ai_app.command("down")
+def shadow_ai_down(
+    dir: str = typer.Option(
+        "./shadow-ai",
+        "--dir",
+        help="Directory holding docker-compose.yml.",
+    ),
+) -> None:
+    """Stop the shim + signer stack via docker compose down."""
+    import subprocess
+    from pathlib import Path
+
+    base = Path(dir)
+    compose = base / "docker-compose.yml"
+    if not compose.exists():
+        print(f"No docker-compose.yml at {compose}.")
+        raise typer.Exit(code=1)
+    cmd = ["docker", "compose", "-f", str(compose), "down"]
+    try:
+        result = subprocess.run(cmd, cwd=str(base), check=False)
+    except FileNotFoundError as exc:
+        print("Error: docker CLI not found on PATH.")
+        raise typer.Exit(code=1) from exc
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)
+
+
+@shadow_ai_app.command("status")
+def shadow_ai_status(
+    dir: str = typer.Option(
+        "./shadow-ai",
+        "--dir",
+        help="Directory holding docker-compose.yml (read for scaffold presence; health probe is over HTTP).",
+    ),
+    shim_url: str = typer.Option(
+        "http://localhost:8080",
+        "--shim-url",
+        help="Base URL of the local egress shim.",
+    ),
+    signer_url: str = typer.Option(
+        "http://localhost:8000",
+        "--signer-url",
+        help="Base URL of the local signer.",
+    ),
+) -> None:
+    """Probe shim /_healthz and signer /api/v1/health/; exit 0 only if both are healthy."""
+    from pathlib import Path
+
+    compose = Path(dir) / "docker-compose.yml"
+    if not compose.exists():
+        print(
+            f"No docker-compose.yml at {compose}. Run `asqav shadow-ai init --dir {dir}` first."
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        import httpx
+    except ImportError as exc:
+        print("Error: status requires httpx. Install with: pip install asqav[cli]")
+        raise typer.Exit(code=1) from exc
+
+    shim_endpoint = shim_url.rstrip("/") + "/_healthz"
+    signer_endpoint = signer_url.rstrip("/") + "/api/v1/health/"
+
+    def _probe(label: str, url: str) -> bool:
+        try:
+            resp = httpx.get(url, timeout=5.0)
+        except httpx.HTTPError as exc:
+            print(f"{label}: unreachable ({exc.__class__.__name__})")
+            return False
+        ok = 200 <= resp.status_code < 300
+        print(f"{label}: {'healthy' if ok else 'unhealthy'} (HTTP {resp.status_code}) at {url}")
+        return ok
+
+    shim_ok = _probe("shim", shim_endpoint)
+    signer_ok = _probe("signer", signer_endpoint)
+    if not (shim_ok and signer_ok):
+        raise typer.Exit(code=1)
+
+
+@shadow_ai_app.command("logs")
+def shadow_ai_logs(
+    dir: str = typer.Option(
+        "./shadow-ai",
+        "--dir",
+        help="Directory holding docker-compose.yml.",
+    ),
+    follow: bool = typer.Option(
+        False,
+        "--follow",
+        "-f",
+        help="Stream logs (docker compose logs -f).",
+    ),
+    tail: int = typer.Option(
+        0,
+        "--tail",
+        help="Show only the last N log lines (0 = all).",
+    ),
+) -> None:
+    """Tail docker compose logs for the shim + signer stack."""
+    import subprocess
+    from pathlib import Path
+
+    base = Path(dir)
+    compose = base / "docker-compose.yml"
+    if not compose.exists():
+        print(f"No docker-compose.yml at {compose}.")
+        raise typer.Exit(code=1)
+    cmd = ["docker", "compose", "-f", str(compose), "logs"]
+    if follow:
+        cmd.append("-f")
+    if tail > 0:
+        cmd.extend(["--tail", str(tail)])
+    try:
+        result = subprocess.run(cmd, cwd=str(base), check=False)
+    except FileNotFoundError as exc:
+        print("Error: docker CLI not found on PATH.")
+        raise typer.Exit(code=1) from exc
+    if result.returncode != 0:
+        raise typer.Exit(code=result.returncode)

--- a/python/src/asqav/templates/shadow-ai/.env.template
+++ b/python/src/asqav/templates/shadow-ai/.env.template
@@ -1,0 +1,15 @@
+# Asqav shadow-AI shim - environment configuration.
+#
+# Copy this file to .env, fill in the values, then run `asqav shadow-ai up`.
+
+# Required: Asqav API key minted from https://asqav.com/dashboard/keys.
+ASQAV_API_KEY=
+
+# Required: Agent ID this shim will sign actions under.
+ASQAV_AGENT_ID=
+
+# Required: Postgres password the bundled signer + database share.
+POSTGRES_PASSWORD=
+
+# Optional: override the OpenAI upstream (defaults to https://api.openai.com).
+OPENAI_UPSTREAM=https://api.openai.com

--- a/python/src/asqav/templates/shadow-ai/README.md
+++ b/python/src/asqav/templates/shadow-ai/README.md
@@ -1,0 +1,49 @@
+# Asqav shadow-AI shim
+
+Drop-in egress proxy that signs every outbound LLM request through the
+co-located asqav-signer and forwards the request upstream unchanged.
+Sign-only, fail-open: if the signer is unreachable the request still
+goes out.
+
+## Quickstart
+
+```bash
+asqav shadow-ai init --dir ./shadow-ai
+cd shadow-ai
+cp .env.template .env
+# fill in ASQAV_API_KEY, ASQAV_AGENT_ID, POSTGRES_PASSWORD
+asqav shadow-ai up --dir .
+asqav shadow-ai status --dir .
+```
+
+Point your application at `http://localhost:8080` instead of
+`https://api.openai.com` (or `https://api.anthropic.com`) and every
+request will be signed before it leaves the host.
+
+## What the shim does
+
+1. Receives the upstream-shaped request on `:8080`.
+2. Calls the local `asqav-signer` to mint a Compliance Receipt.
+3. Forwards the original request to the configured upstream.
+4. Returns the upstream response unchanged.
+
+The signer writes receipts to its embedded Postgres so the audit trail
+survives shim restarts.
+
+## Files in this directory
+
+- `docker-compose.yml` - the two-container stack (shim + signer).
+- `.env.template` - required environment variables.
+- `secrets/license.json` - your Asqav signer license, mounted read-only.
+
+## CLI commands
+
+| Command | What it does |
+| --- | --- |
+| `asqav shadow-ai init` | Scaffold this directory. |
+| `asqav shadow-ai up` | `docker compose up -d --build`. |
+| `asqav shadow-ai down` | `docker compose down`. |
+| `asqav shadow-ai status` | Probe shim + signer health endpoints. |
+| `asqav shadow-ai logs` | `docker compose logs`. |
+
+Full setup notes live at https://asqav.com/docs/shadow-ai.

--- a/python/src/asqav/templates/shadow-ai/docker-compose.yml
+++ b/python/src/asqav/templates/shadow-ai/docker-compose.yml
@@ -1,0 +1,34 @@
+# Asqav shadow-AI capture - egress signing proxy for managed workloads
+#
+# Sign-only, fail-open. The shim signs every outbound LLM request via the
+# co-located asqav-signer, then forwards the request upstream unchanged.
+# See docs/shadow-ai-via-corporate-proxy.md for the full pattern.
+
+services:
+  asqav-egress-shim:
+    build:
+      context: ./shim
+    ports:
+      - "8080:8080"
+    environment:
+      - ASQAV_SIGNER_URL=http://asqav-signer:8000
+      - ASQAV_API_KEY=${ASQAV_API_KEY:?ASQAV_API_KEY must be set in .env}
+      - ASQAV_AGENT_ID=${ASQAV_AGENT_ID:?ASQAV_AGENT_ID must be set in .env}
+      - ASQAV_FAIL_OPEN=1
+      - OPENAI_UPSTREAM=https://api.openai.com
+      - ANTHROPIC_UPSTREAM=https://api.anthropic.com
+    depends_on:
+      - asqav-signer
+    restart: unless-stopped
+
+  asqav-signer:
+    extends:
+      file: ../../docker-compose.signer.yml
+      service: asqav-signer
+    volumes:
+      - ./secrets/license.json:/run/secrets/asqav-license.json:ro
+      - signer-keys:/var/lib/asqav/keys
+    restart: unless-stopped
+
+volumes:
+  signer-keys:

--- a/python/tests/test_cli_shadow_ai.py
+++ b/python/tests/test_cli_shadow_ai.py
@@ -1,0 +1,90 @@
+"""Tests for the `asqav shadow-ai` CLI subcommand group."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from typer.testing import CliRunner
+
+from asqav.cli import app
+
+runner = CliRunner()
+
+
+def test_init_creates_files_in_target_dir(tmp_path: Path) -> None:
+    """`shadow-ai init --dir X` writes the three template files into X."""
+    target = tmp_path / "stack"
+    result = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
+    assert result.exit_code == 0, result.output
+    assert (target / "docker-compose.yml").exists()
+    assert (target / ".env.template").exists()
+    assert (target / "README.md").exists()
+    body = (target / ".env.template").read_text(encoding="utf-8")
+    assert "ASQAV_API_KEY" in body
+    assert "ASQAV_AGENT_ID" in body
+    assert "POSTGRES_PASSWORD" in body
+
+
+def test_init_refuses_to_overwrite(tmp_path: Path) -> None:
+    """A second `init` against the same dir exits non-zero unless --force is passed."""
+    target = tmp_path / "stack"
+    first = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
+    assert second.exit_code != 0
+    assert "Refusing to overwrite" in second.output
+
+    forced = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target), "--force"])
+    assert forced.exit_code == 0, forced.output
+
+
+def test_status_handles_missing_compose_gracefully(tmp_path: Path) -> None:
+    """`shadow-ai status` against a directory with no docker-compose.yml fails clearly."""
+    missing = tmp_path / "does-not-exist"
+    result = runner.invoke(app, ["shadow-ai", "status", "--dir", str(missing)])
+    assert result.exit_code != 0
+    assert "No docker-compose.yml" in result.output
+    assert "asqav shadow-ai init" in result.output
+
+
+def test_up_validates_env_present(tmp_path: Path) -> None:
+    """`shadow-ai up` without a .env file errors with a clear message."""
+    target = tmp_path / "stack"
+    init = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
+    assert init.exit_code == 0, init.output
+
+    result = runner.invoke(app, ["shadow-ai", "up", "--dir", str(target)])
+    assert result.exit_code != 0
+    assert ".env" in result.output
+
+
+def test_up_validates_required_env_vars(tmp_path: Path) -> None:
+    """`shadow-ai up` rejects a .env that is missing required variables."""
+    target = tmp_path / "stack"
+    init = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
+    assert init.exit_code == 0, init.output
+
+    (target / ".env").write_text(
+        "ASQAV_API_KEY=\nASQAV_AGENT_ID=\nPOSTGRES_PASSWORD=\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["shadow-ai", "up", "--dir", str(target)])
+    assert result.exit_code != 0
+    assert "ASQAV_API_KEY" in result.output
+
+
+def test_init_with_upstream_override(tmp_path: Path) -> None:
+    """`--upstream` rewrites OPENAI_UPSTREAM in the generated .env.template."""
+    target = tmp_path / "stack"
+    result = runner.invoke(
+        app,
+        ["shadow-ai", "init", "--dir", str(target), "--upstream", "https://proxy.example.com"],
+    )
+    assert result.exit_code == 0, result.output
+    body = (target / ".env.template").read_text(encoding="utf-8")
+    assert "OPENAI_UPSTREAM=https://proxy.example.com" in body


### PR DESCRIPTION
## Summary

Adds the `asqav shadow-ai` subcommand group so customers can scaffold and run the Asqav shadow-AI egress signing shim from one CLI invocation. Templates (docker-compose.yml, .env.template, README.md) ship inside the wheel under `asqav/templates/shadow-ai/` and resolve via `importlib.resources`, so there is no network fetch at scaffold time.

## What was added

- New Typer sub-app `shadow_ai_app` mounted as `asqav shadow-ai`.
- Package-data templates under `python/src/asqav/templates/shadow-ai/` (3 files).
- Wheel + sdist `force-include` entries in `pyproject.toml` so the templates land in the built artifact.
- Test file `python/tests/test_cli_shadow_ai.py` exercising the real CLI via `CliRunner` and `tmp_path`.

## Subcommands

| Command | Signature | Behaviour |
| --- | --- | --- |
| `asqav shadow-ai init` | `[--dir PATH] [--upstream URL] [--force]` | Scaffolds the three template files into `PATH` (default `./shadow-ai`). Refuses to overwrite unless `--force`. |
| `asqav shadow-ai up` | `[--dir PATH]` | Runs `docker compose -f PATH/docker-compose.yml up -d --build`. Validates `.env` is present with the three required vars set. |
| `asqav shadow-ai down` | `[--dir PATH]` | Runs `docker compose down` against `PATH/docker-compose.yml`. |
| `asqav shadow-ai status` | `[--dir PATH] [--shim-url URL] [--signer-url URL]` | Probes shim `/_healthz` + signer `/api/v1/health/`. Exits 0 only when both return 2xx. |
| `asqav shadow-ai logs` | `[--dir PATH] [--follow] [--tail N]` | Wraps `docker compose logs` with `-f` / `--tail N`. |

## Test plan

Six tests in `python/tests/test_cli_shadow_ai.py`, all real CLI invocations via `CliRunner` + `tmp_path` (no docker mocks needed because validation fails before docker is invoked):

- `test_init_creates_files_in_target_dir` - `init --dir X` writes all three template files and `.env.template` contains the required vars.
- `test_init_refuses_to_overwrite` - second `init` exits non-zero; `--force` overrides.
- `test_status_handles_missing_compose_gracefully` - status on a missing dir exits non-zero with a helpful pointer to `init`.
- `test_up_validates_env_present` - `up` without a `.env` exits non-zero and mentions `.env`.
- `test_up_validates_required_env_vars` - `up` with a blank-valued `.env` exits non-zero and names the missing variable.
- `test_init_with_upstream_override` - `--upstream URL` rewrites `OPENAI_UPSTREAM` in the generated template.

All 6 pass locally (`python3 -m pytest python/tests/test_cli_shadow_ai.py -v`). `ruff check python/src/asqav/cli.py python/tests/test_cli_shadow_ai.py` passes. Existing `python/tests/test_cli.py` (65 tests) still passes.

comment hygiene clean