### PR TITLE
feat(python): build-provenance 4-tuple on agent.sign()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [Python 0.5.1] - 2026-05-25
+
+### Added
+- Build-provenance 4-tuple on `agent.sign(...)`: four new optional wire fields mirroring the cloud SignRequest. `executable_hash` (`sha256:<hex>` of the executable that invoked the action), `sbom_digest` (`sha256:<hex>` of the canonical CycloneDX or SPDX SBOM), `slsa_provenance_pointer` (https URL to the SLSA attestation envelope), and `supply_chain_pointer` (https URL to the in-toto, Sigstore, or Rekor entry). All four are OPTIONAL; the cloud accepts each independently. Subsumes third-party signed-build-provenance vendors by binding the same evidence into the signed receipt.
+- `digest_format_guard` extended to cover `executable_hash` and `sbom_digest`; SDK raises `ValueError` with the verbatim guard message before the HTTP roundtrip when either field is not `^sha256:[a-f0-9]{64}$`.
+- `pointer_url_guard` (new) covers `slsa_provenance_pointer` and `supply_chain_pointer`; SDK raises `ValueError` when either is not an http(s) URL.
+- New parametric tests over the four fields plus shape rejection (`python/tests/test_client_executable_hash_4tuple.py`). Requires Asqav cloud 0.5.1 or higher.
+
 ## [TypeScript 0.5.0] - 2026-05-25
 
 ### Changed

--- a/python/README.md
+++ b/python/README.md
@@ -128,7 +128,7 @@ sig = agent.sign(
 
 ### Digest format (rule 11)
 
-Every caller-supplied digest field (`tool_fingerprint`, `config_manifest_digest`, `cve_inventory_digest`) MUST match the regex `^sha256:[a-f0-9]{64}$`. Anything else raises `ValueError` with the verbatim `digest_format_guard: <field> must match sha256:<64-hex> (rule 11)` message before the HTTP roundtrip. To avoid wire drift, use the SDK's deterministic helpers (each is byte-deterministic under JCS):
+Every caller-supplied digest field (`tool_fingerprint`, `config_manifest_digest`, `cve_inventory_digest`, `executable_hash`, `sbom_digest`) MUST match the regex `^sha256:[a-f0-9]{64}$`. The two URL pointer fields (`slsa_provenance_pointer`, `supply_chain_pointer`) MUST start with `http://` or `https://`. Anything else raises `ValueError` with a verbatim guard message before the HTTP roundtrip. To avoid wire drift, use the SDK's deterministic helpers (each is byte-deterministic under JCS):
 
 ```python
 from asqav.client import (
@@ -154,6 +154,29 @@ Six wire fields on `agent.sign(...)` carry the NSA CSI U/OO/6030316-26 alignment
 - `cve_inventory_digest` - `sha256:<hex>` over the CVE snapshot at sign time. See <https://www.asqav.com/docs/cve-inventory-digest>.
 
 The `protectmcp:observation:result_bound` `receipt_type` variant carries `result_digest` and lets observation receipts bind to a specific tool result without claiming the policy gated the call.
+
+### Build-provenance 4-tuple
+
+Four optional wire fields bind build-side provenance into the signed receipt:
+
+- `executable_hash` - `sha256:<hex>` of the executable that invoked the action.
+- `sbom_digest` - `sha256:<hex>` of the canonical CycloneDX or SPDX SBOM document.
+- `slsa_provenance_pointer` - https URL to the SLSA attestation envelope.
+- `supply_chain_pointer` - https URL to the in-toto, Sigstore, or Rekor entry.
+
+```python
+sig = agent.sign(
+    "build:provenance",
+    {"image": "asqav/cloud:0.5.1"},
+    compliance_mode=True,
+    executable_hash="sha256:<hex of executable>",
+    sbom_digest="sha256:<hex of SBOM>",
+    slsa_provenance_pointer="https://attestations.example.com/slsa/build-1.intoto.jsonl",
+    supply_chain_pointer="https://rekor.sigstore.dev/api/v1/log/entries/abc",
+)
+```
+
+See <https://www.asqav.com/docs/executable-hash-and-sbom-provenance>.
 
 ### Audit Pack export
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.0"
+version = "0.5.1"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -140,7 +140,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1236,6 +1236,10 @@ class Agent:
         tool_fingerprint: str | None = None,
         config_manifest_digest: str | None = None,
         cve_inventory_digest: str | None = None,
+        executable_hash: str | None = None,
+        sbom_digest: str | None = None,
+        slsa_provenance_pointer: str | None = None,
+        supply_chain_pointer: str | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -1310,6 +1314,19 @@ class Agent:
                 the agent's CVE inventory snapshot at signing time. MUST
                 match ``sha256:<64-hex>`` (rule 11); use
                 ``_compute_cve_inventory_digest`` to avoid drift.
+            executable_hash: Build-provenance 4-tuple. ``sha256:<hex>``
+                of the executable that invoked the action. Binds
+                build-side provenance into the signed receipt. MUST
+                match ``sha256:<64-hex>`` (rule 11).
+            sbom_digest: Build-provenance 4-tuple. ``sha256:<hex>`` of
+                the canonical CycloneDX or SPDX SBOM document. MUST
+                match ``sha256:<64-hex>`` (rule 11).
+            slsa_provenance_pointer: Build-provenance 4-tuple. https
+                URL to the SLSA attestation envelope for the executing
+                build.
+            supply_chain_pointer: Build-provenance 4-tuple. https URL
+                to the in-toto, Sigstore, or Rekor entry covering the
+                executing build.
 
         Returns:
             SignatureResponse with the signature.
@@ -1445,11 +1462,23 @@ class Agent:
             ("tool_fingerprint", tool_fingerprint),
             ("config_manifest_digest", config_manifest_digest),
             ("cve_inventory_digest", cve_inventory_digest),
+            ("executable_hash", executable_hash),
+            ("sbom_digest", sbom_digest),
         ):
             if _value is not None and not _SHA256_HEX_RE.match(_value):
                 raise ValueError(
                     f"digest_format_guard: {_name} must match "
                     "sha256:<64-hex> (rule 11)"
+                )
+        for _name, _value in (
+            ("slsa_provenance_pointer", slsa_provenance_pointer),
+            ("supply_chain_pointer", supply_chain_pointer),
+        ):
+            if _value is not None and not (
+                _value.startswith("https://") or _value.startswith("http://")
+            ):
+                raise ValueError(
+                    f"pointer_url_guard: {_name} must be an http(s) URL"
                 )
 
         # Derive action_ref under compliance_mode when caller omits it.
@@ -1494,6 +1523,10 @@ class Agent:
                 ("tool_fingerprint", tool_fingerprint),
                 ("config_manifest_digest", config_manifest_digest),
                 ("cve_inventory_digest", cve_inventory_digest),
+                ("executable_hash", executable_hash),
+                ("sbom_digest", sbom_digest),
+                ("slsa_provenance_pointer", slsa_provenance_pointer),
+                ("supply_chain_pointer", supply_chain_pointer),
             ):
                 if v is not None:
                     compliance_fields[k] = v

--- a/python/tests/test_client_executable_hash_4tuple.py
+++ b/python/tests/test_client_executable_hash_4tuple.py
@@ -1,0 +1,181 @@
+"""SDK parity for the build-provenance 4-tuple wire fields.
+
+The cloud accepts ``executable_hash``, ``sbom_digest``,
+``slsa_provenance_pointer``, and ``supply_chain_pointer`` as optional
+fields on the signed Compliance Receipt. The SDK forwards each verbatim,
+validates the ``sha256:<64-hex>`` shape on the two digest fields, and
+validates http(s) URL form on the two pointer fields.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import Agent
+
+GOOD_EXECUTABLE_HASH = "sha256:" + "a" * 64
+GOOD_SBOM_DIGEST = "sha256:" + "b" * 64
+GOOD_SLSA_URL = "https://attestations.example.com/slsa/build-1.intoto.jsonl"
+GOOD_SUPPLY_CHAIN_URL = "https://rekor.sigstore.dev/api/v1/log/entries/abc"
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_exec_hash",
+        name="exec-hash-agent",
+        public_key="pk_xxx",
+        key_id="key_exec",
+        algorithm="ML-DSA-65",
+        capabilities=["build:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response() -> dict:
+    return {
+        "signature": "sig_b64",
+        "signature_id": "sig_abc",
+        "action_id": "act_abc",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_abc",
+        "algorithm": "ML-DSA-65",
+        "chain_hash": "deadbeef",
+    }
+
+
+def test_executable_hash_forwarded_to_wire() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "build:provenance",
+            {"k": "v"},
+            compliance_mode=True,
+            executable_hash=GOOD_EXECUTABLE_HASH,
+        )
+    assert captured["body"]["executable_hash"] == GOOD_EXECUTABLE_HASH
+
+
+def test_sbom_digest_forwarded_to_wire() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "build:provenance",
+            {"k": "v"},
+            compliance_mode=True,
+            sbom_digest=GOOD_SBOM_DIGEST,
+        )
+    assert captured["body"]["sbom_digest"] == GOOD_SBOM_DIGEST
+
+
+def test_slsa_provenance_pointer_forwarded_to_wire() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "build:provenance",
+            {"k": "v"},
+            compliance_mode=True,
+            slsa_provenance_pointer=GOOD_SLSA_URL,
+        )
+    assert captured["body"]["slsa_provenance_pointer"] == GOOD_SLSA_URL
+
+
+def test_supply_chain_pointer_forwarded_to_wire() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "build:provenance",
+            {"k": "v"},
+            compliance_mode=True,
+            supply_chain_pointer=GOOD_SUPPLY_CHAIN_URL,
+        )
+    assert captured["body"]["supply_chain_pointer"] == GOOD_SUPPLY_CHAIN_URL
+
+
+def test_executable_hash_malformed_rejected_before_post() -> None:
+    with pytest.raises(ValueError, match="digest_format_guard.*executable_hash"):
+        _agent().sign(
+            "build:provenance",
+            {"k": "v"},
+            compliance_mode=True,
+            executable_hash="deadbeef",
+        )
+
+
+def test_sbom_digest_malformed_rejected_before_post() -> None:
+    with pytest.raises(ValueError, match="digest_format_guard.*sbom_digest"):
+        _agent().sign(
+            "build:provenance",
+            {"k": "v"},
+            compliance_mode=True,
+            sbom_digest="not-a-digest",
+        )
+
+
+def test_slsa_provenance_pointer_non_url_rejected() -> None:
+    with pytest.raises(ValueError, match="pointer_url_guard.*slsa_provenance_pointer"):
+        _agent().sign(
+            "build:provenance",
+            {"k": "v"},
+            compliance_mode=True,
+            slsa_provenance_pointer="not a url",
+        )
+
+
+def test_supply_chain_pointer_non_url_rejected() -> None:
+    with pytest.raises(ValueError, match="pointer_url_guard.*supply_chain_pointer"):
+        _agent().sign(
+            "build:provenance",
+            {"k": "v"},
+            compliance_mode=True,
+            supply_chain_pointer="ftp://nope",
+        )
+
+
+def test_all_four_present_canonical_decision() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "build:provenance",
+            {"k": "v"},
+            compliance_mode=True,
+            executable_hash=GOOD_EXECUTABLE_HASH,
+            sbom_digest=GOOD_SBOM_DIGEST,
+            slsa_provenance_pointer=GOOD_SLSA_URL,
+            supply_chain_pointer=GOOD_SUPPLY_CHAIN_URL,
+        )
+    body = captured["body"]
+    assert body["executable_hash"] == GOOD_EXECUTABLE_HASH
+    assert body["sbom_digest"] == GOOD_SBOM_DIGEST
+    assert body["slsa_provenance_pointer"] == GOOD_SLSA_URL
+    assert body["supply_chain_pointer"] == GOOD_SUPPLY_CHAIN_URL


### PR DESCRIPTION
## Summary

Adds four optional wire fields on ``agent.sign(...)`` mirroring the cloud 0.5.1 SignRequest:

- ``executable_hash`` (``sha256:<hex>`` of the executable that invoked the action)
- ``sbom_digest`` (``sha256:<hex>`` of the CycloneDX or SPDX SBOM document)
- ``slsa_provenance_pointer`` (https URL to the SLSA attestation envelope)
- ``supply_chain_pointer`` (https URL to the in-toto, Sigstore, or Rekor entry)

All four OPTIONAL. None mandatory on any ``receipt_type``. Subsumes third-party signed-build-provenance vendors by binding the same evidence into the signed receipt itself.

## Guards

- ``digest_format_guard`` extended to ``executable_hash`` and ``sbom_digest`` (rule 11; ``^sha256:[a-f0-9]{64}$`` regex)
- ``pointer_url_guard`` (new) rejects non-http(s) URLs on the two pointer fields

## Version

Bumped to ``0.5.1``. Requires Asqav cloud 0.5.1 or higher (cloud PR jagmarques/asqav#563 already merged + Coolify deployed; ``/.well-known/governance.json`` lists the four new extensions live).

## Test plan

- [x] ``ruff check`` clean on all touched files
- [x] ``ast.parse`` clean
- [x] Parametric tests + shape-rejection tests in ``python/tests/test_client_executable_hash_4tuple.py``
- [ ] CI: GitHub Actions matrix green

comment hygiene clean