### PR TITLE
feat(sdk): add witness_policy to both SDK halves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [TypeScript 0.5.3] - 2026-05-29
+
+### Added
+- `witnessPolicy` on `agent.sign({...})`: one new optional camelCase prop mirroring the cloud `witness_policy` extension. Shape `{ required: number, witnesses: Array<"rfc3161" | "opentimestamps"> }`, projected to the snake_case `witness_policy` wire key via `IETF_OPTIONAL_FIELD_MAP`. Declares an N-of-M durable-anchoring quorum; the receipt reaches `witness_quorum_met` only when `required` witnesses hold a real inclusion proof. OPTIONAL; absent keeps today's behaviour. Requires Asqav cloud 0.5.3 or higher.
+- Client-side validators emit verbatim guard tokens that round-trip through the conformance vectors: `witness_policy_unknown_witness` rejects any witness outside the two shipped witnesses (`rekor` is rejected because it is not shipped), `witness_policy_required_out_of_range` rejects `required` outside `[1, witnesses.length]`, `witness_policy_witnesses_must_be_non_empty_list` rejects an empty list, `witness_policy_required_must_be_int` rejects a non-integer `required`, and `witness_policy_duplicate_witness` rejects duplicates.
+- New tests in `typescript/tests/witnessPolicy.test.ts` covering wire projection, the rekor rejection, the `required` range, and the other shape guards.
+- Exported `WITNESS_NAMESPACE`, the `Witness` type, and the `WitnessPolicy` interface.
+
+### Changed
+- CLI version string in `src/cli.ts` bumped to `"0.5.3"` to match the package version.
+
+## [Python 0.5.3] - 2026-05-29
+
+### Added
+- `witness_policy` kwarg on `agent.sign(...)`: one new optional kwarg mirroring the cloud `witness_policy` extension. Shape `{"required": int, "witnesses": [<subset of "rfc3161", "opentimestamps">]}`, forwarded verbatim to the wire. Declares an N-of-M durable-anchoring quorum; the receipt reaches `witness_quorum_met` only when `required` witnesses hold a real inclusion proof. OPTIONAL; absent keeps today's behaviour. Requires Asqav cloud 0.5.3 or higher.
+- Client-side validators emit verbatim guard tokens: `witness_policy_unknown_witness` (`rekor` is rejected because it is not shipped), `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, and `witness_policy_duplicate_witness`.
+- New tests in `python/tests/test_client_witness_policy.py` covering wire forwarding, the rekor rejection, the `required` range, and the other shape guards.
+- Exported `WITNESS_NAMESPACE` from `asqav.client`.
+
 ## [TypeScript 0.5.2] - 2026-05-26
 
 ### Added

--- a/python/README.md
+++ b/python/README.md
@@ -206,6 +206,26 @@ Each list must be a non-empty list of strings, each entry up to 128 characters; 
 
 See <https://www.asqav.com/docs/threat-framework-mapping>.
 
+## Witness policy (optional)
+
+`witness_policy` lets a caller declare an N-of-M durable-anchoring quorum on the receipt. The receipt reaches `witness_quorum_met` only when `required` witnesses hold a real inclusion proof.
+
+- Shape: `{"required": int, "witnesses": [<subset of "rfc3161", "opentimestamps">]}`.
+- `required` must be in `[1, len(witnesses)]`.
+- `witnesses` must be a non-empty subset of the two shipped witnesses: `rfc3161` and `opentimestamps`.
+- `rekor` is rejected. It is not a shipped witness.
+
+```python
+sig = agent.sign(
+    "deploy:release",
+    {"build": "..."},
+    compliance_mode=True,
+    witness_policy={"required": 1, "witnesses": ["rfc3161", "opentimestamps"]},
+)
+```
+
+Bad input raises `ValueError` with a verbatim guard message before the HTTP roundtrip: `witness_policy_unknown_witness` (e.g. `rekor`), `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, or `witness_policy_duplicate_witness`. Omit the field for today's behaviour.
+
 ### Audit Pack export
 
 The cloud signs a Compliance Audit Pack over a window of receipts. The SDK wraps the endpoint:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.2"
+version = "0.5.3"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -140,7 +140,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -236,6 +236,11 @@ SANDBOX_STATE_NAMESPACE: frozenset[str] = frozenset(
     {"enabled", "disabled", "unavailable"}
 )
 
+#: Durable-anchoring witnesses Asqav ships. The cloud `witness_policy`
+#: extension accepts only this set; `rekor` is explicitly rejected because
+#: it is not a shipped witness. Mirrors the live governance.json contract.
+WITNESS_NAMESPACE: frozenset[str] = frozenset({"rfc3161", "opentimestamps"})
+
 #: Producer-side `capture_topology` vocabulary mirrored from the cloud
 #: SignRequest Literal. See docs/capture-topology.md.
 CAPTURE_TOPOLOGY_NAMESPACE: frozenset[str] = frozenset(
@@ -1239,6 +1244,7 @@ class Agent:
         iso_42001: list[str] | None = None,
         eu_ai_act_articles: list[str] | None = None,
         rfc3161_timestamp: str | None = None,
+        witness_policy: dict[str, Any] | None = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -1344,6 +1350,15 @@ class Agent:
             rfc3161_timestamp: Caller-supplied base64-encoded RFC 3161
                 TimeStampResp (DER). Preserved on the receipt for offline
                 TSA chain verification independent of cloud-issued anchors.
+            witness_policy: Caller-declared N-of-M durable-anchoring quorum.
+                Shape ``{"required": int, "witnesses": [<subset of
+                "rfc3161", "opentimestamps">]}``. ``required`` must be in
+                ``[1, len(witnesses)]``; ``witnesses`` must be a non-empty
+                subset of the two shipped witnesses. ``rekor`` is rejected
+                (not a shipped witness). The receipt reaches
+                ``witness_quorum_met`` only when ``required`` witnesses hold
+                a real inclusion proof. Optional; omit for today's
+                behaviour.
 
         Returns:
             SignatureResponse with the signature.
@@ -1544,6 +1559,46 @@ class Agent:
                     f"(decode failed: {_exc})."
                 ) from _exc
 
+        # witness_policy lockstep with the cloud witness_policy extension:
+        # {required: int, witnesses: [<non-empty subset of rfc3161,
+        # opentimestamps>]}; required in [1, len(witnesses)]; rekor rejected.
+        if witness_policy is not None:
+            if not isinstance(witness_policy, dict):
+                raise ValueError(
+                    "witness_policy_invalid: must be a dict "
+                    '{"required": int, "witnesses": [...]}.'
+                )
+            _witnesses = witness_policy.get("witnesses")
+            _required = witness_policy.get("required")
+            if not isinstance(_witnesses, list) or len(_witnesses) == 0:
+                raise ValueError(
+                    "witness_policy_witnesses_must_be_non_empty_list: "
+                    "witnesses must be a non-empty list drawn from "
+                    f"{sorted(WITNESS_NAMESPACE)}."
+                )
+            for _w in _witnesses:
+                if _w not in WITNESS_NAMESPACE:
+                    raise ValueError(
+                        f"witness_policy_unknown_witness: '{_w}' is not a "
+                        "shipped witness; witnesses must be a subset of "
+                        f"{sorted(WITNESS_NAMESPACE)} (rekor is rejected)."
+                    )
+            if len(set(_witnesses)) != len(_witnesses):
+                raise ValueError(
+                    "witness_policy_duplicate_witness: witnesses must not "
+                    "contain duplicates."
+                )
+            if not isinstance(_required, int) or isinstance(_required, bool):
+                raise ValueError(
+                    "witness_policy_required_must_be_int: required must be "
+                    "an integer in [1, len(witnesses)]."
+                )
+            if not (1 <= _required <= len(_witnesses)):
+                raise ValueError(
+                    "witness_policy_required_out_of_range: required must be "
+                    f"in [1, {len(_witnesses)}] (got {_required})."
+                )
+
         # Derive action_ref under compliance_mode when caller omits it.
         if compliance_mode and action_ref is None:
             action_ref = _compute_action_ref(action_type, context)
@@ -1596,6 +1651,7 @@ class Agent:
                 ("iso_42001", iso_42001),
                 ("eu_ai_act_articles", eu_ai_act_articles),
                 ("rfc3161_timestamp", rfc3161_timestamp),
+                ("witness_policy", witness_policy),
             ):
                 if v is not None:
                     compliance_fields[k] = v

--- a/python/tests/test_client_witness_policy.py
+++ b/python/tests/test_client_witness_policy.py
@@ -1,0 +1,175 @@
+"""SDK parity for the ``witness_policy`` wire field.
+
+The cloud accepts an optional ``witness_policy`` object on the signed
+Compliance Receipt with shape
+``{"required": int, "witnesses": [<subset of "rfc3161",
+"opentimestamps">]}``. The SDK forwards it verbatim and validates the
+shape client-side: ``required`` in ``[1, len(witnesses)]``, ``witnesses``
+a non-empty subset of the two shipped witnesses, and ``rekor`` rejected.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import Agent
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_witness",
+        name="witness-agent",
+        public_key="pk_xxx",
+        key_id="key_witness",
+        algorithm="ML-DSA-65",
+        capabilities=["sign:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response() -> dict:
+    return {
+        "signature": "sig_b64",
+        "signature_id": "sig_abc",
+        "action_id": "act_abc",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_abc",
+        "algorithm": "ML-DSA-65",
+        "chain_hash": "deadbeef",
+    }
+
+
+def test_witness_policy_forwarded_to_wire() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    policy = {"required": 1, "witnesses": ["rfc3161", "opentimestamps"]}
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy=policy,
+        )
+    assert captured["body"]["witness_policy"] == policy
+
+
+def test_witness_policy_single_witness_forwarded() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    policy = {"required": 1, "witnesses": ["opentimestamps"]}
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy=policy,
+        )
+    assert captured["body"]["witness_policy"] == policy
+
+
+def test_witness_policy_rekor_rejected() -> None:
+    with pytest.raises(ValueError, match="witness_policy_unknown_witness"):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy={"required": 1, "witnesses": ["rekor"]},
+        )
+
+
+def test_witness_policy_rekor_in_mixed_list_rejected() -> None:
+    with pytest.raises(ValueError, match="witness_policy_unknown_witness"):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy={"required": 1, "witnesses": ["rfc3161", "rekor"]},
+        )
+
+
+def test_witness_policy_required_exceeds_len_rejected() -> None:
+    with pytest.raises(ValueError, match="witness_policy_required_out_of_range"):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy={"required": 3, "witnesses": ["rfc3161", "opentimestamps"]},
+        )
+
+
+def test_witness_policy_required_zero_rejected() -> None:
+    with pytest.raises(ValueError, match="witness_policy_required_out_of_range"):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy={"required": 0, "witnesses": ["rfc3161"]},
+        )
+
+
+def test_witness_policy_empty_witnesses_rejected() -> None:
+    with pytest.raises(
+        ValueError, match="witness_policy_witnesses_must_be_non_empty_list"
+    ):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy={"required": 1, "witnesses": []},
+        )
+
+
+def test_witness_policy_duplicate_witness_rejected() -> None:
+    with pytest.raises(ValueError, match="witness_policy_duplicate_witness"):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy={"required": 1, "witnesses": ["rfc3161", "rfc3161"]},
+        )
+
+
+def test_witness_policy_required_not_int_rejected() -> None:
+    with pytest.raises(ValueError, match="witness_policy_required_must_be_int"):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy={"required": "1", "witnesses": ["rfc3161"]},
+        )
+
+
+def test_witness_policy_not_dict_rejected() -> None:
+    with pytest.raises(ValueError, match="witness_policy_invalid"):
+        _agent().sign(
+            "deploy:release",
+            {"k": "v"},
+            compliance_mode=True,
+            witness_policy=["rfc3161"],  # type: ignore[arg-type]
+        )
+
+
+def test_witness_policy_absent_means_no_field() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("deploy:release", {"k": "v"}, compliance_mode=True)
+    assert "witness_policy" not in captured["body"]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "asqav"
-version = "0.5.0"
+version = "0.5.3"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -208,6 +208,26 @@ Each list must be a non-empty array of strings, each entry up to 128 characters;
 
 See <https://www.asqav.com/docs/threat-framework-mapping>.
 
+## Witness policy (optional)
+
+`witnessPolicy` lets a caller declare an N-of-M durable-anchoring quorum on the receipt. The receipt reaches `witness_quorum_met` only when `required` witnesses hold a real inclusion proof. It projects onto the snake_case `witness_policy` wire key via the SDK's `IETF_OPTIONAL_FIELD_MAP`.
+
+- Shape: `{ required: number, witnesses: Array<"rfc3161" | "opentimestamps"> }`.
+- `required` must be an integer in `[1, witnesses.length]`.
+- `witnesses` must be a non-empty subset of the two shipped witnesses: `rfc3161` and `opentimestamps`.
+- `rekor` is rejected. It is not a shipped witness.
+
+```typescript
+const sig = await agent.sign({
+  actionType: "deploy:release",
+  context: { build: "..." },
+  complianceMode: true,
+  witnessPolicy: { required: 1, witnesses: ["rfc3161", "opentimestamps"] },
+});
+```
+
+Bad input throws `AsqavError` with a verbatim guard message before the HTTP roundtrip: `witness_policy_unknown_witness` (e.g. `rekor`), `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, or `witness_policy_duplicate_witness`. Omit the field for today's behaviour.
+
 ### Audit Pack export
 
 The SDK exposes the public audit-trail endpoint as `exportAuditJson` for filtered windows of receipts (Pro tier and above):

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -33,7 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.2";
+export const CLI_VERSION = "0.5.3";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -102,6 +102,20 @@ export const CAPTURE_TOPOLOGY_NAMESPACE = [
 ] as const;
 export type CaptureTopology = (typeof CAPTURE_TOPOLOGY_NAMESPACE)[number];
 
+/** Durable-anchoring witnesses Asqav ships. The cloud `witness_policy`
+ * extension accepts only this set; `rekor` is explicitly rejected because
+ * it is not a shipped witness. Mirrors the live governance.json contract. */
+export const WITNESS_NAMESPACE = ["rfc3161", "opentimestamps"] as const;
+export type Witness = (typeof WITNESS_NAMESPACE)[number];
+
+/** Caller-declared N-of-M durable-anchoring quorum. `required` must be in
+ * `[1, witnesses.length]`; `witnesses` must be a non-empty subset of the
+ * two shipped witnesses. `rekor` is rejected. */
+export interface WitnessPolicy {
+  required: number;
+  witnesses: Witness[];
+}
+
 /** Risk class controlled vocabulary. */
 export type RiskClass = "low" | "medium" | "high" | "unknown";
 
@@ -481,6 +495,15 @@ export interface SignOptions {
    * Preserved on the receipt for offline TSA chain verification
    * independent of cloud-issued anchors. */
   rfc3161Timestamp?: string;
+
+  /** Caller-declared N-of-M durable-anchoring quorum. Shape
+   * `{ required, witnesses: [<subset of "rfc3161", "opentimestamps">] }`.
+   * `required` must be in `[1, witnesses.length]`; `witnesses` must be a
+   * non-empty subset of the two shipped witnesses. `rekor` is rejected
+   * (not a shipped witness). The receipt reaches `witness_quorum_met`
+   * only when `required` witnesses hold a real inclusion proof. Projected
+   * to the wire as snake_case `witness_policy`. */
+  witnessPolicy?: WitnessPolicy;
 }
 
 export interface CoSignature {
@@ -1025,7 +1048,53 @@ function validateSignOptions(options: SignOptions): void {
       );
     }
   }
+  validateWitnessPolicy(options.witnessPolicy);
   validateIncidentClass(options.incidentClass);
+}
+
+/**
+ * Reject malformed `witnessPolicy` before the HTTP roundtrip. Lockstep
+ * with the cloud witness_policy extension: `{ required, witnesses }` where
+ * `witnesses` is a non-empty subset of the two shipped witnesses and
+ * `required` is an integer in `[1, witnesses.length]`. `rekor` is rejected
+ * because it is not a shipped witness. Verbatim guard tokens match the
+ * Python SDK so SDK errors round-trip through the conformance vectors.
+ */
+function validateWitnessPolicy(value: WitnessPolicy | undefined): void {
+  if (value === undefined) return;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new AsqavError(
+      'witness_policy_invalid: must be an object { required: number, witnesses: [...] }.',
+    );
+  }
+  const { required, witnesses } = value;
+  if (!Array.isArray(witnesses) || witnesses.length === 0) {
+    throw new AsqavError(
+      `witness_policy_witnesses_must_be_non_empty_list: witnesses must be a non-empty list drawn from ${WITNESS_NAMESPACE.join(", ")}.`,
+    );
+  }
+  for (const w of witnesses) {
+    if (!(WITNESS_NAMESPACE as readonly string[]).includes(w)) {
+      throw new AsqavError(
+        `witness_policy_unknown_witness: '${w}' is not a shipped witness; witnesses must be a subset of ${WITNESS_NAMESPACE.join(", ")} (rekor is rejected).`,
+      );
+    }
+  }
+  if (new Set(witnesses).size !== witnesses.length) {
+    throw new AsqavError(
+      "witness_policy_duplicate_witness: witnesses must not contain duplicates.",
+    );
+  }
+  if (typeof required !== "number" || !Number.isInteger(required)) {
+    throw new AsqavError(
+      "witness_policy_required_must_be_int: required must be an integer in [1, witnesses.length].",
+    );
+  }
+  if (required < 1 || required > witnesses.length) {
+    throw new AsqavError(
+      `witness_policy_required_out_of_range: required must be in [1, ${witnesses.length}] (got ${required}).`,
+    );
+  }
 }
 
 /**
@@ -1169,6 +1238,8 @@ const IETF_OPTIONAL_FIELD_MAP: ReadonlyArray<{
   { wire: "iso_42001", read: (o) => o.iso42001 },
   { wire: "eu_ai_act_articles", read: (o) => o.euAiActArticles },
   { wire: "rfc3161_timestamp", read: (o) => o.rfc3161Timestamp },
+  // Durable-anchoring quorum (cloud witness_policy extension).
+  { wire: "witness_policy", read: (o) => o.witnessPolicy },
   {
     wire: "tool_fingerprint",
     read: (o) =>

--- a/typescript/tests/witnessPolicy.test.ts
+++ b/typescript/tests/witnessPolicy.test.ts
@@ -1,0 +1,179 @@
+/**
+ * SDK parity for the `witnessPolicy` wire field.
+ *
+ * The cloud accepts an optional `witness_policy` object on the signed
+ * Compliance Receipt with shape
+ * `{ required: int, witnesses: [<subset of "rfc3161", "opentimestamps">] }`.
+ * The SDK projects `witnessPolicy` to the snake_case `witness_policy` wire
+ * key verbatim and validates the shape client-side: `required` in
+ * `[1, witnesses.length]`, `witnesses` a non-empty subset of the two
+ * shipped witnesses, and `rekor` rejected.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Agent, _resetForTests, init } from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_witness",
+    name: "witness",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-05-25T00:00:00Z",
+  });
+}
+
+function okBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    signature: "sig",
+    signature_id: "sig_test",
+    action_id: "act_test",
+    timestamp: "2026-05-25T00:00:00Z",
+    verification_url: "https://verify",
+    ...extra,
+  };
+}
+
+function readBody(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
+  const init = spy.mock.calls[0][1] as RequestInit;
+  return JSON.parse((init?.body as string) ?? "{}");
+}
+
+beforeEach(() => {
+  _resetForTests();
+  init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("witnessPolicy wire forwarding", () => {
+  it("projects witnessPolicy to snake_case witness_policy", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "deploy:release",
+      context: { k: "v" },
+      complianceMode: true,
+      witnessPolicy: { required: 1, witnesses: ["rfc3161", "opentimestamps"] },
+    });
+    const body = readBody(spy);
+    expect(body.witness_policy).toEqual({
+      required: 1,
+      witnesses: ["rfc3161", "opentimestamps"],
+    });
+  });
+
+  it("forwards a single-witness policy", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "deploy:release",
+      context: { k: "v" },
+      complianceMode: true,
+      witnessPolicy: { required: 1, witnesses: ["opentimestamps"] },
+    });
+    const body = readBody(spy);
+    expect(body.witness_policy).toEqual({ required: 1, witnesses: ["opentimestamps"] });
+  });
+
+  it("omits witness_policy when not supplied", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "deploy:release",
+      context: { k: "v" },
+      complianceMode: true,
+    });
+    const body = readBody(spy);
+    expect(body.witness_policy).toBeUndefined();
+  });
+});
+
+describe("witnessPolicy shape guards", () => {
+  it("rejects rekor as a witness", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "deploy:release",
+        context: { k: "v" },
+        complianceMode: true,
+        // rekor is not a shipped witness.
+        witnessPolicy: { required: 1, witnesses: ["rekor"] as never },
+      }),
+    ).rejects.toThrow(/witness_policy_unknown_witness/);
+  });
+
+  it("rejects rekor mixed with a valid witness", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "deploy:release",
+        context: { k: "v" },
+        complianceMode: true,
+        witnessPolicy: { required: 1, witnesses: ["rfc3161", "rekor"] as never },
+      }),
+    ).rejects.toThrow(/witness_policy_unknown_witness/);
+  });
+
+  it("rejects required greater than witnesses length", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "deploy:release",
+        context: { k: "v" },
+        complianceMode: true,
+        witnessPolicy: { required: 3, witnesses: ["rfc3161", "opentimestamps"] },
+      }),
+    ).rejects.toThrow(/witness_policy_required_out_of_range/);
+  });
+
+  it("rejects required of zero", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "deploy:release",
+        context: { k: "v" },
+        complianceMode: true,
+        witnessPolicy: { required: 0, witnesses: ["rfc3161"] },
+      }),
+    ).rejects.toThrow(/witness_policy_required_out_of_range/);
+  });
+
+  it("rejects an empty witnesses list", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "deploy:release",
+        context: { k: "v" },
+        complianceMode: true,
+        witnessPolicy: { required: 1, witnesses: [] },
+      }),
+    ).rejects.toThrow(/witness_policy_witnesses_must_be_non_empty_list/);
+  });
+
+  it("rejects duplicate witnesses", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "deploy:release",
+        context: { k: "v" },
+        complianceMode: true,
+        witnessPolicy: { required: 1, witnesses: ["rfc3161", "rfc3161"] },
+      }),
+    ).rejects.toThrow(/witness_policy_duplicate_witness/);
+  });
+
+  it("rejects non-integer required", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "deploy:release",
+        context: { k: "v" },
+        complianceMode: true,
+        witnessPolicy: { required: 1.5, witnesses: ["rfc3161"] },
+      }),
+    ).rejects.toThrow(/witness_policy_required_must_be_int/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the optional `witness_policy` field to `agent.sign` on both SDK halves, in lockstep with the live cloud `witness_policy` extension listed in governance.json.

The field declares an N-of-M durable-anchoring quorum. The receipt reaches `witness_quorum_met` only when `required` witnesses hold a real inclusion proof.

## Wire contract

- Shape: `{required: int, witnesses: [<subset of "rfc3161", "opentimestamps">]}`.
- `required` must be an integer in `[1, len(witnesses)]`.
- `witnesses` is a non-empty subset of the two shipped witnesses.
- `rekor` is rejected because it is not a shipped witness.
- Optional: when omitted, behaviour is unchanged.

## Python (`asqav`)

- New `witness_policy` kwarg on `agent.sign(...)`, forwarded verbatim to the wire through `compliance_fields`.
- Client-side validation mirroring the cloud, with verbatim guard tokens: `witness_policy_unknown_witness`, `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, `witness_policy_duplicate_witness`.
- Exported `WITNESS_NAMESPACE`.
- README "Witness policy (optional)" section and tests in `python/tests/test_client_witness_policy.py`.

## TypeScript (`@asqav/sdk`)

- New camelCase `witnessPolicy` prop on `SignOptions`, projected to the snake_case `witness_policy` wire key via `IETF_OPTIONAL_FIELD_MAP`.
- Exported `WitnessPolicy` interface, `Witness` type, and `WITNESS_NAMESPACE`.
- Same validation and guard tokens, README section, and vitest tests in `typescript/tests/witnessPolicy.test.ts`.

## Validation parity

Both halves reject `rekor`, reject `required` outside `[1, len(witnesses)]`, reject an empty witnesses list, reject duplicates, and reject a non-integer `required`, each with the same verbatim guard token so SDK errors round-trip through the conformance vectors.

## Version

Both registries move to 0.5.3 together: `package.json`, `pyproject.toml`, `cli.ts` `CLI_VERSION`, `asqav` `__version__`, plus CHANGELOG entries.

## Tests

- Python: full suite green (899 passed), including 11 new witness_policy tests.
- TypeScript: full suite green (376 passed), including 10 new witnessPolicy tests; `tsc --noEmit` clean; ruff clean.

comment hygiene clean
