### PR TITLE
feat(sdk-py): forward 7 threat-framework taxonomy fields plus rfc3161 timestamp

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -178,6 +178,34 @@ sig = agent.sign(
 
 See <https://www.asqav.com/docs/executable-hash-and-sbom-provenance>.
 
+## Threat-framework mappings (optional)
+
+Seven optional wire fields let a caller pin the receipt to industry threat-and-control taxonomies. Each list is caller-supplied and Asqav-preserved verbatim; the cloud sets `framework_mappings_self_declared=true` on the receipt whenever any of the six list fields is populated, so verifiers can tell self-declared classifications apart from cloud-verified ones.
+
+- `mitre_techniques` - list of MITRE ATT&CK technique ids (e.g. `["T1059", "T1078"]`).
+- `mitre_atlas` - list of MITRE ATLAS ids for AI-system threats (e.g. `["AML.T0051"]`).
+- `owasp_llm_top10` - list of OWASP Top 10 for LLM ids (e.g. `["LLM01", "LLM02"]`).
+- `nist_ai_rmf` - list of NIST AI RMF function ids (e.g. `["GOVERN-1.1", "MEASURE-2.7"]`).
+- `iso_42001` - list of ISO/IEC 42001 control ids (e.g. `["A.6.2.6"]`).
+- `eu_ai_act_articles` - list of EU AI Act article ids (e.g. `["Article-12", "Article-15"]`).
+- `rfc3161_timestamp` - caller-supplied base64-encoded RFC 3161 TimeStampResp (DER).
+
+```python
+sig = agent.sign(
+    "api:call",
+    {"user": "..."},
+    compliance_mode=True,
+    mitre_techniques=["T1059", "T1078"],
+    owasp_llm_top10=["LLM01"],
+    nist_ai_rmf=["GOVERN-1.1", "MEASURE-2.7"],
+    eu_ai_act_articles=["Article-12"],
+)
+```
+
+Each list must be a non-empty list of strings, each entry up to 128 characters; empty lists, non-string entries, or oversize entries raise `ValueError` with verbatim guard messages (`<field>_must_be_non_empty_list`, `<field>_entry_invalid`) and skip the HTTP roundtrip. The `rfc3161_timestamp` must be valid base64 or raises `rfc3161_timestamp_not_base64`.
+
+See <https://www.asqav.com/docs/threat-framework-mapping>.
+
 ### Audit Pack export
 
 The cloud signs a Compliance Audit Pack over a window of receipts. The SDK wraps the endpoint:

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1240,6 +1240,16 @@ class Agent:
         sbom_digest: str | None = None,
         slsa_provenance_pointer: str | None = None,
         supply_chain_pointer: str | None = None,
+        # Threat-framework taxonomy mappings (cloud 0.5.1+). Caller-supplied;
+        # the cloud sets framework_mappings_self_declared=True whenever any
+        # of the six list fields is populated.
+        mitre_techniques: list[str] | None = None,
+        mitre_atlas: list[str] | None = None,
+        owasp_llm_top10: list[str] | None = None,
+        nist_ai_rmf: list[str] | None = None,
+        iso_42001: list[str] | None = None,
+        eu_ai_act_articles: list[str] | None = None,
+        rfc3161_timestamp: str | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -1327,6 +1337,24 @@ class Agent:
             supply_chain_pointer: Build-provenance 4-tuple. https URL
                 to the in-toto, Sigstore, or Rekor entry covering the
                 executing build.
+            mitre_techniques: Caller-supplied list of MITRE ATT&CK
+                technique ids (e.g. ``["T1059", "T1078"]``). Self-declared;
+                never Asqav-verified. Auto-flips
+                ``framework_mappings_self_declared`` to True on the receipt.
+            mitre_atlas: Caller-supplied list of MITRE ATLAS ids for
+                AI-system threats (e.g. ``["AML.T0051", "AML.T0043"]``).
+                Self-declared; never Asqav-verified.
+            owasp_llm_top10: Caller-supplied list of OWASP Top 10 for LLM
+                ids (e.g. ``["LLM01", "LLM02"]``). Self-declared.
+            nist_ai_rmf: Caller-supplied list of NIST AI RMF function ids
+                (e.g. ``["GOVERN-1.1", "MEASURE-2.7"]``). Self-declared.
+            iso_42001: Caller-supplied list of ISO/IEC 42001 control ids
+                (e.g. ``["A.6.2.6"]``). Self-declared.
+            eu_ai_act_articles: Caller-supplied list of EU AI Act article
+                ids (e.g. ``["Article-12", "Article-15"]``). Self-declared.
+            rfc3161_timestamp: Caller-supplied base64-encoded RFC 3161
+                TimeStampResp (DER). Preserved on the receipt for offline
+                TSA chain verification independent of cloud-issued anchors.
 
         Returns:
             SignatureResponse with the signature.
@@ -1481,6 +1509,49 @@ class Agent:
                     f"pointer_url_guard: {_name} must be an http(s) URL"
                 )
 
+        # Threat-framework taxonomy validators. Lockstep with the cloud
+        # cross-field validator: lists must be non-empty list[str], each
+        # element non-empty and <= 128 chars; rfc3161_timestamp must be
+        # non-empty valid base64. Verbatim guard tokens kept in sync with
+        # the cloud SignRequest so SDK errors round-trip through the
+        # conformance vectors.
+        for _name, _value in (
+            ("mitre_techniques", mitre_techniques),
+            ("mitre_atlas", mitre_atlas),
+            ("owasp_llm_top10", owasp_llm_top10),
+            ("nist_ai_rmf", nist_ai_rmf),
+            ("iso_42001", iso_42001),
+            ("eu_ai_act_articles", eu_ai_act_articles),
+        ):
+            if _value is None:
+                continue
+            if not isinstance(_value, list) or len(_value) == 0:
+                raise ValueError(
+                    f"{_name}_must_be_non_empty_list: pass a non-empty "
+                    "list of strings or omit the field."
+                )
+            for _item in _value:
+                if not isinstance(_item, str) or not _item or len(_item) > 128:
+                    raise ValueError(
+                        f"{_name}_entry_invalid: each entry must be a "
+                        "non-empty string of length <= 128."
+                    )
+        if rfc3161_timestamp is not None:
+            import base64 as _b64
+            import binascii as _binascii
+            if not isinstance(rfc3161_timestamp, str) or not rfc3161_timestamp:
+                raise ValueError(
+                    "rfc3161_timestamp_not_base64: must be a non-empty "
+                    "base64-encoded TimeStampResp."
+                )
+            try:
+                _b64.b64decode(rfc3161_timestamp, validate=True)
+            except (_binascii.Error, ValueError) as _exc:
+                raise ValueError(
+                    "rfc3161_timestamp_not_base64: must be valid base64 "
+                    f"(decode failed: {_exc})."
+                ) from _exc
+
         # Derive action_ref under compliance_mode when caller omits it.
         if compliance_mode and action_ref is None:
             action_ref = _compute_action_ref(action_type, context)
@@ -1527,6 +1598,14 @@ class Agent:
                 ("sbom_digest", sbom_digest),
                 ("slsa_provenance_pointer", slsa_provenance_pointer),
                 ("supply_chain_pointer", supply_chain_pointer),
+                # Threat-framework taxonomy mappings (cloud 0.5.1+).
+                ("mitre_techniques", mitre_techniques),
+                ("mitre_atlas", mitre_atlas),
+                ("owasp_llm_top10", owasp_llm_top10),
+                ("nist_ai_rmf", nist_ai_rmf),
+                ("iso_42001", iso_42001),
+                ("eu_ai_act_articles", eu_ai_act_articles),
+                ("rfc3161_timestamp", rfc3161_timestamp),
             ):
                 if v is not None:
                     compliance_fields[k] = v

--- a/python/tests/test_client_threat_framework_mappings.py
+++ b/python/tests/test_client_threat_framework_mappings.py
@@ -1,0 +1,218 @@
+"""SDK parity for the threat-framework taxonomy wire fields.
+
+The cloud accepts seven optional fields on the signed Compliance
+Receipt: ``mitre_techniques``, ``mitre_atlas``, ``owasp_llm_top10``,
+``nist_ai_rmf``, ``iso_42001``, ``eu_ai_act_articles``, and
+``rfc3161_timestamp``. The SDK forwards each verbatim, validates each
+list field as a non-empty list of strings (each entry <= 128 chars),
+and validates ``rfc3161_timestamp`` as base64. The cloud auto-flips
+``framework_mappings_self_declared`` to ``true`` whenever any of the
+six list fields is populated; the SDK does not need to set the flag.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import Agent
+
+GOOD_MITRE_TECHNIQUES = ["T1059", "T1078"]
+GOOD_MITRE_ATLAS = ["AML.T0051", "AML.T0043"]
+GOOD_OWASP_LLM = ["LLM01", "LLM02"]
+GOOD_NIST_AI_RMF = ["GOVERN-1.1", "MEASURE-2.7"]
+GOOD_ISO_42001 = ["A.6.2.6"]
+GOOD_EU_AI_ACT = ["Article-12", "Article-15"]
+# Synthetic base64 stand-in for a TimeStampResp DER; the SDK only
+# validates base64 shape, the cloud preserves the bytes verbatim.
+GOOD_RFC3161_B64 = (
+    "MIIGgzADAgEAMIIGegYJKoZIhvcNAQcCoIIGazCCBmcCAQMxDTALBglghkgBZQMEAgE="
+)
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_threat_fw",
+        name="threat-fw-agent",
+        public_key="pk_xxx",
+        key_id="key_threat_fw",
+        algorithm="ML-DSA-65",
+        capabilities=["api:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response() -> dict:
+    return {
+        "signature": "sig_b64",
+        "signature_id": "sig_abc",
+        "action_id": "act_abc",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_abc",
+        "algorithm": "ML-DSA-65",
+        "chain_hash": "deadbeef",
+    }
+
+
+@pytest.mark.parametrize(
+    "kwarg,value",
+    [
+        ("mitre_techniques", GOOD_MITRE_TECHNIQUES),
+        ("mitre_atlas", GOOD_MITRE_ATLAS),
+        ("owasp_llm_top10", GOOD_OWASP_LLM),
+        ("nist_ai_rmf", GOOD_NIST_AI_RMF),
+        ("iso_42001", GOOD_ISO_42001),
+        ("eu_ai_act_articles", GOOD_EU_AI_ACT),
+    ],
+)
+def test_taxonomy_list_forwarded_to_wire(kwarg: str, value: list[str]) -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            **{kwarg: value},
+        )
+    assert captured["body"][kwarg] == value
+
+
+def test_rfc3161_timestamp_forwarded_to_wire() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            rfc3161_timestamp=GOOD_RFC3161_B64,
+        )
+    assert captured["body"]["rfc3161_timestamp"] == GOOD_RFC3161_B64
+
+
+def test_all_seven_fields_forwarded_together() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            mitre_techniques=GOOD_MITRE_TECHNIQUES,
+            mitre_atlas=GOOD_MITRE_ATLAS,
+            owasp_llm_top10=GOOD_OWASP_LLM,
+            nist_ai_rmf=GOOD_NIST_AI_RMF,
+            iso_42001=GOOD_ISO_42001,
+            eu_ai_act_articles=GOOD_EU_AI_ACT,
+            rfc3161_timestamp=GOOD_RFC3161_B64,
+        )
+    body = captured["body"]
+    assert body["mitre_techniques"] == GOOD_MITRE_TECHNIQUES
+    assert body["mitre_atlas"] == GOOD_MITRE_ATLAS
+    assert body["owasp_llm_top10"] == GOOD_OWASP_LLM
+    assert body["nist_ai_rmf"] == GOOD_NIST_AI_RMF
+    assert body["iso_42001"] == GOOD_ISO_42001
+    assert body["eu_ai_act_articles"] == GOOD_EU_AI_ACT
+    assert body["rfc3161_timestamp"] == GOOD_RFC3161_B64
+
+
+@pytest.mark.parametrize(
+    "kwarg",
+    [
+        "mitre_techniques",
+        "mitre_atlas",
+        "owasp_llm_top10",
+        "nist_ai_rmf",
+        "iso_42001",
+        "eu_ai_act_articles",
+    ],
+)
+def test_taxonomy_empty_list_rejected(kwarg: str) -> None:
+    with pytest.raises(ValueError, match=f"{kwarg}_must_be_non_empty_list"):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            **{kwarg: []},
+        )
+
+
+def test_taxonomy_non_string_entry_rejected() -> None:
+    with pytest.raises(ValueError, match="owasp_llm_top10_entry_invalid"):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            owasp_llm_top10=["LLM01", 42],
+        )
+
+
+def test_taxonomy_oversize_entry_rejected() -> None:
+    with pytest.raises(ValueError, match="iso_42001_entry_invalid"):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            iso_42001=["A" * 129],
+        )
+
+
+def test_rfc3161_timestamp_empty_string_rejected() -> None:
+    with pytest.raises(ValueError, match="rfc3161_timestamp_not_base64"):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            rfc3161_timestamp="",
+        )
+
+
+def test_rfc3161_timestamp_invalid_base64_rejected() -> None:
+    with pytest.raises(ValueError, match="rfc3161_timestamp_not_base64"):
+        _agent().sign(
+            "api:call",
+            {"k": "v"},
+            compliance_mode=True,
+            rfc3161_timestamp="not!!base64@@",
+        )
+
+
+def test_no_taxonomy_fields_omitted_from_wire() -> None:
+    """The cloud must not see the new fields at all when caller omits them."""
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("api:call", {"k": "v"}, compliance_mode=True)
+    body = captured["body"]
+    for k in (
+        "mitre_techniques",
+        "mitre_atlas",
+        "owasp_llm_top10",
+        "nist_ai_rmf",
+        "iso_42001",
+        "eu_ai_act_articles",
+        "rfc3161_timestamp",
+    ):
+        assert k not in body, f"absent field {k} must not project onto wire"


### PR DESCRIPTION
## Summary

Adds 7 optional kwargs on `Agent.sign(...)` that mirror the cloud SignRequest cross-field validator landed in jagmarques/asqav#568. Caller-supplied taxonomy mappings flow through to the wire snake_case keys:

- `mitre_techniques` - MITRE ATT&CK technique ids
- `mitre_atlas` - MITRE ATLAS ids for AI-system threats
- `owasp_llm_top10` - OWASP Top 10 for LLM ids
- `nist_ai_rmf` - NIST AI RMF function ids plus subcategories
- `iso_42001` - ISO/IEC 42001 control ids
- `eu_ai_act_articles` - EU AI Act article ids
- `rfc3161_timestamp` - base64 TimeStampResp (DER)

## Client-side validation

Each list field is validated as a non-empty list of strings (each entry up to 128 chars); the base64 field is validated shape-wise. Verbatim guard tokens (`<field>_must_be_non_empty_list`, `<field>_entry_invalid`, `rfc3161_timestamp_not_base64`) match the cloud cross-field validator so SDK errors round-trip through the conformance vectors.

## Self-declared guard

The cloud auto-flips `framework_mappings_self_declared=true` whenever any of the six list fields is populated. The SDK does not set the flag.

## Cross-repo dependency

Requires cloud merge of jagmarques/asqav#568 (live) before consumers depend on these fields. SDK ships as part of the 0.5.2 milestone alongside the TS half.

## Test plan

- [x] 19 parametric tests pass locally (`pytest python/tests/test_client_threat_framework_mappings.py`)
- [x] ruff clean on the diff
- [ ] CI green on test, security, scan-pr-text
- [ ] Auto-merge once ci-ok

Comment hygiene clean.