### PR TITLE
feat: standalone receipt verifier, one dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,6 +50,10 @@ dependencies = []
 
 [project.optional-dependencies]
 httpx = ["httpx>=0.24.0"]
+# Standalone receipt verifier (verifier/verify_receipt.py). Pure-python FIPS 204
+# ML-DSA-65 so a buyer can verify a receipt offline without liboqs. Optional:
+# the main SDK defers signature crypto to the cloud and never imports this.
+verify = ["dilithium-py>=1.0.0"]
 cli = ["typer>=0.12.0", "httpx>=0.24.0"]
 langchain = ["langchain-core>=0.2.0"]
 crewai = ["crewai>=0.41.0"]

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -1,0 +1,88 @@
+# Verify an Asqav receipt yourself, one dependency
+
+`verify_receipt.py` is a single standalone file that verifies an Asqav
+Compliance Receipt on your own machine, without the Asqav SDK and without
+liboqs. It is deliberately outside the `asqav` package so you can copy it into an
+audit environment and read every line.
+
+It does the check that actually matters for third-party trust: it verifies the
+post-quantum **ML-DSA-65 (FIPS 204)** signature over the receipt's canonical
+bytes, resolves the issuer's public key from Asqav's public
+`/.well-known/jwks.json` (so you never take our word for which key signed),
+re-walks the SHA-256 hash chain, and reports the anchor binding and timestamp
+skew. Everything except the signature math is Python standard library.
+
+## Install
+
+Standard library covers structure, canonical bytes, the hash chain, the anchor
+binding, and the skew check with zero installs. The single dependency is the
+post-quantum signature verify:
+
+```bash
+pip install dilithium-py
+```
+
+`dilithium-py` is a pure-python FIPS 204 implementation; its verify path uses
+only stdlib SHAKE, so nothing compiles. If you skip it, every other check still
+runs and the signature axis reports `SKIPPED`; the overall verdict is then
+`INCOMPLETE`. The tool never prints `PASS` unless the signature was actually
+verified.
+
+## Verify a live receipt
+
+Fetch a receipt and the key directory straight from the API and verify:
+
+```bash
+python verify_receipt.py --id sig_abc123
+```
+
+The public worked example needs no API key:
+
+```bash
+python verify_receipt.py --id sig_example_loan_decision_2026
+```
+
+This pulls `https://api.asqav.com/api/v1/verify/<id>` and
+`https://api.asqav.com/.well-known/jwks.json`, then prints a per-axis report.
+(The public `/verify/example` fixture ships a placeholder signature to document
+the receipt shape; point `--id` at one of your own signed receipts to exercise
+the full cryptographic path against a real signature.)
+
+## Verify fully offline
+
+Save the receipt and the key directory, then verify with no network at all:
+
+```bash
+curl https://api.asqav.com/api/v1/verify/sig_abc123 > receipt.json
+curl https://api.asqav.com/.well-known/jwks.json    > jwks.json
+python verify_receipt.py --receipt receipt.json --jwks jwks.json --offline
+```
+
+To check the hash-chain link, also save the predecessor receipt and pass it:
+
+```bash
+python verify_receipt.py --receipt receipt.json --jwks jwks.json \
+    --predecessor previous.json --offline
+```
+
+## What it checks
+
+| Axis | Checked | How |
+|---|---|---|
+| signature | ML-DSA-65 over canonical bytes | `dilithium-py` against the jwks public key |
+| canonical bytes | JCS reproduction | stdlib `json` (sorted keys, no whitespace, UTF-8) |
+| issuer_key | key resolution by `kid` | matched against `/.well-known/jwks.json` |
+| chain | SHA-256 link to predecessor | stdlib `hashlib` |
+| anchors | which envelope each anchor binds | stdlib `hashlib` + `base64` |
+| skew | `issued_at` within 300s of now | stdlib `datetime` |
+| structure | required fields and type namespace | stdlib |
+
+It does **not** perform the full RFC3161 certificate-chain walk or
+`policy_digest` artefact resolution; both need server state or ASN.1. For those,
+use the hosted `/verify` endpoint or the full Asqav SDK.
+
+## Exit codes
+
+- `0` - PASS (every non-skipped axis passed, signature verified)
+- `1` - FAIL (at least one axis failed)
+- `2` - INCOMPLETE (a blocking axis, typically the signature, was skipped)

--- a/verifier/verify_receipt.py
+++ b/verifier/verify_receipt.py
@@ -1,0 +1,317 @@
+"""Standalone Asqav receipt verifier - one dependency, mostly stdlib.
+
+Verify an Asqav Compliance Receipt yourself, without the Asqav SDK or liboqs.
+
+WHAT THIS CHECKS (independently, on your machine):
+  - ML-DSA-65 (FIPS 204) signature over the receipt's canonical bytes
+  - canonical-bytes integrity (JCS / RFC8785 reproduction, stdlib json)
+  - hash-chain link to a predecessor receipt
+  - anchor binding (which envelope each anchor commits to) plus anchor presence
+  - issuer public-key resolution from the public /.well-known/jwks.json
+
+WHAT THIS DOES NOT CHECK (needs server state or ASN.1; use the hosted /verify):
+  - full RFC3161 certificate-chain walk
+  - policy_digest artefact resolution
+
+The only non-stdlib dependency is the signature check:
+  pip install dilithium-py        (pure python; verify path uses stdlib SHAKE)
+Without it, every other check still runs and the signature axis reports SKIPPED;
+the overall verdict is then INCOMPLETE, never a PASS. This tool will not emit a
+PASS unless the post-quantum signature was actually verified.
+
+Security note: dilithium-py is a pure-python FIPS 204 implementation that is not
+constant-time. For a verify-only tool this is acceptable: verification touches
+only public data (public key, signature, message), so there is no secret to leak
+through timing.
+
+Run:
+  python verify_receipt.py --id sig_abc123
+  python verify_receipt.py --receipt receipt.json --jwks jwks.json --offline
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+import urllib.request
+from datetime import datetime, timezone
+
+API_BASE = "https://api.asqav.com/api/v1"
+JWKS_URL = "https://api.asqav.com/.well-known/jwks.json"
+SKEW_BOUND_SECONDS = 300
+FIRST_RECEIPT_SEED = "0" * 64  # mirrors core/integrity.py FIRST_RECEIPT_SEED
+REQUIRED_FIELDS = (
+    "type",
+    "issued_at",
+    "issuer_id",
+    "action_ref",
+    "payload_digest",
+    "policy_digest",
+    "previousReceiptHash",
+    "decision",
+)
+ALLOWED_TYPES = {
+    "protectmcp:decision",
+    "protectmcp:restraint",
+    "protectmcp:lifecycle",
+    "protectmcp:lifecycle:configuration_change",
+    "protectmcp:acknowledgment",
+    "protectmcp:observation",
+    "protectmcp:observation:result_bound",
+}
+
+
+def canonical_json(obj) -> bytes:
+    """JCS canonical bytes - byte-identical to the server's canonical_json.
+
+    Sorted keys, no whitespace, UTF-8, NaN/Infinity rejected. This is the exact
+    byte string the server signs and the verifier must reproduce.
+    """
+    return json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def envelope_minus_anchors_jcs(env: dict) -> bytes:
+    """JCS bytes of the envelope with ``anchors`` removed (the anchored bytes)."""
+    e = dict(env)
+    e.pop("anchors", None)
+    return canonical_json(e)
+
+
+def _get_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _b64decode(value: str) -> bytes:
+    """Decode standard or url-safe base64, padding-tolerant."""
+    s = value.replace("-", "+").replace("_", "/")
+    s += "=" * ((-len(s)) % 4)
+    return base64.b64decode(s, validate=False)
+
+
+def _safe_b64(v: str) -> bool:
+    try:
+        _b64decode(v)
+        return True
+    except Exception:
+        return False
+
+
+def normalise_envelope(raw: dict) -> dict:
+    """Remap a hosted /verify response into the canonical 3-key envelope.
+
+    An Audit Pack already ships the canonical ``{payload, signature, anchors}``
+    shape, so pass it through untouched. The hosted ``/verify/{id}`` JSON instead
+    nests the signed dict under ``payload`` and exposes the signature object as
+    ``signature_envelope`` (and a possibly flat-string ``signature``); rebuild
+    the canonical envelope from those parts so ``run()`` sees one shape.
+    """
+    # Already canonical: a top-level signature object plus a payload dict.
+    sig = raw.get("signature")
+    if isinstance(sig, dict) and isinstance(raw.get("payload"), dict):
+        return raw
+
+    payload = raw.get("payload")
+    if not isinstance(payload, dict):
+        # Not a hosted response and not canonical; hand it back as-is so the
+        # structure check reports the problem clearly.
+        return raw
+
+    sig_obj = raw.get("signature_envelope")
+    if not isinstance(sig_obj, dict):
+        if isinstance(sig, dict):
+            sig_obj = sig
+        else:
+            sig_obj = {
+                "alg": raw.get("algorithm", "ML-DSA-65"),
+                "kid": payload.get("issuer_id", ""),
+                "sig": sig if isinstance(sig, str) else "",
+            }
+    return {
+        "payload": payload,
+        "signature": sig_obj,
+        "anchors": raw.get("anchors") or [],
+    }
+
+
+def resolve_key(jwks: dict, kid: str):
+    """Return (public_key_bytes, status, alg) for the receipt's signature.kid.
+
+    The public jwks directory lists each key under both its bare issuer id and
+    its crypto key id; match either so the bare-kid wire form resolves.
+    """
+    for k in jwks.get("keys", []):
+        if kid and kid in (k.get("issuer_id"), k.get("kid")):
+            return _b64decode(k["public_key"]), k.get("status"), k.get("alg")
+    return None, None, None
+
+
+def verify_signature(pk: bytes, msg: bytes, sig: bytes, alg: str):
+    """ML-DSA-65 verify. Returns (result, note); result in PASS/FAIL/SKIPPED."""
+    if (alg or "").upper() != "ML-DSA-65":
+        return "SKIPPED", f"unsupported alg {alg!r} (this tool checks ML-DSA-65)"
+    try:
+        from dilithium_py.ml_dsa import ML_DSA_65
+    except ImportError:
+        return "SKIPPED", "run 'pip install dilithium-py' for the post-quantum check"
+    try:
+        ok = ML_DSA_65.verify(pk, msg, sig)
+        return ("PASS" if ok else "FAIL"), ("signature valid" if ok else "signature mismatch")
+    except Exception as exc:  # malformed key or signature bytes
+        return "FAIL", f"verify error: {exc}"
+
+
+def check_skew(issued_at: str):
+    try:
+        ts = datetime.fromisoformat(issued_at.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return "FAIL", f"unparseable issued_at {issued_at!r}"
+    skew = (ts - datetime.now(timezone.utc)).total_seconds()
+    if skew > SKEW_BOUND_SECONDS:
+        return "FAIL", f"issued_at {skew:.0f}s ahead of wall clock (> {SKEW_BOUND_SECONDS}s)"
+    return "PASS", f"skew {skew:.0f}s within bound"
+
+
+def check_chain(payload: dict, predecessor_payload: dict | None):
+    prev = payload.get("previousReceiptHash")
+    if prev == FIRST_RECEIPT_SEED:
+        return "PASS", "first receipt on chain (all-zero seed)"
+    if predecessor_payload is None:
+        return "SKIPPED", "no predecessor supplied (pass --predecessor to check)"
+    actual = hashlib.sha256(canonical_json(predecessor_payload)).hexdigest()
+    if actual == prev:
+        return "PASS", "chain link rederives from predecessor"
+    return "FAIL", f"chain break: expected {str(prev)[:16]}.. got {actual[:16]}.."
+
+
+def check_anchors(envelope: dict):
+    anchors = envelope.get("anchors") or []
+    if not anchors:
+        return "SKIPPED", "no anchors on this receipt"
+    bound = hashlib.sha256(envelope_minus_anchors_jcs(envelope)).hexdigest()
+    lines = [f"anchors bind envelope digest sha256:{bound[:16]}.."]
+    all_ok = True
+    for a in anchors:
+        atype = a.get("type", "?")
+        val = a.get("value")
+        ok = bool(val) and _safe_b64(val)
+        all_ok = all_ok and ok
+        state = "present, base64-ok" if ok else "MISSING or malformed"
+        lines.append(f"    - {atype}: value {state}")
+    return ("PASS" if all_ok else "FAIL"), "; ".join(lines)
+
+
+def check_structure(payload: dict):
+    missing = [f for f in REQUIRED_FIELDS if f not in payload]
+    if missing:
+        return "FAIL", f"missing required fields: {','.join(missing)}"
+    rt = payload.get("type")
+    if rt not in ALLOWED_TYPES:
+        return "FAIL", f"type {rt!r} outside the allowed namespace"
+    return "PASS", f"required fields present; type {rt}"
+
+
+def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
+    envelope = normalise_envelope(envelope)
+    payload = envelope.get("payload", envelope)
+    sig_obj = envelope.get("signature", {})
+    if isinstance(sig_obj, str):  # flat-string signature, derive the object
+        sig_obj = {
+            "alg": envelope.get("algorithm", "ML-DSA-65"),
+            "kid": payload.get("issuer_id", ""),
+            "sig": sig_obj,
+        }
+    kid = sig_obj.get("kid", "")
+    alg = sig_obj.get("alg", "ML-DSA-65")
+    msg = canonical_json(payload)
+
+    results = []
+    results.append(("structure", *check_structure(payload)))
+
+    pk, status, jwks_alg = resolve_key(jwks, kid)
+    if pk is None:
+        results.append(("issuer_key", "FAIL", f"kid {kid!r} not in jwks directory"))
+        results.append(("signature", "SKIPPED", "no issuer key to verify against"))
+    else:
+        results.append(("issuer_key", "PASS", f"resolved kid {kid} (status={status})"))
+        sig = _b64decode(sig_obj.get("sig", ""))
+        results.append(("signature", *verify_signature(pk, msg, sig, alg or jwks_alg)))
+
+    results.append(("chain", *check_chain(payload, predecessor_payload)))
+    results.append(("anchors", *check_anchors(envelope)))
+    results.append(("skew", *check_skew(payload.get("issued_at", ""))))
+
+    print("Asqav receipt verification")
+    print(f"  canonical bytes: sha256:{hashlib.sha256(msg).hexdigest()}")
+    print(f"  signature.kid:   {kid}")
+    for name, res, note in results:
+        mark = {"PASS": "ok", "FAIL": "FAIL", "SKIPPED": "skip"}[res]
+        print(f"  [{mark:>4}] {name:<11} {note}")
+
+    has_fail = any(r == "FAIL" for _, r, _ in results)
+    # A skipped chain (no predecessor supplied) is expected and does not block a
+    # PASS; any other skip - notably the signature - downgrades to INCOMPLETE.
+    has_blocking_skip = any(r == "SKIPPED" and n != "chain" for n, r, _ in results)
+    if has_fail:
+        verdict, code = "FAIL", 1
+    elif has_blocking_skip:
+        verdict, code = "INCOMPLETE (some checks skipped; never a PASS)", 2
+    else:
+        verdict, code = "PASS", 0
+    print(f"\n  => {verdict}")
+    return code
+
+
+def _load(path: str) -> dict:
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Standalone Asqav receipt verifier.")
+    p.add_argument("--id", help="signature id to fetch from api.asqav.com")
+    p.add_argument("--receipt", help="path to a saved receipt JSON")
+    p.add_argument("--jwks", help="path to a saved jwks.json (offline)")
+    p.add_argument(
+        "--predecessor", help="path to predecessor receipt JSON for the chain check"
+    )
+    p.add_argument(
+        "--offline", action="store_true", help="never reach the network"
+    )
+    args = p.parse_args()
+
+    if args.receipt:
+        envelope = _load(args.receipt)
+    elif args.id and not args.offline:
+        envelope = _get_json(f"{API_BASE}/verify/{args.id}")
+    else:
+        p.error("supply --receipt FILE, or --id ID without --offline")
+        return 2
+
+    if args.jwks:
+        jwks = _load(args.jwks)
+    elif not args.offline:
+        jwks = _get_json(JWKS_URL)
+    else:
+        p.error("offline mode needs --jwks FILE")
+        return 2
+
+    predecessor_payload = None
+    if args.predecessor:
+        pred = _load(args.predecessor)
+        predecessor_payload = pred.get("payload", pred)
+
+    return run(envelope, jwks, predecessor_payload)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a single standalone file, verifier/verify_receipt.py, that verifies an
Asqav Compliance Receipt on the buyer's own machine, without the asqav package
and without liboqs. It sits outside python/src/asqav so it is copy-pasteable
into an audit environment and short enough to read end to end.

What it verifies, independently:
  - ML-DSA-65 (FIPS204) signature over the receipt's canonical JCS bytes
  - canonical-bytes reproduction via stdlib json (sorted keys, no whitespace)
  - issuer public-key resolution from the public /.well-known/jwks.json
  - SHA-256 hash-chain link to a supplied predecessor
  - anchor binding (which envelope each anchor commits to) plus skew bound
  - required fields and type namespace

One dependency: dilithium-py, a pure-python FIPS204 implementation whose verify
path uses only stdlib SHAKE, so nothing compiles. It is wired as an optional
extra (asqav[verify]); the main SDK keeps an empty dependency set and never
imports it. Everything except the signature math is Python standard library.

No false PASS: if dilithium-py is absent the signature axis reports SKIPPED and
the overall verdict is INCOMPLETE (exit 2), never PASS. Every stdlib axis still
runs so a locked-down Python sees structure, chain, anchor and skew results with
zero installs.

Smoke tested with a real ML-DSA-65 keypair end to end: a genuine signature gives
PASS (exit 0), a tampered payload gives signature FAIL (exit 1), the hosted
/verify response shape remaps and verifies, and the no-dependency path yields
INCOMPLETE. Canonical-bytes and signed-message derivation were cold-verified
against the core canonical and identity sources so the verifier validates a real
receipt rather than a guess.

Ships verifier/README.md with the install line and a worked example. Tooling and
docs only; no change under src/asqav, so no package version bump.