### PR TITLE
fix(python): drop redundant wheel force-include block (PyPI duplicate-headers rejection)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.4.6"
+version = "0.4.7"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"
@@ -97,12 +97,6 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/asqav"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/asqav/templates" = "asqav/templates"
-
-[tool.hatch.build.targets.sdist.force-include]
-"src/asqav/templates" = "src/asqav/templates"
 
 [tool.ruff]
 target-version = "py310"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -140,7 +140,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 __all__ = [
     # Initialization
     "init",


### PR DESCRIPTION
## Bug

PyPI rejected the asqav 0.4.6 publish with:

```
400 Invalid distribution file. ZIP archive not accepted:
Duplicate filename in local headers
```

for `asqav/templates/shadow-ai/README.md` and `asqav/templates/shadow-ai/docker-compose.yml`.

The 0.4.6 release only landed after a one-time manual `zip -d` on the wheel to delete the duplicate entries before `twine upload`. That was a hack and should not be required again.

## Root cause

`python/pyproject.toml` had:

```
[tool.hatch.build.targets.wheel]
packages = ["src/asqav"]

[tool.hatch.build.targets.wheel.force-include]
"src/asqav/templates" = "asqav/templates"
```

`packages = ["src/asqav"]` already pulls every file under `src/asqav/` (including `templates/`) into the wheel under `asqav/`. The `force-include` block then mapped the SAME source path to the SAME destination path, so hatch wrote each template file twice into the zip - one local header per write.

`twine`/PyPI treat duplicate local headers as malformed.

## Fix

Drop the `[tool.hatch.build.targets.wheel.force-include]` and `[tool.hatch.build.targets.sdist.force-include]` blocks entirely. The package config already covers them.

Bumped 0.4.6 -> 0.4.7. Python-only; TypeScript version untouched.

## Verification

```
cd python && rm -rf dist/ && uv build
unzip -l dist/asqav-0.4.7-py3-none-any.whl | grep templates
```

Output:

```
1608  ... asqav/templates/shadow-ai/README.md
1065  ... asqav/templates/shadow-ai/docker-compose.yml
```

Each template path appears exactly once. No duplicate filenames anywhere in the wheel.

```
cd python && uv run --no-sync pytest tests/ -q
```

`805 passed in 12.96s` - matches the 0.4.6 baseline.

comment hygiene clean