### PR TITLE
feat(sdk-ts): forward 7 threat-framework taxonomy fields plus rfc3161 timestamp

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -180,6 +180,34 @@ const receipt = await agent.sign({
 
 See <https://www.asqav.com/docs/executable-hash-and-sbom-provenance> for the field semantics and a worked policy example.
 
+## Threat-framework mappings (optional)
+
+Seven optional wire fields let a caller pin the receipt to industry threat-and-control taxonomies. Each list is caller-supplied and Asqav-preserved verbatim; the cloud sets `framework_mappings_self_declared=true` on the receipt whenever any of the six list fields is populated, so verifiers can tell self-declared classifications apart from cloud-verified ones.
+
+- `mitreTechniques` - list of MITRE ATT&CK technique ids (e.g. `["T1059", "T1078"]`).
+- `mitreAtlas` - list of MITRE ATLAS ids for AI-system threats (e.g. `["AML.T0051"]`).
+- `owaspLlmTop10` - list of OWASP Top 10 for LLM ids (e.g. `["LLM01", "LLM02"]`).
+- `nistAiRmf` - list of NIST AI RMF function ids (e.g. `["GOVERN-1.1", "MEASURE-2.7"]`).
+- `iso42001` - list of ISO/IEC 42001 control ids (e.g. `["A.6.2.6"]`).
+- `euAiActArticles` - list of EU AI Act article ids (e.g. `["Article-12", "Article-15"]`).
+- `rfc3161Timestamp` - caller-supplied base64-encoded RFC 3161 TimeStampResp (DER).
+
+```ts
+const receipt = await agent.sign({
+  actionType: "api:call",
+  context: { user: "..." },
+  complianceMode: true,
+  mitreTechniques: ["T1059", "T1078"],
+  owaspLlmTop10: ["LLM01"],
+  nistAiRmf: ["GOVERN-1.1", "MEASURE-2.7"],
+  euAiActArticles: ["Article-12"],
+});
+```
+
+Each list must be a non-empty array of strings, each entry up to 128 characters; empty arrays, non-string entries, or oversize entries throw `AsqavError` with verbatim guard messages (`<field>_must_be_non_empty_list`, `<field>_entry_invalid`) and skip the HTTP roundtrip. The `rfc3161Timestamp` must be valid base64 or throws `rfc3161_timestamp_not_base64`. Camel-case props project onto snake_case wire keys via the SDK's `IETF_OPTIONAL_FIELD_MAP`.
+
+See <https://www.asqav.com/docs/threat-framework-mapping>.
+
 ### Audit export
 
 The SDK exposes the public audit-trail endpoint as `exportAuditJson` for filtered windows of receipts (Pro tier and above):

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -450,6 +450,37 @@ export interface SignOptions {
   /** Build-provenance 4-tuple. https URL to the in-toto, Sigstore, or
    * Rekor entry covering the executing build. */
   supplyChainPointer?: string;
+
+  /** Caller-supplied list of MITRE ATT&CK technique ids (e.g.
+   * `["T1059", "T1078"]`). Self-declared; never Asqav-verified. Cloud
+   * sets `framework_mappings_self_declared=true` whenever any of the six
+   * taxonomy lists is populated. */
+  mitreTechniques?: string[];
+
+  /** Caller-supplied list of MITRE ATLAS ids for AI-system threats
+   * (e.g. `["AML.T0051", "AML.T0043"]`). Self-declared. */
+  mitreAtlas?: string[];
+
+  /** Caller-supplied list of OWASP Top 10 for LLM ids
+   * (e.g. `["LLM01", "LLM02"]`). Self-declared. */
+  owaspLlmTop10?: string[];
+
+  /** Caller-supplied list of NIST AI RMF function ids and subcategories
+   * (e.g. `["GOVERN-1.1", "MEASURE-2.7"]`). Self-declared. */
+  nistAiRmf?: string[];
+
+  /** Caller-supplied list of ISO/IEC 42001 control ids (e.g.
+   * `["A.6.2.6"]`). Self-declared. */
+  iso42001?: string[];
+
+  /** Caller-supplied list of EU AI Act article ids (e.g.
+   * `["Article-12", "Article-15"]`). Self-declared. */
+  euAiActArticles?: string[];
+
+  /** Caller-supplied base64-encoded RFC 3161 TimeStampResp (DER).
+   * Preserved on the receipt for offline TSA chain verification
+   * independent of cloud-issued anchors. */
+  rfc3161Timestamp?: string;
 }
 
 export interface CoSignature {
@@ -931,6 +962,66 @@ function validateSignOptions(options: SignOptions): void {
       );
     }
   }
+  // Threat-framework taxonomy validators. Lockstep with the cloud
+  // SignRequest cross-field validator: lists must be non-empty
+  // arrays of strings (each entry up to 128 chars); rfc3161Timestamp
+  // must be valid base64. Verbatim guard tokens kept in sync with
+  // the cloud and Python SDK so SDK errors round-trip through the
+  // conformance vectors.
+  const _taxonomyChecks: Array<[string, string[] | undefined]> = [
+    ["mitre_techniques", options.mitreTechniques],
+    ["mitre_atlas", options.mitreAtlas],
+    ["owasp_llm_top10", options.owaspLlmTop10],
+    ["nist_ai_rmf", options.nistAiRmf],
+    ["iso_42001", options.iso42001],
+    ["eu_ai_act_articles", options.euAiActArticles],
+  ];
+  for (const [name, value] of _taxonomyChecks) {
+    if (value === undefined) continue;
+    if (!Array.isArray(value) || value.length === 0) {
+      throw new AsqavError(
+        `${name}_must_be_non_empty_list: pass a non-empty list of strings or omit the field.`,
+      );
+    }
+    for (const item of value) {
+      if (typeof item !== "string" || item.length === 0 || item.length > 128) {
+        throw new AsqavError(
+          `${name}_entry_invalid: each entry must be a non-empty string of length <= 128.`,
+        );
+      }
+    }
+  }
+  if (options.rfc3161Timestamp !== undefined) {
+    const t = options.rfc3161Timestamp;
+    if (typeof t !== "string" || t.length === 0) {
+      throw new AsqavError(
+        "rfc3161_timestamp_not_base64: must be a non-empty base64-encoded TimeStampResp.",
+      );
+    }
+    // Tight base64 shape check; reject any non-base64 char or bad padding.
+    if (!/^[A-Za-z0-9+/]+={0,2}$/.test(t) || (t.length % 4) !== 0) {
+      throw new AsqavError(
+        "rfc3161_timestamp_not_base64: must be valid base64.",
+      );
+    }
+    try {
+      // Node Buffer round-trip catches padding errors strict mode misses.
+      const { Buffer } = require("node:buffer") as typeof import("node:buffer");
+      const decoded = Buffer.from(t, "base64");
+      const reencoded = decoded.toString("base64");
+      // Reject when re-encoded form differs (catches non-canonical padding).
+      if (reencoded !== t) {
+        throw new AsqavError(
+          "rfc3161_timestamp_not_base64: must be valid base64.",
+        );
+      }
+    } catch (err) {
+      if (err instanceof AsqavError) throw err;
+      throw new AsqavError(
+        `rfc3161_timestamp_not_base64: must be valid base64 (decode failed: ${err}).`,
+      );
+    }
+  }
   validateIncidentClass(options.incidentClass);
 }
 
@@ -1067,6 +1158,14 @@ const IETF_OPTIONAL_FIELD_MAP: ReadonlyArray<{
   { wire: "sbom_digest", read: (o) => o.sbomDigest },
   { wire: "slsa_provenance_pointer", read: (o) => o.slsaProvenancePointer },
   { wire: "supply_chain_pointer", read: (o) => o.supplyChainPointer },
+  // Threat-framework taxonomy mappings (cloud 0.5.1+).
+  { wire: "mitre_techniques", read: (o) => o.mitreTechniques },
+  { wire: "mitre_atlas", read: (o) => o.mitreAtlas },
+  { wire: "owasp_llm_top10", read: (o) => o.owaspLlmTop10 },
+  { wire: "nist_ai_rmf", read: (o) => o.nistAiRmf },
+  { wire: "iso_42001", read: (o) => o.iso42001 },
+  { wire: "eu_ai_act_articles", read: (o) => o.euAiActArticles },
+  { wire: "rfc3161_timestamp", read: (o) => o.rfc3161Timestamp },
   {
     wire: "tool_fingerprint",
     read: (o) =>

--- a/typescript/tests/threatFrameworkMappings.test.ts
+++ b/typescript/tests/threatFrameworkMappings.test.ts
@@ -1,0 +1,209 @@
+/**
+ * SDK parity for the threat-framework taxonomy wire fields.
+ *
+ * Seven optional wire fields on `agent.sign({...})` mirror the cloud
+ * SignRequest cross-field validator: `mitre_techniques`, `mitre_atlas`,
+ * `owasp_llm_top10`, `nist_ai_rmf`, `iso_42001`, `eu_ai_act_articles`,
+ * and `rfc3161_timestamp`. The SDK forwards each verbatim, validates
+ * each list field as a non-empty array of strings (each entry <= 128
+ * chars), and validates `rfc3161Timestamp` as base64.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Agent, _resetForTests, init } from "../src/index.js";
+
+const GOOD_MITRE_TECHNIQUES = ["T1059", "T1078"];
+const GOOD_MITRE_ATLAS = ["AML.T0051", "AML.T0043"];
+const GOOD_OWASP_LLM = ["LLM01", "LLM02"];
+const GOOD_NIST_AI_RMF = ["GOVERN-1.1", "MEASURE-2.7"];
+const GOOD_ISO_42001 = ["A.6.2.6"];
+const GOOD_EU_AI_ACT = ["Article-12", "Article-15"];
+const GOOD_RFC3161_B64 =
+  "MIIGgzADAgEAMIIGegYJKoZIhvcNAQcCoIIGazCCBmcCAQMxDTALBglghkgBZQMEAgE=";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_threat_fw",
+    name: "threat_fw",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-05-25T00:00:00Z",
+  });
+}
+
+function okBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    signature: "sig",
+    signature_id: "sig_test",
+    action_id: "act_test",
+    timestamp: "2026-05-25T00:00:00Z",
+    verification_url: "https://verify",
+    ...extra,
+  };
+}
+
+function readBody(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
+  const init = spy.mock.calls[0][1] as RequestInit;
+  return JSON.parse((init?.body as string) ?? "{}");
+}
+
+beforeEach(() => {
+  _resetForTests();
+  init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("threat-framework taxonomy wire forwarding", () => {
+  it.each([
+    ["mitre_techniques", "mitreTechniques", GOOD_MITRE_TECHNIQUES],
+    ["mitre_atlas", "mitreAtlas", GOOD_MITRE_ATLAS],
+    ["owasp_llm_top10", "owaspLlmTop10", GOOD_OWASP_LLM],
+    ["nist_ai_rmf", "nistAiRmf", GOOD_NIST_AI_RMF],
+    ["iso_42001", "iso42001", GOOD_ISO_42001],
+    ["eu_ai_act_articles", "euAiActArticles", GOOD_EU_AI_ACT],
+  ])("forwards %s to the wire as snake_case", async (wire, kwarg, value) => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "api:call",
+      context: { k: "v" },
+      complianceMode: true,
+      [kwarg]: value,
+    } as any);
+    const body = readBody(spy);
+    expect(body[wire]).toEqual(value);
+  });
+
+  it("forwards rfc3161_timestamp to the wire", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "api:call",
+      context: { k: "v" },
+      complianceMode: true,
+      rfc3161Timestamp: GOOD_RFC3161_B64,
+    });
+    const body = readBody(spy);
+    expect(body.rfc3161_timestamp).toBe(GOOD_RFC3161_B64);
+  });
+
+  it("forwards all seven fields together", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "api:call",
+      context: { k: "v" },
+      complianceMode: true,
+      mitreTechniques: GOOD_MITRE_TECHNIQUES,
+      mitreAtlas: GOOD_MITRE_ATLAS,
+      owaspLlmTop10: GOOD_OWASP_LLM,
+      nistAiRmf: GOOD_NIST_AI_RMF,
+      iso42001: GOOD_ISO_42001,
+      euAiActArticles: GOOD_EU_AI_ACT,
+      rfc3161Timestamp: GOOD_RFC3161_B64,
+    });
+    const body = readBody(spy);
+    expect(body.mitre_techniques).toEqual(GOOD_MITRE_TECHNIQUES);
+    expect(body.mitre_atlas).toEqual(GOOD_MITRE_ATLAS);
+    expect(body.owasp_llm_top10).toEqual(GOOD_OWASP_LLM);
+    expect(body.nist_ai_rmf).toEqual(GOOD_NIST_AI_RMF);
+    expect(body.iso_42001).toEqual(GOOD_ISO_42001);
+    expect(body.eu_ai_act_articles).toEqual(GOOD_EU_AI_ACT);
+    expect(body.rfc3161_timestamp).toBe(GOOD_RFC3161_B64);
+  });
+
+  it("omits all seven fields from the wire when caller passes none", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "api:call",
+      context: { k: "v" },
+      complianceMode: true,
+    });
+    const body = readBody(spy);
+    for (const k of [
+      "mitre_techniques",
+      "mitre_atlas",
+      "owasp_llm_top10",
+      "nist_ai_rmf",
+      "iso_42001",
+      "eu_ai_act_articles",
+      "rfc3161_timestamp",
+    ]) {
+      expect(body[k]).toBeUndefined();
+    }
+  });
+});
+
+describe("threat-framework taxonomy validation", () => {
+  it.each([
+    ["mitre_techniques", "mitreTechniques"],
+    ["mitre_atlas", "mitreAtlas"],
+    ["owasp_llm_top10", "owaspLlmTop10"],
+    ["nist_ai_rmf", "nistAiRmf"],
+    ["iso_42001", "iso42001"],
+    ["eu_ai_act_articles", "euAiActArticles"],
+  ])("rejects empty list on %s with verbatim guard token", async (wire, kwarg) => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { k: "v" },
+        complianceMode: true,
+        [kwarg]: [],
+      } as any),
+    ).rejects.toThrow(`${wire}_must_be_non_empty_list`);
+  });
+
+  it("rejects non-string entry with verbatim guard token", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { k: "v" },
+        complianceMode: true,
+        owaspLlmTop10: ["LLM01", 42 as any],
+      }),
+    ).rejects.toThrow("owasp_llm_top10_entry_invalid");
+  });
+
+  it("rejects oversize entry with verbatim guard token", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { k: "v" },
+        complianceMode: true,
+        iso42001: ["A".repeat(129)],
+      }),
+    ).rejects.toThrow("iso_42001_entry_invalid");
+  });
+
+  it("rejects empty rfc3161Timestamp with verbatim guard token", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { k: "v" },
+        complianceMode: true,
+        rfc3161Timestamp: "",
+      }),
+    ).rejects.toThrow("rfc3161_timestamp_not_base64");
+  });
+
+  it("rejects invalid base64 rfc3161Timestamp with verbatim guard token", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { k: "v" },
+        complianceMode: true,
+        rfc3161Timestamp: "not!!base64@@",
+      }),
+    ).rejects.toThrow("rfc3161_timestamp_not_base64");
+  });
+});


### PR DESCRIPTION
## Summary

Adds 7 optional camelCase props on `SignOptions` that project onto snake_case wire keys via `IETF_OPTIONAL_FIELD_MAP`, mirroring the SDK Python half landed alongside this PR (jagmarques/asqav-sdk c31/sdk-py-threat-frameworks):

- `mitreTechniques` -> `mitre_techniques`
- `mitreAtlas` -> `mitre_atlas`
- `owaspLlmTop10` -> `owasp_llm_top10`
- `nistAiRmf` -> `nist_ai_rmf`
- `iso42001` -> `iso_42001`
- `euAiActArticles` -> `eu_ai_act_articles`
- `rfc3161Timestamp` -> `rfc3161_timestamp`

## Client-side validation

Each list field is validated as a non-empty array of strings (each entry up to 128 chars); the base64 field is validated shape-wise via regex plus Buffer round-trip. Verbatim guard tokens match the cloud cross-field validator and the Python SDK so SDK errors round-trip through the conformance vectors.

## Self-declared guard

The cloud auto-flips `framework_mappings_self_declared=true` whenever any of the six list fields is populated. The SDK does not set the flag.

## Cross-repo dependency

Requires cloud merge of jagmarques/asqav#568 (live) before consumers depend on these fields. SDK ships as part of the 0.5.2 milestone alongside the Python half.

## Test plan

- [x] 19 vitest cases pass locally (`npx vitest run tests/threatFrameworkMappings.test.ts`)
- [x] `tsc --noEmit` clean
- [ ] CI green on test, security, scan-pr-text
- [ ] Auto-merge once ci-ok

Comment hygiene clean.