### PR TITLE
chore(docs): brand sweep ASQAV to capital-A Asqav in prose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to ASQAV SDK
+# Contributing to Asqav SDK
 
-First off, thank you for considering contributing to ASQAV SDK! It's people like you that make open source such a great tool for the community.
+First off, thank you for considering contributing to Asqav SDK! It's people like you that make open source such a great tool for the community.
 
 Following these guidelines helps to communicate that you respect the time of the developers managing and developing this open-source project. In return, they should reciprocate that respect in addressing your issue, assessing changes, and helping you finalize your pull requests.
 
@@ -43,7 +43,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/jagmar
 * **Use a clear and descriptive title.**
 * **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 * **Describe the current behavior** and explain which behavior you expected to see instead and why.
-* **Explain why this enhancement would be useful** to most ASQAV SDK users.
+* **Explain why this enhancement would be useful** to most Asqav SDK users.
 
 ### Your First Code Contribution
 


### PR DESCRIPTION
# Brand sweep

Standardises `ASQAV` (all caps) to `Asqav` (capital-A) in prose across documentation, per CLAUDE.md Brand rule. Env-var names like `ASQAV_API_KEY`, header names like `X-ASQAV-*`, and any token inside backticks or fenced code blocks are preserved.

# Files touched

- `CONTRIBUTING.md` (3 occurrences: H1 heading on L1, paragraph on L3, bullet on L46)

# Verification

`grep -rnP --include="*.md" '(?<![A-Za-z0-9_])ASQAV(?![A-Za-z0-9_])' .` returns zero hits in prose after the sweep.

comment hygiene clean