### PR TITLE
test(sdk): pin the fail-closed sign decorator trust contract

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -2531,6 +2531,11 @@ def secure(func: F) -> F:
     Wraps the function in an asqav session, signing the call as an action.
     All ML-DSA cryptography happens server-side.
 
+    Trust contract (fail-closed): the call is signed BEFORE the wrapped body runs.
+    If signing is refused (a blocked policy, a non-2xx response, or a network error),
+    the error propagates and the body never executes. Unsigned actions abort by
+    default - the caller does not need to inspect a return value to stay safe.
+
     Args:
         func: The function to secure.
 

--- a/python/src/asqav/decorators.py
+++ b/python/src/asqav/decorators.py
@@ -80,6 +80,11 @@ def sign(func: Any = None, *, action_type: str | None = None) -> Any:
     """Decorator that auto-signs function execution (sync + async, with or without parens).
 
     ``action_type`` overrides the default ``"function:call"``.
+
+    Trust contract (fail-closed): the ``function:call`` sign runs BEFORE the wrapped
+    body. If signing is refused (a blocked policy, a non-2xx response, or a network
+    error), the raised error propagates and the body never executes. Unsigned actions
+    abort by default - the caller does not need to check a return value to stay safe.
     """
 
     def decorator(fn: Any) -> Any:

--- a/python/tests/test_decorators.py
+++ b/python/tests/test_decorators.py
@@ -155,6 +155,44 @@ def test_sign_decorator_with_action_type(mock_post: MagicMock, mock_patch: Magic
     assert call_args[0][1]["action_type"] == "deploy:prod"
 
 
+def _mock_post_blocks_sign(path: str, data: dict) -> dict:
+    """Agent creation succeeds; every sign is blocked with a non-2xx error."""
+    if path == "/agents/create":
+        return MOCK_AGENT_RESPONSE
+    if "/sign" in path:
+        raise asqav_client.APIError("policy blocked the action", 403)
+    return {}
+
+
+@patch("asqav.client._patch", side_effect=_mock_patch_side_effect)
+@patch("asqav.client._post", side_effect=_mock_post_blocks_sign)
+def test_sign_decorator_fail_closed_on_blocked_sign(
+    mock_post: MagicMock, mock_patch: MagicMock
+) -> None:
+    """Trust contract: a blocked/non-2xx pre-action sign aborts the action.
+
+    The function:call sign runs BEFORE the wrapped body; if it is refused the
+    error propagates and the body never executes (unsigned = abort by default).
+    """
+    _reset_global_agent()
+    ran = {"body": False}
+
+    @sign
+    def transfer(amount: int) -> str:
+        ran["body"] = True
+        return "done"
+
+    try:
+        transfer(100)
+        assert False, "Should have raised APIError when signing is blocked"
+    except asqav_client.APIError:
+        pass
+
+    assert ran["body"] is False, (
+        "fail-closed: the wrapped body must not run when the pre-action sign is blocked"
+    )
+
+
 @patch("asqav.client._patch", side_effect=_mock_patch_side_effect)
 @patch("asqav.client._post", side_effect=_mock_post_side_effect)
 def test_sign_decorator_reraises_exception(mock_post: MagicMock, mock_patch: MagicMock) -> None:


### PR DESCRIPTION
Documents and regression-tests the fail-closed trust contract for @sign / @secure: the function:call sign runs before the wrapped body, so a refused sign (blocked policy, non-2xx, network) propagates and the body never executes - unsigned actions abort by default. No behavior change (the guarantee already held); this pins it with a blocked-sign test (8/8 pass locally) and states it in both docstrings. No version bump; docs + test only.

comment hygiene clean