### PR TITLE
chore: drop internal-cloud-version ref + rename verify test for contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,7 +236,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 - `BitcoinAnchor` dataclass and `SignatureResponse.bitcoin_anchor` field. Status is one of `none`, `pending`, `confirmed`, `failed` so callers can branch before treating a signature as Bitcoin-anchored. Addresses a gap where the ML-DSA `signature` was present but anchoring state was invisible to client code.
 
 ### Changed
-- README tier clarification: removed stale "managed KMS on Pro" claim, added an Enterprise sentence covering Managed KMS and bring-your-own KMS. Reflects cloud v0.2.10 tier move.
+- README tier clarification: removed the "managed KMS on Pro" claim, added an Enterprise sentence covering Managed KMS and bring-your-own KMS. Reflects the cloud's Managed KMS tier move.
 
 ## [0.2.19] - 2026-04-20
 

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -115,11 +115,10 @@ def test_all_three_namespace_values_accepted() -> None:
         assert result.receipt_type_in_namespace is True, rt
 
 
-def test_legacy_receipt_type_attribute_still_accepted_for_namespace() -> None:
-    """Callers that have not yet migrated their emitter to the wire form
-    may still ship a ``receipt_type`` attribute; the namespace check
-    falls back to it. The REQUIRED-fields check, however, demands the
-    wire ``type``."""
+def test_receipt_type_attribute_satisfies_namespace_but_not_required_fields() -> None:
+    """When the envelope ships a ``receipt_type`` attribute instead of the
+    wire ``type``, the namespace check falls back to it and passes; the
+    REQUIRED-fields check still demands the wire ``type`` and fails."""
     env = _good_envelope()
     env["receipt_type"] = env.pop("type")
     result = verify_compliance_receipt(env)


### PR DESCRIPTION
## Summary

Two rule-4 public-content hygiene fixes found during a sweep of `CHANGELOG.md` and the verify-compliance-receipt test module.

- Drop internal-cloud-version reference from `CHANGELOG.md` line 239. The 0.2.20 README tier-clarification entry was pinned to an internal-cloud version number; the wire change being described is the Managed KMS tier move, so the entry now references that directly.
- Rename the `test_verify_compliance_receipt.py:118` test to describe the contract it asserts: the `receipt_type` attribute satisfies the namespace check via fallback, while the REQUIRED-fields check still demands the wire `type`. Docstring rewritten to match. Test body unchanged.

## Test plan

- [x] Touched-file rule-4 sweep returns zero hits (`CHANGELOG.md`, `python/tests/test_verify_compliance_receipt.py`).
- [x] `python3 -c "import ast; ast.parse(...)"` parses the touched test file cleanly.
- [x] No external references to the renamed test name in the repo (grep clean).
- [ ] CI green on the branch (`ci-ok` required for auto-merge).

comment hygiene clean