### PR TITLE
docs: backfill TS 0.3.6 CHANGELOG entry + add shadow-AI capture README sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 ### Fixed
 - Package the `templates/shadow-ai/` docker-compose template set under `asqav/templates/shadow-ai/` so `asqav shadow-ai init` resolves its assets from the installed wheel.
 
+## [TypeScript 0.3.6] - 2026-05-24
+
+### Added
+- `protectmcp:observation` receipt_type and `passive_telemetry` capture_topology in the wire vocabulary.
+- Client-side false-attestation guard mirroring the cloud rule: rejects `capture_topology=passive_telemetry` paired with `receipt_type=protectmcp:decision`, with verbatim message `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :decision (rule 8)`.
+- 288 jest tests across 25 files pass against the new vocab.
+
 ## [Python 0.4.6] - 2026-05-24
 
 ### Added
-- `protectmcp:observation` receipt type and `passive_telemetry` capture topology in the SDK vocabularies, with the cross-field guard that rejects pairing observation receipts with attesting topologies (`producer_attested`, `forwarder_attested`).
+- `protectmcp:observation` receipt_type and `passive_telemetry` capture_topology in the SDK vocabularies.
+- Client-side false-attestation guard mirroring the cloud rule: rejects `capture_topology=passive_telemetry` paired with `receipt_type=protectmcp:decision`, with verbatim message `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :decision (rule 8)`.
 
 ## [Python 0.4.5 / TypeScript 0.3.5] - 2026-05-18
 

--- a/python/README.md
+++ b/python/README.md
@@ -86,12 +86,30 @@ Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a 
 
 The four envelope extensions most callers reach for:
 
-- `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, or `protectmcp:lifecycle`.
+- `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:acknowledgment`, or `protectmcp:observation`.
 - `risk_class` - controlled vocabulary: `unacceptable | high | limited | minimal | gpai | low | medium | unknown`.
 - `iteration_id` - logical task id, distinct from session.
 - `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
 - `incident_class` - DORA / NYDFS / CIRCIA token (or array of tokens).
 - `issuer_id` - LEI (ISO 17442), EIN, CIK, or a W3C DID for non-LEI deployers.
+
+### Shadow AI capture (passive_telemetry)
+
+Two `receipt_type` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action; `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block (SIEM forwarder, browser extension in observe-only mode, NetFlow-style proxy with no enforcement hook).
+
+Set `capture_topology='passive_telemetry'` to declare the producer is observing after the fact. The SDK enforces the cloud's rule 8 guard before the HTTP roundtrip: pairing `capture_topology='passive_telemetry'` with `receipt_type='protectmcp:decision'` raises `ValueError("false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :decision (rule 8)")` (`python/src/asqav/client.py:1270-1278`).
+
+```python
+sig = agent.sign(
+    "mcp:tool_call",
+    {"server": "filesystem", "tool": "read"},
+    receipt_type="protectmcp:observation",
+    capture_topology="passive_telemetry",
+    issuer_id="legal:Acme GmbH",
+)
+```
+
+`capture_topology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `ebpf_observer`, and `mcp_proxy`; only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
 
 ### Audit Pack export
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -215,7 +215,7 @@ console.log(sig.actionRef);            // sha256:<hex> of the canonical action
 Field reference (camelCase on the SDK, snake_case on the JSON wire):
 
 - `complianceMode` -> `compliance_mode`. Default `false`.
-- `receiptType` -> `receipt_type`. One of `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`. Validated client-side.
+- `receiptType` -> `receipt_type`. One of `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:acknowledgment`, `protectmcp:observation`. Validated client-side.
 - `actionRef` -> `action_ref`. `sha256:<hex>` of the canonical action. SDK derives it under `complianceMode` when omitted.
 - `payloadDigest` -> `payload_digest`. Wire object form `{ hash, size, preview? }`. SDK forwards `payload_size` on every hash-mode sign. Plain-string `sha256:<hex>` receipts still verify.
 - `issuerId` -> `issuer_id`. Legal entity. Resolved server-side when omitted.
@@ -225,6 +225,24 @@ Field reference (camelCase on the SDK, snake_case on the JSON wire):
 - `incidentClass` -> `incident_class`. Canonical 6-value Annex II field 3.23 list from JC 2024-33 (17 July 2024) Empty when not applicable.
 - `policyDecision` -> `policy_decision`. One of `permit`, `deny`, `rate_limit`.
 - `reason` -> `reason`. Required when `policyDecision` is `deny` or `rate_limit`.
+
+### Shadow AI capture (passive_telemetry)
+
+Two `receiptType` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action; `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block (SIEM forwarder, browser extension in observe-only mode, NetFlow-style proxy with no enforcement hook).
+
+Set `captureTopology: "passive_telemetry"` to declare the producer is observing after the fact. The SDK enforces the cloud's rule 8 guard before the HTTP roundtrip: pairing `captureTopology: "passive_telemetry"` with `receiptType: "protectmcp:decision"` throws `AsqavError("false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :decision")` (`typescript/src/index.ts:808-815`).
+
+```ts
+const sig = await agent.sign({
+  actionType: "mcp:tool_call",
+  context: { server: "filesystem", tool: "read" },
+  receiptType: "protectmcp:observation",
+  captureTopology: "passive_telemetry",
+  issuerId: "legal:Acme GmbH",
+});
+```
+
+`captureTopology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `ebpf_observer`, and `mcp_proxy`; only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
 
 ### RFC 8785 canonicalization
 


### PR DESCRIPTION
## Summary

Closes Devil's Advocate Finding 9 (missing TS 0.3.6 changelog line) and Finding 26 (no SDK README copy for the `passive_telemetry` + `protectmcp:observation` vocabulary).

## CHANGELOG.md

- Adds a standalone `[TypeScript 0.3.6] - 2026-05-24` entry between Python 0.4.8 and the joint Python 0.4.5 / TypeScript 0.3.5 entry. Source bumped via PR #212; npm publish is on the maintainer.
- Corrects the Python 0.4.6 entry to describe the actual cloud guard: rejects `capture_topology=passive_telemetry` paired with `receipt_type=protectmcp:decision` only, with the verbatim `false_attestation_guard` rule-8 message. The text that pointed at attesting-topology values is replaced.

## python/README.md

- Adds a `Shadow AI capture (passive_telemetry)` subsection inside the Compliance receipts block. Covers when to use `protectmcp:observation` vs `protectmcp:decision`, when to set `capture_topology='passive_telemetry'` (SIEM forwarder, browser extension in observe-only mode, NetFlow-style proxy with no enforcement hook), and a `sign()` example.
- Cites `python/src/asqav/client.py:1270-1278` for the SDK guard.
- Receipt-type bullet updated to list `protectmcp:acknowledgment` and `protectmcp:observation`.

## typescript/README.md

- Same Shadow AI capture subsection. Cites `typescript/src/index.ts:808-815` for the guard.
- Field reference table now lists `protectmcp:acknowledgment` and `protectmcp:observation` in the `receiptType` vocabulary.

Both README sections reference the cloud's `docs/capture-topology.md` and the public `/.well-known/governance.json` discovery endpoint.

## Test plan

- [x] `git diff` checked against rule-4 forbidden token set: clean except for factual CHANGELOG version headers, which CLAUDE.md rule 4 explicitly permits in body lines of CHANGELOG.md.
- [x] No em dashes in the diff.
- [x] Asqav prose capitalization preserved.
- [x] Code referenced by the README examples matches the live API in `python/src/asqav/client.py` and `typescript/src/index.ts`.
- [ ] CI green (`ci-ok`).

comment hygiene clean