### PR TITLE
feat(typescript): build-provenance 4-tuple on agent.sign({...})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [TypeScript 0.5.1] - 2026-05-25
+
+### Added
+- Build-provenance 4-tuple on `agent.sign({...})`: four new optional wire fields mirroring the cloud SignRequest. `executableHash` (wire `executable_hash`, `sha256:<hex>` of the executable that invoked the action), `sbomDigest` (wire `sbom_digest`, `sha256:<hex>` of the CycloneDX or SPDX SBOM), `slsaProvenancePointer` (wire `slsa_provenance_pointer`, https URL to the SLSA attestation envelope), and `supplyChainPointer` (wire `supply_chain_pointer`, https URL to the in-toto, Sigstore, or Rekor entry). All four OPTIONAL. Requires Asqav cloud 0.5.1 or higher.
+- `digest_format_guard` extended to cover `executableHash` and `sbomDigest`; SDK throws `AsqavError` with the verbatim guard message before the HTTP roundtrip when either is not `^sha256:[a-f0-9]{64}$`.
+- `pointer_url_guard` (new) covers `slsaProvenancePointer` and `supplyChainPointer`; SDK throws when either is not an http(s) URL.
+- New tests in `typescript/tests/executableHash4Tuple.test.ts` covering wire forwarding plus shape rejection.
+
+### Changed
+- CLI version string in `src/cli.ts` bumped to `"0.5.1"` to match the package version.
+
 ## [Python 0.5.1] - 2026-05-25
 
 ### Added

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -33,7 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.0";
+export const CLI_VERSION = "0.5.1";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -433,6 +433,23 @@ export interface SignOptions {
    * MUST match `sha256:<64-hex>` (rule 11); use
    * `computeCveInventoryDigest` to avoid drift. */
   cveInventoryDigest?: string;
+
+  /** Build-provenance 4-tuple. `sha256:<hex>` of the executable that
+   * invoked the action. Binds build-side provenance into the signed
+   * receipt. MUST match `sha256:<64-hex>` (rule 11). */
+  executableHash?: string;
+
+  /** Build-provenance 4-tuple. `sha256:<hex>` of the canonical CycloneDX
+   * or SPDX SBOM document. MUST match `sha256:<64-hex>` (rule 11). */
+  sbomDigest?: string;
+
+  /** Build-provenance 4-tuple. https URL to the SLSA attestation envelope
+   * for the executing build. */
+  slsaProvenancePointer?: string;
+
+  /** Build-provenance 4-tuple. https URL to the in-toto, Sigstore, or
+   * Rekor entry covering the executing build. */
+  supplyChainPointer?: string;
 }
 
 export interface CoSignature {
@@ -893,11 +910,24 @@ function validateSignOptions(options: SignOptions): void {
     ["tool_fingerprint", options.toolFingerprint],
     ["config_manifest_digest", options.configManifestDigest],
     ["cve_inventory_digest", options.cveInventoryDigest],
+    ["executable_hash", options.executableHash],
+    ["sbom_digest", options.sbomDigest],
   ];
   for (const [name, value] of _digestChecks) {
     if (value !== undefined && !SHA256_HEX_RE.test(value)) {
       throw new AsqavError(
         `digest_format_guard: ${name} must match sha256:<64-hex> (rule 11)`,
+      );
+    }
+  }
+  const _pointerChecks: Array<[string, string | undefined]> = [
+    ["slsa_provenance_pointer", options.slsaProvenancePointer],
+    ["supply_chain_pointer", options.supplyChainPointer],
+  ];
+  for (const [name, value] of _pointerChecks) {
+    if (value !== undefined && !(value.startsWith("https://") || value.startsWith("http://"))) {
+      throw new AsqavError(
+        `pointer_url_guard: ${name} must be an http(s) URL`,
       );
     }
   }
@@ -1033,6 +1063,10 @@ const IETF_OPTIONAL_FIELD_MAP: ReadonlyArray<{
   { wire: "expires_at", read: (o) => o.expiresAt },
   { wire: "config_manifest_digest", read: (o) => o.configManifestDigest },
   { wire: "cve_inventory_digest", read: (o) => o.cveInventoryDigest },
+  { wire: "executable_hash", read: (o) => o.executableHash },
+  { wire: "sbom_digest", read: (o) => o.sbomDigest },
+  { wire: "slsa_provenance_pointer", read: (o) => o.slsaProvenancePointer },
+  { wire: "supply_chain_pointer", read: (o) => o.supplyChainPointer },
   {
     wire: "tool_fingerprint",
     read: (o) =>

--- a/typescript/tests/executableHash4Tuple.test.ts
+++ b/typescript/tests/executableHash4Tuple.test.ts
@@ -55,7 +55,7 @@ function readBody(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
 
 beforeEach(() => {
   _resetForTests();
-  init({ apiKey: "k", apiUrl: "https://api.test" });
+  init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
 });
 
 afterEach(() => {

--- a/typescript/tests/executableHash4Tuple.test.ts
+++ b/typescript/tests/executableHash4Tuple.test.ts
@@ -1,0 +1,177 @@
+/**
+ * SDK parity for the build-provenance 4-tuple wire fields.
+ *
+ * Four optional wire fields on `agent.sign({...})` mirror the cloud
+ * 0.5.1 SignRequest: `executable_hash`, `sbom_digest`,
+ * `slsa_provenance_pointer`, `supply_chain_pointer`. The SDK forwards
+ * each verbatim, validates the `sha256:<64-hex>` shape on the two
+ * digest fields, and validates http(s) URL form on the two pointer
+ * fields.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Agent, _resetForTests, init } from "../src/index.js";
+
+const GOOD_EXECUTABLE_HASH = "sha256:" + "a".repeat(64);
+const GOOD_SBOM_DIGEST = "sha256:" + "b".repeat(64);
+const GOOD_SLSA_URL = "https://attestations.example.com/slsa/build-1.intoto.jsonl";
+const GOOD_SUPPLY_CHAIN_URL = "https://rekor.sigstore.dev/api/v1/log/entries/abc";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_exec_hash",
+    name: "exec_hash",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-05-25T00:00:00Z",
+  });
+}
+
+function okBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    signature: "sig",
+    signature_id: "sig_test",
+    action_id: "act_test",
+    timestamp: "2026-05-25T00:00:00Z",
+    verification_url: "https://verify",
+    ...extra,
+  };
+}
+
+function readBody(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
+  const init = spy.mock.calls[0][1] as RequestInit;
+  return JSON.parse((init?.body as string) ?? "{}");
+}
+
+beforeEach(() => {
+  _resetForTests();
+  init({ apiKey: "k", apiUrl: "https://api.test" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("executableHash wire forwarding", () => {
+  it("forwards executable_hash to the request body", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "build:provenance",
+      context: { k: "v" },
+      complianceMode: true,
+      executableHash: GOOD_EXECUTABLE_HASH,
+    });
+    const body = readBody(spy);
+    expect(body.executable_hash).toBe(GOOD_EXECUTABLE_HASH);
+  });
+
+  it("forwards sbom_digest to the request body", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "build:provenance",
+      context: { k: "v" },
+      complianceMode: true,
+      sbomDigest: GOOD_SBOM_DIGEST,
+    });
+    const body = readBody(spy);
+    expect(body.sbom_digest).toBe(GOOD_SBOM_DIGEST);
+  });
+
+  it("forwards slsa_provenance_pointer to the request body", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "build:provenance",
+      context: { k: "v" },
+      complianceMode: true,
+      slsaProvenancePointer: GOOD_SLSA_URL,
+    });
+    const body = readBody(spy);
+    expect(body.slsa_provenance_pointer).toBe(GOOD_SLSA_URL);
+  });
+
+  it("forwards supply_chain_pointer to the request body", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "build:provenance",
+      context: { k: "v" },
+      complianceMode: true,
+      supplyChainPointer: GOOD_SUPPLY_CHAIN_URL,
+    });
+    const body = readBody(spy);
+    expect(body.supply_chain_pointer).toBe(GOOD_SUPPLY_CHAIN_URL);
+  });
+
+  it("forwards all four when supplied together", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "build:provenance",
+      context: { k: "v" },
+      complianceMode: true,
+      executableHash: GOOD_EXECUTABLE_HASH,
+      sbomDigest: GOOD_SBOM_DIGEST,
+      slsaProvenancePointer: GOOD_SLSA_URL,
+      supplyChainPointer: GOOD_SUPPLY_CHAIN_URL,
+    });
+    const body = readBody(spy);
+    expect(body.executable_hash).toBe(GOOD_EXECUTABLE_HASH);
+    expect(body.sbom_digest).toBe(GOOD_SBOM_DIGEST);
+    expect(body.slsa_provenance_pointer).toBe(GOOD_SLSA_URL);
+    expect(body.supply_chain_pointer).toBe(GOOD_SUPPLY_CHAIN_URL);
+  });
+});
+
+describe("executableHash shape guards", () => {
+  it("rejects malformed executable_hash before the HTTP roundtrip", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "build:provenance",
+        context: { k: "v" },
+        complianceMode: true,
+        executableHash: "deadbeef",
+      }),
+    ).rejects.toThrow(/digest_format_guard: executable_hash/);
+  });
+
+  it("rejects malformed sbom_digest before the HTTP roundtrip", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "build:provenance",
+        context: { k: "v" },
+        complianceMode: true,
+        sbomDigest: "not-a-digest",
+      }),
+    ).rejects.toThrow(/digest_format_guard: sbom_digest/);
+  });
+
+  it("rejects non-http slsa_provenance_pointer", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "build:provenance",
+        context: { k: "v" },
+        complianceMode: true,
+        slsaProvenancePointer: "not a url",
+      }),
+    ).rejects.toThrow(/pointer_url_guard: slsa_provenance_pointer/);
+  });
+
+  it("rejects non-http supply_chain_pointer", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "build:provenance",
+        context: { k: "v" },
+        complianceMode: true,
+        supplyChainPointer: "ftp://nope",
+      }),
+    ).rejects.toThrow(/pointer_url_guard: supply_chain_pointer/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds four optional wire fields on ``agent.sign({...})`` mirroring the cloud 0.5.1 SignRequest:

- ``executableHash`` (wire ``executable_hash``, ``sha256:<hex>`` of the executable that invoked the action)
- ``sbomDigest`` (wire ``sbom_digest``, ``sha256:<hex>`` of the CycloneDX or SPDX SBOM)
- ``slsaProvenancePointer`` (wire ``slsa_provenance_pointer``, https URL to the SLSA attestation envelope)
- ``supplyChainPointer`` (wire ``supply_chain_pointer``, https URL to the in-toto, Sigstore, or Rekor entry)

All four OPTIONAL. None mandatory on any ``receiptType``. Subsumes third-party signed-build-provenance vendors by binding the same evidence into the signed receipt itself.

## Guards

- ``digest_format_guard`` extended to ``executableHash`` and ``sbomDigest`` (rule 11; ``^sha256:[a-f0-9]{64}$``)
- ``pointer_url_guard`` (new) rejects non-http(s) URLs on the two pointer fields

## Version

Bumped to ``0.5.1`` (package.json + package-lock.json + ``src/cli.ts`` ``CLI_VERSION``). Requires Asqav cloud 0.5.1 or higher (cloud PR jagmarques/asqav#563 already merged + Coolify deployed; ``/.well-known/governance.json`` lists the four new extensions live).

## Test plan

- [x] Atomic landing matches Python SDK PR jagmarques/asqav-sdk#224
- [ ] CI: GitHub Actions matrix green (vitest + tsc)

comment hygiene clean