### PR TITLE
feat(cli): add asqav shadow-ai ensure-policy + auto-call from init

### DIFF
--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -1837,7 +1837,69 @@ def shadow_ai_init(
     print(f"Scaffolded shadow-AI shim into {target}")
     for path in written:
         print(f"  wrote {path}")
+
+    import os as _os
+    if _os.environ.get("ASQAV_API_KEY"):
+        _ensure_shadow_ai_policy()
+    else:
+        print(
+            "Hint: set ASQAV_API_KEY then run `asqav shadow-ai ensure-policy` to "
+            "register the monitor policy required by the no-false-attestation gate."
+        )
+
     print("Next: copy .env.template to .env, fill in the values, then `asqav shadow-ai up`.")
+
+
+SHADOW_AI_POLICY_NAME = "shadow-ai egress monitor"
+
+
+def _ensure_shadow_ai_policy() -> bool:
+    """Idempotently register the `monitor *` policy required by the cloud
+    no-false-attestation gate for compliance-mode sign calls; returns False on failure without raising."""
+    _init_sdk()
+    from asqav.client import _get, _post
+
+    try:
+        existing = _get("/policies")
+    except Exception as exc:
+        print(f"Could not list policies to ensure the shadow-ai policy: {exc}")
+        return False
+    rows = existing if isinstance(existing, list) else []
+    for p in rows:
+        if (
+            p.get("action_pattern") == "*"
+            and p.get("action") == "monitor"
+            and p.get("is_active")
+        ):
+            print(f"Shadow-AI monitor policy already present: id={p.get('id')}")
+            return True
+    try:
+        created = _post(
+            "/policies",
+            {
+                "name": SHADOW_AI_POLICY_NAME,
+                "action_pattern": "*",
+                "action": "monitor",
+                "is_active": True,
+            },
+        )
+        print(
+            f"Created shadow-AI monitor policy: id={created.get('id', '?')}. "
+            "Required so compliance_mode=true sign calls pass the no-false-attestation gate."
+        )
+        return True
+    except Exception as exc:
+        print(f"Could not create shadow-ai monitor policy: {exc}")
+        return False
+
+
+@shadow_ai_app.command("ensure-policy")
+def shadow_ai_ensure_policy() -> None:
+    """Idempotently register the `monitor *` policy that the cloud needs to
+    accept `compliance_mode=true` shadow-AI sign calls."""
+    ok = _ensure_shadow_ai_policy()
+    if not ok:
+        raise typer.Exit(code=1)
 
 
 @shadow_ai_app.command("up")

--- a/python/tests/test_cli_shadow_ai.py
+++ b/python/tests/test_cli_shadow_ai.py
@@ -88,3 +88,121 @@ def test_init_with_upstream_override(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     body = (target / ".env.template").read_text(encoding="utf-8")
     assert "OPENAI_UPSTREAM=https://proxy.example.com" in body
+
+
+def test_init_calls_ensure_policy_when_api_key_set(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`init` triggers _ensure_shadow_ai_policy when ASQAV_API_KEY is in env."""
+    from asqav import cli as cli_mod
+
+    calls: list[bool] = []
+    monkeypatch.setattr(cli_mod, "_ensure_shadow_ai_policy", lambda: calls.append(True) or True)
+    monkeypatch.setenv("ASQAV_API_KEY", "sk_test_dummy")
+
+    target = tmp_path / "stack"
+    result = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
+    assert result.exit_code == 0, result.output
+    assert calls == [True]
+
+
+def test_init_prints_hint_when_api_key_absent(tmp_path: Path, monkeypatch) -> None:
+    """`init` skips ensure_policy and prints the hint when ASQAV_API_KEY is unset."""
+    from asqav import cli as cli_mod
+
+    calls: list[bool] = []
+    monkeypatch.setattr(cli_mod, "_ensure_shadow_ai_policy", lambda: calls.append(True) or True)
+    monkeypatch.delenv("ASQAV_API_KEY", raising=False)
+
+    target = tmp_path / "stack"
+    result = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
+    assert result.exit_code == 0, result.output
+    assert calls == []
+    assert "ensure-policy" in result.output
+
+
+def test_ensure_policy_noop_when_present(monkeypatch) -> None:
+    """`ensure-policy` exits 0 with an 'already present' line when a matching policy exists."""
+    from asqav import cli as cli_mod
+    from asqav import client as client_mod
+
+    monkeypatch.setattr(cli_mod, "_init_sdk", lambda: None)
+    monkeypatch.setattr(
+        client_mod,
+        "_get",
+        lambda path: [
+            {"id": "pol_existing_abc", "action_pattern": "*", "action": "monitor", "is_active": True}
+        ],
+    )
+
+    def _refuse_post(path, data):
+        raise AssertionError("ensure-policy must not POST when a matching policy already exists")
+
+    monkeypatch.setattr(client_mod, "_post", _refuse_post)
+
+    result = runner.invoke(app, ["shadow-ai", "ensure-policy"])
+    assert result.exit_code == 0, result.output
+    assert "already present" in result.output
+    assert "pol_existing_abc" in result.output
+
+
+def test_ensure_policy_creates_when_absent(monkeypatch) -> None:
+    """`ensure-policy` POSTs a new monitor policy when none matches."""
+    from asqav import cli as cli_mod
+    from asqav import client as client_mod
+
+    monkeypatch.setattr(cli_mod, "_init_sdk", lambda: None)
+    monkeypatch.setattr(client_mod, "_get", lambda path: [])
+
+    posted: list[dict] = []
+
+    def _capture_post(path, data):
+        posted.append({"path": path, "data": data})
+        return {"id": "pol_new_xyz", "action_pattern": "*", "action": "monitor", "is_active": True}
+
+    monkeypatch.setattr(client_mod, "_post", _capture_post)
+
+    result = runner.invoke(app, ["shadow-ai", "ensure-policy"])
+    assert result.exit_code == 0, result.output
+    assert "Created shadow-AI monitor policy" in result.output
+    assert "pol_new_xyz" in result.output
+    assert len(posted) == 1
+    assert posted[0]["path"] == "/policies"
+    assert posted[0]["data"]["action_pattern"] == "*"
+    assert posted[0]["data"]["action"] == "monitor"
+    assert posted[0]["data"]["is_active"] is True
+
+
+def test_ensure_policy_exits_nonzero_when_list_fails(monkeypatch) -> None:
+    """`ensure-policy` exits 1 with a diagnostic when listing policies raises."""
+    from asqav import cli as cli_mod
+    from asqav import client as client_mod
+
+    monkeypatch.setattr(cli_mod, "_init_sdk", lambda: None)
+
+    def _boom(path):
+        raise RuntimeError("network unreachable")
+
+    monkeypatch.setattr(client_mod, "_get", _boom)
+
+    result = runner.invoke(app, ["shadow-ai", "ensure-policy"])
+    assert result.exit_code == 1
+    assert "Could not list policies" in result.output
+
+
+def test_ensure_policy_exits_nonzero_when_create_fails(monkeypatch) -> None:
+    """`ensure-policy` exits 1 with a diagnostic when POSTing the new policy raises."""
+    from asqav import cli as cli_mod
+    from asqav import client as client_mod
+
+    monkeypatch.setattr(cli_mod, "_init_sdk", lambda: None)
+    monkeypatch.setattr(client_mod, "_get", lambda path: [])
+
+    def _boom(path, data):
+        raise RuntimeError("server returned 403")
+
+    monkeypatch.setattr(client_mod, "_post", _boom)
+
+    result = runner.invoke(app, ["shadow-ai", "ensure-policy"])
+    assert result.exit_code == 1
+    assert "Could not create shadow-ai monitor policy" in result.output


### PR DESCRIPTION
# Summary

Adds an idempotent \`asqav shadow-ai ensure-policy\` subcommand that registers the \`monitor *\` policy the cloud needs to accept \`compliance_mode=true\` shadow-AI sign calls (no-false-attestation gate). \`asqav shadow-ai init\` auto-invokes the same helper when \`ASQAV_API_KEY\` is already in the environment, so a straight-through dev experience (init + .env + up) no longer needs a manual policy-registration step.

# Why now

Per the cycle-24 verdict, the shadow-AI shim shipped in PR #209 + cloud PRs #527-#534 leaves one rough edge: a developer scaffolds the stack, fills the \`.env\`, runs \`up\`, and the first signed request fails the no-false-attestation gate because no \`monitor *\` policy exists yet. The verdict picked this CLI helper as in-scope polish (not Splunk HEC ingester, not \`passive_telemetry\`) because it raises the success rate of the existing cooperative shim without spending eng budget on a new capture topology.

# Behaviour

- \`ensure-policy\` lists existing policies via \`_get(\"/policies\")\` and exits 0 with an \`already present\` line when a matching active policy exists.
- Otherwise POSTs a new policy via \`_post(\"/policies\", ...)\` and prints the new id.
- On either failure prints a one-line diagnostic and exits non-zero so CI surfaces it.
- \`init\` adds 7 lines: when \`ASQAV_API_KEY\` is set, call \`_ensure_shadow_ai_policy\`; otherwise print a hint to run \`ensure-policy\`.

# Tests

6 new pytest cases in \`python/tests/test_cli_shadow_ai.py\` cover:
1. init auto-calls ensure-policy when ASQAV_API_KEY is set
2. init prints the hint when ASQAV_API_KEY is absent
3. ensure-policy is a no-op when a matching policy already exists
4. ensure-policy POSTs the correct shape when no matching policy exists
5. ensure-policy exits 1 when listing policies fails
6. ensure-policy exits 1 when creating the policy fails

Full suite (12 cases including the 6 prior cases from #209) passes locally on python 3.13.

# Hygiene

- Single-sentence docstring on the helper (rule 10).
- No forbidden tokens, no em-dashes, no internal versioning.
- Brand: capital-A \`Asqav\` in prose, lowercase \`asqav\` in code identifiers per CLAUDE.md.

comment hygiene clean