### PR TITLE
chore: bump SDK to 0.5.2 for threat-framework taxonomy mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [TypeScript 0.5.2] - 2026-05-26
+
+### Added
+- Threat-framework taxonomy mappings on `agent.sign({...})`: seven new optional camelCase props mirroring the cloud SignRequest cross-field validator. `mitreTechniques` (wire `mitre_techniques`, MITRE ATT&CK technique ids), `mitreAtlas` (`mitre_atlas`, MITRE ATLAS ids for AI-system threats), `owaspLlmTop10` (`owasp_llm_top10`, OWASP Top 10 for LLM ids), `nistAiRmf` (`nist_ai_rmf`, NIST AI RMF function ids and subcategories), `iso42001` (`iso_42001`, ISO/IEC 42001 control ids), `euAiActArticles` (`eu_ai_act_articles`, EU AI Act article ids), and `rfc3161Timestamp` (`rfc3161_timestamp`, base64-encoded TimeStampResp DER). All seven OPTIONAL. The cloud auto-flips `framework_mappings_self_declared=true` whenever any of the six list fields is populated, so verifiers can tell self-declared classifications apart from cloud-verified ones. Requires Asqav cloud 0.5.2 or higher.
+- Client-side validators emit verbatim guard tokens that round-trip through the conformance vectors: `<field>_must_be_non_empty_list` rejects an empty array; `<field>_entry_invalid` rejects non-string entries or strings >128 chars; `rfc3161_timestamp_not_base64` rejects malformed base64.
+- New tests in `typescript/tests/threatFrameworkMappings.test.ts` covering wire forwarding, validation rejection, omission, and the all-seven-together happy path.
+
+### Changed
+- CLI version string in `src/cli.ts` bumped to `"0.5.2"` to match the package version.
+
+## [Python 0.5.2] - 2026-05-26
+
+### Added
+- Threat-framework taxonomy mappings on `agent.sign(...)`: seven new optional kwargs mirroring the cloud SignRequest cross-field validator. `mitre_techniques` (MITRE ATT&CK technique ids), `mitre_atlas` (MITRE ATLAS ids for AI-system threats), `owasp_llm_top10` (OWASP Top 10 for LLM ids), `nist_ai_rmf` (NIST AI RMF function ids and subcategories), `iso_42001` (ISO/IEC 42001 control ids), `eu_ai_act_articles` (EU AI Act article ids), and `rfc3161_timestamp` (base64-encoded TimeStampResp DER). All seven are OPTIONAL; the cloud auto-flips `framework_mappings_self_declared=true` whenever any of the six list fields is populated. Requires Asqav cloud 0.5.2 or higher.
+- Client-side validators emit verbatim guard tokens that round-trip through the conformance vectors: `<field>_must_be_non_empty_list`, `<field>_entry_invalid`, `rfc3161_timestamp_not_base64`.
+- New parametric tests over the seven fields plus validation rejection (`python/tests/test_client_threat_framework_mappings.py`).
+
 ## [TypeScript 0.5.1] - 2026-05-25
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.1"
+version = "0.5.2"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -140,7 +140,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -33,7 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.1";
+export const CLI_VERSION = "0.5.2";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,


### PR DESCRIPTION
## Summary

Joint Python + TS version bump to 0.5.2 covering the 7 threat-framework taxonomy fields plus `rfc3161_timestamp` landed via PR #227 (Python) and PR #228 (TS). Single coordinated milestone bump per dual-publish rule; batch threshold met (7 fields + rfc3161 + matching cloud SignRequest validator + matching docs page).

## Files changed

- `python/pyproject.toml` version = `0.5.2`
- `typescript/package.json` version = `0.5.2`
- `typescript/src/cli.ts` `CLI_VERSION` = `"0.5.2"`
- `CHANGELOG.md` sections for `Python 0.5.2` and `TypeScript 0.5.2`

## Order of merge

This PR lands AFTER:
1. Cloud PR jagmarques/asqav#568 merges and the post-deploy probe confirms the wire vocabulary live in `/.well-known/governance.json`
2. SDK feature PR #227 (Python) merges via auto-merge on `ci-ok`
3. SDK feature PR #228 (TS) merges via auto-merge on `ci-ok`

Once merged, the maintainer runs `cd python && uv publish` and `cd typescript && npm publish --access public` per the playbook recipe.

## Test plan

- [x] No source-code changes (version strings + CHANGELOG only)
- [x] No forbidden tokens in commit body (sweep clean)
- [ ] CI green on test, security, scan-pr-text
- [ ] Auto-merge once ci-ok

Comment hygiene clean.