### PR TITLE
feat(sdk): consume renamed anchor_* wire fields + add protectmcp:lifecycle:configuration_change vocab; bump 0.4.9 / 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [Python 0.4.9] - 2026-05-25
+
+### Changed
+- Wire-format break: SDK now reads the provider-agnostic anchor field names from cloud responses. `bitcoin.bitcoin_tx` is now `bitcoin.anchor_tx_ref` and `bitcoin.bitcoin_block` is now `bitcoin.anchor_block_height` on `/api/v1/sessions/{id}/signatures` and `/api/v1/agents/{id}/sign` response bodies. Requires Asqav cloud 0.3.8 or higher.
+- Public dataclass fields `BitcoinAnchor.bitcoin_tx` and `BitcoinAnchor.bitcoin_block` (and `BitcoinAnchorStatus.bitcoin_tx` / `bitcoin_block`) are renamed to `anchor_tx_ref` and `anchor_block_height` to match the new wire vocabulary. Consumers reading these attributes MUST update.
+
+### Added
+- `protectmcp:lifecycle:configuration_change` is now part of `RECEIPT_TYPE_NAMESPACE`. The Asqav cloud accepts this token to record lifecycle conflict receipts; the SDK was rejecting it client-side with `invalid_receipt_type`. The vocabulary on `python/src/asqav/client.py` now mirrors the cloud's pydantic validator and the parametrised test covers the new value.
+
+## [TypeScript 0.3.7] - 2026-05-25
+
+### Changed
+- Wire-format break: SDK now reads the provider-agnostic anchor field names from cloud responses. `bitcoin.bitcoin_tx` is now `bitcoin.anchor_tx_ref` and `bitcoin.bitcoin_block` is now `bitcoin.anchor_block_height` on the verify response. Requires Asqav cloud 0.3.8 or higher.
+- Public interface `BitcoinAnchorStatus.bitcoinTx` and `bitcoinBlock` are renamed to `anchorTxRef` and `anchorBlockHeight` to match the new wire vocabulary. Consumers reading these properties MUST update.
+
+### Added
+- `protectmcp:lifecycle:configuration_change` is now part of `RECEIPT_TYPE_NAMESPACE` so the SDK forwards the value through `agent.sign(...)` instead of throwing `invalid_receipt_type` client-side.
+
 ## [Python 0.4.8] - 2026-05-24
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.4.8"
+version = "0.4.9"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -140,7 +140,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -169,25 +169,28 @@ def _parse_bitcoin_anchor(raw: dict[str, Any] | None) -> "BitcoinAnchor | None":
         return None
     return BitcoinAnchor(
         status=raw.get("status") or "none",
-        bitcoin_tx=raw.get("bitcoin_tx"),
-        bitcoin_block=raw.get("bitcoin_block"),
+        anchor_tx_ref=raw.get("anchor_tx_ref"),
+        anchor_block_height=raw.get("anchor_block_height"),
     )
 
 
 @dataclass
 class BitcoinAnchor:
-    """Bitcoin anchor state for a signed action.
+    """Anchor attestation state for a signed action.
 
-    Branch on ``status`` before treating the signature as Bitcoin-anchored:
+    Branch on ``status`` before treating the signature as anchored:
     - ``none``: no OpenTimestamps proof was attached (free tier path).
-    - ``pending``: OTS stamp submitted, not yet included in a Bitcoin block.
+    - ``pending``: OTS stamp submitted, not yet included in a block.
     - ``confirmed``: OTS calendar upgraded the proof to a specific block.
     - ``failed``: OTS upgrade failed permanently; treat as unanchored.
+
+    Field names are provider-agnostic so the response shape survives a
+    future switch off OpenTimestamps + Bitcoin.
     """
 
     status: str
-    bitcoin_tx: str | None = None
-    bitcoin_block: int | None = None
+    anchor_tx_ref: str | None = None
+    anchor_block_height: int | None = None
 
 
 # Receipt type namespace mirrored from cloud's SignRequest validator so SDK rejects bad inputs.
@@ -196,6 +199,7 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
         "protectmcp:decision",
         "protectmcp:restraint",
         "protectmcp:lifecycle",
+        "protectmcp:lifecycle:configuration_change",
         "protectmcp:acknowledgment",
         "protectmcp:observation",
     }
@@ -473,16 +477,18 @@ class VerificationDetail:
 
 @dataclass
 class BitcoinAnchorStatus:
-    """Bitcoin anchor state on a verification response.
+    """Anchor attestation state on a verification response.
 
     `status` vocabulary: none, pending, confirmed, failed.
-    `bitcoin_tx` and `bitcoin_block` populate once the OpenTimestamps
-    proof upgrades to a confirmed Bitcoin attestation.
+    `anchor_tx_ref` and `anchor_block_height` populate once the
+    OpenTimestamps proof upgrades to a confirmed attestation. Field
+    names are provider-agnostic so the response shape survives a future
+    switch off OpenTimestamps + Bitcoin.
     """
 
     status: str
-    bitcoin_tx: str | None = None
-    bitcoin_block: int | None = None
+    anchor_tx_ref: str | None = None
+    anchor_block_height: int | None = None
 
 
 @dataclass
@@ -2385,8 +2391,8 @@ def verify_signature(signature_id: str) -> VerificationResponse:
     bitcoin_anchor = (
         BitcoinAnchorStatus(
             status=anchor_raw.get("status", "none"),
-            bitcoin_tx=anchor_raw.get("bitcoin_tx"),
-            bitcoin_block=anchor_raw.get("bitcoin_block"),
+            anchor_tx_ref=anchor_raw.get("anchor_tx_ref"),
+            anchor_block_height=anchor_raw.get("anchor_block_height"),
         )
         if isinstance(anchor_raw, dict)
         else None

--- a/python/tests/test_client_capture_topology.py
+++ b/python/tests/test_client_capture_topology.py
@@ -247,7 +247,7 @@ def test_capture_topology_parametrised_rejects_unknown(bad_value: str) -> None:
 
 @pytest.mark.parametrize("value", sorted(RECEIPT_TYPE_NAMESPACE))
 def test_receipt_type_parametrised_accepts_all_values(value: str) -> None:
-    """All 5 receipt_type tokens (incl. :observation) accepted client-side."""
+    """Every token in the receipt_type vocabulary is accepted client-side."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -258,8 +258,8 @@ def test_receipt_type_parametrised_accepts_all_values(value: str) -> None:
         "compliance_mode": True,
         "receipt_type": value,
     }
-    # `protectmcp:lifecycle` paired with `none` exercises the opt-out path.
-    if value == "protectmcp:lifecycle":
+    # Lifecycle namespace pairs with `none` to exercise the opt-out path.
+    if value.startswith("protectmcp:lifecycle"):
         kwargs["policy_decision"] = "none"
 
     with patch("asqav.client._post", side_effect=fake_post):

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -76,6 +76,7 @@ def test_receipt_type_namespace_constant() -> None:
             "protectmcp:decision",
             "protectmcp:restraint",
             "protectmcp:lifecycle",
+            "protectmcp:lifecycle:configuration_change",
             "protectmcp:acknowledgment",
             "protectmcp:observation",
         }

--- a/python/tests/test_verify_response_fields.py
+++ b/python/tests/test_verify_response_fields.py
@@ -42,8 +42,8 @@ def _full_cloud_payload() -> dict:
         "verification_url": "https://verify.example/sig_test_full",
         "bitcoin_anchor": {
             "status": "confirmed",
-            "bitcoin_tx": "abc123",
-            "bitcoin_block": 850000,
+            "anchor_tx_ref": "abc123",
+            "anchor_block_height": 850000,
         },
         "verification_detail": {
             "signer_key_match": True,
@@ -89,8 +89,8 @@ def test_verification_response_exposes_ietf_projection_fields() -> None:
     assert response.type == "signature"
     assert isinstance(response.bitcoin_anchor, BitcoinAnchorStatus)
     assert response.bitcoin_anchor.status == "confirmed"
-    assert response.bitcoin_anchor.bitcoin_tx == "abc123"
-    assert response.bitcoin_anchor.bitcoin_block == 850000
+    assert response.bitcoin_anchor.anchor_tx_ref == "abc123"
+    assert response.bitcoin_anchor.anchor_block_height == 850000
     assert response.signature_envelope == {"alg": "ML-DSA-65", "kid": "key_full"}
     assert response.anchors is not None
     assert len(response.anchors) == 2

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "asqav"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.3.5",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.3.5",
+      "version": "0.3.7",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -33,7 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.3.6";
+export const CLI_VERSION = "0.3.7";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -27,6 +27,7 @@ export const RECEIPT_TYPE_NAMESPACE = [
   "protectmcp:decision",
   "protectmcp:restraint",
   "protectmcp:lifecycle",
+  "protectmcp:lifecycle:configuration_change",
   "protectmcp:acknowledgment",
   "protectmcp:observation",
 ] as const;
@@ -514,14 +515,15 @@ export interface VerificationDetail {
   regimesSatisfied?: string[];
 }
 
-/** Bitcoin anchor state on a verification response. `status` vocabulary:
- * none | pending | confirmed | failed. `bitcoinTx` and `bitcoinBlock`
- * populate once the OpenTimestamps proof upgrades to a confirmed
- * Bitcoin attestation. */
+/** Anchor attestation state on a verification response. `status`
+ * vocabulary: none | pending | confirmed | failed. `anchorTxRef` and
+ * `anchorBlockHeight` populate once the OpenTimestamps proof upgrades
+ * to a confirmed attestation. Field names are provider-agnostic so the
+ * response shape survives a future switch off OpenTimestamps + Bitcoin. */
 export interface BitcoinAnchorStatus {
   status: "none" | "pending" | "confirmed" | "failed" | string;
-  bitcoinTx?: string | null;
-  bitcoinBlock?: number | null;
+  anchorTxRef?: string | null;
+  anchorBlockHeight?: number | null;
 }
 
 export interface VerificationResponse {
@@ -1323,8 +1325,8 @@ export async function verifySignature(signatureId: string): Promise<Verification
     type?: string;
     bitcoin_anchor?: {
       status: string;
-      bitcoin_tx?: string | null;
-      bitcoin_block?: number | null;
+      anchor_tx_ref?: string | null;
+      anchor_block_height?: number | null;
     };
     signature_envelope?: { alg: string; kid: string } & Record<string, string>;
     anchors?: Array<
@@ -1371,8 +1373,8 @@ export async function verifySignature(signatureId: string): Promise<Verification
     bitcoinAnchor: data.bitcoin_anchor
       ? {
           status: data.bitcoin_anchor.status,
-          bitcoinTx: data.bitcoin_anchor.bitcoin_tx,
-          bitcoinBlock: data.bitcoin_anchor.bitcoin_block,
+          anchorTxRef: data.bitcoin_anchor.anchor_tx_ref,
+          anchorBlockHeight: data.bitcoin_anchor.anchor_block_height,
         }
       : undefined,
     signatureEnvelope: data.signature_envelope,

--- a/typescript/tests/captureTopology.test.ts
+++ b/typescript/tests/captureTopology.test.ts
@@ -73,6 +73,7 @@ describe("RECEIPT_TYPE_NAMESPACE", () => {
         "protectmcp:acknowledgment",
         "protectmcp:decision",
         "protectmcp:lifecycle",
+        "protectmcp:lifecycle:configuration_change",
         "protectmcp:observation",
         "protectmcp:restraint",
       ],
@@ -281,6 +282,7 @@ describe("agent.sign capture_topology + observation wire fields", () => {
     "protectmcp:decision",
     "protectmcp:restraint",
     "protectmcp:lifecycle",
+    "protectmcp:lifecycle:configuration_change",
     "protectmcp:acknowledgment",
     "protectmcp:observation",
   ] as const)("accepts receiptType=%s on the outgoing body", async (value) => {
@@ -298,7 +300,7 @@ describe("agent.sign capture_topology + observation wire fields", () => {
       actionType: "t.test",
       complianceMode: true,
       receiptType: value,
-      policyDecision: value === "protectmcp:lifecycle" ? "none" : "permit",
+      policyDecision: value.startsWith("protectmcp:lifecycle") ? "none" : "permit",
     });
     const init = fetchSpy.mock.calls[0][1];
     const body = JSON.parse((init?.body as string) ?? "{}");

--- a/typescript/tests/verify-response-fields.test.ts
+++ b/typescript/tests/verify-response-fields.test.ts
@@ -43,8 +43,8 @@ function fullCloudPayload() {
     verification_url: "https://verify.example/sig_test_full",
     bitcoin_anchor: {
       status: "confirmed",
-      bitcoin_tx: "abc123",
-      bitcoin_block: 850000,
+      anchor_tx_ref: "abc123",
+      anchor_block_height: 850000,
     },
     verification_detail: {
       signer_key_match: true,
@@ -92,8 +92,8 @@ describe("verifySignature response fields", () => {
     expect(response.type).toBe("signature");
     expect(response.bitcoinAnchor).toEqual({
       status: "confirmed",
-      bitcoinTx: "abc123",
-      bitcoinBlock: 850000,
+      anchorTxRef: "abc123",
+      anchorBlockHeight: 850000,
     });
     expect(response.signatureEnvelope).toEqual({
       alg: "ML-DSA-65",


### PR DESCRIPTION
## Summary

Wire-format break that lines up the SDKs with the provider-agnostic `anchor_*` family the cloud rolled out at 0.3.8. The SDK now reads the new wire field names from sign and sessions responses, the public dataclass / interface fields are renamed to match, and the receipt-type vocabulary picks up the new lifecycle token the cloud accepts.

## What changed

### Wire reader rename (consumers MUST update)

The cloud 0.3.8 sign and sessions endpoints emit `bitcoin.anchor_tx_ref` and `bitcoin.anchor_block_height` in place of `bitcoin.bitcoin_tx` and `bitcoin.bitcoin_block`. Calling cloud 0.3.8 with SDK 0.4.8 / 0.3.6 returns Python `None` and TypeScript `undefined` for both fields. 0.4.9 / 0.3.7 wire it through.

Public dataclass / interface fields are renamed to match:

- Python: `BitcoinAnchor.bitcoin_tx` is now `BitcoinAnchor.anchor_tx_ref`; `BitcoinAnchor.bitcoin_block` is now `BitcoinAnchor.anchor_block_height`. Same rename on `BitcoinAnchorStatus`.
- TypeScript: `BitcoinAnchorStatus.bitcoinTx` is now `BitcoinAnchorStatus.anchorTxRef`; `BitcoinAnchorStatus.bitcoinBlock` is now `BitcoinAnchorStatus.anchorBlockHeight`.

The SDK's own `ComplianceBundle.merkle_root` is unchanged. Only the bitcoin-anchor reader changed.

### Vocabulary addition

`protectmcp:lifecycle:configuration_change` joins `RECEIPT_TYPE_NAMESPACE` in both `python/src/asqav/client.py` and `typescript/src/index.ts`. The cloud emits this token on lifecycle-conflict receipts; the SDKs were throwing `invalid_receipt_type` client-side. Tests that pin the namespace (`test_receipt_type_namespace_constant`, `captureTopology.test.ts` namespace + parametrised receipt-type) include the new value. The parametrised lifecycle/`none` opt-out test now checks `startswith("protectmcp:lifecycle")` so both lifecycle tokens exercise the opt-out path.

### Version bumps

- Python: 0.4.8 to 0.4.9 (`python/pyproject.toml` + `python/src/asqav/__init__.py`).
- TypeScript: 0.3.6 to 0.3.7 (`typescript/package.json` + `typescript/src/cli.ts`).

CHANGELOG.md carries dated entries for both bumps under 2026-05-25.

## Test plan

- [x] `npm test` (TypeScript): 289 vitest tests pass across 25 files.
- [x] `tsc --noEmit`: clean.
- [x] `ruff check src/asqav/client.py tests/...`: All checks passed.
- [x] `pytest tests/`: 808 tests pass.
- [x] Forbidden-token sweep on the diff is empty.
- [x] No em dashes added.
- [x] Capital-A "Asqav" in CHANGELOG prose.

## Compatibility

This is a wire-format break. Consumers MUST upgrade to 0.4.9 / 0.3.7 to talk to Asqav cloud 0.3.8 or higher. The vocabulary addition is additive.

comment hygiene clean