### PR TITLE
docs(ts-sdk): document build provenance fields in README (DA Sweep #1 B2 fix-forward)

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -155,6 +155,31 @@ Six wire fields on `agent.sign(...)` carry the NSA CSI U/OO/6030316-26 alignment
 
 The `protectmcp:observation:result_bound` `receiptType` variant carries `resultDigest` and lets observation receipts bind to a specific tool result without claiming the policy gated the call.
 
+### Build provenance fields (optional)
+
+Four optional wire fields bind build-side provenance into the signed receipt, subsuming standalone SBOM or SLSA verifiers in a single envelope. All four are independent and may be set together or individually:
+
+- `executableHash` - `sha256:<hex>` of the executable that invoked the action. MUST match `sha256:<64-hex>`.
+- `sbomDigest` - `sha256:<hex>` of the canonical CycloneDX or SPDX SBOM document.
+- `slsaProvenancePointer` - https URL to the SLSA attestation envelope for the executing build.
+- `supplyChainPointer` - https URL to the in-toto, Sigstore, or Rekor entry covering the build.
+
+```ts
+import { Agent } from "@asqav/sdk";
+
+const agent = await Agent.create({ apiKey: process.env.ASQAV_API_KEY! });
+const receipt = await agent.sign({
+  action: "tool.invoke",
+  toolName: "exec_query",
+  executableHash: "sha256:" + "a".repeat(64),
+  sbomDigest: "sha256:" + "b".repeat(64),
+  slsaProvenancePointer: "https://example.com/slsa/build-123.json",
+  supplyChainPointer: "https://rekor.sigstore.dev/api/v1/log/entries/abc",
+});
+```
+
+See <https://www.asqav.com/docs/executable-hash-and-sbom-provenance> for the field semantics and a worked policy example.
+
 ### Audit export
 
 The SDK exposes the public audit-trail endpoint as `exportAuditJson` for filtered windows of receipts (Pro tier and above):


### PR DESCRIPTION
## Summary

DA Sweep #1 finding **B2** fix-forward: `typescript/README.md` had zero mention of `executable_hash`/`sbom`/`slsa`/`supply_chain` despite the 4-tuple shipping in the SDK source (`typescript/src/index.ts` lines 437-452, 913-925, 1066-1069).

Adds a "Build provenance fields (optional)" subsection under "Compliance receipts (IETF profile)" covering all four optional wire fields (`executableHash`, `sbomDigest`, `slsaProvenancePointer`, `supplyChainPointer`) with a TS code example and a link to the canonical docs page at https://www.asqav.com/docs/executable-hash-and-sbom-provenance.

Pairs with the docs page shipped in asqav PR #566 (`website/docs/executable-hash-and-sbom-provenance.{md,html}`, live and returning 200).

## No version bump

Per `feedback_version_bump_threshold`: hold version bumps for substantial batches. README-only change. `@asqav/sdk` stays at 0.5.1.

## DA Sweep #1 finding B1 (related, no action)

B1 claimed `/docs/executable-hash`, `/docs/sbom-digest`, `/docs/supply-chain-provenance` returned 404. Cold-verified: DA was probing wrong slugs. The actual page shipped as `/docs/executable-hash-and-sbom-provenance` (HTTP 200 verified via curl). No fix needed in asqav repo.

## Test plan

- [x] `grep -c "executable_hash\|sbom\|slsa\|supply_chain\|executableHash\|sbomDigest\|slsaProvenance\|supplyChain" typescript/README.md` returns 9 (was 0)
- [x] Forbidden-token sweep clean (no em dashes, no forbidden email aliases)
- [x] `package.json` version unchanged at 0.5.1
- [ ] CI green
- [ ] Auto-merge on ci-ok