### PR TITLE
Add risk-acceptance receipt to the Asqav SDK (Python + TypeScript) and verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [TypeScript 0.5.6] - 2026-06-01
+
+### Added
+- Risk-acceptance / exception receipt support on `agent.sign({...})`. New `receiptType` value `protectmcp:lifecycle:risk_acceptance` plus nine optional camelCase props projected to snake_case wire keys: `approverId`, `initiatorId`, `acceptanceReason`, `acceptedAt`, `supersedes`, `sarifDigest`, `findingRef`, `approvalRef`, and `riskSnapshot`. The `riskSnapshot` object carries a producer-asserted point-in-time read of third-party risk signals (`snapshotAt`, `snapshotSource`, `epss`, `cvss`, `cvssVector`, `kevListed`, `cveIds`); numerics travel as strings. Every field records that a producer-asserted value existed at signing time; none is computed, scored, or verified by Asqav.
+- Client-side validators in lockstep with the cloud SignRequest guards: `sarifDigest` must be `sha256:<64 hex>`; a populated `riskSnapshot` numeric requires `snapshotSource`; the nine fields are fenced to `receiptType=protectmcp:lifecycle:risk_acceptance`; the receipt requires `approverId` + `acceptanceReason`, `policyDecision='none'`, and `complianceMode` (the fields project into the signed receipt only under compliance mode). Each rejection carries a `docsUrl` pointing at the risk-acceptance docs page.
+- New `RiskSnapshot` interface, `RISK_ACCEPTANCE_DOCS_URL` constant, and `AsqavError.docsUrl`. Tests in `typescript/tests/riskAcceptance.test.ts`.
+
+### Notes
+- Requires an Asqav cloud build that advertises `protectmcp:lifecycle:risk_acceptance` in `/.well-known/governance.json` (live as of 2026-06-01). Verified against the live build before this release.
+
+## [Python 0.5.6] - 2026-06-01
+
+### Added
+- Risk-acceptance / exception receipt support on `agent.sign(...)`. New `receipt_type` value `protectmcp:lifecycle:risk_acceptance` plus nine optional kwargs forwarded to the wire: `approver_id`, `initiator_id`, `acceptance_reason`, `accepted_at`, `supersedes`, `sarif_digest`, `finding_ref`, `approval_ref`, and `risk_snapshot`. The `risk_snapshot` dict carries a producer-asserted point-in-time read of third-party risk signals (`snapshot_at`, `snapshot_source`, `epss`, `cvss`, `cvss_vector`, `kev_listed`, `cve_ids`); numerics travel as strings. Every field records that a producer-asserted value existed at signing time; none is computed, scored, or verified by Asqav.
+- Client-side validators in lockstep with the cloud SignRequest guards: `sarif_digest` must be `sha256:<64 hex>`; a populated `risk_snapshot` numeric requires `snapshot_source`; the nine fields are fenced to `receipt_type=protectmcp:lifecycle:risk_acceptance`; the receipt requires `approver_id` + `acceptance_reason`, `policy_decision='none'`, and `compliance_mode` (the fields project into the signed receipt only under compliance mode). Each rejection raises `AsqavValidationError` carrying a `docs_url` pointing at the risk-acceptance docs page.
+- New `AsqavValidationError` exception, `RiskSnapshot` TypedDict, and `RISK_ACCEPTANCE_DOCS_URL` constant, exported from `asqav`. Tests in `python/tests/test_client_risk_acceptance.py`.
+
+### Fixed
+- The zero-dependency verifier (`verifier/verify_receipt.py`) added `protectmcp:lifecycle:risk_acceptance` to its accepted receipt-type set; without it the structure axis rejected a valid risk-acceptance receipt on type and downgraded the whole verdict to FAIL. Test in `verifier/test_verify_receipt.py`.
+
+### Notes
+- Requires an Asqav cloud build that advertises `protectmcp:lifecycle:risk_acceptance` in `/.well-known/governance.json` (live as of 2026-06-01). Verified against the live build before this release.
+
 ## [TypeScript 0.5.5] - 2026-05-31
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.5"
+version = "0.5.6"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -34,12 +34,14 @@ from .client import (
     CAPTURE_TOPOLOGY_NAMESPACE,
     DORA_INCIDENT_CLASS_NAMESPACE,
     RECEIPT_TYPE_NAMESPACE,
+    RISK_ACCEPTANCE_DOCS_URL,
     SKEW_BOUND_SECONDS,
     Agent,
     AgentResponse,
     APIError,
     ApprovalResponse,
     AsqavError,
+    AsqavValidationError,
     AuthenticationError,
     BitcoinAnchorStatus,
     BudgetCheckResult,
@@ -53,6 +55,7 @@ from .client import (
     PreflightResult,
     RateLimitError,
     RiskRuleResponse,
+    RiskSnapshot,
     SDTokenResponse,
     SessionResponse,
     ShareRecoveryResponse,
@@ -140,7 +143,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 __all__ = [
     # Initialization
     "init",
@@ -282,11 +285,14 @@ __all__ = [
     "clear_hooks",
     # Exceptions
     "AsqavError",
+    "AsqavValidationError",
     "AuthenticationError",
     "RateLimitError",
     "APIError",
     # IETF Compliance Receipts profile
     "RECEIPT_TYPE_NAMESPACE",
+    "RISK_ACCEPTANCE_DOCS_URL",
+    "RiskSnapshot",
     "SKEW_BOUND_SECONDS",
     "ComplianceReceiptVerification",
     "verify_compliance_receipt",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -33,7 +33,7 @@ import uuid
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar
 from urllib.parse import urljoin
 
 if TYPE_CHECKING:
@@ -142,6 +142,20 @@ class APIError(AsqavError):
         self.status_code = status_code
 
 
+class AsqavValidationError(ValueError):
+    """Client-side wire-vocabulary rejection carrying a docs pointer (rule 3.9).
+
+    Subclasses ValueError so existing callers that catch ValueError keep
+    working; the docs_url attribute points a developer at the rule's docs page
+    so they do not have to grep. Message echoes the offending value truncated to
+    64 chars to match the cloud guard-message convention.
+    """
+
+    def __init__(self, message: str, *, docs_url: str) -> None:
+        super().__init__(message)
+        self.docs_url = docs_url
+
+
 @dataclass
 class AgentResponse:
     """Response from agent creation."""
@@ -201,11 +215,25 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
         "protectmcp:restraint",
         "protectmcp:lifecycle",
         "protectmcp:lifecycle:configuration_change",
+        #: risk-acceptance / exception receipt; no-policy lifecycle opt-out.
+        "protectmcp:lifecycle:risk_acceptance",
         "protectmcp:acknowledgment",
         "protectmcp:observation",
         #: observation receipts that carry a result_digest use the :result_bound suffix.
         "protectmcp:observation:result_bound",
     }
+)
+
+#: Docs page anchoring the risk-acceptance validation errors (rule 3.9).
+RISK_ACCEPTANCE_DOCS_URL: str = "https://asqav.com/docs/risk-acceptance-receipt"
+
+#: Numeric risk-snapshot signals whose presence demands a snapshot_source label.
+#: Mirrors cloud core/conformance.py _RISK_SNAPSHOT_NUMERIC_KEYS.
+_RISK_SNAPSHOT_NUMERIC_KEYS: tuple[str, ...] = (
+    "epss",
+    "cvss",
+    "cvss_vector",
+    "kev_listed",
 )
 
 #: Canonical `incident_class` vocabulary under DORA Annex II field 3.23.
@@ -929,6 +957,176 @@ _ALLOWED_CONTROL_KEYS: frozenset[str] = frozenset(
 _TOOL_FINGERPRINT_RE = re.compile(r"^[0-9a-f]{32}$")
 
 
+class RiskSnapshot(TypedDict, total=False):
+    """Producer-asserted point-in-time snapshot of third-party risk signals.
+
+    Mirrors the cloud RiskSnapshot model (routes/agents.py). Every value is a
+    snapshot the producer READ at ``snapshot_at`` from ``snapshot_source``;
+    Asqav never fetches, computes, verifies, or vouches for any of them. The
+    ``snapshot_at`` + ``snapshot_source`` labels are normative: a numeric
+    (``epss`` / ``cvss`` / ``cvss_vector`` / ``kev_listed``) without
+    ``snapshot_source`` is rejected so a value can never appear unlabeled and be
+    mistaken for an Asqav-derived score. Numerics are strings on the wire.
+    """
+
+    #: RFC 3339 read-time of the signals (REQUIRED). Producer-asserted.
+    snapshot_at: str
+    #: Free-text label naming the source. REQUIRED when any numeric is present.
+    snapshot_source: str
+    #: EPSS probability as a STRING (floats rejected). Producer-asserted.
+    epss: str
+    #: CVSS base score as a STRING. Producer-asserted; not computed by Asqav.
+    cvss: str
+    #: CVSS vector string snapshot. Producer-asserted; not parsed by Asqav.
+    cvss_vector: str
+    #: Whether the CVE was in the named KEV catalog at snapshot_at, as observed.
+    kev_listed: bool
+    #: CVE ids the snapshot pertains to; non-empty list[str], entries <= 128.
+    cve_ids: list[str]
+
+
+def _validate_risk_snapshot(rs: Any) -> None:
+    """Mirror cloud RiskSnapshot._validate_snapshot_shape + _check_risk_snapshot.
+
+    Rejects a snapshot that is not an object, that is missing snapshot_at, that
+    carries a numeric without snapshot_source, that passes a non-string epss /
+    cvss, or that passes an empty / malformed cve_ids list. Verbatim guard
+    tokens match the cloud so SDK and cloud errors round-trip.
+    """
+    if not isinstance(rs, dict):
+        raise AsqavValidationError(
+            "risk_snapshot_not_object: risk_snapshot must be an object of "
+            f"producer-asserted snapshot signals (got: {repr(rs)[:64]})",
+            docs_url=RISK_ACCEPTANCE_DOCS_URL,
+        )
+    if not rs.get("snapshot_at") or not isinstance(rs.get("snapshot_at"), str):
+        raise AsqavValidationError(
+            "risk_snapshot_missing_snapshot_at: snapshot_at (RFC 3339 string) "
+            "is required on a risk_snapshot.",
+            docs_url=RISK_ACCEPTANCE_DOCS_URL,
+        )
+    source = rs.get("snapshot_source")
+    numeric_present = any(
+        rs.get(k) is not None for k in _RISK_SNAPSHOT_NUMERIC_KEYS
+    )
+    if numeric_present and (not isinstance(source, str) or not source):
+        raise AsqavValidationError(
+            "risk_snapshot_numeric_requires_snapshot_source: a populated "
+            "risk_snapshot signal requires snapshot_source so the value is "
+            "never read as an Asqav-derived score.",
+            docs_url=RISK_ACCEPTANCE_DOCS_URL,
+        )
+    for _k in ("epss", "cvss"):
+        _v = rs.get(_k)
+        if _v is not None and not isinstance(_v, str):
+            raise AsqavValidationError(
+                f"risk_snapshot_{_k}_not_string: numeric risk signals MUST be "
+                f"strings on the wire, never floats (got: {repr(_v)[:64]}).",
+                docs_url=RISK_ACCEPTANCE_DOCS_URL,
+            )
+    cve_ids = rs.get("cve_ids")
+    if cve_ids is not None:
+        if not isinstance(cve_ids, list) or len(cve_ids) == 0:
+            raise AsqavValidationError(
+                "risk_snapshot_cve_ids_must_be_non_empty_list: pass a "
+                "non-empty list of strings or omit cve_ids.",
+                docs_url=RISK_ACCEPTANCE_DOCS_URL,
+            )
+        for _entry in cve_ids:
+            if not isinstance(_entry, str) or not _entry or len(_entry) > 128:
+                raise AsqavValidationError(
+                    "risk_snapshot_cve_ids_entry_invalid: each cve id must be "
+                    f"a non-empty string of length <= 128 (got: {repr(_entry)[:64]}).",
+                    docs_url=RISK_ACCEPTANCE_DOCS_URL,
+                )
+
+
+#: The risk-acceptance signed-payload extension fields, fenced to the
+#: protectmcp:lifecycle:risk_acceptance receipt type (mirrors cloud SignRequest).
+_RISK_ACCEPTANCE_RECEIPT_TYPE = "protectmcp:lifecycle:risk_acceptance"
+
+
+def _validate_risk_acceptance(
+    *,
+    receipt_type: str | None,
+    compliance_mode: bool,
+    policy_decision: str,
+    approver_id: str | None,
+    initiator_id: str | None,
+    acceptance_reason: str | None,
+    accepted_at: str | None,
+    supersedes: str | None,
+    sarif_digest: str | None,
+    finding_ref: str | None,
+    approval_ref: str | None,
+    risk_snapshot: Any,
+) -> None:
+    """Mirror the cloud SignRequest._validate_risk_acceptance_extensions guards.
+
+    sarif_digest must be a sha256:<64 hex> existence proof. The extension fields
+    are fenced to receipt_type=protectmcp:lifecycle:risk_acceptance; a
+    risk-acceptance receipt requires approver_id + acceptance_reason and signs
+    via policy_decision='none' so the no-false-attestation guard stays honest.
+    The risk fields project into the signed bytes only on the compliance-mode
+    path, so the SDK requires compliance_mode=True (mirrors the cloud
+    compliance-mode guard) rather than silently dropping the fields.
+    """
+    if sarif_digest is not None and not _SHA256_HEX_RE.match(sarif_digest):
+        raise AsqavValidationError(
+            "sarif_digest_not_sha256_wire_form: must look like "
+            f"'sha256:<64 lowercase hex>' (got: {repr(sarif_digest)[:64]}).",
+            docs_url=RISK_ACCEPTANCE_DOCS_URL,
+        )
+    if risk_snapshot is not None:
+        _validate_risk_snapshot(risk_snapshot)
+    risk_fields_present = any(
+        v is not None
+        for v in (
+            approver_id,
+            initiator_id,
+            acceptance_reason,
+            accepted_at,
+            supersedes,
+            sarif_digest,
+            finding_ref,
+            approval_ref,
+            risk_snapshot,
+        )
+    )
+    if risk_fields_present and receipt_type != _RISK_ACCEPTANCE_RECEIPT_TYPE:
+        raise AsqavValidationError(
+            "risk_acceptance_fields_require_risk_acceptance_receipt: "
+            "approver_id / initiator_id / acceptance_reason / accepted_at / "
+            "supersedes / sarif_digest / finding_ref / approval_ref / "
+            "risk_snapshot are only valid on "
+            f"receipt_type={_RISK_ACCEPTANCE_RECEIPT_TYPE}.",
+            docs_url=RISK_ACCEPTANCE_DOCS_URL,
+        )
+    if receipt_type == _RISK_ACCEPTANCE_RECEIPT_TYPE:
+        if not (approver_id and acceptance_reason):
+            raise AsqavValidationError(
+                "risk_acceptance_missing_required_field: "
+                f"receipt_type={_RISK_ACCEPTANCE_RECEIPT_TYPE} requires "
+                "approver_id and acceptance_reason.",
+                docs_url=RISK_ACCEPTANCE_DOCS_URL,
+            )
+        if policy_decision != "none":
+            raise AsqavValidationError(
+                "risk_acceptance_requires_no_policy_decision: "
+                f"receipt_type={_RISK_ACCEPTANCE_RECEIPT_TYPE} records no policy "
+                "evaluation; sign it with policy_decision='none'.",
+                docs_url=RISK_ACCEPTANCE_DOCS_URL,
+            )
+        if not compliance_mode:
+            raise AsqavValidationError(
+                "risk_acceptance_requires_compliance_mode: "
+                f"receipt_type={_RISK_ACCEPTANCE_RECEIPT_TYPE} fields project "
+                "into the signed receipt only under compliance_mode=True; "
+                "passing compliance_mode=False would silently drop them.",
+                docs_url=RISK_ACCEPTANCE_DOCS_URL,
+            )
+
+
 def _compute_tool_fingerprint(
     tool_name: str, tool_schema: dict[str, Any] | None
 ) -> str:
@@ -1270,6 +1468,17 @@ class Agent:
         eu_ai_act_articles: list[str] | None = None,
         rfc3161_timestamp: str | None = None,
         witness_policy: dict[str, Any] | None = None,
+        # Risk-acceptance / exception receipt extension fields. Valid only on
+        # receipt_type=protectmcp:lifecycle:risk_acceptance (fenced below).
+        approver_id: str | None = None,
+        initiator_id: str | None = None,
+        acceptance_reason: str | None = None,
+        accepted_at: str | None = None,
+        supersedes: str | None = None,
+        sarif_digest: str | None = None,
+        finding_ref: str | None = None,
+        approval_ref: str | None = None,
+        risk_snapshot: "RiskSnapshot | dict[str, Any] | None" = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -1511,6 +1720,22 @@ class Agent:
                 "receipt_type=protectmcp:observation:result_bound requires "
                 "result_digest (sha256:<64 hex>)."
             )
+        # Risk-acceptance receipt: shape + namespace fence + no-policy opt-out,
+        # lockstep with the cloud SignRequest._validate_risk_acceptance_extensions.
+        _validate_risk_acceptance(
+            receipt_type=receipt_type,
+            compliance_mode=compliance_mode,
+            policy_decision=policy_decision,
+            approver_id=approver_id,
+            initiator_id=initiator_id,
+            acceptance_reason=acceptance_reason,
+            accepted_at=accepted_at,
+            supersedes=supersedes,
+            sarif_digest=sarif_digest,
+            finding_ref=finding_ref,
+            approval_ref=approval_ref,
+            risk_snapshot=risk_snapshot,
+        )
 
         # Rule 10: an absolute horizon and a duration together are ambiguous; reject both.
         if valid_seconds is not None and expires_at is not None:
@@ -1698,6 +1923,16 @@ class Agent:
                 ("eu_ai_act_articles", eu_ai_act_articles),
                 ("rfc3161_timestamp", rfc3161_timestamp),
                 ("witness_policy", witness_policy),
+                # Risk-acceptance extension fields (fenced to the receipt type).
+                ("approver_id", approver_id),
+                ("initiator_id", initiator_id),
+                ("acceptance_reason", acceptance_reason),
+                ("accepted_at", accepted_at),
+                ("supersedes", supersedes),
+                ("sarif_digest", sarif_digest),
+                ("finding_ref", finding_ref),
+                ("approval_ref", approval_ref),
+                ("risk_snapshot", risk_snapshot),
             ):
                 if v is not None:
                     compliance_fields[k] = v

--- a/python/tests/test_client_capture_topology.py
+++ b/python/tests/test_client_capture_topology.py
@@ -267,6 +267,10 @@ def test_receipt_type_parametrised_accepts_all_values(value: str) -> None:
     # Rule 9 lockstep: result_bound receipts MUST carry result_digest.
     if value == "protectmcp:observation:result_bound":
         kwargs["result_digest"] = "sha256:" + "0" * 64
+    # Risk-acceptance receipts MUST carry approver_id + acceptance_reason.
+    if value == "protectmcp:lifecycle:risk_acceptance":
+        kwargs["approver_id"] = "approver:alice@example.com"
+        kwargs["acceptance_reason"] = "accepted"
 
     with patch("asqav.client._post", side_effect=fake_post):
         _agent().sign("api:call", {"k": "v"}, **kwargs)

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -77,6 +77,8 @@ def test_receipt_type_namespace_constant() -> None:
             "protectmcp:restraint",
             "protectmcp:lifecycle",
             "protectmcp:lifecycle:configuration_change",
+            # risk-acceptance / exception receipt; no-policy lifecycle opt-out.
+            "protectmcp:lifecycle:risk_acceptance",
             "protectmcp:acknowledgment",
             "protectmcp:observation",
             # NSA CSI U/OO/6030316-26 alignment (cloud 0.5.0): result-bound

--- a/python/tests/test_client_nsa_aligned_fields.py
+++ b/python/tests/test_client_nsa_aligned_fields.py
@@ -595,6 +595,10 @@ class TestResultBoundReceiptType:
         # result_bound requires result_digest, lockstep with cloud rule 9.
         if receipt_type == "protectmcp:observation:result_bound":
             kwargs["result_digest"] = "sha256:" + "0" * 64
+        # Risk-acceptance requires approver_id + acceptance_reason.
+        if receipt_type == "protectmcp:lifecycle:risk_acceptance":
+            kwargs["approver_id"] = "approver:alice@example.com"
+            kwargs["acceptance_reason"] = "accepted"
         # Lifecycle receipts use policy_decision=none.
         if receipt_type.startswith("protectmcp:lifecycle") or (
             receipt_type.startswith("protectmcp:observation")

--- a/python/tests/test_client_risk_acceptance.py
+++ b/python/tests/test_client_risk_acceptance.py
@@ -1,0 +1,200 @@
+"""SDK parity for the risk-acceptance / exception receipt.
+
+Mirrors the deployed cloud SignRequest validators (routes/agents.py
+``_validate_risk_acceptance_extensions`` + RiskSnapshot) for
+``receipt_type='protectmcp:lifecycle:risk_acceptance'``. The SDK forwards the
+nine extension fields verbatim, validates the sarif_digest shape, the
+risk_snapshot numeric-requires-source rule, the field-fence to the
+risk-acceptance type, and requires compliance_mode so the fields are never
+silently dropped from the signed bytes. Each rejection carries a docs_url
+(rule 3.9).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import (
+    RECEIPT_TYPE_NAMESPACE,
+    RISK_ACCEPTANCE_DOCS_URL,
+    Agent,
+    AsqavValidationError,
+)
+
+RISK_TYPE = "protectmcp:lifecycle:risk_acceptance"
+GOOD_SARIF = "sha256:" + "a" * 64
+GOOD_SNAPSHOT = {
+    "snapshot_at": "2026-06-01T19:00:00Z",
+    "snapshot_source": "CISA KEV catalog + FIRST EPSS feed",
+    "epss": "0.94210",
+    "cvss": "9.8",
+    "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+    "kev_listed": True,
+    "cve_ids": ["CVE-2026-1234", "CVE-2026-5678"],
+}
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_risk",
+        name="risk-agent",
+        public_key="pk_test",
+        key_id="key_risk",
+        algorithm="ML-DSA-65",
+        capabilities=["risk:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response(extra: dict | None = None) -> dict:
+    base = {
+        "signature": "sig_b64",
+        "signature_id": "sig_abc",
+        "action_id": "act_abc",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_abc",
+        "algorithm": "ML-DSA-65",
+        "chain_hash": "deadbeef",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+def _good_kwargs() -> dict:
+    return dict(
+        compliance_mode=True,
+        receipt_type=RISK_TYPE,
+        policy_decision="none",
+        approver_id="approver:alice@example.com",
+        initiator_id="initiator:bob@example.com",
+        acceptance_reason="Compensating control in place; accepted 90 days.",
+        accepted_at="2026-06-01T19:05:00Z",
+        supersedes="act_prior_0001",
+        sarif_digest=GOOD_SARIF,
+        finding_ref="github.com/acme/repo/security/code-scanning/42",
+        approval_ref="JIRA-SEC-9001",
+        risk_snapshot=dict(GOOD_SNAPSHOT),
+    )
+
+
+def _sign(**overrides) -> dict:
+    """Sign with the good kwargs (plus overrides) and return the wire body."""
+    kwargs = _good_kwargs()
+    kwargs.update(overrides)
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response(
+            {"compliance_mode": True, "policy_decision": "none", "decision": "observation"}
+        )
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("risk:accept", {"k": "v"}, **kwargs)
+    return captured["body"]
+
+
+# === namespace ===
+
+
+def test_namespace_includes_risk_acceptance() -> None:
+    assert RISK_TYPE in RECEIPT_TYPE_NAMESPACE
+
+
+# === valid: all nine fields project ===
+
+
+def test_all_risk_fields_project_to_wire() -> None:
+    body = _sign()
+    assert body["approver_id"] == "approver:alice@example.com"
+    assert body["initiator_id"] == "initiator:bob@example.com"
+    assert body["acceptance_reason"].startswith("Compensating control")
+    assert body["accepted_at"] == "2026-06-01T19:05:00Z"
+    assert body["supersedes"] == "act_prior_0001"
+    assert body["sarif_digest"] == GOOD_SARIF
+    assert body["finding_ref"].startswith("github.com")
+    assert body["approval_ref"] == "JIRA-SEC-9001"
+    assert body["risk_snapshot"]["snapshot_source"].startswith("CISA KEV")
+    assert body["receipt_type"] == RISK_TYPE
+
+
+def test_cvss_epss_are_strings_on_the_wire() -> None:
+    body = _sign()
+    assert isinstance(body["risk_snapshot"]["cvss"], str)
+    assert isinstance(body["risk_snapshot"]["epss"], str)
+
+
+# === rejections ===
+
+
+def test_rejects_bad_sarif_digest_shape() -> None:
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(sarif_digest="not-a-sha256-digest")
+    assert "sarif_digest_not_sha256_wire_form" in str(exc.value)
+    assert exc.value.docs_url == RISK_ACCEPTANCE_DOCS_URL
+
+
+def test_rejects_numeric_without_snapshot_source() -> None:
+    bad_snapshot = {"snapshot_at": "2026-06-01T19:00:00Z", "snapshot_source": "", "cvss": "9.8"}
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(risk_snapshot=bad_snapshot)
+    assert "risk_snapshot_numeric_requires_snapshot_source" in str(exc.value)
+
+
+def test_rejects_risk_fields_on_wrong_receipt_type() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):  # noqa: SIM117
+        with pytest.raises(AsqavValidationError) as exc:
+            _agent().sign(
+                "lifecycle:change",
+                {"k": "v"},
+                compliance_mode=True,
+                receipt_type="protectmcp:lifecycle",
+                policy_decision="none",
+                sarif_digest=GOOD_SARIF,
+            )
+    assert "risk_acceptance_fields_require_risk_acceptance_receipt" in str(exc.value)
+
+
+def test_rejects_missing_required_field() -> None:
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(approver_id=None, acceptance_reason=None)
+    assert "risk_acceptance_missing_required_field" in str(exc.value)
+
+
+def test_rejects_without_compliance_mode() -> None:
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(compliance_mode=False)
+    assert "risk_acceptance_requires_compliance_mode" in str(exc.value)
+
+
+def test_rejects_non_none_policy_decision() -> None:
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(policy_decision="permit")
+    assert "risk_acceptance_requires_no_policy_decision" in str(exc.value)
+
+
+def test_rejects_cve_ids_empty_list() -> None:
+    bad_snapshot = dict(GOOD_SNAPSHOT)
+    bad_snapshot["cve_ids"] = []
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(risk_snapshot=bad_snapshot)
+    assert "risk_snapshot_cve_ids_must_be_non_empty_list" in str(exc.value)
+
+
+def test_validation_error_is_a_valueerror() -> None:
+    """AsqavValidationError subclasses ValueError for backward compat."""
+    with pytest.raises(ValueError):
+        _sign(sarif_digest="bad")

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -33,7 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.5";
+export const CLI_VERSION = "0.5.6";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -28,12 +28,17 @@ export const RECEIPT_TYPE_NAMESPACE = [
   "protectmcp:restraint",
   "protectmcp:lifecycle",
   "protectmcp:lifecycle:configuration_change",
+  // risk-acceptance / exception receipt; no-policy lifecycle opt-out.
+  "protectmcp:lifecycle:risk_acceptance",
   "protectmcp:acknowledgment",
   "protectmcp:observation",
   // observation receipts with a result_digest use the :result_bound suffix for auditor indexing.
   "protectmcp:observation:result_bound",
 ] as const;
 export type ReceiptType = (typeof RECEIPT_TYPE_NAMESPACE)[number];
+
+/** Docs page anchoring the risk-acceptance validation errors (rule 3.9). */
+export const RISK_ACCEPTANCE_DOCS_URL = "https://asqav.com/docs/risk-acceptance-receipt" as const;
 
 /** Receipt type emitted by an acknowledging agent (B) over an originating
  * receipt; the binding object travels on B's signed payload. */
@@ -249,9 +254,13 @@ const config: Config = {
 // === Errors ===
 
 export class AsqavError extends Error {
-  constructor(message: string) {
+  /** Docs page for the violated rule (rule 3.9). Set on wire-vocabulary
+   * validation rejections so a developer does not have to grep the docs. */
+  docsUrl?: string;
+  constructor(message: string, docsUrl?: string) {
     super(message);
     this.name = "AsqavError";
+    if (docsUrl !== undefined) this.docsUrl = docsUrl;
   }
 }
 
@@ -508,6 +517,73 @@ export interface SignOptions {
    * only when `required` witnesses hold a real inclusion proof. Projected
    * to the wire as snake_case `witness_policy`. */
   witnessPolicy?: WitnessPolicy;
+
+  /** Risk-acceptance receipt: identity that authored the acceptance.
+   * REQUIRED on `receiptType='protectmcp:lifecycle:risk_acceptance'`. Field
+   * only: bound into the signed bytes, never compared or authenticated. */
+  approverId?: string;
+
+  /** Risk-acceptance receipt: identity that requested the acceptance.
+   * Field only; never compared to `approverId`. */
+  initiatorId?: string;
+
+  /** Risk-acceptance receipt: free-text human rationale. REQUIRED on
+   * `receiptType='protectmcp:lifecycle:risk_acceptance'`. Proves the reason
+   * existed at signing time; never parsed or scored. */
+  acceptanceReason?: string;
+
+  /** Risk-acceptance receipt: RFC 3339 wall-clock the approver authored the
+   * acceptance. Producer-asserted; Asqav-attested time is the anchors. */
+  acceptedAt?: string;
+
+  /** Risk-acceptance receipt: pointer to the prior risk-acceptance receipt
+   * this one replaces. The chain stays immutable; supersession is a forward
+   * pointer only. */
+  supersedes?: string;
+
+  /** Risk-acceptance receipt: `sha256:<64 hex>` of the SARIF scan artifact
+   * the acceptance rested on. Proves THAT SARIF existed unaltered; Asqav does
+   * not re-run or validate the scan. */
+  sarifDigest?: string;
+
+  /** Risk-acceptance receipt: opaque pointer to a finding / rule id inside
+   * the SARIF. Free-text; not resolved by Asqav. */
+  findingRef?: string;
+
+  /** Risk-acceptance receipt: opaque pointer to an approval ticket or HITL
+   * approval id. Free-text correlation anchor. */
+  approvalRef?: string;
+
+  /** Risk-acceptance receipt: producer-asserted point-in-time risk snapshot.
+   * Projected to the wire as snake_case `risk_snapshot`. A numeric without
+   * `snapshotSource` is rejected so it is never read as an Asqav score. */
+  riskSnapshot?: RiskSnapshot;
+}
+
+/** Producer-asserted point-in-time snapshot of third-party risk signals.
+ *
+ * Mirrors the cloud RiskSnapshot model. Every value is a snapshot the
+ * producer READ at `snapshot_at` from `snapshot_source`; Asqav never
+ * fetches, computes, verifies, or vouches for any of them. The
+ * `snapshot_at` + `snapshot_source` labels are normative: a numeric
+ * (`epss` / `cvss` / `cvssVector` / `kevListed`) without `snapshotSource`
+ * is rejected so a value can never appear unlabeled and be mistaken for an
+ * Asqav-derived score. Numerics are strings on the wire. */
+export interface RiskSnapshot {
+  /** RFC 3339 read-time of the signals (REQUIRED). Producer-asserted. */
+  snapshotAt: string;
+  /** Free-text source label. REQUIRED when any numeric is present. */
+  snapshotSource: string;
+  /** EPSS probability as a STRING (floats rejected). Producer-asserted. */
+  epss?: string;
+  /** CVSS base score as a STRING. Producer-asserted; not computed by Asqav. */
+  cvss?: string;
+  /** CVSS vector string snapshot. Producer-asserted; not parsed by Asqav. */
+  cvssVector?: string;
+  /** Whether the CVE was in the named KEV catalog at snapshotAt, as observed. */
+  kevListed?: boolean;
+  /** CVE ids the snapshot pertains to; non-empty array, entries <= 128 chars. */
+  cveIds?: string[];
 }
 
 export interface CoSignature {
@@ -893,7 +969,7 @@ function surfaceKwargsIntoContext(options: SignOptions): Record<string, unknown>
  * obvious mistakes do not consume a network call. Throws AsqavError on
  * the first offending field.
  */
-function validateSignOptions(options: SignOptions): void {
+function validateSignOptions(options: SignOptions, complianceMode: boolean): void {
   if (
     options.receiptType !== undefined
     && !(RECEIPT_TYPE_NAMESPACE as readonly string[]).includes(options.receiptType)
@@ -1054,6 +1130,9 @@ function validateSignOptions(options: SignOptions): void {
   }
   validateWitnessPolicy(options.witnessPolicy);
   validateIncidentClass(options.incidentClass);
+  // Risk-acceptance receipt: shape + namespace fence + no-policy opt-out +
+  // compliance_mode requirement, lockstep with the cloud SignRequest validator.
+  validateRiskAcceptance(options, complianceMode);
 }
 
 /**
@@ -1113,6 +1192,120 @@ function validateIncidentClass(value: string | string[] | undefined): void {
     if (!(INCIDENT_CLASS_NAMESPACE as readonly string[]).includes(ic)) {
       throw new AsqavError(
         `invalid_incident_class: '${ic}' must be one of ${INCIDENT_CLASS_NAMESPACE.join(", ")}`,
+      );
+    }
+  }
+}
+
+/** Receipt type carrying the risk-acceptance extension fields. */
+const RISK_ACCEPTANCE_RECEIPT_TYPE = "protectmcp:lifecycle:risk_acceptance";
+
+/**
+ * Reject a malformed `riskSnapshot` before the HTTP roundtrip. Lockstep with
+ * the cloud RiskSnapshot validator: `snapshotAt` is required, a numeric
+ * (`epss` / `cvss` / `cvssVector` / `kevListed`) requires `snapshotSource`,
+ * `epss` / `cvss` must be strings, and `cveIds` must be a non-empty array of
+ * strings (<= 128 chars). Verbatim guard tokens match the Python SDK.
+ */
+function validateRiskSnapshot(rs: RiskSnapshot | undefined): void {
+  if (rs === undefined) return;
+  if (typeof rs !== "object" || rs === null || Array.isArray(rs)) {
+    throw new AsqavError(
+      `risk_snapshot_not_object: risk_snapshot must be an object of producer-asserted snapshot signals (got: ${JSON.stringify(rs).slice(0, 64)})`,
+      RISK_ACCEPTANCE_DOCS_URL,
+    );
+  }
+  if (typeof rs.snapshotAt !== "string" || rs.snapshotAt.length === 0) {
+    throw new AsqavError(
+      "risk_snapshot_missing_snapshot_at: snapshotAt (RFC 3339 string) is required on a risk_snapshot.",
+      RISK_ACCEPTANCE_DOCS_URL,
+    );
+  }
+  const numericPresent = rs.epss !== undefined
+    || rs.cvss !== undefined
+    || rs.cvssVector !== undefined
+    || rs.kevListed !== undefined;
+  if (numericPresent && (typeof rs.snapshotSource !== "string" || rs.snapshotSource.length === 0)) {
+    throw new AsqavError(
+      "risk_snapshot_numeric_requires_snapshot_source: a populated risk_snapshot signal requires snapshot_source so the value is never read as an Asqav-derived score.",
+      RISK_ACCEPTANCE_DOCS_URL,
+    );
+  }
+  for (const [name, value] of [["epss", rs.epss], ["cvss", rs.cvss]] as const) {
+    if (value !== undefined && typeof value !== "string") {
+      throw new AsqavError(
+        `risk_snapshot_${name}_not_string: numeric risk signals MUST be strings on the wire, never floats.`,
+        RISK_ACCEPTANCE_DOCS_URL,
+      );
+    }
+  }
+  if (rs.cveIds !== undefined) {
+    if (!Array.isArray(rs.cveIds) || rs.cveIds.length === 0) {
+      throw new AsqavError(
+        "risk_snapshot_cve_ids_must_be_non_empty_list: pass a non-empty list of strings or omit cveIds.",
+        RISK_ACCEPTANCE_DOCS_URL,
+      );
+    }
+    for (const entry of rs.cveIds) {
+      if (typeof entry !== "string" || entry.length === 0 || entry.length > 128) {
+        throw new AsqavError(
+          "risk_snapshot_cve_ids_entry_invalid: each cve id must be a non-empty string of length <= 128.",
+          RISK_ACCEPTANCE_DOCS_URL,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Reject malformed risk-acceptance receipts before the HTTP roundtrip.
+ * Lockstep with the cloud SignRequest `_validate_risk_acceptance_extensions`:
+ * sarifDigest must be `sha256:<64 hex>`; the extension fields are fenced to
+ * `receiptType='protectmcp:lifecycle:risk_acceptance'`; the receipt requires
+ * `approverId` + `acceptanceReason`, signs with `policyDecision='none'`, and
+ * (mirroring the cloud compliance-mode guard) requires `complianceMode` so the
+ * fields are never silently dropped from the signed bytes.
+ */
+function validateRiskAcceptance(options: SignOptions, complianceMode: boolean): void {
+  if (options.sarifDigest !== undefined && !SHA256_HEX_RE.test(options.sarifDigest)) {
+    throw new AsqavError(
+      `sarif_digest_not_sha256_wire_form: must look like 'sha256:<64 lowercase hex>' (got: ${options.sarifDigest.slice(0, 64)}).`,
+      RISK_ACCEPTANCE_DOCS_URL,
+    );
+  }
+  validateRiskSnapshot(options.riskSnapshot);
+  const riskFieldsPresent = options.approverId !== undefined
+    || options.initiatorId !== undefined
+    || options.acceptanceReason !== undefined
+    || options.acceptedAt !== undefined
+    || options.supersedes !== undefined
+    || options.sarifDigest !== undefined
+    || options.findingRef !== undefined
+    || options.approvalRef !== undefined
+    || options.riskSnapshot !== undefined;
+  if (riskFieldsPresent && options.receiptType !== RISK_ACCEPTANCE_RECEIPT_TYPE) {
+    throw new AsqavError(
+      `risk_acceptance_fields_require_risk_acceptance_receipt: approver_id / initiator_id / acceptance_reason / accepted_at / supersedes / sarif_digest / finding_ref / approval_ref / risk_snapshot are only valid on receipt_type=${RISK_ACCEPTANCE_RECEIPT_TYPE}.`,
+      RISK_ACCEPTANCE_DOCS_URL,
+    );
+  }
+  if (options.receiptType === RISK_ACCEPTANCE_RECEIPT_TYPE) {
+    if (!options.approverId || !options.acceptanceReason) {
+      throw new AsqavError(
+        `risk_acceptance_missing_required_field: receipt_type=${RISK_ACCEPTANCE_RECEIPT_TYPE} requires approver_id and acceptance_reason.`,
+        RISK_ACCEPTANCE_DOCS_URL,
+      );
+    }
+    if (options.policyDecision !== "none") {
+      throw new AsqavError(
+        `risk_acceptance_requires_no_policy_decision: receipt_type=${RISK_ACCEPTANCE_RECEIPT_TYPE} records no policy evaluation; sign it with policy_decision='none'.`,
+        RISK_ACCEPTANCE_DOCS_URL,
+      );
+    }
+    if (!complianceMode) {
+      throw new AsqavError(
+        `risk_acceptance_requires_compliance_mode: receipt_type=${RISK_ACCEPTANCE_RECEIPT_TYPE} fields project into the signed receipt only under compliance_mode=true; passing compliance_mode=false would silently drop them.`,
+        RISK_ACCEPTANCE_DOCS_URL,
       );
     }
   }
@@ -1229,6 +1422,23 @@ function applyOptionalWireFields(
   }
 }
 
+/** Convert a camelCase `RiskSnapshot` to its snake_case wire object so the
+ * signed payload uses the same keys the cloud RiskSnapshot model emits.
+ * Returns undefined when no snapshot is supplied (field omitted from wire). */
+function riskSnapshotToWire(rs: RiskSnapshot | undefined): Record<string, unknown> | undefined {
+  if (rs === undefined) return undefined;
+  const wire: Record<string, unknown> = {
+    snapshot_at: rs.snapshotAt,
+    snapshot_source: rs.snapshotSource,
+  };
+  if (rs.epss !== undefined) wire.epss = rs.epss;
+  if (rs.cvss !== undefined) wire.cvss = rs.cvss;
+  if (rs.cvssVector !== undefined) wire.cvss_vector = rs.cvssVector;
+  if (rs.kevListed !== undefined) wire.kev_listed = rs.kevListed;
+  if (rs.cveIds !== undefined) wire.cve_ids = rs.cveIds;
+  return wire;
+}
+
 /** Snake_case wire-key projection of the optional IETF profile fields
  * that do not depend on `complianceMode`. Defined as a const table so
  * the `applyComplianceFields` loop stays single-pass. */
@@ -1262,6 +1472,16 @@ const IETF_OPTIONAL_FIELD_MAP: ReadonlyArray<{
   { wire: "rfc3161_timestamp", read: (o) => o.rfc3161Timestamp },
   // Durable-anchoring quorum (cloud witness_policy extension).
   { wire: "witness_policy", read: (o) => o.witnessPolicy },
+  // Risk-acceptance receipt extension fields (fenced to the receipt type).
+  { wire: "approver_id", read: (o) => o.approverId },
+  { wire: "initiator_id", read: (o) => o.initiatorId },
+  { wire: "acceptance_reason", read: (o) => o.acceptanceReason },
+  { wire: "accepted_at", read: (o) => o.acceptedAt },
+  { wire: "supersedes", read: (o) => o.supersedes },
+  { wire: "sarif_digest", read: (o) => o.sarifDigest },
+  { wire: "finding_ref", read: (o) => o.findingRef },
+  { wire: "approval_ref", read: (o) => o.approvalRef },
+  { wire: "risk_snapshot", read: (o) => riskSnapshotToWire(o.riskSnapshot) },
   {
     wire: "tool_fingerprint",
     read: (o) =>
@@ -1495,7 +1715,7 @@ export class Agent {
     const finalContext = _dispatchBefore(options.actionType, initialContext);
     const complianceMode = options.complianceMode !== false;
 
-    validateSignOptions(options);
+    validateSignOptions(options, complianceMode);
 
     const actionRef = deriveActionRef(
       complianceMode,

--- a/typescript/tests/captureTopology.test.ts
+++ b/typescript/tests/captureTopology.test.ts
@@ -74,6 +74,7 @@ describe("RECEIPT_TYPE_NAMESPACE", () => {
         "protectmcp:decision",
         "protectmcp:lifecycle",
         "protectmcp:lifecycle:configuration_change",
+        "protectmcp:lifecycle:risk_acceptance",
         "protectmcp:observation",
         // NSA CSI U/OO/6030316-26 alignment (cloud 0.5.0): result-bound
         // observation receipts use the `:result_bound` suffix.

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -200,6 +200,13 @@ describe("agent.sign IETF profile fields", () => {
       if (t === "protectmcp:observation:result_bound") {
         opts.resultDigest = `sha256:${"0".repeat(64)}`;
       }
+      // Risk-acceptance carries approver_id + acceptance_reason and the
+      // no-policy opt-out (policy_decision='none').
+      if (t === "protectmcp:lifecycle:risk_acceptance") {
+        opts.approverId = "approver:alice@example.com";
+        opts.acceptanceReason = "accepted";
+        opts.policyDecision = "none";
+      }
       await expect(agent.sign(opts)).resolves.toBeDefined();
     }
   });

--- a/typescript/tests/nsaAlignedFields.test.ts
+++ b/typescript/tests/nsaAlignedFields.test.ts
@@ -513,6 +513,10 @@ describe("protectmcp:observation:result_bound receipt type", () => {
       if (receiptType === "protectmcp:observation:result_bound") {
         opts.resultDigest = `sha256:${"0".repeat(64)}`;
       }
+      if (receiptType === "protectmcp:lifecycle:risk_acceptance") {
+        opts.approverId = "approver:alice@example.com";
+        opts.acceptanceReason = "accepted";
+      }
       if (
         receiptType.startsWith("protectmcp:lifecycle")
         || receiptType.startsWith("protectmcp:observation")

--- a/typescript/tests/riskAcceptance.test.ts
+++ b/typescript/tests/riskAcceptance.test.ts
@@ -1,0 +1,206 @@
+/**
+ * SDK parity for the risk-acceptance / exception receipt.
+ *
+ * Mirrors the deployed cloud SignRequest validators (routes/agents.py
+ * `_validate_risk_acceptance_extensions` + RiskSnapshot) for
+ * `receiptType='protectmcp:lifecycle:risk_acceptance'`. The SDK forwards the
+ * nine extension fields verbatim (camelCase -> snake_case), validates the
+ * sarifDigest shape, the risk_snapshot numeric-requires-source rule, the
+ * field-fence to the risk-acceptance type, and requires complianceMode so the
+ * fields are never silently dropped from the signed bytes.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  AsqavError,
+  RECEIPT_TYPE_NAMESPACE,
+  RISK_ACCEPTANCE_DOCS_URL,
+  _resetForTests,
+  init,
+} from "../src/index.js";
+
+const RISK_TYPE = "protectmcp:lifecycle:risk_acceptance";
+const GOOD_SARIF = "sha256:" + "a".repeat(64);
+const GOOD_SNAPSHOT = {
+  snapshotAt: "2026-06-01T19:00:00Z",
+  snapshotSource: "CISA KEV catalog + FIRST EPSS feed",
+  epss: "0.94210",
+  cvss: "9.8",
+  cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+  kevListed: true,
+  cveIds: ["CVE-2026-1234", "CVE-2026-5678"],
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_risk",
+    name: "risk",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-05-25T00:00:00Z",
+  });
+}
+
+function okBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    signature: "sig",
+    signature_id: "sig_test",
+    action_id: "act_test",
+    timestamp: "2026-06-01T19:00:00Z",
+    verification_url: "https://verify",
+    ...extra,
+  };
+}
+
+function readBody(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
+  const init = spy.mock.calls[0][1] as RequestInit;
+  return JSON.parse((init?.body as string) ?? "{}");
+}
+
+function goodRiskOptions(): Record<string, unknown> {
+  return {
+    actionType: "risk:accept",
+    context: { k: "v" },
+    complianceMode: true,
+    receiptType: RISK_TYPE,
+    policyDecision: "none",
+    approverId: "approver:alice@example.com",
+    initiatorId: "initiator:bob@example.com",
+    acceptanceReason: "Compensating control in place; accepted 90 days.",
+    acceptedAt: "2026-06-01T19:05:00Z",
+    supersedes: "act_prior_0001",
+    sarifDigest: GOOD_SARIF,
+    findingRef: "github.com/acme/repo/security/code-scanning/42",
+    approvalRef: "JIRA-SEC-9001",
+    riskSnapshot: GOOD_SNAPSHOT,
+  };
+}
+
+beforeEach(() => {
+  _resetForTests();
+  init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("risk-acceptance receipt namespace", () => {
+  it("includes the risk_acceptance type in the namespace", () => {
+    expect(RECEIPT_TYPE_NAMESPACE).toContain(RISK_TYPE);
+  });
+});
+
+describe("risk-acceptance wire forwarding (valid)", () => {
+  it("forwards all nine extension fields as snake_case", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign(goodRiskOptions() as any);
+    const body = readBody(spy);
+    expect(body.approver_id).toBe("approver:alice@example.com");
+    expect(body.initiator_id).toBe("initiator:bob@example.com");
+    expect(body.acceptance_reason).toBe(
+      "Compensating control in place; accepted 90 days.",
+    );
+    expect(body.accepted_at).toBe("2026-06-01T19:05:00Z");
+    expect(body.supersedes).toBe("act_prior_0001");
+    expect(body.sarif_digest).toBe(GOOD_SARIF);
+    expect(body.finding_ref).toBe("github.com/acme/repo/security/code-scanning/42");
+    expect(body.approval_ref).toBe("JIRA-SEC-9001");
+    expect(body.risk_snapshot).toEqual({
+      snapshot_at: "2026-06-01T19:00:00Z",
+      snapshot_source: "CISA KEV catalog + FIRST EPSS feed",
+      epss: "0.94210",
+      cvss: "9.8",
+      cvss_vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      kev_listed: true,
+      cve_ids: ["CVE-2026-1234", "CVE-2026-5678"],
+    });
+  });
+
+  it("keeps cvss/epss as strings on the wire", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign(goodRiskOptions() as any);
+    const body = readBody(spy);
+    const snap = body.risk_snapshot as Record<string, unknown>;
+    expect(typeof snap.cvss).toBe("string");
+    expect(typeof snap.epss).toBe("string");
+  });
+});
+
+describe("risk-acceptance rejections", () => {
+  it("rejects a bad sarif_digest shape", async () => {
+    await expect(
+      fakeAgent().sign({ ...goodRiskOptions(), sarifDigest: "not-a-sha256" } as any),
+    ).rejects.toThrow(/sarif_digest_not_sha256_wire_form/);
+  });
+
+  it("rejects a risk_snapshot numeric without snapshot_source", async () => {
+    await expect(
+      fakeAgent().sign({
+        ...goodRiskOptions(),
+        riskSnapshot: { snapshotAt: "2026-06-01T19:00:00Z", snapshotSource: "", cvss: "9.8" },
+      } as any),
+    ).rejects.toThrow(/risk_snapshot_numeric_requires_snapshot_source/);
+  });
+
+  it("rejects risk fields on a non-risk-acceptance receipt type", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "lifecycle:change",
+        complianceMode: true,
+        receiptType: "protectmcp:lifecycle",
+        sarifDigest: GOOD_SARIF,
+      } as any),
+    ).rejects.toThrow(/risk_acceptance_fields_require_risk_acceptance_receipt/);
+  });
+
+  it("rejects a risk-acceptance receipt missing approver_id/acceptance_reason", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "risk:accept",
+        complianceMode: true,
+        receiptType: RISK_TYPE,
+        policyDecision: "none",
+      } as any),
+    ).rejects.toThrow(/risk_acceptance_missing_required_field/);
+  });
+
+  it("rejects a risk-acceptance receipt without compliance_mode", async () => {
+    await expect(
+      fakeAgent().sign({
+        ...goodRiskOptions(),
+        complianceMode: false,
+      } as any),
+    ).rejects.toThrow(/risk_acceptance_requires_compliance_mode/);
+  });
+
+  it("rejects a risk-acceptance receipt with a non-none policy_decision", async () => {
+    await expect(
+      fakeAgent().sign({
+        ...goodRiskOptions(),
+        policyDecision: "permit",
+      } as any),
+    ).rejects.toThrow(/risk_acceptance_requires_no_policy_decision/);
+  });
+
+  it("attaches the docs_url to the validation error (rule 3.9)", async () => {
+    try {
+      await fakeAgent().sign({ ...goodRiskOptions(), sarifDigest: "bad" } as any);
+      throw new Error("expected rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AsqavError);
+      expect((err as AsqavError).docsUrl).toBe(RISK_ACCEPTANCE_DOCS_URL);
+    }
+  });
+});

--- a/verifier/test_verify_receipt.py
+++ b/verifier/test_verify_receipt.py
@@ -1,0 +1,70 @@
+"""Zero-dep verifier accepts the risk-acceptance receipt type.
+
+verify_receipt.py carries protectmcp:lifecycle:risk_acceptance in ALLOWED_TYPES
+so the structure axis recognises a valid risk-acceptance receipt and PASSes on
+it; an unknown type still fails closed. These tests pin both behaviours.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import verify_receipt as v
+
+RISK_TYPE = "protectmcp:lifecycle:risk_acceptance"
+
+
+def _risk_payload() -> dict:
+    return {
+        "type": RISK_TYPE,
+        "issued_at": "2026-06-01T19:26:44.289388Z",
+        "issuer_id": "c37probe-org-00001",
+        "action_ref": "sha256:" + "8" * 64,
+        "payload_digest": {"hash": "8" * 64, "size": 512},
+        "policy_digest": "sha256:" + "3" * 64,
+        "previousReceiptHash": "0" * 64,
+        "decision": "observation",
+        "approver_id": "approver:alice@example.com",
+        "acceptance_reason": "accepted",
+        "sarif_digest": "sha256:" + "9" * 64,
+    }
+
+
+def test_risk_acceptance_in_allowed_types() -> None:
+    assert RISK_TYPE in v.ALLOWED_TYPES
+
+
+def test_structure_accepts_risk_acceptance() -> None:
+    """The structure axis PASSes on a real risk-acceptance receipt; the type is
+    inside ALLOWED_TYPES so it is recognised, not rejected."""
+    res, note = v.check_structure(_risk_payload())
+    assert res == "PASS"
+    assert RISK_TYPE in note
+
+
+def test_structure_still_rejects_unknown_type() -> None:
+    payload = _risk_payload()
+    payload["type"] = "protectmcp:not_a_real_type"
+    res, _note = v.check_structure(payload)
+    assert res == "FAIL"
+
+
+def test_run_structure_axis_passes_on_risk_acceptance(capsys) -> None:
+    """A full run over a risk-acceptance envelope prints `[  ok] structure`:
+    the type is recognised, so the structure axis contributes a PASS and the
+    risk-acceptance type never appears in a FAIL line."""
+    envelope = {
+        "payload": _risk_payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "c37probe-org-00001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    v.run(envelope, {"keys": []}, predecessor_payload=None)
+    out = capsys.readouterr().out
+    assert "[  ok] structure" in out
+    # The risk-acceptance type must never appear in a FAIL line.
+    for line in out.splitlines():
+        if "[FAIL]" in line:
+            assert "structure" not in line

--- a/verifier/verify_receipt.py
+++ b/verifier/verify_receipt.py
@@ -57,6 +57,8 @@ ALLOWED_TYPES = {
     "protectmcp:restraint",
     "protectmcp:lifecycle",
     "protectmcp:lifecycle:configuration_change",
+    # risk-acceptance / exception receipt; no-policy lifecycle opt-out.
+    "protectmcp:lifecycle:risk_acceptance",
     "protectmcp:acknowledgment",
     "protectmcp:observation",
     "protectmcp:observation:result_bound",


### PR DESCRIPTION
## Summary

Mirrors the deployed Asqav cloud risk-acceptance vocab on the SDK write side (Python + TypeScript) and the zero-dependency verifier. The cloud build advertising `protectmcp:lifecycle:risk_acceptance` is live in `/.well-known/governance.json` (verified 2026-06-01); this change brings the consumers to parity.

## What changed

Python SDK (`python/src/asqav/`)
- `RECEIPT_TYPE_NAMESPACE` gains `protectmcp:lifecycle:risk_acceptance`.
- `agent.sign(...)` gains nine optional kwargs: `approver_id`, `initiator_id`, `acceptance_reason`, `accepted_at`, `supersedes`, `sarif_digest`, `finding_ref`, `approval_ref`, `risk_snapshot`.
- Validators in lockstep with the cloud `SignRequest` guards: `sarif_digest` must be `sha256:<64 hex>`; a populated `risk_snapshot` numeric requires `snapshot_source`; `epss` / `cvss` must be strings; the nine fields are fenced to the risk-acceptance receipt type; the receipt requires `approver_id` + `acceptance_reason`, `policy_decision='none'`, and `compliance_mode`.
- New `AsqavValidationError(ValueError)` carrying `docs_url`; `RiskSnapshot` TypedDict; `RISK_ACCEPTANCE_DOCS_URL` constant. All exported from `asqav`.

TypeScript SDK (`typescript/src/`)
- Identical surface and guards in `validateRiskAcceptance` / `validateRiskSnapshot`, the `RiskSnapshot` interface, `AsqavError.docsUrl`, the `RISK_ACCEPTANCE_DOCS_URL` constant, and a camelCase-to-snake_case wire projection for `risk_snapshot`.

Verifier (`verifier/verify_receipt.py`)
- Added the type to `ALLOWED_TYPES` so the structure axis recognises a valid risk-acceptance receipt and verifies it instead of rejecting on type.

## Parity

Python and TypeScript expose the same field names, the same verbatim guard tokens, and the same docs-url-bearing rejections, so SDK errors round-trip identically across language users.

## Tests

- Python: `python/tests/test_client_risk_acceptance.py` plus updates to three namespace-iterating tests; full suite green aside from a set of pre-existing environment failures unrelated to this change.
- TypeScript: `typescript/tests/riskAcceptance.test.ts` plus three namespace-iterating tests; 388 tests green; `tsc --noEmit` clean.
- Verifier: `verifier/test_verify_receipt.py`.

## Versioning

Bumped to `0.5.6` across `pyproject.toml`, `asqav.__version__`, `package.json`, and `CLI_VERSION`; CHANGELOG updated. Publishing to PyPI and npm is a separate gated step handled by the orchestrator, not this PR (rule 2.8).

## THREAT_MODEL

- New attack surface: a caller could try to ride the risk-acceptance extension fields onto an unrelated receipt type, supply an unlabeled risk number that reads as an Asqav-derived score, or sign without compliance mode so the fields drop from the signed bytes.
- Existing guard: the cloud `SignRequest` validators enforce the field fence, the numeric-requires-source rule, the no-policy opt-out, and the sha256 shape; this change mirrors them client-side so the SDK fails fast before the roundtrip.
- New test: the unit tests assert each rejection (wrong-type fence, missing snapshot source, missing compliance mode, bad sarif shape, missing required fields, non-none policy decision).
- Trust boundary change: no. The SDK is the write-side consumer; the cloud remains authoritative and re-validates every field.
