### PR TITLE
chore(sdk): bump @asqav/sdk to 0.5.0 for cloud parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [TypeScript 0.5.0] - 2026-05-25
+
+### Changed
+- Version bump from 0.4.0 to 0.5.0 to align the npm @asqav/sdk version with the Python `asqav` package and the Asqav cloud 0.5.0 release. No wire-shape changes versus TypeScript 0.4.0; all NSA CSI U/OO/6030316-26 alignment features (five new optional props on `agent.sign({...})`, rule 9 / rule 10 / rule 11 cross-field guards, `protectmcp:observation:result_bound` receipt type, and the public digest helpers) shipped in 0.4.0 and are unchanged. CLI version string in `src/cli.ts` bumped from `"0.4.0"` to `"0.5.0"` to match the package version. Requires Asqav cloud 0.5.0 or higher.
+
 ## [Python 0.5.0] - 2026-05-25
 
 ### Added

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.3.7",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.3.7",
+      "version": "0.5.0",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -33,7 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.4.0";
+export const CLI_VERSION = "0.5.0";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,


### PR DESCRIPTION
## Summary
- Bumps `@asqav/sdk` from 0.4.0 to 0.5.0 to align the npm package version with the Python `asqav` package and the Asqav cloud 0.5.0 release.
- No wire-shape changes vs TypeScript 0.4.0. All NSA CSI U/OO/6030316-26 alignment features (five new optional `agent.sign({...})` props, rule 9 / rule 10 / rule 11 cross-field guards, `protectmcp:observation:result_bound` receipt type, public digest helpers) shipped in 0.4.0 and are unchanged here.
- Bumps `CLI_VERSION` in `src/cli.ts` from `"0.4.0"` to `"0.5.0"` to match the package version.
- CHANGELOG entry added under `[TypeScript 0.5.0] - 2026-05-25`.

## Verification
- `npm install` clean.
- `npm run build` clean (CJS + ESM + DTS).
- `npm test`: 338/338 pass across 26 test files.
- Wire-vocab parity: `protectmcp:observation:result_bound` present in `src/index.ts` `RECEIPT_TYPE_NAMESPACE`.
- Cloud already on 0.5.0 (`https://api.asqav.com/api/v1/health/` returns `version=0.5.0`, `build_sha=ad1dcdc1...`), so the SDK ship is safe.

## Test plan
- [x] `npm install`
- [x] `npm run build`
- [x] `npm test` (338 passed)
- [ ] CI `ci-ok` green
- [ ] After merge: `npm publish --access public` and `npm view @asqav/sdk version` reports `0.5.0`

comment hygiene clean