### PR TITLE
feat(sdk): add protectmcp:observation + passive_telemetry vocabularies + v0.4.6/v0.3.6 bumps

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.4.5"
+version = "0.4.6"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -140,7 +140,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -197,6 +197,7 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
         "protectmcp:restraint",
         "protectmcp:lifecycle",
         "protectmcp:acknowledgment",
+        "protectmcp:observation",
     }
 )
 
@@ -237,6 +238,7 @@ CAPTURE_TOPOLOGY_NAMESPACE: frozenset[str] = frozenset(
         "browser_extension",
         "ebpf_observer",
         "mcp_proxy",
+        "passive_telemetry",
     }
 )
 
@@ -255,6 +257,7 @@ CaptureTopology = Literal[
     "browser_extension",
     "ebpf_observer",
     "mcp_proxy",
+    "passive_telemetry",
 ]
 
 # Verifier rejects receipts further than this from the wall clock.
@@ -1185,8 +1188,10 @@ class Agent:
                 Only the name string travels; the prompt does not.
             capture_topology: Producer-side topology. One of
                 ``in_process_sdk``, ``network_proxy``, ``browser_extension``,
-                ``ebpf_observer``, ``mcp_proxy``. Stamped on the audit-pack
-                manifest entry; never on the signed payload.
+                ``ebpf_observer``, ``mcp_proxy``, ``passive_telemetry``.
+                Stamped on the audit-pack manifest entry; never on the
+                signed payload. ``passive_telemetry`` requires
+                ``receipt_type='protectmcp:observation'`` (false-attestation guard).
 
         Returns:
             SignatureResponse with the signature.
@@ -1258,6 +1263,18 @@ class Agent:
             raise ValueError(
                 "invalid_capture_topology: must be one of "
                 f"{sorted(CAPTURE_TOPOLOGY_NAMESPACE)}."
+            )
+        # Mirror cloud rule 8: passive_telemetry observes after the fact, so
+        # it cannot certify a policy evaluation; receipts MUST use
+        # protectmcp:observation rather than :decision.
+        if (
+            capture_topology == "passive_telemetry"
+            and receipt_type == "protectmcp:decision"
+        ):
+            raise ValueError(
+                "false_attestation_guard: capture_topology=passive_telemetry "
+                "receipts must use receipt_type=protectmcp:observation, "
+                "not :decision."
             )
         # Fail fast on incident_class vocabulary before the HTTP roundtrip.
         # The field accepts a JSON string or a JSON array of such strings.

--- a/python/tests/test_client_capture_topology.py
+++ b/python/tests/test_client_capture_topology.py
@@ -20,6 +20,7 @@ import asqav
 from asqav.client import (
     CAPTURE_TOPOLOGY_NAMESPACE,
     DECISION_MAP,
+    RECEIPT_TYPE_NAMESPACE,
     Agent,
     _map_policy_decision_to_decision,
 )
@@ -123,6 +124,7 @@ def test_capture_topology_namespace_matches_cloud_literal() -> None:
             "browser_extension",
             "ebpf_observer",
             "mcp_proxy",
+            "passive_telemetry",
         }
     )
 
@@ -198,3 +200,120 @@ def test_capture_topology_dropped_outside_compliance_mode() -> None:
             capture_topology="mcp_proxy",
         )
     assert "capture_topology" not in captured["body"]
+
+
+# === parametrised vocabulary parity (capture_topology + receipt_type) ===
+
+
+@pytest.mark.parametrize("value", sorted(CAPTURE_TOPOLOGY_NAMESPACE))
+def test_capture_topology_parametrised_accepts_all_values(value: str) -> None:
+    """Every value in the 6-token vocabulary is forwarded on the body."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            capture_topology=value,
+            receipt_type=(
+                "protectmcp:observation"
+                if value == "passive_telemetry"
+                else "protectmcp:decision"
+            ),
+        )
+    assert captured["body"]["capture_topology"] == value
+
+
+@pytest.mark.parametrize(
+    "bad_value", ["bogus", "in-process-sdk", "PASSIVE_TELEMETRY", " "]
+)
+def test_capture_topology_parametrised_rejects_unknown(bad_value: str) -> None:
+    """Any value outside the closed vocabulary is rejected client-side."""
+    with patch("asqav.client._post") as p:
+        with pytest.raises(ValueError, match="invalid_capture_topology"):
+            _agent().sign(
+                "api:call",
+                {"k": "v"},
+                compliance_mode=True,
+                capture_topology=bad_value,
+            )
+        p.assert_not_called()
+
+
+@pytest.mark.parametrize("value", sorted(RECEIPT_TYPE_NAMESPACE))
+def test_receipt_type_parametrised_accepts_all_values(value: str) -> None:
+    """All 5 receipt_type tokens (incl. :observation) accepted client-side."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    kwargs: dict = {
+        "compliance_mode": True,
+        "receipt_type": value,
+    }
+    # `protectmcp:lifecycle` paired with `none` exercises the opt-out path.
+    if value == "protectmcp:lifecycle":
+        kwargs["policy_decision"] = "none"
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("api:call", {"k": "v"}, **kwargs)
+    assert captured["body"]["receipt_type"] == value
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ["protectmcp:bogus", "protectmcp:Observation", "decision", "observation"],
+)
+def test_receipt_type_parametrised_rejects_unknown(bad_value: str) -> None:
+    """Any token outside the closed receipt-type vocabulary is rejected."""
+    with patch("asqav.client._post") as p:
+        with pytest.raises(ValueError, match="invalid_receipt_type"):
+            _agent().sign(
+                "api:call",
+                {"k": "v"},
+                compliance_mode=True,
+                receipt_type=bad_value,
+            )
+        p.assert_not_called()
+
+
+def test_passive_telemetry_with_decision_receipt_rejected() -> None:
+    """Client-side mirror of cloud rule 8: passive_telemetry +
+    protectmcp:decision fails before the HTTP roundtrip."""
+    with patch("asqav.client._post") as p:
+        with pytest.raises(ValueError, match="false_attestation_guard"):
+            _agent().sign(
+                "api:call",
+                {"k": "v"},
+                compliance_mode=True,
+                capture_topology="passive_telemetry",
+                receipt_type="protectmcp:decision",
+            )
+        p.assert_not_called()
+
+
+def test_passive_telemetry_with_observation_receipt_accepted() -> None:
+    """The matched pair (passive_telemetry + :observation) passes through."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            capture_topology="passive_telemetry",
+            receipt_type="protectmcp:observation",
+        )
+    assert captured["body"]["capture_topology"] == "passive_telemetry"
+    assert captured["body"]["receipt_type"] == "protectmcp:observation"

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -77,6 +77,7 @@ def test_receipt_type_namespace_constant() -> None:
             "protectmcp:restraint",
             "protectmcp:lifecycle",
             "protectmcp:acknowledgment",
+            "protectmcp:observation",
         }
     )
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "asqav"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -33,7 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.3.5";
+export const CLI_VERSION = "0.3.6";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -28,6 +28,7 @@ export const RECEIPT_TYPE_NAMESPACE = [
   "protectmcp:restraint",
   "protectmcp:lifecycle",
   "protectmcp:acknowledgment",
+  "protectmcp:observation",
 ] as const;
 export type ReceiptType = (typeof RECEIPT_TYPE_NAMESPACE)[number];
 
@@ -90,6 +91,7 @@ export const CAPTURE_TOPOLOGY_NAMESPACE = [
   "browser_extension",
   "ebpf_observer",
   "mcp_proxy",
+  "passive_telemetry",
 ] as const;
 export type CaptureTopology = (typeof CAPTURE_TOPOLOGY_NAMESPACE)[number];
 
@@ -364,7 +366,8 @@ export interface SignOptions {
   payloadDigest?: string | { hash: string; size?: number; preview?: string };
 
   /** Receipt namespace. One of `protectmcp:decision` |
-   * `protectmcp:restraint` | `protectmcp:lifecycle`. Defaults to
+   * `protectmcp:restraint` | `protectmcp:lifecycle` |
+   * `protectmcp:acknowledgment` | `protectmcp:observation`. Defaults to
    * `protectmcp:decision`. Validated client-side. */
   receiptType?: ReceiptType;
 
@@ -380,8 +383,10 @@ export interface SignOptions {
   policyDecision?: PolicyDecision;
 
   /** Producer-side topology. One of `in_process_sdk`, `network_proxy`,
-   * `browser_extension`, `ebpf_observer`, `mcp_proxy`. Stamped on the
-   * audit-pack manifest entry; never on the signed payload. */
+   * `browser_extension`, `ebpf_observer`, `mcp_proxy`, `passive_telemetry`.
+   * Stamped on the audit-pack manifest entry; never on the signed payload.
+   * `passive_telemetry` requires `receiptType='protectmcp:observation'`
+   * (false-attestation guard). */
   captureTopology?: CaptureTopology;
 }
 
@@ -798,6 +803,14 @@ function validateSignOptions(options: SignOptions): void {
   ) {
     throw new AsqavError(
       `invalid_capture_topology: '${options.captureTopology}' must be one of ${CAPTURE_TOPOLOGY_NAMESPACE.join(", ")}`,
+    );
+  }
+  if (
+    options.captureTopology === "passive_telemetry"
+    && options.receiptType === "protectmcp:decision"
+  ) {
+    throw new AsqavError(
+      "false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :decision",
     );
   }
   validateIncidentClass(options.incidentClass);

--- a/typescript/tests/captureTopology.test.ts
+++ b/typescript/tests/captureTopology.test.ts
@@ -12,6 +12,7 @@ import {
   Agent,
   CAPTURE_TOPOLOGY_NAMESPACE,
   DECISION_MAP,
+  RECEIPT_TYPE_NAMESPACE,
   _resetForTests,
   init,
   mapPolicyDecisionToDecision,
@@ -59,6 +60,21 @@ describe("CAPTURE_TOPOLOGY_NAMESPACE", () => {
         "in_process_sdk",
         "mcp_proxy",
         "network_proxy",
+        "passive_telemetry",
+      ],
+    );
+  });
+});
+
+describe("RECEIPT_TYPE_NAMESPACE", () => {
+  it("includes the observation token paired with passive_telemetry", () => {
+    expect([...RECEIPT_TYPE_NAMESPACE].sort()).toEqual(
+      [
+        "protectmcp:acknowledgment",
+        "protectmcp:decision",
+        "protectmcp:lifecycle",
+        "protectmcp:observation",
+        "protectmcp:restraint",
       ],
     );
   });
@@ -158,6 +174,7 @@ describe("agent.sign capture_topology + observation wire fields", () => {
     "browser_extension",
     "ebpf_observer",
     "mcp_proxy",
+    "passive_telemetry",
   ] as const)("passes captureTopology=%s through on the outgoing body", async (value) => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       jsonResponse({
@@ -174,6 +191,9 @@ describe("agent.sign capture_topology + observation wire fields", () => {
       actionType: "t.test",
       complianceMode: true,
       captureTopology: value,
+      receiptType: value === "passive_telemetry"
+        ? "protectmcp:observation"
+        : "protectmcp:decision",
     });
 
     const init = fetchSpy.mock.calls[0][1];
@@ -236,5 +256,108 @@ describe("agent.sign capture_topology + observation wire fields", () => {
     const init = fetchSpy.mock.calls[0][1];
     const body = JSON.parse((init?.body as string) ?? "{}");
     expect(body.capture_topology).toBeUndefined();
+  });
+
+  it.each([
+    "bogus",
+    "in-process-sdk",
+    "PASSIVE_TELEMETRY",
+    "ROOTKIT",
+  ] as const)("rejects out-of-vocabulary captureTopology=%s", async (bad) => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "t.test",
+        complianceMode: true,
+        // @ts-expect-error - intentionally outside the closed Literal
+        captureTopology: bad,
+      }),
+    ).rejects.toThrow(/invalid_capture_topology/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "protectmcp:decision",
+    "protectmcp:restraint",
+    "protectmcp:lifecycle",
+    "protectmcp:acknowledgment",
+    "protectmcp:observation",
+  ] as const)("accepts receiptType=%s on the outgoing body", async (value) => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-15T00:00:00Z",
+        verification_url: "https://verify",
+      }),
+    );
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "t.test",
+      complianceMode: true,
+      receiptType: value,
+      policyDecision: value === "protectmcp:lifecycle" ? "none" : "permit",
+    });
+    const init = fetchSpy.mock.calls[0][1];
+    const body = JSON.parse((init?.body as string) ?? "{}");
+    expect(body.receipt_type).toBe(value);
+  });
+
+  it.each([
+    "protectmcp:bogus",
+    "protectmcp:Observation",
+    "decision",
+    "observation",
+  ] as const)("rejects out-of-vocabulary receiptType=%s", async (bad) => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "t.test",
+        complianceMode: true,
+        // @ts-expect-error - intentionally outside the closed Literal
+        receiptType: bad,
+      }),
+    ).rejects.toThrow(/invalid_receipt_type/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects passive_telemetry paired with protectmcp:decision (rule 8)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "t.test",
+        complianceMode: true,
+        captureTopology: "passive_telemetry",
+        receiptType: "protectmcp:decision",
+      }),
+    ).rejects.toThrow(/false_attestation_guard/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts passive_telemetry paired with protectmcp:observation", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        signature: "sig",
+        signature_id: "sig_test",
+        action_id: "act_test",
+        timestamp: "2026-05-15T00:00:00Z",
+        verification_url: "https://verify",
+      }),
+    );
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "t.test",
+      complianceMode: true,
+      captureTopology: "passive_telemetry",
+      receiptType: "protectmcp:observation",
+    });
+    const init = fetchSpy.mock.calls[0][1];
+    const body = JSON.parse((init?.body as string) ?? "{}");
+    expect(body.capture_topology).toBe("passive_telemetry");
+    expect(body.receipt_type).toBe("protectmcp:observation");
   });
 });


### PR DESCRIPTION
## Summary

Adds the two new wire-vocabulary tokens the cloud landed in this cycle, across both Python and TypeScript SDKs:

- **receipt_type** gains `protectmcp:observation` (5th token). Pairs with `capture_topology=passive_telemetry` for SIEM/log-derived attestations that observe after the fact and cannot certify a policy evaluation.
- **capture_topology** gains `passive_telemetry` (6th token). Covers out-of-band capture from EDR / SIEM / OTel pipelines that never saw the request in real time.

Both SDKs:
- Mirror the cloud's `_validate_no_false_attestation_on_passive_telemetry` cross-field guard. A request with `capture_topology=passive_telemetry` + `receipt_type=protectmcp:decision` is rejected client-side before the HTTP roundtrip with `false_attestation_guard:`.
- Reject unknown values per axis client-side with `invalid_receipt_type:` / `invalid_capture_topology:` (cloud remains the authoritative gate).

## Parametrised parity tests

- All 6 `capture_topology` values accepted.
- All 5 `receipt_type` values accepted.
- 4 unknown `capture_topology` tokens rejected, 4 unknown `receipt_type` tokens rejected (per SDK).
- Cross-field guard: rejects passive_telemetry + :decision; accepts passive_telemetry + :observation.

## Test counts

- Python: 805 passed (`cd python && uv run --no-sync pytest tests/`)
- TypeScript: 288 passed across 25 files (`cd typescript && npm test`)

## Version bumps

- Python: 0.4.5 -> 0.4.6 (`python/pyproject.toml` + `python/src/asqav/__init__.py`)
- TypeScript: 0.3.5 -> 0.3.6 (`typescript/package.json` + `typescript/src/cli.ts`)

## Build artefacts (publish handoff to user)

- Python dist: `python/dist/asqav-0.4.6-py3-none-any.whl` + `python/dist/asqav-0.4.6.tar.gz`
- TypeScript dist: `typescript/dist/` (cjs `index.js`, esm `index.mjs`, types `index.d.ts`, plus `extras/` and `cli.*`)

`uv publish` / `npm publish` deferred to the user.

## Test plan

- [x] Python full suite green locally
- [x] TypeScript full suite green locally
- [x] Both dists build cleanly
- [x] Cross-field guard parity verified against `asqav-c25-cloud-spec/api/routes/agents.py::_validate_no_false_attestation_on_passive_telemetry`

comment hygiene clean