### PR TITLE
docs(sdk): align risk_class README vocabulary with the type

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -83,7 +83,7 @@ Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a 
 The envelope extensions most callers reach for:
 
 - `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:lifecycle:configuration_change`, `protectmcp:acknowledgment`, `protectmcp:observation`, or `protectmcp:observation:result_bound` (observation receipts that bind tool output via `result_digest`).
-- `risk_class` - controlled vocabulary: `unacceptable | high | limited | minimal | gpai | low | medium | unknown`.
+- `risk_class` - controlled vocabulary: `low | medium | high | unknown`.
 - `iteration_id` - logical task id, distinct from session.
 - `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
 - `incident_class` - DORA / NYDFS / CIRCIA token (or array of tokens).

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -83,7 +83,7 @@ Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a 
 The envelope extensions most callers reach for (camelCase on the SDK, snake_case on the JSON wire):
 
 - `receiptType` -> `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:lifecycle:configuration_change`, `protectmcp:acknowledgment`, `protectmcp:observation`, or `protectmcp:observation:result_bound` (observation receipts that bind tool output via `resultDigest`).
-- `riskClass` -> `risk_class` - controlled vocabulary: `unacceptable | high | limited | minimal | gpai | low | medium | unknown`.
+- `riskClass` -> `risk_class` - controlled vocabulary: `low | medium | high | unknown`.
 - `iterationId` -> `iteration_id` - logical task id, distinct from session.
 - `sandboxState` -> `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
 - `incidentClass` -> `incident_class` - DORA / NYDFS / CIRCIA token (or array of tokens).


### PR DESCRIPTION
Both READMEs list an eight-value risk_class set; the enforced RiskClass type, the CLI help, and the cloud governance.json contract all declare four values (low | medium | high | unknown). A TypeScript caller passing one of the extra values hits a compile error against RiskClass, so the README contradicted the type. Align both READMEs to the four-value contract. Docs-only; no version bump (rides the next batched publish).