### PR TITLE
Add code-authorship receipt to the Asqav SDK (Python and TS) and verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [TypeScript 0.5.7] - 2026-06-02
+
+### Added
+- Code-authorship receipt support on `agent.sign({...})`. New `receiptType` value `protectmcp:lifecycle:code_authorship` plus eight optional camelCase props projected to snake_case wire keys: `repoRef`, `commitSha`, `baseSha`, `changeDigest`, `changeRef`, `changeApprovalRef`, `changeClass`, and `authoredBy`. The `authoredBy` object names the producer-asserted author (`humanId`, `modelId`, `modelVersion`, `attestationSource`). Every field records that a producer-asserted value existed at signing time; Asqav does not re-run the diff, resolve the refs, or attest the model.
+- Client-side validators in lockstep with the cloud SignRequest guards: `changeDigest` must be `sha256:<64 hex>`; `changeClass` must be one of `read|write|delete|execute|deploy`; a populated `authoredBy.modelId` / `modelVersion` requires `authoredBy.attestationSource`; the eight fields are fenced to `receiptType=protectmcp:lifecycle:code_authorship`; the receipt requires `repoRef` + `commitSha`, `policyDecision='none'`, and `complianceMode` (the fields project into the signed receipt only under compliance mode). Each rejection carries a `docsUrl` pointing at the code-authorship docs page.
+- New `AuthoredBy` interface, `CODE_AUTHORSHIP_DOCS_URL` and `CODE_AUTHORSHIP_CHANGE_CLASS_NAMESPACE` constants. Tests in `typescript/tests/codeAuthorship.test.ts`.
+
+### Notes
+- Requires an Asqav cloud build that advertises `protectmcp:lifecycle:code_authorship` in `/.well-known/governance.json`. Mirrors the cloud guards landed in the cloud build for this receipt type.
+
+## [Python 0.5.7] - 2026-06-02
+
+### Added
+- Code-authorship receipt support on `agent.sign(...)`. New `receipt_type` value `protectmcp:lifecycle:code_authorship` plus eight optional kwargs forwarded to the wire: `repo_ref`, `commit_sha`, `base_sha`, `change_digest`, `change_ref`, `change_approval_ref`, `change_class`, and `authored_by`. The `authored_by` dict names the producer-asserted author (`human_id`, `model_id`, `model_version`, `attestation_source`). Every field records that a producer-asserted value existed at signing time; Asqav does not re-run the diff, resolve the refs, or attest the model.
+- Client-side validators in lockstep with the cloud SignRequest guards: `change_digest` must be `sha256:<64 hex>`; `change_class` must be one of `read|write|delete|execute|deploy`; a populated `authored_by.model_id` / `model_version` requires `authored_by.attestation_source`; the eight fields are fenced to `receipt_type=protectmcp:lifecycle:code_authorship`; the receipt requires `repo_ref` + `commit_sha`, `policy_decision='none'`, and `compliance_mode` (the fields project into the signed receipt only under compliance mode). Each rejection raises `AsqavValidationError` carrying a `docs_url` pointing at the code-authorship docs page.
+- New `AuthoredBy` TypedDict and `CODE_AUTHORSHIP_DOCS_URL` constant, exported from `asqav`. Tests in `python/tests/test_client_code_authorship.py`.
+
+### Fixed
+- The zero-dependency verifier (`verifier/verify_receipt.py`) added `protectmcp:lifecycle:code_authorship` to its accepted receipt-type set; without it the structure axis rejected a valid code-authorship receipt on type and downgraded the whole verdict to FAIL. Test in `verifier/test_verify_receipt.py`.
+
+### Notes
+- Requires an Asqav cloud build that advertises `protectmcp:lifecycle:code_authorship` in `/.well-known/governance.json`. Mirrors the cloud guards landed in the cloud build for this receipt type.
+
 ## [TypeScript 0.5.6] - 2026-06-01
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.6"
+version = "0.5.7"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -32,6 +32,7 @@ from .async_client import AsyncAgent
 from .canonicalize import canonicalize, canonicalize_tool_args, hash_action
 from .client import (
     CAPTURE_TOPOLOGY_NAMESPACE,
+    CODE_AUTHORSHIP_DOCS_URL,
     DORA_INCIDENT_CLASS_NAMESPACE,
     RECEIPT_TYPE_NAMESPACE,
     RISK_ACCEPTANCE_DOCS_URL,
@@ -43,6 +44,7 @@ from .client import (
     AsqavError,
     AsqavValidationError,
     AuthenticationError,
+    AuthoredBy,
     BitcoinAnchorStatus,
     BudgetCheckResult,
     BudgetTracker,
@@ -143,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 __all__ = [
     # Initialization
     "init",
@@ -293,6 +295,8 @@ __all__ = [
     "RECEIPT_TYPE_NAMESPACE",
     "RISK_ACCEPTANCE_DOCS_URL",
     "RiskSnapshot",
+    "CODE_AUTHORSHIP_DOCS_URL",
+    "AuthoredBy",
     "SKEW_BOUND_SECONDS",
     "ComplianceReceiptVerification",
     "verify_compliance_receipt",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -217,6 +217,8 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
         "protectmcp:lifecycle:configuration_change",
         #: risk-acceptance / exception receipt; no-policy lifecycle opt-out.
         "protectmcp:lifecycle:risk_acceptance",
+        #: code-authorship receipt; producer-asserted record of who authored a code change.
+        "protectmcp:lifecycle:code_authorship",
         "protectmcp:acknowledgment",
         "protectmcp:observation",
         #: observation receipts that carry a result_digest use the :result_bound suffix.
@@ -226,6 +228,21 @@ RECEIPT_TYPE_NAMESPACE: frozenset[str] = frozenset(
 
 #: Docs page anchoring the risk-acceptance validation errors (rule 3.9).
 RISK_ACCEPTANCE_DOCS_URL: str = "https://asqav.com/docs/risk-acceptance-receipt"
+
+#: Docs page anchoring the code-authorship validation errors (rule 3.9).
+CODE_AUTHORSHIP_DOCS_URL: str = "https://asqav.com/docs/code-authorship-receipt"
+
+#: Closed vocabulary for code_authorship `change_class`. Mirrors the cloud
+#: SignRequest closed set; anything outside is rejected client-side.
+_CODE_AUTHORSHIP_CHANGE_CLASS_NAMESPACE: frozenset[str] = frozenset(
+    {
+        "read",
+        "write",
+        "delete",
+        "execute",
+        "deploy",
+    }
+)
 
 #: Numeric risk-snapshot signals whose presence demands a snapshot_source label.
 #: Mirrors cloud core/conformance.py _RISK_SNAPSHOT_NUMERIC_KEYS.
@@ -985,6 +1002,28 @@ class RiskSnapshot(TypedDict, total=False):
     cve_ids: list[str]
 
 
+class AuthoredBy(TypedDict, total=False):
+    """Producer-asserted author of a code change on a code-authorship receipt.
+
+    Mirrors the cloud AuthoredBy model (routes/agents.py). Every value is
+    producer-asserted; Asqav never verifies the identity, the model, or the
+    change. ``model_id`` / ``model_version`` are a machine-authorship claim: if
+    either is populated, ``attestation_source`` is REQUIRED so the claim is
+    recorded as producer-asserted and is never read as an Asqav-verified
+    attestation.
+    """
+
+    #: Human author identity (free-text id / email). Producer-asserted.
+    human_id: str
+    #: Model id if a model authored the change. Requires attestation_source.
+    model_id: str
+    #: Model version if a model authored the change. Requires attestation_source.
+    model_version: str
+    #: Free-text label naming where the machine-authorship claim came from.
+    #: REQUIRED when model_id / model_version is present.
+    attestation_source: str
+
+
 def _validate_risk_snapshot(rs: Any) -> None:
     """Mirror cloud RiskSnapshot._validate_snapshot_shape + _check_risk_snapshot.
 
@@ -1125,6 +1164,130 @@ def _validate_risk_acceptance(
                 "passing compliance_mode=False would silently drop them.",
                 docs_url=RISK_ACCEPTANCE_DOCS_URL,
             )
+
+
+#: The code-authorship signed-payload extension fields, fenced to the
+#: protectmcp:lifecycle:code_authorship receipt type (mirrors cloud SignRequest).
+_CODE_AUTHORSHIP_RECEIPT_TYPE = "protectmcp:lifecycle:code_authorship"
+
+
+def _validate_code_authorship(
+    *,
+    receipt_type: str | None,
+    compliance_mode: bool,
+    policy_decision: str,
+    repo_ref: str | None,
+    commit_sha: str | None,
+    base_sha: str | None,
+    change_digest: str | None,
+    change_ref: str | None,
+    change_approval_ref: str | None,
+    change_class: str | None,
+    authored_by: Any,
+) -> None:
+    """Mirror the cloud SignRequest._validate_code_authorship_extensions guards.
+
+    change_digest must be a sha256:<64 hex> existence proof. change_class is a
+    closed read|write|delete|execute|deploy vocabulary. authored_by is an
+    object; a populated model_id / model_version requires
+    authored_by.attestation_source so a model claim is never read as
+    Asqav-verified. The extension fields are fenced to
+    receipt_type=protectmcp:lifecycle:code_authorship; a code-authorship receipt
+    requires repo_ref + commit_sha and signs via policy_decision='none' so the
+    no-false-attestation guard stays honest. The fields project into the signed
+    bytes only on the compliance-mode path, so the SDK requires
+    compliance_mode=True (mirrors the cloud compliance-mode guard) rather than
+    silently dropping the fields. Honest-scope: every field is
+    producer-asserted / recorded-not-verified; Asqav never re-runs the diff,
+    resolves the refs, or attests the model.
+    """
+    if change_digest is not None and not _SHA256_HEX_RE.match(change_digest):
+        raise AsqavValidationError(
+            "change_digest_not_sha256_wire_form: must look like "
+            f"'sha256:<64 lowercase hex>' (got: {repr(change_digest)[:64]}).",
+            docs_url=CODE_AUTHORSHIP_DOCS_URL,
+        )
+    if (
+        change_class is not None
+        and change_class not in _CODE_AUTHORSHIP_CHANGE_CLASS_NAMESPACE
+    ):
+        raise AsqavValidationError(
+            "code_authorship_change_class_invalid: change_class must be one of "
+            "read|write|delete|execute|deploy "
+            f"(got: {repr(change_class)[:64]}).",
+            docs_url=CODE_AUTHORSHIP_DOCS_URL,
+        )
+    if authored_by is not None:
+        _validate_authored_by(authored_by)
+    code_fields_present = any(
+        v is not None
+        for v in (
+            repo_ref,
+            commit_sha,
+            base_sha,
+            change_digest,
+            change_ref,
+            change_approval_ref,
+            change_class,
+            authored_by,
+        )
+    )
+    if code_fields_present and receipt_type != _CODE_AUTHORSHIP_RECEIPT_TYPE:
+        raise AsqavValidationError(
+            "code_authorship_fields_require_code_authorship_receipt: "
+            "repo_ref / commit_sha / base_sha / change_digest / change_ref / "
+            "change_approval_ref / change_class / authored_by are only valid on "
+            f"receipt_type={_CODE_AUTHORSHIP_RECEIPT_TYPE}.",
+            docs_url=CODE_AUTHORSHIP_DOCS_URL,
+        )
+    if receipt_type == _CODE_AUTHORSHIP_RECEIPT_TYPE:
+        if not (repo_ref and commit_sha):
+            raise AsqavValidationError(
+                "code_authorship_missing_required_field: "
+                f"receipt_type={_CODE_AUTHORSHIP_RECEIPT_TYPE} requires "
+                "repo_ref and commit_sha.",
+                docs_url=CODE_AUTHORSHIP_DOCS_URL,
+            )
+        if policy_decision != "none":
+            raise AsqavValidationError(
+                "code_authorship_requires_no_policy_decision: "
+                f"receipt_type={_CODE_AUTHORSHIP_RECEIPT_TYPE} records no policy "
+                "evaluation; sign it with policy_decision='none'.",
+                docs_url=CODE_AUTHORSHIP_DOCS_URL,
+            )
+        if not compliance_mode:
+            raise AsqavValidationError(
+                "code_authorship_requires_compliance_mode: "
+                f"receipt_type={_CODE_AUTHORSHIP_RECEIPT_TYPE} fields project "
+                "into the signed receipt only under compliance_mode=True; "
+                "passing compliance_mode=False would silently drop them.",
+                docs_url=CODE_AUTHORSHIP_DOCS_URL,
+            )
+
+
+def _validate_authored_by(ab: Any) -> None:
+    """Mirror the cloud AuthoredBy validator (routes/agents.py).
+
+    authored_by must be an object. A populated model_id / model_version is a
+    machine-authorship claim and requires authored_by.attestation_source so the
+    model claim is recorded as producer-asserted, never read as an
+    Asqav-verified attestation.
+    """
+    if not isinstance(ab, dict):
+        raise AsqavValidationError(
+            "authored_by_not_object: authored_by must be an object naming the "
+            f"producer-asserted author of the change (got: {repr(ab)[:64]}).",
+            docs_url=CODE_AUTHORSHIP_DOCS_URL,
+        )
+    model_present = bool(ab.get("model_id")) or bool(ab.get("model_version"))
+    source = ab.get("attestation_source")
+    if model_present and (not isinstance(source, str) or not source):
+        raise AsqavValidationError(
+            "authored_by_model_requires_attestation_source: a populated "
+            "model_id / model_version requires authored_by.attestation_source "
+            "so the machine-authorship claim is never read as Asqav-verified.",
+            docs_url=CODE_AUTHORSHIP_DOCS_URL,
+        )
 
 
 def _compute_tool_fingerprint(
@@ -1479,6 +1642,16 @@ class Agent:
         finding_ref: str | None = None,
         approval_ref: str | None = None,
         risk_snapshot: "RiskSnapshot | dict[str, Any] | None" = None,
+        # Code-authorship receipt extension fields. Valid only on
+        # receipt_type=protectmcp:lifecycle:code_authorship (fenced below).
+        repo_ref: str | None = None,
+        commit_sha: str | None = None,
+        base_sha: str | None = None,
+        change_digest: str | None = None,
+        change_ref: str | None = None,
+        change_approval_ref: str | None = None,
+        change_class: str | None = None,
+        authored_by: "AuthoredBy | dict[str, Any] | None" = None,
     ) -> SignatureResponse:
         """Sign an action cryptographically.
 
@@ -1736,6 +1909,21 @@ class Agent:
             approval_ref=approval_ref,
             risk_snapshot=risk_snapshot,
         )
+        # Code-authorship receipt: shape + namespace fence + no-policy opt-out,
+        # lockstep with the cloud SignRequest._validate_code_authorship_extensions.
+        _validate_code_authorship(
+            receipt_type=receipt_type,
+            compliance_mode=compliance_mode,
+            policy_decision=policy_decision,
+            repo_ref=repo_ref,
+            commit_sha=commit_sha,
+            base_sha=base_sha,
+            change_digest=change_digest,
+            change_ref=change_ref,
+            change_approval_ref=change_approval_ref,
+            change_class=change_class,
+            authored_by=authored_by,
+        )
 
         # Rule 10: an absolute horizon and a duration together are ambiguous; reject both.
         if valid_seconds is not None and expires_at is not None:
@@ -1933,6 +2121,15 @@ class Agent:
                 ("finding_ref", finding_ref),
                 ("approval_ref", approval_ref),
                 ("risk_snapshot", risk_snapshot),
+                # Code-authorship extension fields (fenced to the receipt type).
+                ("repo_ref", repo_ref),
+                ("commit_sha", commit_sha),
+                ("base_sha", base_sha),
+                ("change_digest", change_digest),
+                ("change_ref", change_ref),
+                ("change_approval_ref", change_approval_ref),
+                ("change_class", change_class),
+                ("authored_by", authored_by),
             ):
                 if v is not None:
                     compliance_fields[k] = v

--- a/python/tests/test_client_capture_topology.py
+++ b/python/tests/test_client_capture_topology.py
@@ -271,6 +271,10 @@ def test_receipt_type_parametrised_accepts_all_values(value: str) -> None:
     if value == "protectmcp:lifecycle:risk_acceptance":
         kwargs["approver_id"] = "approver:alice@example.com"
         kwargs["acceptance_reason"] = "accepted"
+    # Code-authorship receipts MUST carry repo_ref + commit_sha.
+    if value == "protectmcp:lifecycle:code_authorship":
+        kwargs["repo_ref"] = "github.com/acme/repo"
+        kwargs["commit_sha"] = "c0ffee0000000000000000000000000000000000"
 
     with patch("asqav.client._post", side_effect=fake_post):
         _agent().sign("api:call", {"k": "v"}, **kwargs)

--- a/python/tests/test_client_code_authorship.py
+++ b/python/tests/test_client_code_authorship.py
@@ -1,0 +1,194 @@
+"""SDK parity for the code-authorship receipt.
+
+Mirrors the deployed cloud SignRequest validators (routes/agents.py
+``_validate_code_authorship_extensions`` + AuthoredBy) for
+``receipt_type='protectmcp:lifecycle:code_authorship'``. The SDK forwards the
+eight extension fields verbatim, validates the change_digest shape, the
+change_class closed vocabulary, the authored_by model-requires-attestation_source
+rule, the field-fence to the code-authorship type, and requires compliance_mode
+so the fields are never silently dropped from the signed bytes. Honest-scope:
+every field is producer-asserted / recorded-not-verified; Asqav never re-runs the
+diff or attests the model. Each rejection carries a docs_url (rule 3.9).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import (
+    CODE_AUTHORSHIP_DOCS_URL,
+    RECEIPT_TYPE_NAMESPACE,
+    Agent,
+    AsqavValidationError,
+)
+
+CODE_TYPE = "protectmcp:lifecycle:code_authorship"
+GOOD_DIGEST = "sha256:" + "a" * 64
+GOOD_AUTHORED_BY = {
+    "human_id": "human:alice@example.com",
+    "model_id": "claude-opus-4-8",
+    "model_version": "2026-01",
+    "attestation_source": "GitHub Copilot session export",
+}
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_code",
+        name="code-agent",
+        public_key="pk_test",
+        key_id="key_code",
+        algorithm="ML-DSA-65",
+        capabilities=["code:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response(extra: dict | None = None) -> dict:
+    base = {
+        "signature": "sig_b64",
+        "signature_id": "sig_abc",
+        "action_id": "act_abc",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_abc",
+        "algorithm": "ML-DSA-65",
+        "chain_hash": "deadbeef",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+def _good_kwargs() -> dict:
+    return dict(
+        compliance_mode=True,
+        receipt_type=CODE_TYPE,
+        policy_decision="none",
+        repo_ref="github.com/acme/repo",
+        commit_sha="c0ffee0000000000000000000000000000000000",
+        base_sha="ba5e0000000000000000000000000000000000000",
+        change_digest=GOOD_DIGEST,
+        change_ref="github.com/acme/repo/pull/42",
+        change_approval_ref="JIRA-ENG-9001",
+        change_class="write",
+        authored_by=dict(GOOD_AUTHORED_BY),
+    )
+
+
+def _sign(**overrides) -> dict:
+    """Sign with the good kwargs (plus overrides) and return the wire body."""
+    kwargs = _good_kwargs()
+    kwargs.update(overrides)
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response(
+            {"compliance_mode": True, "policy_decision": "none", "decision": "observation"}
+        )
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("code:author", {"k": "v"}, **kwargs)
+    return captured["body"]
+
+
+# === namespace ===
+
+
+def test_namespace_includes_code_authorship() -> None:
+    assert CODE_TYPE in RECEIPT_TYPE_NAMESPACE
+
+
+# === valid: all eight fields project ===
+
+
+def test_all_code_fields_project_to_wire() -> None:
+    body = _sign()
+    assert body["repo_ref"] == "github.com/acme/repo"
+    assert body["commit_sha"].startswith("c0ffee")
+    assert body["base_sha"].startswith("ba5e")
+    assert body["change_digest"] == GOOD_DIGEST
+    assert body["change_ref"] == "github.com/acme/repo/pull/42"
+    assert body["change_approval_ref"] == "JIRA-ENG-9001"
+    assert body["change_class"] == "write"
+    assert body["authored_by"]["attestation_source"].startswith("GitHub Copilot")
+    assert body["receipt_type"] == CODE_TYPE
+
+
+def test_valid_human_only_author_without_attestation_source() -> None:
+    """A human-only author needs no attestation_source (no model claim)."""
+    body = _sign(authored_by={"human_id": "human:alice@example.com"})
+    assert body["authored_by"]["human_id"] == "human:alice@example.com"
+
+
+# === rejections ===
+
+
+def test_rejects_bad_change_digest_shape() -> None:
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(change_digest="not-a-sha256-digest")
+    assert "change_digest_not_sha256_wire_form" in str(exc.value)
+    assert exc.value.docs_url == CODE_AUTHORSHIP_DOCS_URL
+
+
+def test_rejects_change_class_outside_vocabulary() -> None:
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(change_class="merge")
+    assert "code_authorship_change_class_invalid" in str(exc.value)
+
+
+def test_rejects_model_author_without_attestation_source() -> None:
+    bad_author = {"model_id": "claude-opus-4-8", "attestation_source": ""}
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(authored_by=bad_author)
+    assert "authored_by_model_requires_attestation_source" in str(exc.value)
+
+
+def test_rejects_code_fields_on_wrong_receipt_type() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):  # noqa: SIM117
+        with pytest.raises(AsqavValidationError) as exc:
+            _agent().sign(
+                "lifecycle:change",
+                {"k": "v"},
+                compliance_mode=True,
+                receipt_type="protectmcp:lifecycle",
+                policy_decision="none",
+                change_digest=GOOD_DIGEST,
+            )
+    assert "code_authorship_fields_require_code_authorship_receipt" in str(exc.value)
+
+
+def test_rejects_missing_required_field() -> None:
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(repo_ref=None, commit_sha=None)
+    assert "code_authorship_missing_required_field" in str(exc.value)
+
+
+def test_rejects_without_compliance_mode() -> None:
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(compliance_mode=False)
+    assert "code_authorship_requires_compliance_mode" in str(exc.value)
+
+
+def test_rejects_non_none_policy_decision() -> None:
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(policy_decision="permit")
+    assert "code_authorship_requires_no_policy_decision" in str(exc.value)
+
+
+def test_validation_error_is_a_valueerror() -> None:
+    """AsqavValidationError subclasses ValueError for backward compat."""
+    with pytest.raises(ValueError):
+        _sign(change_digest="bad")

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -79,6 +79,8 @@ def test_receipt_type_namespace_constant() -> None:
             "protectmcp:lifecycle:configuration_change",
             # risk-acceptance / exception receipt; no-policy lifecycle opt-out.
             "protectmcp:lifecycle:risk_acceptance",
+            # code-authorship receipt; producer-asserted record of who authored a code change.
+            "protectmcp:lifecycle:code_authorship",
             "protectmcp:acknowledgment",
             "protectmcp:observation",
             # NSA CSI U/OO/6030316-26 alignment (cloud 0.5.0): result-bound

--- a/python/tests/test_client_nsa_aligned_fields.py
+++ b/python/tests/test_client_nsa_aligned_fields.py
@@ -599,6 +599,10 @@ class TestResultBoundReceiptType:
         if receipt_type == "protectmcp:lifecycle:risk_acceptance":
             kwargs["approver_id"] = "approver:alice@example.com"
             kwargs["acceptance_reason"] = "accepted"
+        # Code-authorship requires repo_ref + commit_sha.
+        if receipt_type == "protectmcp:lifecycle:code_authorship":
+            kwargs["repo_ref"] = "github.com/acme/repo"
+            kwargs["commit_sha"] = "c0ffee0000000000000000000000000000000000"
         # Lifecycle receipts use policy_decision=none.
         if receipt_type.startswith("protectmcp:lifecycle") or (
             receipt_type.startswith("protectmcp:observation")

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.1",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.5.1",
+      "version": "0.5.7",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -33,7 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.6";
+export const CLI_VERSION = "0.5.7";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -30,6 +30,8 @@ export const RECEIPT_TYPE_NAMESPACE = [
   "protectmcp:lifecycle:configuration_change",
   // risk-acceptance / exception receipt; no-policy lifecycle opt-out.
   "protectmcp:lifecycle:risk_acceptance",
+  // code-authorship receipt; producer-asserted record of who authored a code change.
+  "protectmcp:lifecycle:code_authorship",
   "protectmcp:acknowledgment",
   "protectmcp:observation",
   // observation receipts with a result_digest use the :result_bound suffix for auditor indexing.
@@ -39,6 +41,19 @@ export type ReceiptType = (typeof RECEIPT_TYPE_NAMESPACE)[number];
 
 /** Docs page anchoring the risk-acceptance validation errors (rule 3.9). */
 export const RISK_ACCEPTANCE_DOCS_URL = "https://asqav.com/docs/risk-acceptance-receipt" as const;
+
+/** Docs page anchoring the code-authorship validation errors (rule 3.9). */
+export const CODE_AUTHORSHIP_DOCS_URL = "https://asqav.com/docs/code-authorship-receipt" as const;
+
+/** Closed vocabulary for code_authorship `changeClass`. Mirrors the cloud
+ * SignRequest closed set; anything outside is rejected client-side. */
+export const CODE_AUTHORSHIP_CHANGE_CLASS_NAMESPACE = [
+  "read",
+  "write",
+  "delete",
+  "execute",
+  "deploy",
+] as const;
 
 /** Receipt type emitted by an acknowledging agent (B) over an originating
  * receipt; the binding object travels on B's signed payload. */
@@ -558,6 +573,42 @@ export interface SignOptions {
    * Projected to the wire as snake_case `risk_snapshot`. A numeric without
    * `snapshotSource` is rejected so it is never read as an Asqav score. */
   riskSnapshot?: RiskSnapshot;
+
+  /** Code-authorship receipt: opaque pointer to the repository the change
+   * lives in. REQUIRED on `receiptType='protectmcp:lifecycle:code_authorship'`.
+   * Free-text; recorded, never resolved by Asqav. */
+  repoRef?: string;
+
+  /** Code-authorship receipt: commit sha of the change. REQUIRED on
+   * `receiptType='protectmcp:lifecycle:code_authorship'`. Producer-asserted;
+   * Asqav records it, never fetches or verifies the commit. */
+  commitSha?: string;
+
+  /** Code-authorship receipt: base sha the change is measured against.
+   * Producer-asserted; recorded, not verified. */
+  baseSha?: string;
+
+  /** Code-authorship receipt: `sha256:<64 hex>` of the change / diff artifact.
+   * Proves THAT diff existed unaltered; Asqav does not re-run or diff it. */
+  changeDigest?: string;
+
+  /** Code-authorship receipt: opaque pointer to the change (PR / patch id).
+   * Free-text; not resolved by Asqav. */
+  changeRef?: string;
+
+  /** Code-authorship receipt: opaque pointer to a change-approval ticket or
+   * HITL approval id. Free-text correlation anchor. */
+  changeApprovalRef?: string;
+
+  /** Code-authorship receipt: closed vocabulary class of the change,
+   * one of read|write|delete|execute|deploy. */
+  changeClass?: string;
+
+  /** Code-authorship receipt: producer-asserted author of the change.
+   * Projected to the wire as snake_case `authored_by`. A populated
+   * `modelId` / `modelVersion` requires `attestationSource` so the
+   * machine-authorship claim is never read as Asqav-verified. */
+  authoredBy?: AuthoredBy;
 }
 
 /** Producer-asserted point-in-time snapshot of third-party risk signals.
@@ -584,6 +635,26 @@ export interface RiskSnapshot {
   kevListed?: boolean;
   /** CVE ids the snapshot pertains to; non-empty array, entries <= 128 chars. */
   cveIds?: string[];
+}
+
+/** Producer-asserted author of a code change on a code-authorship receipt.
+ *
+ * Mirrors the cloud AuthoredBy model. Every value is producer-asserted;
+ * Asqav never verifies the identity, the model, or the change. `modelId` /
+ * `modelVersion` are a machine-authorship claim: if either is populated,
+ * `attestationSource` is REQUIRED so the claim is recorded as
+ * producer-asserted and is never read as an Asqav-verified attestation.
+ * Projected to the wire as snake_case keys. */
+export interface AuthoredBy {
+  /** Human author identity (free-text id / email). Producer-asserted. */
+  humanId?: string;
+  /** Model id if a model authored the change. Requires attestationSource. */
+  modelId?: string;
+  /** Model version if a model authored the change. Requires attestationSource. */
+  modelVersion?: string;
+  /** Free-text label naming where the machine-authorship claim came from.
+   * REQUIRED when modelId / modelVersion is present. */
+  attestationSource?: string;
 }
 
 export interface CoSignature {
@@ -1133,6 +1204,9 @@ function validateSignOptions(options: SignOptions, complianceMode: boolean): voi
   // Risk-acceptance receipt: shape + namespace fence + no-policy opt-out +
   // compliance_mode requirement, lockstep with the cloud SignRequest validator.
   validateRiskAcceptance(options, complianceMode);
+  // Code-authorship receipt: shape + namespace fence + no-policy opt-out +
+  // compliance_mode requirement, lockstep with the cloud SignRequest validator.
+  validateCodeAuthorship(options, complianceMode);
 }
 
 /**
@@ -1311,6 +1385,97 @@ function validateRiskAcceptance(options: SignOptions, complianceMode: boolean): 
   }
 }
 
+/** Receipt type carrying the code-authorship extension fields. */
+const CODE_AUTHORSHIP_RECEIPT_TYPE = "protectmcp:lifecycle:code_authorship";
+
+/**
+ * Reject a malformed `authoredBy` before the HTTP roundtrip. Lockstep with the
+ * cloud AuthoredBy validator: it must be an object, and a populated `modelId` /
+ * `modelVersion` (a machine-authorship claim) requires `attestationSource` so
+ * the claim is never read as Asqav-verified. Verbatim guard tokens match the
+ * Python SDK.
+ */
+function validateAuthoredBy(ab: AuthoredBy | undefined): void {
+  if (ab === undefined) return;
+  if (typeof ab !== "object" || ab === null || Array.isArray(ab)) {
+    throw new AsqavError(
+      `authored_by_not_object: authored_by must be an object naming the producer-asserted author of the change (got: ${JSON.stringify(ab).slice(0, 64)})`,
+      CODE_AUTHORSHIP_DOCS_URL,
+    );
+  }
+  const modelPresent = Boolean(ab.modelId) || Boolean(ab.modelVersion);
+  if (modelPresent && (typeof ab.attestationSource !== "string" || ab.attestationSource.length === 0)) {
+    throw new AsqavError(
+      "authored_by_model_requires_attestation_source: a populated model_id / model_version requires authored_by.attestation_source so the machine-authorship claim is never read as Asqav-verified.",
+      CODE_AUTHORSHIP_DOCS_URL,
+    );
+  }
+}
+
+/**
+ * Reject malformed code-authorship receipts before the HTTP roundtrip.
+ * Lockstep with the cloud SignRequest `_validate_code_authorship_extensions`:
+ * changeDigest must be `sha256:<64 hex>`; changeClass is a closed
+ * read|write|delete|execute|deploy set; the extension fields are fenced to
+ * `receiptType='protectmcp:lifecycle:code_authorship'`; the receipt requires
+ * `repoRef` + `commitSha`, signs with `policyDecision='none'`, and (mirroring
+ * the cloud compliance-mode guard) requires `complianceMode` so the fields are
+ * never silently dropped from the signed bytes. Honest-scope: every field is
+ * producer-asserted / recorded-not-verified.
+ */
+function validateCodeAuthorship(options: SignOptions, complianceMode: boolean): void {
+  if (options.changeDigest !== undefined && !SHA256_HEX_RE.test(options.changeDigest)) {
+    throw new AsqavError(
+      `change_digest_not_sha256_wire_form: must look like 'sha256:<64 lowercase hex>' (got: ${options.changeDigest.slice(0, 64)}).`,
+      CODE_AUTHORSHIP_DOCS_URL,
+    );
+  }
+  if (
+    options.changeClass !== undefined
+    && !(CODE_AUTHORSHIP_CHANGE_CLASS_NAMESPACE as readonly string[]).includes(options.changeClass)
+  ) {
+    throw new AsqavError(
+      `code_authorship_change_class_invalid: change_class must be one of read|write|delete|execute|deploy (got: ${options.changeClass.slice(0, 64)}).`,
+      CODE_AUTHORSHIP_DOCS_URL,
+    );
+  }
+  validateAuthoredBy(options.authoredBy);
+  const codeFieldsPresent = options.repoRef !== undefined
+    || options.commitSha !== undefined
+    || options.baseSha !== undefined
+    || options.changeDigest !== undefined
+    || options.changeRef !== undefined
+    || options.changeApprovalRef !== undefined
+    || options.changeClass !== undefined
+    || options.authoredBy !== undefined;
+  if (codeFieldsPresent && options.receiptType !== CODE_AUTHORSHIP_RECEIPT_TYPE) {
+    throw new AsqavError(
+      `code_authorship_fields_require_code_authorship_receipt: repo_ref / commit_sha / base_sha / change_digest / change_ref / change_approval_ref / change_class / authored_by are only valid on receipt_type=${CODE_AUTHORSHIP_RECEIPT_TYPE}.`,
+      CODE_AUTHORSHIP_DOCS_URL,
+    );
+  }
+  if (options.receiptType === CODE_AUTHORSHIP_RECEIPT_TYPE) {
+    if (!options.repoRef || !options.commitSha) {
+      throw new AsqavError(
+        `code_authorship_missing_required_field: receipt_type=${CODE_AUTHORSHIP_RECEIPT_TYPE} requires repo_ref and commit_sha.`,
+        CODE_AUTHORSHIP_DOCS_URL,
+      );
+    }
+    if (options.policyDecision !== "none") {
+      throw new AsqavError(
+        `code_authorship_requires_no_policy_decision: receipt_type=${CODE_AUTHORSHIP_RECEIPT_TYPE} records no policy evaluation; sign it with policy_decision='none'.`,
+        CODE_AUTHORSHIP_DOCS_URL,
+      );
+    }
+    if (!complianceMode) {
+      throw new AsqavError(
+        `code_authorship_requires_compliance_mode: receipt_type=${CODE_AUTHORSHIP_RECEIPT_TYPE} fields project into the signed receipt only under compliance_mode=true; passing compliance_mode=false would silently drop them.`,
+        CODE_AUTHORSHIP_DOCS_URL,
+      );
+    }
+  }
+}
+
 /**
  * Derive `action_ref` locally when omitted under compliance mode; matches
  * the cloud's `hash_action` shape (`sha256:<hex>` over canonical JSON of
@@ -1439,6 +1604,19 @@ function riskSnapshotToWire(rs: RiskSnapshot | undefined): Record<string, unknow
   return wire;
 }
 
+/** Convert a camelCase `AuthoredBy` to its snake_case wire object so the
+ * signed payload uses the same keys the cloud AuthoredBy model emits.
+ * Returns undefined when no author is supplied (field omitted from wire). */
+function authoredByToWire(ab: AuthoredBy | undefined): Record<string, unknown> | undefined {
+  if (ab === undefined) return undefined;
+  const wire: Record<string, unknown> = {};
+  if (ab.humanId !== undefined) wire.human_id = ab.humanId;
+  if (ab.modelId !== undefined) wire.model_id = ab.modelId;
+  if (ab.modelVersion !== undefined) wire.model_version = ab.modelVersion;
+  if (ab.attestationSource !== undefined) wire.attestation_source = ab.attestationSource;
+  return wire;
+}
+
 /** Snake_case wire-key projection of the optional IETF profile fields
  * that do not depend on `complianceMode`. Defined as a const table so
  * the `applyComplianceFields` loop stays single-pass. */
@@ -1482,6 +1660,15 @@ const IETF_OPTIONAL_FIELD_MAP: ReadonlyArray<{
   { wire: "finding_ref", read: (o) => o.findingRef },
   { wire: "approval_ref", read: (o) => o.approvalRef },
   { wire: "risk_snapshot", read: (o) => riskSnapshotToWire(o.riskSnapshot) },
+  // Code-authorship receipt extension fields (fenced to the receipt type).
+  { wire: "repo_ref", read: (o) => o.repoRef },
+  { wire: "commit_sha", read: (o) => o.commitSha },
+  { wire: "base_sha", read: (o) => o.baseSha },
+  { wire: "change_digest", read: (o) => o.changeDigest },
+  { wire: "change_ref", read: (o) => o.changeRef },
+  { wire: "change_approval_ref", read: (o) => o.changeApprovalRef },
+  { wire: "change_class", read: (o) => o.changeClass },
+  { wire: "authored_by", read: (o) => authoredByToWire(o.authoredBy) },
   {
     wire: "tool_fingerprint",
     read: (o) =>

--- a/typescript/tests/captureTopology.test.ts
+++ b/typescript/tests/captureTopology.test.ts
@@ -73,6 +73,7 @@ describe("RECEIPT_TYPE_NAMESPACE", () => {
         "protectmcp:acknowledgment",
         "protectmcp:decision",
         "protectmcp:lifecycle",
+        "protectmcp:lifecycle:code_authorship",
         "protectmcp:lifecycle:configuration_change",
         "protectmcp:lifecycle:risk_acceptance",
         "protectmcp:observation",

--- a/typescript/tests/codeAuthorship.test.ts
+++ b/typescript/tests/codeAuthorship.test.ts
@@ -1,0 +1,205 @@
+/**
+ * SDK parity for the code-authorship receipt.
+ *
+ * Mirrors the deployed cloud SignRequest validators (routes/agents.py
+ * `_validate_code_authorship_extensions` + AuthoredBy) for
+ * `receiptType='protectmcp:lifecycle:code_authorship'`. The SDK forwards the
+ * eight extension fields verbatim (camelCase -> snake_case), validates the
+ * changeDigest shape, the changeClass closed vocabulary, the authored_by
+ * model-requires-attestation_source rule, the field-fence to the
+ * code-authorship type, and requires complianceMode so the fields are never
+ * silently dropped from the signed bytes. Honest-scope: every field is
+ * producer-asserted / recorded-not-verified.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  AsqavError,
+  CODE_AUTHORSHIP_DOCS_URL,
+  RECEIPT_TYPE_NAMESPACE,
+  _resetForTests,
+  init,
+} from "../src/index.js";
+
+const CODE_TYPE = "protectmcp:lifecycle:code_authorship";
+const GOOD_DIGEST = "sha256:" + "a".repeat(64);
+const GOOD_AUTHORED_BY = {
+  humanId: "human:alice@example.com",
+  modelId: "claude-opus-4-8",
+  modelVersion: "2026-01",
+  attestationSource: "GitHub Copilot session export",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_code",
+    name: "code",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-05-25T00:00:00Z",
+  });
+}
+
+function okBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    signature: "sig",
+    signature_id: "sig_test",
+    action_id: "act_test",
+    timestamp: "2026-06-01T19:00:00Z",
+    verification_url: "https://verify",
+    ...extra,
+  };
+}
+
+function readBody(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
+  const init = spy.mock.calls[0][1] as RequestInit;
+  return JSON.parse((init?.body as string) ?? "{}");
+}
+
+function goodCodeOptions(): Record<string, unknown> {
+  return {
+    actionType: "code:author",
+    context: { k: "v" },
+    complianceMode: true,
+    receiptType: CODE_TYPE,
+    policyDecision: "none",
+    repoRef: "github.com/acme/repo",
+    commitSha: "c0ffee0000000000000000000000000000000000",
+    baseSha: "ba5e0000000000000000000000000000000000000",
+    changeDigest: GOOD_DIGEST,
+    changeRef: "github.com/acme/repo/pull/42",
+    changeApprovalRef: "JIRA-ENG-9001",
+    changeClass: "write",
+    authoredBy: GOOD_AUTHORED_BY,
+  };
+}
+
+beforeEach(() => {
+  _resetForTests();
+  init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("code-authorship receipt namespace", () => {
+  it("includes the code_authorship type in the namespace", () => {
+    expect(RECEIPT_TYPE_NAMESPACE).toContain(CODE_TYPE);
+  });
+});
+
+describe("code-authorship wire forwarding (valid)", () => {
+  it("forwards all eight extension fields as snake_case", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign(goodCodeOptions() as any);
+    const body = readBody(spy);
+    expect(body.repo_ref).toBe("github.com/acme/repo");
+    expect(body.commit_sha).toBe("c0ffee0000000000000000000000000000000000");
+    expect(body.base_sha).toBe("ba5e0000000000000000000000000000000000000");
+    expect(body.change_digest).toBe(GOOD_DIGEST);
+    expect(body.change_ref).toBe("github.com/acme/repo/pull/42");
+    expect(body.change_approval_ref).toBe("JIRA-ENG-9001");
+    expect(body.change_class).toBe("write");
+    expect(body.authored_by).toEqual({
+      human_id: "human:alice@example.com",
+      model_id: "claude-opus-4-8",
+      model_version: "2026-01",
+      attestation_source: "GitHub Copilot session export",
+    });
+  });
+
+  it("accepts a human-only author without attestation_source", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      ...goodCodeOptions(),
+      authoredBy: { humanId: "human:alice@example.com" },
+    } as any);
+    const body = readBody(spy);
+    expect((body.authored_by as Record<string, unknown>).human_id).toBe("human:alice@example.com");
+  });
+});
+
+describe("code-authorship rejections", () => {
+  it("rejects a bad change_digest shape", async () => {
+    await expect(
+      fakeAgent().sign({ ...goodCodeOptions(), changeDigest: "not-a-sha256" } as any),
+    ).rejects.toThrow(/change_digest_not_sha256_wire_form/);
+  });
+
+  it("rejects a change_class outside the closed vocabulary", async () => {
+    await expect(
+      fakeAgent().sign({ ...goodCodeOptions(), changeClass: "merge" } as any),
+    ).rejects.toThrow(/code_authorship_change_class_invalid/);
+  });
+
+  it("rejects a model author without attestation_source", async () => {
+    await expect(
+      fakeAgent().sign({
+        ...goodCodeOptions(),
+        authoredBy: { modelId: "claude-opus-4-8", attestationSource: "" },
+      } as any),
+    ).rejects.toThrow(/authored_by_model_requires_attestation_source/);
+  });
+
+  it("rejects code fields on a non-code-authorship receipt type", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "lifecycle:change",
+        complianceMode: true,
+        receiptType: "protectmcp:lifecycle",
+        changeDigest: GOOD_DIGEST,
+      } as any),
+    ).rejects.toThrow(/code_authorship_fields_require_code_authorship_receipt/);
+  });
+
+  it("rejects a code-authorship receipt missing repo_ref/commit_sha", async () => {
+    await expect(
+      fakeAgent().sign({
+        actionType: "code:author",
+        complianceMode: true,
+        receiptType: CODE_TYPE,
+        policyDecision: "none",
+      } as any),
+    ).rejects.toThrow(/code_authorship_missing_required_field/);
+  });
+
+  it("rejects a code-authorship receipt without compliance_mode", async () => {
+    await expect(
+      fakeAgent().sign({
+        ...goodCodeOptions(),
+        complianceMode: false,
+      } as any),
+    ).rejects.toThrow(/code_authorship_requires_compliance_mode/);
+  });
+
+  it("rejects a code-authorship receipt with a non-none policy_decision", async () => {
+    await expect(
+      fakeAgent().sign({
+        ...goodCodeOptions(),
+        policyDecision: "permit",
+      } as any),
+    ).rejects.toThrow(/code_authorship_requires_no_policy_decision/);
+  });
+
+  it("attaches the docs_url to the validation error (rule 3.9)", async () => {
+    try {
+      await fakeAgent().sign({ ...goodCodeOptions(), changeDigest: "bad" } as any);
+      throw new Error("expected rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AsqavError);
+      expect((err as AsqavError).docsUrl).toBe(CODE_AUTHORSHIP_DOCS_URL);
+    }
+  });
+});

--- a/typescript/tests/ietfProfile.test.ts
+++ b/typescript/tests/ietfProfile.test.ts
@@ -207,6 +207,13 @@ describe("agent.sign IETF profile fields", () => {
         opts.acceptanceReason = "accepted";
         opts.policyDecision = "none";
       }
+      // Code-authorship carries repo_ref + commit_sha and the no-policy
+      // opt-out (policy_decision='none').
+      if (t === "protectmcp:lifecycle:code_authorship") {
+        opts.repoRef = "github.com/acme/repo";
+        opts.commitSha = "c0ffee0000000000000000000000000000000000";
+        opts.policyDecision = "none";
+      }
       await expect(agent.sign(opts)).resolves.toBeDefined();
     }
   });

--- a/typescript/tests/nsaAlignedFields.test.ts
+++ b/typescript/tests/nsaAlignedFields.test.ts
@@ -517,6 +517,10 @@ describe("protectmcp:observation:result_bound receipt type", () => {
         opts.approverId = "approver:alice@example.com";
         opts.acceptanceReason = "accepted";
       }
+      if (receiptType === "protectmcp:lifecycle:code_authorship") {
+        opts.repoRef = "github.com/acme/repo";
+        opts.commitSha = "c0ffee0000000000000000000000000000000000";
+      }
       if (
         receiptType.startsWith("protectmcp:lifecycle")
         || receiptType.startsWith("protectmcp:observation")

--- a/verifier/test_verify_receipt.py
+++ b/verifier/test_verify_receipt.py
@@ -1,8 +1,9 @@
-"""Zero-dep verifier accepts the risk-acceptance receipt type.
+"""Zero-dep verifier accepts the risk-acceptance and code-authorship receipt types.
 
-verify_receipt.py carries protectmcp:lifecycle:risk_acceptance in ALLOWED_TYPES
-so the structure axis recognises a valid risk-acceptance receipt and PASSes on
-it; an unknown type still fails closed. These tests pin both behaviours.
+verify_receipt.py carries protectmcp:lifecycle:risk_acceptance and
+protectmcp:lifecycle:code_authorship in ALLOWED_TYPES so the structure axis
+recognises a valid receipt of either type and PASSes on it; an unknown type
+still fails closed. These tests pin both behaviours.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 import verify_receipt as v
 
 RISK_TYPE = "protectmcp:lifecycle:risk_acceptance"
+CODE_TYPE = "protectmcp:lifecycle:code_authorship"
 
 
 def _risk_payload() -> dict:
@@ -65,6 +67,53 @@ def test_run_structure_axis_passes_on_risk_acceptance(capsys) -> None:
     out = capsys.readouterr().out
     assert "[  ok] structure" in out
     # The risk-acceptance type must never appear in a FAIL line.
+    for line in out.splitlines():
+        if "[FAIL]" in line:
+            assert "structure" not in line
+
+
+def _code_payload() -> dict:
+    return {
+        "type": CODE_TYPE,
+        "issued_at": "2026-06-02T10:00:00.000000Z",
+        "issuer_id": "c39probe-org-00001",
+        "action_ref": "sha256:" + "8" * 64,
+        "payload_digest": {"hash": "8" * 64, "size": 512},
+        "policy_digest": "sha256:" + "3" * 64,
+        "previousReceiptHash": "0" * 64,
+        "decision": "observation",
+        "repo_ref": "github.com/acme/repo",
+        "commit_sha": "c0ffee0000000000000000000000000000000000",
+        "change_digest": "sha256:" + "9" * 64,
+        "change_class": "write",
+    }
+
+
+def test_code_authorship_in_allowed_types() -> None:
+    assert CODE_TYPE in v.ALLOWED_TYPES
+
+
+def test_structure_accepts_code_authorship() -> None:
+    """The structure axis PASSes on a real code-authorship receipt; the type is
+    inside ALLOWED_TYPES so it is recognised, not rejected."""
+    res, note = v.check_structure(_code_payload())
+    assert res == "PASS"
+    assert CODE_TYPE in note
+
+
+def test_run_structure_axis_passes_on_code_authorship(capsys) -> None:
+    """A full run over a code-authorship envelope prints `[  ok] structure`:
+    the type is recognised, so the structure axis contributes a PASS and the
+    code-authorship type never appears in a FAIL line."""
+    envelope = {
+        "payload": _code_payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "c39probe-org-00001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    v.run(envelope, {"keys": []}, predecessor_payload=None)
+    out = capsys.readouterr().out
+    assert "[  ok] structure" in out
+    # The code-authorship type must never appear in a FAIL line.
     for line in out.splitlines():
         if "[FAIL]" in line:
             assert "structure" not in line

--- a/verifier/verify_receipt.py
+++ b/verifier/verify_receipt.py
@@ -59,6 +59,8 @@ ALLOWED_TYPES = {
     "protectmcp:lifecycle:configuration_change",
     # risk-acceptance / exception receipt; no-policy lifecycle opt-out.
     "protectmcp:lifecycle:risk_acceptance",
+    # code-authorship receipt; producer-asserted record of who authored a code change.
+    "protectmcp:lifecycle:code_authorship",
     "protectmcp:acknowledgment",
     "protectmcp:observation",
     "protectmcp:observation:result_bound",


### PR DESCRIPTION
Adds `protectmcp:lifecycle:code_authorship` support to the Python and TypeScript SDKs and the zero-dep verifier, mirroring the risk-acceptance landing. The cloud half is live (deployed, governance.json advertises the type and all eight fields, e2e signed-and-verified on prod).

Eight signed-payload fields on `sign()`: repo_ref, commit_sha, base_sha, change_digest, change_ref, change_approval_ref, change_class, authored_by. Six guards mirror the cloud byte-for-byte so Python and TypeScript clients reject the same bad input with the same strings. The verifier accepts the new type so it does not fail closed on a real code-authorship receipt. Version 0.5.7.

Tests: pytest code-authorship plus the parametrised and verifier suites pass; vitest full suite passes; tsup build clean.

comment hygiene clean
