### PR TITLE
fix(sdk-ts): align guard messages with the cloud wire surface

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -899,46 +899,44 @@ function validateSignOptions(options: SignOptions): void {
       `invalid_capture_topology: '${options.captureTopology}' must be one of ${CAPTURE_TOPOLOGY_NAMESPACE.join(", ")}`,
     );
   }
+  // Rule 8 lockstep with the cloud SignRequest validator: passive_telemetry
+  // pairs only with protectmcp:observation or protectmcp:observation:result_bound.
   if (
     options.captureTopology === "passive_telemetry"
     && options.receiptType !== undefined
     && options.receiptType !== "protectmcp:observation"
+    && options.receiptType !== "protectmcp:observation:result_bound"
   ) {
     const offending = options.receiptType.split(":").slice(1).join(":") || options.receiptType;
     throw new AsqavError(
-      `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :${offending} (rule 8)`,
+      `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation[:result_bound], not :${offending} (rule 8)`,
     );
   }
-  // Rule 9 (NSA CSI U/OO/6030316-26 alignment): configuration_change
-  // receipts MUST carry configManifestDigest. Verbatim message kept in
-  // lockstep with the cloud SignRequest cross-field validator.
+  // Rule 9 lockstep with the cloud SignRequest cross-field validator.
   if (
     options.receiptType === "protectmcp:lifecycle:configuration_change"
     && options.configManifestDigest === undefined
   ) {
     throw new AsqavError(
-      "false_attestation_guard: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (rule 9)",
+      "configuration_change_missing_config_manifest_digest: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (sha256:<64 hex>).",
     );
   }
-  // Rule 10 (NSA CSI U/OO/6030316-26 alignment): the SDK accepts both the
-  // legacy `validSeconds` knob (server computes
-  // `valid_until = signed_at + valid_seconds`) and the new caller-supplied
-  // `expiresAt` horizon. Passing both at once produces two different audit
-  // horizons on the same receipt, so the SDK rejects the pair before the
-  // HTTP roundtrip. Verbatim message in lockstep with the cloud
-  // cross-field validator.
+  if (
+    options.receiptType === "protectmcp:observation:result_bound"
+    && options.resultDigest === undefined
+  ) {
+    throw new AsqavError(
+      "result_bound_missing_result_digest: receipt_type=protectmcp:observation:result_bound requires result_digest (sha256:<64 hex>).",
+    );
+  }
+  // Rule 10 lockstep with the cloud SignRequest cross-field validator.
   if (options.validSeconds !== undefined && options.expiresAt !== undefined) {
     throw new AsqavError(
       "expiry_collision_guard: pass either valid_seconds or expires_at, not both (rule 10)",
     );
   }
-  // Rule 11 (NSA CSI U/OO/6030316-26 alignment): every caller-supplied
-  // digest MUST match `sha256:<64-hex>`. A free-form `sha256:abc` would
-  // otherwise reach the cloud, pass the opaque-string accept, and break
-  // tamper detection at audit time. Verbatim message in lockstep with
-  // the cloud cross-field validator.
+  // Rule 11 lockstep: per-field tokens mirror cloud <field>_not_sha256_wire_form.
   const _digestChecks: Array<[string, string | undefined]> = [
-    ["tool_fingerprint", options.toolFingerprint],
     ["config_manifest_digest", options.configManifestDigest],
     ["cve_inventory_digest", options.cveInventoryDigest],
     ["executable_hash", options.executableHash],
@@ -947,9 +945,14 @@ function validateSignOptions(options: SignOptions): void {
   for (const [name, value] of _digestChecks) {
     if (value !== undefined && !SHA256_HEX_RE.test(value)) {
       throw new AsqavError(
-        `digest_format_guard: ${name} must match sha256:<64-hex> (rule 11)`,
+        `${name}_not_sha256_wire_form: must look like 'sha256:<64 lowercase hex>'.`,
       );
     }
+  }
+  if (options.toolFingerprint !== undefined && !SHA256_HEX_RE.test(options.toolFingerprint)) {
+    throw new AsqavError(
+      "digest_format_guard: tool_fingerprint must match sha256:<64-hex> (rule 11)",
+    );
   }
   const _pointerChecks: Array<[string, string | undefined]> = [
     ["slsa_provenance_pointer", options.slsaProvenancePointer],

--- a/typescript/tests/executableHash4Tuple.test.ts
+++ b/typescript/tests/executableHash4Tuple.test.ts
@@ -139,7 +139,7 @@ describe("executableHash shape guards", () => {
         complianceMode: true,
         executableHash: "deadbeef",
       }),
-    ).rejects.toThrow(/digest_format_guard: executable_hash/);
+    ).rejects.toThrow(/executable_hash_not_sha256_wire_form/);
   });
 
   it("rejects malformed sbom_digest before the HTTP roundtrip", async () => {
@@ -150,7 +150,7 @@ describe("executableHash shape guards", () => {
         complianceMode: true,
         sbomDigest: "not-a-digest",
       }),
-    ).rejects.toThrow(/digest_format_guard: sbom_digest/);
+    ).rejects.toThrow(/sbom_digest_not_sha256_wire_form/);
   });
 
   it("rejects non-http slsa_provenance_pointer", async () => {

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -192,10 +192,13 @@ describe("agent.sign IETF profile fields", () => {
         context: {},
         receiptType: t,
       };
-      // Rule 9 (NSA CSI U/OO/6030316-26 alignment): configuration_change
-      // receipts MUST carry config_manifest_digest.
+      // Rule 9 lockstep: configuration_change carries config_manifest_digest.
       if (t === "protectmcp:lifecycle:configuration_change") {
         opts.configManifestDigest = `sha256:${"0".repeat(64)}`;
+      }
+      // Rule 9 lockstep: result_bound carries result_digest.
+      if (t === "protectmcp:observation:result_bound") {
+        opts.resultDigest = `sha256:${"0".repeat(64)}`;
       }
       await expect(agent.sign(opts)).resolves.toBeDefined();
     }

--- a/typescript/tests/nsaAlignedFields.test.ts
+++ b/typescript/tests/nsaAlignedFields.test.ts
@@ -230,7 +230,7 @@ describe("Rule 9: configuration_change requires configManifestDigest", () => {
         policyDecision: "none",
       }),
     ).rejects.toThrow(
-      "false_attestation_guard: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (rule 9)",
+      "configuration_change_missing_config_manifest_digest: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (sha256:<64 hex>).",
     );
     expect(spy).not.toHaveBeenCalled();
   });
@@ -344,13 +344,25 @@ describe("Rule 11: digest_format_guard", () => {
   });
   afterEach(() => vi.restoreAllMocks());
 
-  const digestFields: Array<{ wire: string; opt: keyof Parameters<Agent["sign"]>[0] }> = [
-    { wire: "tool_fingerprint", opt: "toolFingerprint" },
-    { wire: "config_manifest_digest", opt: "configManifestDigest" },
-    { wire: "cve_inventory_digest", opt: "cveInventoryDigest" },
+  const digestFields: Array<{ wire: string; opt: keyof Parameters<Agent["sign"]>[0]; token: (w: string) => string }> = [
+    {
+      wire: "tool_fingerprint",
+      opt: "toolFingerprint",
+      token: (_w) => "digest_format_guard: tool_fingerprint must match sha256:<64-hex> (rule 11)",
+    },
+    {
+      wire: "config_manifest_digest",
+      opt: "configManifestDigest",
+      token: (w) => `${w}_not_sha256_wire_form: must look like 'sha256:<64 lowercase hex>'.`,
+    },
+    {
+      wire: "cve_inventory_digest",
+      opt: "cveInventoryDigest",
+      token: (w) => `${w}_not_sha256_wire_form: must look like 'sha256:<64 lowercase hex>'.`,
+    },
   ];
 
-  for (const { wire, opt } of digestFields) {
+  for (const { wire, opt, token } of digestFields) {
     it(`${wire}: valid format passes`, async () => {
       const spy = vi
         .spyOn(globalThis, "fetch")
@@ -372,9 +384,7 @@ describe("Rule 11: digest_format_guard", () => {
         complianceMode: true,
         [opt]: `md5:${"0".repeat(64)}`,
       } as unknown as Parameters<Agent["sign"]>[0];
-      await expect(fakeAgent().sign(sigOpts)).rejects.toThrow(
-        `digest_format_guard: ${wire} must match sha256:<64-hex> (rule 11)`,
-      );
+      await expect(fakeAgent().sign(sigOpts)).rejects.toThrow(token(wire));
       expect(spy).not.toHaveBeenCalled();
     });
 
@@ -385,9 +395,7 @@ describe("Rule 11: digest_format_guard", () => {
         complianceMode: true,
         [opt]: "sha256:abc123",
       } as unknown as Parameters<Agent["sign"]>[0];
-      await expect(fakeAgent().sign(sigOpts)).rejects.toThrow(
-        `digest_format_guard: ${wire} must match sha256:<64-hex> (rule 11)`,
-      );
+      await expect(fakeAgent().sign(sigOpts)).rejects.toThrow(token(wire));
       expect(spy).not.toHaveBeenCalled();
     });
 
@@ -398,9 +406,7 @@ describe("Rule 11: digest_format_guard", () => {
         complianceMode: true,
         [opt]: `sha256:${"Z".repeat(64)}`,
       } as unknown as Parameters<Agent["sign"]>[0];
-      await expect(fakeAgent().sign(sigOpts)).rejects.toThrow(
-        `digest_format_guard: ${wire} must match sha256:<64-hex> (rule 11)`,
-      );
+      await expect(fakeAgent().sign(sigOpts)).rejects.toThrow(token(wire));
       expect(spy).not.toHaveBeenCalled();
     });
   }
@@ -455,6 +461,9 @@ describe("protectmcp:observation:result_bound receipt type", () => {
       };
       if (receiptType === "protectmcp:lifecycle:configuration_change") {
         opts.configManifestDigest = computeConfigManifestDigest({ mode: "test" });
+      }
+      if (receiptType === "protectmcp:observation:result_bound") {
+        opts.resultDigest = `sha256:${"0".repeat(64)}`;
       }
       if (
         receiptType.startsWith("protectmcp:lifecycle")


### PR DESCRIPTION
## Summary

TS half of the c31-night-consistency SDK-cloud parity fix (mirrors #230).

- **F1 rule-8 widening** - `passive_telemetry` now accepts `protectmcp:observation:result_bound`. Error message carries the `[:result_bound]` suffix verbatim with the cloud.
- **F2 rule-9 prefix fix** - `configuration_change` error reads `configuration_change_missing_config_manifest_digest:` (verbatim cloud token).
- **F3 new rule-9 result_bound guard** - SDK fails closed when `protectmcp:observation:result_bound` is sent without `resultDigest`.
- **F4 rule-11 per-field tokens** - `config_manifest_digest`, `cve_inventory_digest`, `executable_hash`, `sbom_digest` raise `<field>_not_sha256_wire_form: ...`. `tool_fingerprint` keeps the umbrella `digest_format_guard:` token because cloud wire-shape (32 hex no prefix) and SDK helper output (`sha256:<64-hex>`) diverge - deeper parity gap tracked as NEXT.md carryover.

## THREAT_MODEL (per CLAUDE.md 2.3)

- New attack surface: tightened SDK gate around rule-9 result_bound and per-field digest format tokens. No new server-side trust boundary.
- Existing guard cover: yes; cloud already enforces.
- New test: result_bound + every-namespace-member parametrised assertions.
- Trust boundary change: NO.

User Advocate gate (CLAUDE.md 2.7) PASSED.

## Test plan

- [x] `npm run build` -> clean
- [x] `npm test` -> 366/366 pass
- [x] forbidden-token sweep on commit body -> clean
- [x] forbidden-pattern sweep on commit body -> clean
- [ ] CI green
- [ ] Auto-merge after `ci-ok`

## Agent chain

master-orchestrator + audit-1-inconsistency + audit-2-redundancy + audit-3-comments + audit-4-devil + CEO + CTO + FOR/AGAINST + User Advocate.