### PR TITLE
fix: widen sdk false_attestation_guard to mirror cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [Python 0.4.10] - 2026-05-25
+
+### Changed
+- `false_attestation_guard` widened to mirror the Asqav cloud's full guard: `capture_topology=passive_telemetry` now requires `receipt_type=protectmcp:observation`. The SDK client-side check rejects all five other receipt types (`:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, `:acknowledgment`) so callers fail fast instead of receiving HTTP 422 from the cloud. The verbatim error message preserves the `false_attestation_guard:` prefix and the `(rule 8)` suffix; the offending value is interpolated. Requires Asqav cloud 0.4.0 or higher.
+
 ## [Python 0.4.9] - 2026-05-25
 
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.4.9"
+version = "0.4.10"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -140,7 +140,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1270,17 +1270,17 @@ class Agent:
                 "invalid_capture_topology: must be one of "
                 f"{sorted(CAPTURE_TOPOLOGY_NAMESPACE)}."
             )
-        # Mirror cloud rule 8: passive_telemetry observes after the fact, so
-        # it cannot certify a policy evaluation; receipts MUST use
-        # protectmcp:observation rather than :decision.
+        # Rule 8: passive_telemetry pairs only with protectmcp:observation.
         if (
             capture_topology == "passive_telemetry"
-            and receipt_type == "protectmcp:decision"
+            and receipt_type is not None
+            and receipt_type != "protectmcp:observation"
         ):
+            offending = receipt_type.split(":", 1)[-1]
             raise ValueError(
                 "false_attestation_guard: capture_topology=passive_telemetry "
                 "receipts must use receipt_type=protectmcp:observation, "
-                "not :decision."
+                f"not :{offending} (rule 8)"
             )
         # Fail fast on incident_class vocabulary before the HTTP roundtrip.
         # The field accepts a JSON string or a JSON array of such strings.

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -809,10 +809,12 @@ function validateSignOptions(options: SignOptions): void {
   }
   if (
     options.captureTopology === "passive_telemetry"
-    && options.receiptType === "protectmcp:decision"
+    && options.receiptType !== undefined
+    && options.receiptType !== "protectmcp:observation"
   ) {
+    const offending = options.receiptType.split(":").slice(1).join(":") || options.receiptType;
     throw new AsqavError(
-      "false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :decision",
+      `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :${offending} (rule 8)`,
     );
   }
   validateIncidentClass(options.incidentClass);


### PR DESCRIPTION
## Summary

Closes a SDK-cloud guard parity gap that surfaced after jagmarques/asqav#549 widened the cloud's `_validate_no_false_attestation_on_passive_telemetry` validator. The cloud accepts `capture_topology=passive_telemetry` only when `receipt_type=protectmcp:observation`; the SDK client-side check at `python/src/asqav/client.py:1276` and `typescript/src/index.ts:810` only rejected the `protectmcp:decision` pairing. SDK callers using `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, or `:acknowledgment` paired with `passive_telemetry` passed the SDK gate and received HTTP 422 from the cloud.

This PR widens both SDK guards to match. The verbatim error message preserves the `false_attestation_guard:` prefix and the `(rule 8)` suffix; the offending value is interpolated.

## Files

- `python/src/asqav/client.py:1273-1287`: widened condition + message.
- `typescript/src/index.ts:810-820`: widened condition + message.
- `python/pyproject.toml`: 0.4.9 -> 0.4.10.
- `python/src/asqav/__init__.py`: `__version__` 0.4.9 -> 0.4.10.
- `CHANGELOG.md`: Python 0.4.10 entry above the 0.4.9 block.

## Test plan

- [x] AST parse on touched .py file
- [x] rule-4 forbidden-token sweep on diff: zero hits
- [x] no consecutive `#` blocks of 3+ lines in touched .py
- [x] no comment lines >100 chars
- [ ] CI ci-ok green
- [ ] Post-merge: uv publish asqav 0.4.10 to PyPI
- [ ] Post-merge: npm publish for TypeScript half (OAuth-blocked; maintainer carryover)

comment hygiene clean