### PR TITLE
Add GitHub Action and README for code-authorship receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ For self-hosted and split-trust deployments, bring-your-own KMS, SCITT and COSE 
 
 Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/), an Independent Submission that profiles [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) for EU AI Act Articles 12 and 26, and DORA Article 17 bindings.
 
+## Coding agents
+
+Autonomous coding agents open and merge their own pull requests, and a git author string is mutable. The `protectmcp:lifecycle:code_authorship` receipt binds a change to the agent that authored it: the repository, the commit and base SHA, a digest of the diff, the change class, and a producer-asserted `authored_by` block, signed with ML-DSA-65 and chained per agent. Asqav records that the change existed, was key-authored, and was chained at a point in time. It does not clone the repository, re-run the diff, or judge whether the code is correct. A ready-to-use GitHub Action lives in [`github-action/`](github-action/) and can also emit the receipt as an in-toto attestation. See the [code-authorship receipts docs](https://asqav.com/docs/code-authorship-receipts).
+
 ## Why governance
 
 | Without governance | With Asqav |

--- a/github-action/README.md
+++ b/github-action/README.md
@@ -1,0 +1,122 @@
+# Asqav Code-Authorship Receipt Action
+
+Sign an Asqav code-authorship receipt from a CI run. On every pull request this
+action records who authored a code change and signs that record with ML-DSA-65
+(FIPS 204) server-side, then writes it out as an in-toto Statement.
+
+## What it proves (and what it does not)
+
+This action signs a small, honest set of facts:
+
+- a change existed (the diff between a base commit and the head commit, captured
+  as a SHA-256 digest),
+- that change was key-authored (the Asqav agent key signed the record),
+- the record was chained at time T (the receipt is hash-chained and timestamped
+  by Asqav).
+
+It does not verify the code, does not re-run the diff, does not resolve the
+refs, and does not attest the model. The author identity, the tool, and any
+model fields are producer-asserted. Model fields are always recorded with
+`attestation_source=github-actions-input` so they can never be read as
+Asqav-verified. In short: the receipt proves a change with a given digest was
+recorded and key-signed at a point in time, nothing more.
+
+## Usage
+
+```yaml
+name: code-authorship
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so the base..head diff is available
+
+      - name: Sign Asqav code-authorship receipt
+        id: asqav
+        uses: jagmarques/asqav-sdk/github-action@main
+        with:
+          asqav-api-key: ${{ secrets.ASQAV_API_KEY }}
+          asqav-agent-id: ${{ secrets.ASQAV_AGENT_ID }}
+          change-class: write
+          model-id: claude-opus-4-8
+          model-version: "2026-05"
+
+      - name: Show receipt
+        run: |
+          echo "signature: ${{ steps.asqav.outputs.signature-id }}"
+          echo "verify:    ${{ steps.asqav.outputs.verification-url }}"
+          echo "in-toto:   ${{ steps.asqav.outputs.intoto-statement-path }}"
+```
+
+`fetch-depth: 0` matters: the action digests `git diff <base>..<head>`, so the
+base commit must be present in the checkout.
+
+## Inputs
+
+| Input            | Required | Default          | Description |
+| ---------------- | -------- | ---------------- | ----------- |
+| `asqav-api-key`  | yes      |                  | Asqav API key (`sk_...`). Pass via a repository secret. |
+| `asqav-agent-id` | yes      |                  | Asqav agent id whose key signs the receipt. |
+| `change-class`   | no       | `write`          | One of `read`, `write`, `delete`, `execute`, `deploy`. |
+| `model-id`       | no       | (empty)          | Producer-asserted model id. Recorded, never verified. |
+| `model-version`  | no       | (empty)          | Producer-asserted model version. Recorded, never verified. |
+| `tool`           | no       | `github-actions` | Producer-asserted authoring tool label. |
+
+## Outputs
+
+| Output                  | Description |
+| ----------------------- | ----------- |
+| `signature-id`          | Asqav signature id of the signed receipt. |
+| `verification-url`      | Public URL to verify the signed receipt. |
+| `intoto-statement-path` | Path to the emitted in-toto Statement v1 file. |
+
+## How the receipt is derived
+
+The action reads the git context from the GitHub Actions environment:
+
+- `repo_ref` from `GITHUB_REPOSITORY`,
+- `commit_sha` from `GITHUB_SHA`,
+- `base_sha` from the pull request base in the event payload,
+- `change_ref` from the pull request URL,
+- `change_digest` = `sha256:` + SHA-256 of `git diff <base>..<head>`.
+
+It then calls `agent.sign(...)` with
+`receipt_type="protectmcp:lifecycle:code_authorship"`, `compliance_mode=True`,
+and `policy_decision="none"` (a code-authorship receipt records no policy
+evaluation, so it signs under the no-policy opt-out).
+
+## in-toto interop
+
+The signed receipt is also wrapped as an
+[in-toto Statement v1](https://github.com/in-toto/attestation) and written to a
+file. The shape is:
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "<owner/repo>@<commit_sha>",
+      "digest": { "sha256": "<commit_sha>" }
+    }
+  ],
+  "predicateType": "https://asqav.com/CodeAuthorship/v1",
+  "predicate": { "...the signed receipt payload, signature alg ML-DSA-65..." }
+}
+```
+
+Because the receipt is emitted as a standard in-toto Statement, it slots into
+the same attestation workflows that already consume in-toto, including Sigstore
+Rekor transparency-log entries and GitHub Artifact Attestations. Upload the file
+as a build artifact, push it to a transparency log, or attach it to a release
+the same way you would any other in-toto predicate. The Asqav predicate carries
+the ML-DSA-65 signature envelope, so a consumer can re-verify the Asqav receipt
+independently of the surrounding attestation envelope.

--- a/github-action/action.yml
+++ b/github-action/action.yml
@@ -1,0 +1,70 @@
+name: "Asqav Code-Authorship Receipt"
+description: >-
+  Sign an Asqav code-authorship receipt from a CI run. Records who authored a
+  code change (commit, base, diff digest, producer-asserted author) and signs
+  it with ML-DSA-65 server-side. Also emits the receipt as an in-toto Statement.
+author: "Asqav"
+branding:
+  icon: "git-commit"
+  color: "blue"
+
+inputs:
+  asqav-api-key:
+    description: "Asqav API key (sk_...). Pass via a repository secret."
+    required: true
+  asqav-agent-id:
+    description: "Asqav agent id whose key signs the receipt."
+    required: true
+  change-class:
+    description: "Change class: read | write | delete | execute | deploy."
+    required: false
+    default: "write"
+  model-id:
+    description: >-
+      Optional producer-asserted model id if a model authored the change. Always
+      recorded with attestation_source=github-actions-input, never verified.
+    required: false
+    default: ""
+  model-version:
+    description: "Optional producer-asserted model version. Never verified."
+    required: false
+    default: ""
+  tool:
+    description: "Producer-asserted authoring tool label."
+    required: false
+    default: "github-actions"
+
+outputs:
+  signature-id:
+    description: "The Asqav signature id of the signed code-authorship receipt."
+    value: ${{ steps.sign.outputs.signature-id }}
+  verification-url:
+    description: "Public URL to verify the signed receipt."
+    value: ${{ steps.sign.outputs.verification-url }}
+  intoto-statement-path:
+    description: "Path to the emitted in-toto Statement v1 file."
+    value: ${{ steps.sign.outputs.intoto-statement-path }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install Asqav SDK
+      shell: bash
+      run: python -m pip install --upgrade "asqav>=0.5.7"
+
+    - name: Sign code-authorship receipt
+      id: sign
+      shell: bash
+      env:
+        ASQAV_API_KEY: ${{ inputs.asqav-api-key }}
+        ASQAV_AGENT_ID: ${{ inputs.asqav-agent-id }}
+        ASQAV_CHANGE_CLASS: ${{ inputs.change-class }}
+        ASQAV_MODEL_ID: ${{ inputs.model-id }}
+        ASQAV_MODEL_VERSION: ${{ inputs.model-version }}
+        ASQAV_TOOL: ${{ inputs.tool }}
+      run: python "${{ github.action_path }}/sign_code_authorship.py"

--- a/github-action/sign_code_authorship.py
+++ b/github-action/sign_code_authorship.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Sign an Asqav code-authorship receipt from a GitHub Actions run.
+
+Honest scope: this script signs what git reports (the commit, its base, and a
+digest of the diff between them) plus the Asqav agent key. Everything else on
+the receipt is producer-asserted and recorded, never verified by Asqav. Model
+authorship fields (`model_id` / `model_version`) are ALWAYS sent under
+`authored_by.attestation_source="github-actions-input"` so they can never be
+read as an Asqav-verified attestation.
+
+The signed receipt is also wrapped as an in-toto Statement v1 and written to a
+file so it interoperates with attestation tooling that consumes in-toto.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+RECEIPT_TYPE = "protectmcp:lifecycle:code_authorship"
+PREDICATE_TYPE = "https://asqav.com/CodeAuthorship/v1"
+INTOTO_STATEMENT_TYPE = "https://in-toto.io/Statement/v1"
+#: Fixed label so model authorship is always recorded as producer-asserted.
+ATTESTATION_SOURCE = "github-actions-input"
+
+
+@dataclass
+class GitContext:
+    """The git facts the receipt binds to, read from the GitHub Actions env."""
+
+    repo_ref: str
+    commit_sha: str
+    base_sha: str | None
+    change_ref: str | None
+    change_digest: str
+
+
+def _run_git_diff(base_sha: str, head_sha: str) -> str:
+    """Return the textual `git diff <base>..<head>`.
+
+    Raises CalledProcessError if git fails so the action surfaces the problem
+    rather than silently signing an empty digest.
+    """
+    out = subprocess.run(
+        ["git", "diff", f"{base_sha}..{head_sha}"],
+        check=True,
+        capture_output=True,
+    )
+    return out.stdout.decode("utf-8", errors="replace")
+
+
+def compute_change_digest(base_sha: str | None, head_sha: str, diff_text: str | None = None) -> str:
+    """Compute `change_digest` = "sha256:" + sha256(`git diff base..head`).
+
+    When `diff_text` is supplied it is hashed directly (used by tests and to
+    avoid re-shelling). When it is None and a base is known, the diff is read
+    from git. When no base is known, the bare head sha is hashed so the field
+    is always a well-formed sha256:<64 hex> existence proof.
+
+    Always returns the cloud wire form `sha256:<64 lowercase hex>`.
+    """
+    if diff_text is None:
+        if base_sha:
+            diff_text = _run_git_diff(base_sha, head_sha)
+        else:
+            diff_text = head_sha
+    digest = hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def build_authored_by(
+    *,
+    agent_id: str | None,
+    model_id: str | None,
+    model_version: str | None,
+    tool: str | None,
+) -> dict[str, Any]:
+    """Build the producer-asserted `authored_by` object.
+
+    `attestation_source` is ALWAYS set to ``github-actions-input`` so any model
+    authorship claim is recorded as producer-asserted and is never read as an
+    Asqav-verified attestation. The SDK enforces that a populated model_id /
+    model_version requires attestation_source; we satisfy that unconditionally.
+    """
+    authored_by: dict[str, Any] = {"attestation_source": ATTESTATION_SOURCE}
+    if agent_id:
+        authored_by["agent_id"] = agent_id
+    if model_id:
+        authored_by["model_id"] = model_id
+    if model_version:
+        authored_by["model_version"] = model_version
+    if tool:
+        authored_by["tool"] = tool
+    return authored_by
+
+
+def _bare_change_digest_hex(change_digest: str) -> str:
+    """Strip the `sha256:` prefix from a change_digest for the in-toto subject."""
+    return change_digest.split(":", 1)[-1]
+
+
+def build_intoto_statement(
+    *,
+    repo_ref: str,
+    commit_sha: str,
+    change_digest: str,
+    signed_receipt: dict[str, Any],
+) -> dict[str, Any]:
+    """Wrap the signed receipt payload as an in-toto Statement v1.
+
+    Subject names the repo at the signed commit and carries the bare commit
+    sha as its sha256 digest (the resource the attestation is about). The
+    predicate is the returned signed receipt payload, including the ML-DSA-65
+    signature envelope, so a consumer can re-verify it offline.
+    """
+    return {
+        "_type": INTOTO_STATEMENT_TYPE,
+        "subject": [
+            {
+                "name": f"{repo_ref}@{commit_sha}",
+                "digest": {"sha256": commit_sha},
+            }
+        ],
+        "predicateType": PREDICATE_TYPE,
+        "predicate": signed_receipt,
+    }
+
+
+def _signed_receipt_payload(response: Any) -> dict[str, Any]:
+    """Project the SDK SignatureResponse into a JSON-able signed-receipt payload.
+
+    Prefers the cloud three-key compliance payload when present; always carries
+    the signature envelope (alg/kid/sig, alg=ML-DSA-65) plus the identifiers a
+    verifier needs.
+    """
+    envelope = None
+    try:
+        envelope = response.signature_envelope()
+    except Exception:
+        envelope = None
+    payload: dict[str, Any] = {
+        "signature_id": response.signature_id,
+        "action_id": response.action_id,
+        "receipt_type": response.receipt_type or RECEIPT_TYPE,
+        "algorithm": response.algorithm,
+        "signature": envelope if envelope is not None else response.signature,
+        "verification_url": response.verification_url,
+        "timestamp": response.timestamp,
+    }
+    if getattr(response, "payload", None) is not None:
+        payload["payload"] = response.payload
+    if getattr(response, "anchors", None) is not None:
+        payload["anchors"] = response.anchors
+    if getattr(response, "previous_receipt_hash", None) is not None:
+        payload["previous_receipt_hash"] = response.previous_receipt_hash
+    return payload
+
+
+def _read_git_context() -> GitContext:
+    """Derive the git context from the GitHub Actions environment.
+
+    repo_ref  <- GITHUB_REPOSITORY (owner/repo)
+    commit_sha<- GITHUB_SHA
+    base_sha  <- the PR base sha read from the event payload (pull_request.base.sha),
+                 else GITHUB_BASE_REF resolved, else None
+    change_ref<- the PR html_url from the event payload, else the run URL
+    """
+    repo_ref = os.environ.get("GITHUB_REPOSITORY", "")
+    commit_sha = os.environ.get("GITHUB_SHA", "")
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+
+    base_sha: str | None = None
+    change_ref: str | None = None
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if event_path and os.path.exists(event_path):
+        try:
+            with open(event_path, encoding="utf-8") as fh:
+                event = json.load(fh)
+            pr = event.get("pull_request") or {}
+            base_sha = (pr.get("base") or {}).get("sha") or base_sha
+            change_ref = pr.get("html_url") or change_ref
+        except (OSError, ValueError):
+            pass
+
+    if change_ref is None and repo_ref:
+        run_id = os.environ.get("GITHUB_RUN_ID", "")
+        change_ref = f"{server}/{repo_ref}/actions/runs/{run_id}"
+
+    change_digest = compute_change_digest(base_sha, commit_sha)
+    return GitContext(
+        repo_ref=repo_ref,
+        commit_sha=commit_sha,
+        base_sha=base_sha,
+        change_ref=change_ref,
+        change_digest=change_digest,
+    )
+
+
+def _write_github_output(values: dict[str, str]) -> None:
+    """Append key=value lines to $GITHUB_OUTPUT if it is set."""
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    with open(out_path, "a", encoding="utf-8") as fh:
+        for key, value in values.items():
+            fh.write(f"{key}={value}\n")
+
+
+def sign_and_export(
+    *,
+    api_key: str,
+    agent_id: str,
+    change_class: str,
+    model_id: str | None,
+    model_version: str | None,
+    tool: str | None,
+    intoto_path: str,
+    git_ctx: GitContext | None = None,
+) -> dict[str, str]:
+    """Sign the code-authorship receipt and emit the in-toto Statement.
+
+    Returns a dict of the GitHub outputs: signature-id, verification-url,
+    intoto-statement-path.
+    """
+    import asqav
+
+    ctx = git_ctx or _read_git_context()
+
+    asqav.init(api_key=api_key)
+    agent = asqav.Agent.get(agent_id)
+
+    authored_by = build_authored_by(
+        agent_id=agent_id,
+        model_id=model_id,
+        model_version=model_version,
+        tool=tool,
+    )
+
+    response = agent.sign(
+        "code:authorship",
+        receipt_type=RECEIPT_TYPE,
+        compliance_mode=True,
+        policy_decision="none",
+        repo_ref=ctx.repo_ref,
+        commit_sha=ctx.commit_sha,
+        base_sha=ctx.base_sha,
+        change_digest=ctx.change_digest,
+        change_ref=ctx.change_ref,
+        change_approval_ref=ctx.change_ref,
+        change_class=change_class,
+        authored_by=authored_by,
+    )
+
+    signed_payload = _signed_receipt_payload(response)
+    statement = build_intoto_statement(
+        repo_ref=ctx.repo_ref,
+        commit_sha=ctx.commit_sha,
+        change_digest=ctx.change_digest,
+        signed_receipt=signed_payload,
+    )
+    with open(intoto_path, "w", encoding="utf-8") as fh:
+        json.dump(statement, fh, indent=2, sort_keys=True)
+
+    print(f"Signed code-authorship receipt: {response.signature_id}")
+    print(f"Verify at: {response.verification_url}")
+    print(f"in-toto Statement written to: {intoto_path}")
+
+    outputs = {
+        "signature-id": response.signature_id,
+        "verification-url": response.verification_url,
+        "intoto-statement-path": intoto_path,
+    }
+    _write_github_output(outputs)
+    return outputs
+
+
+def main() -> int:
+    api_key = os.environ.get("ASQAV_API_KEY", "")
+    agent_id = os.environ.get("ASQAV_AGENT_ID", "")
+    if not api_key or not agent_id:
+        print(
+            "ERROR: ASQAV_API_KEY and ASQAV_AGENT_ID must be set.",
+            file=sys.stderr,
+        )
+        return 2
+
+    change_class = os.environ.get("ASQAV_CHANGE_CLASS", "write") or "write"
+    model_id = os.environ.get("ASQAV_MODEL_ID") or None
+    model_version = os.environ.get("ASQAV_MODEL_VERSION") or None
+    tool = os.environ.get("ASQAV_TOOL") or "github-actions"
+
+    workspace = os.environ.get("GITHUB_WORKSPACE", os.getcwd())
+    intoto_path = os.environ.get(
+        "ASQAV_INTOTO_PATH",
+        os.path.join(workspace, "asqav-code-authorship.intoto.jsonl"),
+    )
+
+    try:
+        sign_and_export(
+            api_key=api_key,
+            agent_id=agent_id,
+            change_class=change_class,
+            model_id=model_id,
+            model_version=model_version,
+            tool=tool,
+            intoto_path=intoto_path,
+        )
+    except Exception as exc:  # noqa: BLE001 - surface any failure to the runner
+        print(f"ERROR signing code-authorship receipt: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/github-action/test_sign_code_authorship.py
+++ b/github-action/test_sign_code_authorship.py
@@ -1,0 +1,216 @@
+"""Pure unit tests for the code-authorship signing action.
+
+No network, no real Asqav API. The SDK sign call is mocked. These tests cover
+the three load-bearing pieces of the action:
+
+1. change_digest computation (wire form + diff hashing).
+2. authored_by attestation_source enforcement (always present).
+3. the in-toto Statement v1 wrapper shape (valid JSON, _type, predicateType,
+   subject).
+"""
+
+import hashlib
+import json
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import sign_code_authorship as mod  # noqa: E402
+
+
+# --- change_digest computation ------------------------------------------------
+
+
+def test_change_digest_hashes_supplied_diff_text():
+    diff = "diff --git a/x b/x\n+hello\n"
+    expected = "sha256:" + hashlib.sha256(diff.encode("utf-8")).hexdigest()
+    assert mod.compute_change_digest("base", "head", diff_text=diff) == expected
+
+
+def test_change_digest_is_sha256_wire_form():
+    digest = mod.compute_change_digest("base", "head", diff_text="anything")
+    assert digest.startswith("sha256:")
+    hex_part = digest.split(":", 1)[1]
+    assert len(hex_part) == 64
+    assert all(c in "0123456789abcdef" for c in hex_part)
+
+
+def test_change_digest_falls_back_to_head_sha_without_base():
+    head = "a" * 40
+    expected = "sha256:" + hashlib.sha256(head.encode("utf-8")).hexdigest()
+    assert mod.compute_change_digest(None, head, diff_text=None) == expected
+
+
+# --- authored_by attestation_source enforcement -------------------------------
+
+
+def test_authored_by_always_has_attestation_source():
+    ab = mod.build_authored_by(
+        agent_id="agent-1", model_id=None, model_version=None, tool=None
+    )
+    assert ab["attestation_source"] == "github-actions-input"
+
+
+def test_authored_by_model_fields_carry_attestation_source():
+    ab = mod.build_authored_by(
+        agent_id="agent-1",
+        model_id="claude-opus-4-8",
+        model_version="2026-05",
+        tool="github-actions",
+    )
+    # Model claim present -> attestation_source MUST be present (SDK requires it).
+    assert ab["model_id"] == "claude-opus-4-8"
+    assert ab["model_version"] == "2026-05"
+    assert ab["attestation_source"] == "github-actions-input"
+    assert ab["tool"] == "github-actions"
+
+
+def test_authored_by_omits_empty_optional_fields():
+    ab = mod.build_authored_by(
+        agent_id=None, model_id=None, model_version=None, tool=None
+    )
+    assert ab == {"attestation_source": "github-actions-input"}
+
+
+# --- in-toto Statement wrapper shape ------------------------------------------
+
+
+def _sample_receipt():
+    return {
+        "signature_id": "sig_123",
+        "algorithm": "ML-DSA-65",
+        "signature": {"alg": "ML-DSA-65", "kid": "key_1", "sig": "AAAA"},
+        "receipt_type": mod.RECEIPT_TYPE,
+    }
+
+
+def test_intoto_statement_shape():
+    commit = "f" * 40
+    stmt = mod.build_intoto_statement(
+        repo_ref="owner/repo",
+        commit_sha=commit,
+        change_digest="sha256:" + "0" * 64,
+        signed_receipt=_sample_receipt(),
+    )
+    # Valid JSON round-trip.
+    reparsed = json.loads(json.dumps(stmt))
+    assert reparsed["_type"] == "https://in-toto.io/Statement/v1"
+    assert reparsed["predicateType"] == "https://asqav.com/CodeAuthorship/v1"
+    assert reparsed["subject"] == [
+        {"name": f"owner/repo@{commit}", "digest": {"sha256": commit}}
+    ]
+    # Predicate carries the signed receipt incl ML-DSA-65 envelope.
+    assert reparsed["predicate"]["algorithm"] == "ML-DSA-65"
+    assert reparsed["predicate"]["signature"]["alg"] == "ML-DSA-65"
+
+
+# --- end-to-end with a mocked SDK ---------------------------------------------
+
+
+@dataclass
+class _FakeResponse:
+    signature_id: str = "sig_abc"
+    action_id: str = "act_abc"
+    receipt_type: str = mod.RECEIPT_TYPE
+    algorithm: str = "ML-DSA-65"
+    signature: object = None
+    verification_url: str = "https://asqav.com/v/sig_abc"
+    timestamp: float = 1234.0
+    payload: object = None
+    anchors: object = None
+    previous_receipt_hash: object = None
+
+    def __post_init__(self):
+        if self.signature is None:
+            self.signature = {"alg": "ML-DSA-65", "kid": "key_1", "sig": "AAAA"}
+
+    def signature_envelope(self):
+        if isinstance(self.signature, dict):
+            return self.signature
+        return None
+
+
+def _install_fake_asqav(monkeypatch, captured):
+    fake = types.ModuleType("asqav")
+
+    def fake_init(api_key=None, **kwargs):
+        captured["api_key"] = api_key
+
+    class FakeAgent:
+        def __init__(self, agent_id):
+            self.agent_id = agent_id
+
+        @classmethod
+        def get(cls, agent_id):
+            captured["agent_id"] = agent_id
+            return cls(agent_id)
+
+        def sign(self, action_type, **kwargs):
+            captured["action_type"] = action_type
+            captured["sign_kwargs"] = kwargs
+            return _FakeResponse()
+
+    fake.init = fake_init
+    fake.Agent = FakeAgent
+    monkeypatch.setitem(sys.modules, "asqav", fake)
+
+
+def test_sign_and_export_passes_honest_fields(monkeypatch, tmp_path):
+    captured = {}
+    _install_fake_asqav(monkeypatch, captured)
+
+    ctx = mod.GitContext(
+        repo_ref="owner/repo",
+        commit_sha="c" * 40,
+        base_sha="b" * 40,
+        change_ref="https://github.com/owner/repo/pull/7",
+        change_digest="sha256:" + "1" * 64,
+    )
+    intoto_path = tmp_path / "out.intoto.jsonl"
+
+    outputs = mod.sign_and_export(
+        api_key="sk_test",
+        agent_id="agent-1",
+        change_class="write",
+        model_id="claude-opus-4-8",
+        model_version="2026-05",
+        tool="github-actions",
+        intoto_path=str(intoto_path),
+        git_ctx=ctx,
+    )
+
+    kwargs = captured["sign_kwargs"]
+    # Honest-scope invariants on the sign call.
+    assert kwargs["receipt_type"] == mod.RECEIPT_TYPE
+    assert kwargs["compliance_mode"] is True
+    assert kwargs["policy_decision"] == "none"
+    assert kwargs["repo_ref"] == "owner/repo"
+    assert kwargs["commit_sha"] == "c" * 40
+    assert kwargs["base_sha"] == "b" * 40
+    assert kwargs["change_digest"] == "sha256:" + "1" * 64
+    assert kwargs["change_class"] == "write"
+    # Model claim is always producer-asserted.
+    assert kwargs["authored_by"]["attestation_source"] == "github-actions-input"
+    assert kwargs["authored_by"]["model_id"] == "claude-opus-4-8"
+
+    # Outputs.
+    assert outputs["signature-id"] == "sig_abc"
+    assert outputs["verification-url"] == "https://asqav.com/v/sig_abc"
+    assert outputs["intoto-statement-path"] == str(intoto_path)
+
+    # in-toto file is valid JSON with the right shape.
+    stmt = json.loads(intoto_path.read_text())
+    assert stmt["_type"] == "https://in-toto.io/Statement/v1"
+    assert stmt["predicateType"] == "https://asqav.com/CodeAuthorship/v1"
+    assert stmt["subject"][0]["name"] == "owner/repo@" + "c" * 40
+    assert stmt["subject"][0]["digest"]["sha256"] == "c" * 40
+    assert stmt["predicate"]["algorithm"] == "ML-DSA-65"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Adds a composite GitHub Action (github-action/) that signs an Asqav code-authorship receipt from the CI git context using the published SDK, and can also emit the receipt as an in-toto attestation for interop with transparency-log tooling. authored_by always carries attestation_source, so any producer-asserted model identity is recorded and never read as Asqav-verified. Pure unit tests cover the digest, the attestation_source enforcement, and the in-toto shape. Adds a Coding agents section to the root README.

comment hygiene clean