### PR TITLE
feat(sdk): G1 + G6 verify-side parity (mandate + controls_evaluated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [TypeScript 0.5.5] - 2026-05-31
+
+### Added
+- `mandateId` on `agent.sign({...})`: one new optional camelCase prop projected to the snake_case `mandate_id` wire key. Names the resolvable `man_<token>` mandate the sign is authorised under. The cloud re-verifies the issuer signature, scope, server-clock window, and revocation, then builds the signed `authorized_under_mandate` attestation server-side. The attestation is never a request input. Requires Asqav cloud 0.5.2 or higher.
+
+### Changed
+- CLI version string in `src/cli.ts` bumped to `"0.5.5"` to match the package version.
+
+### Notes
+- `controls_evaluated` is a server-built block and never a request field; the TypeScript verify surface delegates full verification to the cloud `GET /verify/{id}` route, so the controls_evaluated structural recognition lands in the Python `verify_compliance_receipt` helper only. The TypeScript half stays at its established projection plus send-side parity level.
+
+## [Python 0.5.5] - 2026-05-31
+
+### Added
+- `mandate_id` kwarg on `agent.sign(...)`: one new optional kwarg forwarded to the `mandate_id` wire key. Names the resolvable `man_<token>` mandate the sign is authorised under. The cloud re-verifies the issuer signature, scope, server-clock window, and revocation, then builds the signed `authorized_under_mandate` attestation server-side. The attestation is never a request input. Requires Asqav cloud 0.5.2 or higher.
+- `verify_compliance_receipt` recognises `authorized_under_mandate` structurally and rejects a present-but-malformed attestation with the `false_mandate_attestation_guard` error code (lockstep with the cloud guard). A populated attestation must carry `mandate_id`, `issuer_id`, `verified=true`, and a `sha256:<64 hex>` `scope_digest`; an absent attestation is honest silence and never flagged.
+- `verify_compliance_receipt` recognises `controls_evaluated` structurally and rejects a present-but-malformed block with the `false_control_attestation_guard` error code (lockstep with the cloud guard). The block must be an object of known control keys; `quorum` requires `fired=true` and a bare 64-hex `attestation_hash`; `policy.evaluated=true` requires `matched_count >= 1`. An unknown control key or a type mismatch is a forged attestation; an absent key is honest silence. `controls_evaluated` is server-built and never a sign input.
+- New tests in `python/tests/test_verify_compliance_receipt.py` covering a valid mandate plus controls block, the verified!=true and bad scope_digest mandate rejections, and the controls_evaluated forged-key plus `policy.evaluated=true` with `matched_count=0` rejections.
+
 ## [TypeScript 0.5.4] - 2026-05-29
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.4"
+version = "0.5.5"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -140,7 +140,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1217,6 +1217,7 @@ class Agent:
         model_name: str | None = None,
         *,
         co_signers: list[str] | None = None,
+        mandate_id: str | None = None,
         user_intent: dict[str, Any] | None = None,
         nonce: str | None = None,
         valid_seconds: int | None = None,
@@ -1694,6 +1695,10 @@ class Agent:
         )
         if co_signers:
             body["co_signers"] = list(co_signers)
+        # Issuer mandate the sign is authorised under; the cloud re-verifies it
+        # and builds the signed authorized_under_mandate attestation server-side.
+        if mandate_id is not None:
+            body["mandate_id"] = mandate_id
         # Replay protection.
         if nonce is not None:
             body["nonce"] = nonce
@@ -2931,6 +2936,24 @@ def verify_compliance_receipt(
             if not outcome.valid:
                 errors.append(f"counterparty_binding_{outcome.label}")
 
+    # authorized_under_mandate is server-built; recognise it structurally and
+    # reject a present-but-malformed attestation (lockstep with the cloud
+    # false_mandate_attestation_guard). verified=true is self-declared issuer
+    # authority, never Asqav-verified third-party authorization.
+    if isinstance(_payload, dict):
+        _aum = _payload.get("authorized_under_mandate")
+        if _aum is not None:
+            _scope_digest = _aum.get("scope_digest") if isinstance(_aum, dict) else None
+            if (
+                not isinstance(_aum, dict)
+                or not _aum.get("mandate_id")
+                or not _aum.get("issuer_id")
+                or _aum.get("verified") is not True
+                or not isinstance(_scope_digest, str)
+                or not _SHA256_HEX_RE.match(_scope_digest)
+            ):
+                errors.append("false_mandate_attestation_guard")
+
     # Conditional-MUST failures surface through `errors` and `valid` only (no per-axis flag).
     _conditional_must_fail = any(
         e.startswith(
@@ -2938,6 +2961,7 @@ def verify_compliance_receipt(
                 "invalid_sandbox_state",
                 "missing_reason_on_deny_or_rate_limit",
                 "anchor_missing_value:",
+                "false_mandate_attestation_guard",
             )
         )
         for e in errors

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -905,6 +905,23 @@ def _compute_action_ref(
 #: Wire format for caller-supplied sha256 digest fields; matches helper output byte-for-byte.
 _SHA256_HEX_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
 
+#: Bare 64-hex (no self-describing prefix); the controls_evaluated quorum.attestation_hash form.
+_BARE_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+#: Server-built control keys an enumerable controls_evaluated block may carry;
+#: mirrors the cloud false_control_attestation_guard allowlist (conformance.py).
+_ALLOWED_CONTROL_KEYS: frozenset[str] = frozenset(
+    {
+        "emergency_halt",
+        "delegation_scope",
+        "quorum",
+        "mandate",
+        "policy",
+        "content_scan",
+        "result",
+    }
+)
+
 
 #: Wire format for ``tool_fingerprint``: 32 bare lowercase hex chars
 #: (SHA-256[:32]). The cloud validates this field with the bare form, not
@@ -2954,6 +2971,42 @@ def verify_compliance_receipt(
             ):
                 errors.append("false_mandate_attestation_guard")
 
+    # controls_evaluated is server-built; recognise it structurally and reject a
+    # present-but-malformed block (lockstep with the cloud
+    # false_control_attestation_guard, conformance.py:_check_controls_evaluated).
+    # A populated control proves provenance: quorum.fired needs a 64-hex
+    # attestation_hash; policy.evaluated needs matched_count >= 1. An unknown key
+    # or a type mismatch is a forged attestation; an absent key is honest silence.
+    if isinstance(_payload, dict):
+        _ce = _payload.get("controls_evaluated")
+        if _ce is not None:
+            if not isinstance(_ce, dict):
+                errors.append("false_control_attestation_guard")
+            else:
+                if any(k not in _ALLOWED_CONTROL_KEYS for k in _ce):
+                    errors.append("false_control_attestation_guard")
+                _quorum = _ce.get("quorum")
+                if _quorum is not None:
+                    _ah = _quorum.get("attestation_hash") if isinstance(_quorum, dict) else None
+                    if (
+                        not isinstance(_quorum, dict)
+                        or _quorum.get("fired") is not True
+                        or not isinstance(_ah, str)
+                        or not _BARE_SHA256_RE.match(_ah)
+                    ):
+                        errors.append("false_control_attestation_guard")
+                _policy = _ce.get("policy")
+                if _policy is not None:
+                    _mc = _policy.get("matched_count") if isinstance(_policy, dict) else None
+                    if (
+                        not isinstance(_policy, dict)
+                        or _policy.get("evaluated") is not True
+                        or isinstance(_mc, bool)
+                        or not isinstance(_mc, int)
+                        or _mc < 1
+                    ):
+                        errors.append("false_control_attestation_guard")
+
     # Conditional-MUST failures surface through `errors` and `valid` only (no per-axis flag).
     _conditional_must_fail = any(
         e.startswith(
@@ -2962,6 +3015,7 @@ def verify_compliance_receipt(
                 "missing_reason_on_deny_or_rate_limit",
                 "anchor_missing_value:",
                 "false_mandate_attestation_guard",
+                "false_control_attestation_guard",
             )
         )
         for e in errors

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -332,3 +332,151 @@ def test_empty_anchors_array_does_not_trip_the_check() -> None:
     env["anchors"] = []
     result = verify_compliance_receipt(env)
     assert not any(e.startswith("anchor_missing_value:") for e in result.errors)
+
+
+# === authorized_under_mandate (server-built, recognised structurally) ===
+
+
+def _good_mandate(**overrides) -> dict:
+    """A well-formed authorized_under_mandate attestation."""
+    base = {
+        "mandate_id": "man_abc123",
+        "issuer_id": "legal:Acme GmbH",
+        "verified": True,
+        "scope_digest": "sha256:" + "d" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_valid_authorized_under_mandate_passes() -> None:
+    env = _good_envelope(authorized_under_mandate=_good_mandate())
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+    assert "false_mandate_attestation_guard" not in result.errors
+
+
+def test_authorized_under_mandate_absent_is_accepted() -> None:
+    env = _good_envelope()
+    assert "authorized_under_mandate" not in env
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+
+
+def test_mandate_verified_not_true_is_rejected() -> None:
+    """A self-declared attestation with verified!=true is a forged mandate."""
+    env = _good_envelope(authorized_under_mandate=_good_mandate(verified=False))
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "false_mandate_attestation_guard" in result.errors
+
+
+def test_mandate_bad_scope_digest_is_rejected() -> None:
+    """scope_digest must be the sha256:<64-hex> wire form."""
+    env = _good_envelope(
+        authorized_under_mandate=_good_mandate(scope_digest="deadbeef")
+    )
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "false_mandate_attestation_guard" in result.errors
+
+
+def test_mandate_missing_mandate_id_is_rejected() -> None:
+    bad = _good_mandate()
+    del bad["mandate_id"]
+    env = _good_envelope(authorized_under_mandate=bad)
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "false_mandate_attestation_guard" in result.errors
+
+
+# === controls_evaluated (server-built, recognised structurally) ===
+
+
+def test_valid_controls_evaluated_passes() -> None:
+    """A well-formed controls_evaluated block verifies; quorum carries a
+    64-hex attestation_hash and policy carries matched_count >= 1."""
+    env = _good_envelope(
+        controls_evaluated={
+            "quorum": {"fired": True, "attestation_hash": "e" * 64},
+            "policy": {"evaluated": True, "matched_count": 2},
+            "result": {"present": True},
+        }
+    )
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+    assert "false_control_attestation_guard" not in result.errors
+
+
+def test_controls_evaluated_absent_is_accepted() -> None:
+    env = _good_envelope()
+    assert "controls_evaluated" not in env
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+
+
+def test_controls_evaluated_not_object_is_rejected() -> None:
+    env = _good_envelope(controls_evaluated=["quorum"])
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "false_control_attestation_guard" in result.errors
+
+
+def test_controls_evaluated_unknown_key_is_rejected() -> None:
+    """A forged control key the server never emits is a forged attestation."""
+    env = _good_envelope(controls_evaluated={"backdoor": {"fired": True}})
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "false_control_attestation_guard" in result.errors
+
+
+def test_controls_evaluated_quorum_missing_hash_is_rejected() -> None:
+    env = _good_envelope(controls_evaluated={"quorum": {"fired": True}})
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "false_control_attestation_guard" in result.errors
+
+
+def test_controls_evaluated_quorum_bad_hash_is_rejected() -> None:
+    env = _good_envelope(
+        controls_evaluated={
+            "quorum": {"fired": True, "attestation_hash": "sha256:" + "e" * 64}
+        }
+    )
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "false_control_attestation_guard" in result.errors
+
+
+def test_controls_evaluated_policy_matched_count_zero_is_rejected() -> None:
+    """4.7-lesson-7 trap: policy.evaluated=true with matched_count=0 claims a
+    policy ran without a real match; a forged attestation MUST be rejected."""
+    env = _good_envelope(
+        controls_evaluated={"policy": {"evaluated": True, "matched_count": 0}}
+    )
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "false_control_attestation_guard" in result.errors
+
+
+def test_controls_evaluated_policy_matched_count_bool_is_rejected() -> None:
+    """matched_count must be a real int; a bool True must not satisfy >= 1."""
+    env = _good_envelope(
+        controls_evaluated={"policy": {"evaluated": True, "matched_count": True}}
+    )
+    result = verify_compliance_receipt(env)
+    assert result.valid is False
+    assert "false_control_attestation_guard" in result.errors
+
+
+def test_valid_mandate_and_controls_together_pass() -> None:
+    env = _good_envelope(
+        authorized_under_mandate=_good_mandate(),
+        controls_evaluated={
+            "quorum": {"fired": True, "attestation_hash": "e" * 64},
+            "policy": {"evaluated": True, "matched_count": 1},
+        },
+    )
+    result = verify_compliance_receipt(env)
+    assert result.valid is True
+    assert result.errors == []

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -33,7 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.4";
+export const CLI_VERSION = "0.5.5";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -332,6 +332,11 @@ export interface SignOptions {
    * this record. Each peer fetches the record and calls
    * ``agent.countersign(signatureId)``. */
   coSigners?: string[];
+  /** Optional resolvable man_<token> mandate this sign is authorised under.
+   * The cloud re-verifies the issuer signature, scope, server-clock window,
+   * and revocation, then builds the signed authorized_under_mandate
+   * attestation. The attestation is never a request input. */
+  mandateId?: string;
   /** Optional user-intent envelope. The end user signs a digest of the
    * action and the SDK passes it through to the backend verbatim. */
   userIntent?: UserIntent;
@@ -1204,6 +1209,9 @@ function applyOptionalWireFields(
 ): void {
   if (options.coSigners && options.coSigners.length > 0) {
     body.co_signers = [...options.coSigners];
+  }
+  if (options.mandateId !== undefined) {
+    body.mandate_id = options.mandateId;
   }
   body.nonce = options.nonce ?? generateNonce();
   // Convert an absolute expiresAt to a client-computed valid_seconds (cloud owns time-binding).


### PR DESCRIPTION
## Summary

G1 + G6 SDK parity for the two cloud guards live in prod (cloud 0.5.2): `authorized_under_mandate` (G1) and `controls_evaluated` (G6). Both attestations are server-built; the SDK sends only `mandate_id` (G1 has a sign input) and recognises both attestations structurally when it reads a receipt back. `controls_evaluated` has no send input by design.

### G1 (carried in from the prior parity commit)
- Python `Agent.sign()` accepts `mandate_id`; the TypeScript `SignOptions.mandateId` projects to the `mandate_id` wire key.
- `verify_compliance_receipt` rejects a malformed `authorized_under_mandate` with `false_mandate_attestation_guard` (lockstep with the cloud guard): requires `mandate_id`, `issuer_id`, `verified=true`, and a `sha256:<64 hex>` `scope_digest`.

### G6 (new)
- `verify_compliance_receipt` rejects a malformed `controls_evaluated` with `false_control_attestation_guard`, mirroring the cloud `_check_controls_evaluated` exactly: the block must be an object of known control keys; `quorum` requires `fired=true` plus a bare 64-hex `attestation_hash`; `policy.evaluated=true` requires `matched_count >= 1` (a real int, a bool does not satisfy it). An unknown key or a type mismatch is a forged attestation; an absent key is honest silence and never flagged.
- The new guard joins the conditional-MUST tuple that gates `valid`.

### Send-side scope
- `mandate_id` is a sign input on both halves (G1). `controls_evaluated` is server-built only and is NOT a sign input on either half.
- The TypeScript half stays at its established parity level (wire projection plus send-side). It has no full-verify helper; the controls_evaluated structural recognition lands in the Python `verify_compliance_receipt` only, matching the level G1 used for the verify path.

### Version
- Both halves bumped 0.5.4 to 0.5.5 (`python/pyproject.toml`, `python/src/asqav/__init__.py`, `typescript/package.json`, `typescript/src/cli.ts`). CHANGELOG entries added for both halves.

### Tests
- Python: full suite green (917 passed). New cases in `python/tests/test_verify_compliance_receipt.py` cover a valid mandate plus controls receipt, the mandate `verified=false` and bad `scope_digest` rejections, the controls forged-key rejection, and the `policy.evaluated=true` with `matched_count=0` rejection.
- TypeScript: full suite green (377 passed). No TS source change for G6 (no send input, no full-verify path).
- Lint: ruff clean on the changed Python files; `tsc --noEmit` clean.

## THREAT_MODEL
- New attack surface: a receipt reader trusting a forged `controls_evaluated` block that claims a control fired (a quorum that never reached consensus, or a policy that matched nothing) - the false-control-attestation class.
- Existing guard: the cloud `false_control_attestation_guard` (`_check_controls_evaluated`) rejects the block at persist; this PR mirrors it on the SDK read path so an offline verifier reaches the same verdict.
- New test asserting the guard: `test_controls_evaluated_policy_matched_count_zero_is_rejected`, `test_controls_evaluated_unknown_key_is_rejected`, `test_controls_evaluated_quorum_missing_hash_is_rejected`, plus the mandate cases pinning G1.
- Trust boundary change: no new trust anchor. The SDK recognises a server-built attestation structurally and fails closed on a malformed one; it never mints the attestation. `verified=true` and `fired=true` stay server-declared, never Asqav-verified third-party authority on the client.

Not published; the publish stays user-gated. Comment hygiene clean.
