### PR TITLE
Add CLI commands for audit-pack verify, org halt/resume, keys, compliance reports, and observability

### DIFF
--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -18,6 +18,11 @@ Commands:
     asqav budget check / record                - Budget gate / signed spend record
     asqav approve <session_id> <entity_id>     - Sign off a multi-party session
     asqav compliance frameworks / export       - List frameworks / export bundle
+    asqav compliance templates / report / reports / download - Cloud reports (Business+)
+    asqav audit-pack verify <bundle>           - Verify a holder-supplied bundle
+    asqav org halt / resume <org_id>           - Org-wide emergency kill-switch (admin)
+    asqav keys create / list / revoke          - Account API key management (admin)
+    asqav observability summary / metrics      - Read 24h metrics
     asqav sync                                 - Sync local queue to API
     asqav queue list / count / clear           - Manage local queue
     asqav demo / quickstart / doctor           - Onboarding + diagnostics
@@ -1324,6 +1329,80 @@ def audit_pack_export(
     print(f"algorithm:     {bundle.get('bundle_signature_algorithm', '?')}")
 
 
+@audit_pack_app.command("verify")
+def audit_pack_verify(
+    bundle: str = typer.Argument(
+        help="Path to a bundle JSON file, or '-' to read it from stdin."
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text or json."
+    ),
+) -> None:
+    """Verify a holder-supplied Audit Pack bundle and print the signed report.
+
+    Calls POST `/audit-pack/verify`. The cloud re-derives the bundle digest
+    and per-receipt signatures from the bundle bytes alone, then signs the
+    verdict with the org's most-recent active agent key so a downstream
+    consumer can prove the report is an authentic Asqav verdict. Exits
+    non-zero when the bundle signature is invalid, so it works as a gate.
+    """
+    import json as json_mod
+
+    if bundle == "-":
+        try:
+            bundle_obj = json_mod.loads(sys.stdin.read())
+        except json_mod.JSONDecodeError as exc:
+            print(f"Error reading bundle from stdin: {exc}")
+            raise typer.Exit(code=1) from exc
+    else:
+        try:
+            with open(bundle) as f:
+                bundle_obj = json_mod.load(f)
+        except (OSError, json_mod.JSONDecodeError) as exc:
+            print(f"Error reading bundle: {exc}")
+            raise typer.Exit(code=1) from exc
+
+    _init_sdk()
+    from asqav.client import _post
+
+    try:
+        report = _post("/audit-pack/verify", {"bundle": bundle_obj})
+    except Exception as exc:
+        print(f"Error verifying audit pack: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    sig_valid = bool(report.get("bundle_signature_valid"))
+
+    if output == "json":
+        print(json_mod.dumps(report, indent=2, default=str))
+    else:
+        verdict = (
+            typer.style("VALID", fg=typer.colors.GREEN, bold=True)
+            if sig_valid
+            else typer.style("INVALID", fg=typer.colors.RED, bold=True)
+        )
+        typer.echo(f"bundle signature: {verdict}")
+        print(f"bundle_digest:  {report.get('bundle_digest', '?')}")
+        print(f"receipt_count:  {report.get('receipt_count', '?')}")
+        print(f"report_signed:  {report.get('report_signature_algorithm', '?')}")
+        regimes = report.get("regimes_summary") or {}
+        if regimes:
+            joined = ", ".join(f"{k}={v}" for k, v in sorted(regimes.items()))
+            print(f"regimes:        {joined}")
+        bad = [
+            r
+            for r in (report.get("per_receipt") or [])
+            if not r.get("signature_valid", True)
+        ]
+        if bad:
+            print(f"failed receipts: {len(bad)}")
+            for r in bad[:10]:
+                print(f"  - {r.get('record_id', '?')}")
+
+    if not sig_valid:
+        raise typer.Exit(code=1)
+
+
 @audit_pack_app.command("policy")
 def audit_pack_policy(
     digest: str = typer.Argument(
@@ -1417,7 +1496,72 @@ def payloads_erase(
     print("Tombstone written; signature remains cryptographically verifiable.")
 
 
-# === org settings (compliance_mode_strict) ===
+# === session-token (admin/owner) routes ===
+
+
+def _session_request(
+    method: str,
+    path: str,
+    data: dict | None = None,
+) -> Any:
+    """Call an admin/owner route that authenticates with a dashboard JWT.
+
+    The emergency-halt and account-API-key routes resolve the caller via
+    `get_current_user` (cookie or `Authorization: Bearer <jwt>`), not the
+    `X-API-Key` an agent key carries. Reads the JWT from
+    `ASQAV_SESSION_TOKEN` and sends it as a Bearer header. Exits 1 with a
+    clear message when the var is unset. Returns the parsed JSON body, or
+    None for a 204.
+    """
+    import json as json_mod
+    import os
+    import urllib.error
+    import urllib.request
+
+    token = os.environ.get("ASQAV_SESSION_TOKEN")
+    if not token:
+        print(
+            "Error: ASQAV_SESSION_TOKEN env var is required. This route is "
+            "admin/owner-scoped and needs a dashboard session token (JWT), "
+            "not an agent API key."
+        )
+        raise typer.Exit(code=1)
+
+    base = os.environ.get("ASQAV_API_URL", "https://api.asqav.com/api/v1")
+    url = base.rstrip("/") + path
+    body = json_mod.dumps(data).encode("utf-8") if data is not None else b"{}"
+    req = urllib.request.Request(
+        url,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        data=body if method in {"POST", "PATCH", "PUT", "DELETE"} else None,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = exc.read().decode("utf-8")
+        except Exception:
+            detail = str(exc)
+        print(f"HTTP {exc.code} from {path}: {detail}")
+        raise typer.Exit(code=1) from exc
+    except urllib.error.URLError as exc:
+        print(f"Network error: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if not raw:
+        return None
+    try:
+        return json_mod.loads(raw)
+    except json_mod.JSONDecodeError:
+        return raw
+
+
+# === org settings (compliance_mode_strict) + emergency halt ===
 
 
 org_app = typer.Typer(
@@ -1426,6 +1570,59 @@ org_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(org_app, name="org")
+
+
+@org_app.command("halt")
+def org_halt(
+    org_id: str = typer.Argument(help="Organization ID to halt."),
+    reason: str = typer.Option(
+        "", "--reason", help="Admin note recorded with the active halt (audit trail)."
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
+) -> None:
+    """Raise the org-wide emergency halt (kill-switch).
+
+    Calls POST `/orgs/{org_id}/emergency-halt`. While the halt is active
+    every new sign and countersign fails closed with HTTP 403 until an
+    admin lifts it via `asqav org resume`. Admin/owner-scoped, so it reads
+    a dashboard session token from `ASQAV_SESSION_TOKEN`, not an agent key.
+    """
+    if not yes:
+        ok = typer.confirm(
+            f"Halt org {org_id}? Every new sign and countersign will fail "
+            f"closed with 403 until you run `asqav org resume`."
+        )
+        if not ok:
+            print("Cancelled.")
+            raise typer.Exit()
+
+    body: dict = {}
+    if reason:
+        body["reason"] = reason
+    out = _session_request("POST", f"/orgs/{org_id}/emergency-halt", body)
+
+    print(f"Emergency halt RAISED for org {org_id}.")
+    if isinstance(out, dict):
+        if out.get("emergency_halt_at"):
+            print(f"halted_at: {out['emergency_halt_at']}")
+        if out.get("emergency_halt_reason"):
+            print(f"reason:    {out['emergency_halt_reason']}")
+
+
+@org_app.command("resume")
+def org_resume(
+    org_id: str = typer.Argument(help="Organization ID to resume."),
+) -> None:
+    """Lift the org-wide emergency halt so signing resumes.
+
+    Calls POST `/orgs/{org_id}/emergency-halt/deactivate`. This route is
+    never gated by the halt flag, so an org can always lift its own halt
+    (no self-lockout). Admin/owner-scoped via `ASQAV_SESSION_TOKEN`.
+    """
+    out = _session_request("POST", f"/orgs/{org_id}/emergency-halt/deactivate", {})
+    print(f"Emergency halt LIFTED for org {org_id}. Signing resumes.")
+    if isinstance(out, dict) and out.get("emergency_halt") is False:
+        print("server confirms: emergency_halt=False")
 
 
 @org_app.command("set-compliance-strict")
@@ -1515,6 +1712,82 @@ def keys_generate(
 
     print("--- public key ---")
     sys.stdout.write(kp.public_key_pem.decode("utf-8", errors="replace"))
+
+
+@keys_app.command("create")
+def keys_create(
+    name: str = typer.Argument(help="Human-readable name for the new key."),
+    scope: list[str] = typer.Option(
+        [],
+        "--scope",
+        help="Scope to grant; repeat for several (e.g. --scope agents:read --scope sign:write).",
+    ),
+    organization_id: str = typer.Option(
+        "",
+        "--organization-id",
+        help="Mint the key for a specific org (owner/admin only). Defaults to the caller's org.",
+    ),
+) -> None:
+    """Mint a new account API key. The full key is shown once.
+
+    Calls POST `/keys`. Admin/owner-scoped via `get_current_user`, so it
+    reads a dashboard session token from `ASQAV_SESSION_TOKEN` rather than
+    an agent API key. Copy the printed `key` immediately; it is never shown
+    again.
+    """
+    body: dict = {"name": name, "scopes": list(scope)}
+    if organization_id:
+        body["organization_id"] = organization_id
+    out = _session_request("POST", "/keys", body)
+    if not isinstance(out, dict):
+        print("Unexpected response from /keys.")
+        raise typer.Exit(code=1)
+    print(f"Created API key {out.get('id', '?')}: {out.get('name', name)}")
+    print(f"scopes: {', '.join(out.get('scopes', []) or []) or '(none)'}")
+    print(f"key:    {out.get('key', '?')}")
+    print("Store this key now; it is shown only once.")
+
+
+@keys_app.command("list")
+def keys_list() -> None:
+    """List account API keys (prefixes only, never the full secret).
+
+    Calls GET `/keys`. Admin/owner-scoped via `ASQAV_SESSION_TOKEN`.
+    """
+    out = _session_request("GET", "/keys")
+    rows = out if isinstance(out, list) else []
+    if not rows:
+        print("No API keys found.")
+        return
+    for k in rows:
+        state = "revoked" if k.get("revoked") else "active"
+        scopes = ", ".join(k.get("scopes", []) or []) or "(none)"
+        print(
+            f"  {k.get('id', '?')}  {k.get('name', '?')}  "
+            f"prefix={k.get('key_prefix', '?')}  [{state}]  scopes={scopes}"
+        )
+
+
+@keys_app.command("revoke")
+def keys_revoke(
+    key_id: str = typer.Argument(help="API key ID to revoke. Irreversible."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation prompt."),
+) -> None:
+    """Revoke an account API key.
+
+    Calls DELETE `/keys/{key_id}`. Admin/owner-scoped via
+    `ASQAV_SESSION_TOKEN`. Any client still presenting the key starts
+    failing closed immediately.
+    """
+    if not yes:
+        ok = typer.confirm(f"Revoke API key {key_id}? This cannot be undone.")
+        if not ok:
+            print("Cancelled.")
+            raise typer.Exit()
+    out = _session_request("DELETE", f"/keys/{key_id}")
+    print(f"Revoked API key {key_id}.")
+    if isinstance(out, dict) and out.get("message"):
+        print(out["message"])
 
 
 # === replay verify (IETF chain verification) ===
@@ -1720,6 +1993,260 @@ def compliance_export(
     bundle.to_file(output)
     typer.echo(f"wrote {bundle.receipt_count} receipts to {output}")
     typer.echo(f"merkle_root: {bundle.merkle_root}")
+
+
+@compliance_app.command("templates")
+def compliance_templates() -> None:
+    """List the report templates the cloud can generate (Business+).
+
+    Calls GET `/compliance-reports/templates`. Use a `template_id` here as
+    the `--report-type` for `asqav compliance report`.
+    """
+    _init_sdk()
+    from asqav.client import _get
+
+    try:
+        rows = _get("/compliance-reports/templates")
+    except Exception as exc:
+        print(f"Error listing templates: {exc}")
+        raise typer.Exit(code=1) from exc
+    rows = rows if isinstance(rows, list) else []
+    if not rows:
+        print("No report templates available.")
+        return
+    for t in rows:
+        print(
+            f"  {t.get('template_id', '?')}  framework={t.get('framework', '?')}  "
+            f"{t.get('name', '')}"
+        )
+
+
+@compliance_app.command("report")
+def compliance_report(
+    report_type: str = typer.Option(
+        ..., "--report-type", help="Template id (see `asqav compliance templates`)."
+    ),
+    name: str = typer.Option("", "--name", help="Optional report name."),
+    start: str = typer.Option("", "--start", help="Window start, ISO 8601."),
+    end: str = typer.Option("", "--end", help="Window end, ISO 8601."),
+    agent_id: str = typer.Option("", "--agent", help="Scope the report to one agent."),
+    schedule: str = typer.Option(
+        "", "--schedule", help="daily|weekly|monthly to recur; omit for one-off."
+    ),
+) -> None:
+    """Generate a compliance report (Business+). Generation runs server-side.
+
+    Calls POST `/compliance-reports`. Returns the report metadata including
+    its id and status; poll `asqav compliance reports` until status is
+    `ready`, then `asqav compliance download <report_id>`.
+    """
+    _init_sdk()
+    from asqav.client import _post
+
+    body: dict = {"report_type": report_type}
+    for key, value in (
+        ("name", name),
+        ("start_date", start),
+        ("end_date", end),
+        ("agent_id", agent_id),
+        ("schedule", schedule),
+    ):
+        if value:
+            body[key] = value
+
+    try:
+        out = _post("/compliance-reports", body)
+    except Exception as exc:
+        print(f"Error creating report: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if not isinstance(out, dict):
+        print("Unexpected response from /compliance-reports.")
+        raise typer.Exit(code=1)
+    print(f"Created report {out.get('id', '?')}: {out.get('name', '?')}")
+    print(f"framework: {out.get('framework', '?')}")
+    print(f"status:    {out.get('status', '?')}")
+    print("Poll `asqav compliance reports`; download once status is ready.")
+
+
+@compliance_app.command("reports")
+def compliance_reports_list(
+    report_status: str = typer.Option(
+        "", "--status", help="Filter by status (e.g. ready, generating, failed)."
+    ),
+    framework: str = typer.Option("", "--framework", help="Filter by framework key."),
+) -> None:
+    """List generated compliance reports for the org (Business+).
+
+    Calls GET `/compliance-reports`.
+    """
+    _init_sdk()
+    from asqav.client import _get
+
+    path = "/compliance-reports"
+    params = []
+    if report_status:
+        params.append(f"report_status={report_status}")
+    if framework:
+        params.append(f"framework={framework}")
+    if params:
+        path += "?" + "&".join(params)
+
+    try:
+        out = _get(path)
+    except Exception as exc:
+        print(f"Error listing reports: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    rows = out.get("reports", []) if isinstance(out, dict) else []
+    if not rows:
+        print("No compliance reports found.")
+        return
+    for r in rows:
+        print(
+            f"  {r.get('id', '?')}  {r.get('name', '?')}  "
+            f"framework={r.get('framework', '?')}  status={r.get('status', '?')}  "
+            f"records={r.get('record_count', '?')}"
+        )
+
+
+@compliance_app.command("download")
+def compliance_download(
+    report_id: str = typer.Argument(help="Report ID to download."),
+    output_file: str = typer.Option(
+        ..., "--output-file", "-o", help="Path to write the report PDF."
+    ),
+) -> None:
+    """Download a ready compliance report PDF (Business+).
+
+    Calls GET `/compliance-reports/{report_id}/download`, which streams a
+    PDF (not JSON). The cloud returns 409 when the report is not yet
+    `ready`, so generate first and poll `asqav compliance reports`.
+    """
+    import urllib.error
+    import urllib.request
+    from urllib.parse import urljoin
+
+    _init_sdk()
+    from asqav import client as _client_mod
+
+    url = urljoin(
+        _client_mod._api_base.rstrip("/") + "/",
+        f"compliance-reports/{report_id}/download",
+    )
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={"X-API-Key": _client_mod._api_key or ""},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = resp.read()
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = exc.read().decode("utf-8")
+        except Exception:
+            detail = str(exc)
+        print(f"HTTP {exc.code} downloading report: {detail}")
+        raise typer.Exit(code=1) from exc
+    except urllib.error.URLError as exc:
+        print(f"Network error: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    try:
+        with open(output_file, "wb") as f:
+            f.write(data)
+    except OSError as exc:
+        print(f"Error writing report: {exc}")
+        raise typer.Exit(code=1) from exc
+    print(f"wrote {len(data)} bytes to {output_file}")
+
+
+# === observability (read metrics) ===
+
+
+observability_app = typer.Typer(
+    name="observability",
+    help="Read observability metrics (24h summary + per-window detail).",
+    no_args_is_help=True,
+)
+app.add_typer(observability_app, name="observability")
+
+
+@observability_app.command("summary")
+def observability_summary(
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text or json."
+    ),
+) -> None:
+    """Show the 24h observability summary (all tiers).
+
+    Calls GET `/observability/summary`: total actions, active agents,
+    tokens, cost, and weighted-average latency over the last 24 hours.
+    """
+    import json as json_mod
+
+    _init_sdk()
+    from asqav.client import _get
+
+    try:
+        data = _get("/observability/summary")
+    except Exception as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if output == "json":
+        print(json_mod.dumps(data, indent=2, default=str))
+        return
+    print(f"total_actions:      {data.get('total_actions', '?')}")
+    print(f"agents_active:      {data.get('total_agents_active', '?')}")
+    print(f"total_tokens:       {data.get('total_tokens', '?')}")
+    print(f"total_cost_usd:     {data.get('total_cost_usd', '?')}")
+    latency = data.get("avg_latency_ms")
+    print(f"avg_latency_ms:     {latency if latency is not None else 'n/a'}")
+
+
+@observability_app.command("metrics")
+def observability_metrics(
+    hours: int = typer.Option(24, "--hours", help="Lookback window in hours."),
+    window: str = typer.Option(
+        "1hr", "--window", help="Window granularity (e.g. 1hr, 1day)."
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text or json."
+    ),
+) -> None:
+    """Show per-window metric rows (requires the full observability feature).
+
+    Calls GET `/observability/metrics`.
+    """
+    import json as json_mod
+
+    _init_sdk()
+    from asqav.client import _get
+
+    path = f"/observability/metrics?hours={hours}&window_type={window}"
+    try:
+        data = _get(path)
+    except Exception as exc:
+        print(f"Error: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if output == "json":
+        print(json_mod.dumps(data, indent=2, default=str))
+        return
+    rows = data.get("metrics", []) if isinstance(data, dict) else []
+    if not rows:
+        print("No metrics in the window.")
+        return
+    for m in rows:
+        lat = m.get("latency", {}) or {}
+        print(
+            f"  {m.get('window_start', '?')}  agent={m.get('agent_id', '?')}  "
+            f"actions={m.get('total_actions', '?')}  "
+            f"failed={m.get('failed_actions', '?')}  "
+            f"p95={lat.get('p95_ms', 'n/a')}ms"
+        )
 
 
 # === shadow-ai (egress shim scaffolding + lifecycle) ===

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1156,6 +1156,315 @@ def test_keys_generate_ml_dsa_errors() -> None:
     assert "unsupported_algorithm" in result.output.lower()
 
 
+# === audit-pack verify ===
+
+
+@patch("asqav.client._post")
+@patch("asqav.init")
+def test_audit_pack_verify_valid(
+    mock_init: MagicMock, mock_post: MagicMock, tmp_path
+) -> None:
+    """audit-pack verify posts the bundle wrapped in {bundle: ...} and prints VALID."""
+    mock_post.return_value = {
+        "bundle_signature_valid": True,
+        "bundle_digest": "sha256:abc",
+        "receipt_count": 2,
+        "report_signature_algorithm": "ml-dsa-65",
+        "regimes_summary": {"eu_ai_act": 2},
+        "per_receipt": [
+            {"record_id": "r1", "signature_valid": True},
+            {"record_id": "r2", "signature_valid": True},
+        ],
+    }
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_text('{"receipt_count": 2, "receipts": []}')
+    result = runner.invoke(
+        app,
+        ["audit-pack", "verify", str(bundle_path)],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "VALID" in result.output
+    assert "sha256:abc" in result.output
+    called_path = mock_post.call_args.args[0]
+    body = mock_post.call_args.args[1]
+    assert called_path == "/audit-pack/verify"
+    assert body["bundle"] == {"receipt_count": 2, "receipts": []}
+
+
+@patch("asqav.client._post")
+@patch("asqav.init")
+def test_audit_pack_verify_invalid_exits_1(
+    mock_init: MagicMock, mock_post: MagicMock, tmp_path
+) -> None:
+    """audit-pack verify exits 1 and lists failed receipts on an invalid bundle."""
+    mock_post.return_value = {
+        "bundle_signature_valid": False,
+        "bundle_digest": "sha256:def",
+        "receipt_count": 1,
+        "report_signature_algorithm": "ml-dsa-65",
+        "regimes_summary": {},
+        "per_receipt": [{"record_id": "r_bad", "signature_valid": False}],
+    }
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_text("{}")
+    result = runner.invoke(
+        app,
+        ["audit-pack", "verify", str(bundle_path)],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 1
+    assert "INVALID" in result.output
+    assert "r_bad" in result.output
+
+
+# === org halt / resume (emergency kill-switch, JWT-scoped) ===
+
+
+@patch("asqav.cli._session_request")
+def test_org_halt_calls_emergency_route(mock_session: MagicMock) -> None:
+    """org halt --yes POSTs the emergency-halt route with the reason note."""
+    mock_session.return_value = {
+        "emergency_halt": True,
+        "emergency_halt_at": "2026-06-01T00:00:00Z",
+        "emergency_halt_reason": "rogue agent",
+    }
+    result = runner.invoke(
+        app,
+        ["org", "halt", "org_x", "--reason", "rogue agent", "--yes"],
+        env={"ASQAV_SESSION_TOKEN": "jwt_x"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "RAISED" in result.output
+    method, path = mock_session.call_args.args[0], mock_session.call_args.args[1]
+    body = mock_session.call_args.args[2]
+    assert method == "POST"
+    assert path == "/orgs/org_x/emergency-halt"
+    assert body == {"reason": "rogue agent"}
+
+
+@patch("asqav.cli._session_request")
+def test_org_resume_calls_deactivate_route(mock_session: MagicMock) -> None:
+    """org resume POSTs the deactivate route."""
+    mock_session.return_value = {"emergency_halt": False}
+    result = runner.invoke(
+        app,
+        ["org", "resume", "org_x"],
+        env={"ASQAV_SESSION_TOKEN": "jwt_x"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "LIFTED" in result.output
+    path = mock_session.call_args.args[1]
+    assert path == "/orgs/org_x/emergency-halt/deactivate"
+
+
+def test_org_halt_requires_session_token() -> None:
+    """org halt fails closed with a clear message when ASQAV_SESSION_TOKEN is unset."""
+    result = runner.invoke(
+        app,
+        ["org", "halt", "org_x", "--yes"],
+        env={"ASQAV_SESSION_TOKEN": "", "ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 1
+    assert "ASQAV_SESSION_TOKEN" in result.output
+
+
+# === keys create / list / revoke (account API keys, JWT-scoped) ===
+
+
+@patch("asqav.cli._session_request")
+def test_keys_create_prints_full_key_once(mock_session: MagicMock) -> None:
+    """keys create POSTs /keys and prints the one-time full key."""
+    mock_session.return_value = {
+        "id": "key_1",
+        "name": "ci",
+        "scopes": ["agents:read"],
+        "key": "sk_live_secret",
+    }
+    result = runner.invoke(
+        app,
+        ["keys", "create", "ci", "--scope", "agents:read"],
+        env={"ASQAV_SESSION_TOKEN": "jwt_x"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "sk_live_secret" in result.output
+    method, path = mock_session.call_args.args[0], mock_session.call_args.args[1]
+    body = mock_session.call_args.args[2]
+    assert method == "POST"
+    assert path == "/keys"
+    assert body == {"name": "ci", "scopes": ["agents:read"]}
+
+
+@patch("asqav.cli._session_request")
+def test_keys_list_renders_rows(mock_session: MagicMock) -> None:
+    """keys list GETs /keys and renders id + prefix + state."""
+    mock_session.return_value = [
+        {
+            "id": "key_1",
+            "name": "ci",
+            "key_prefix": "sk_live_ab",
+            "scopes": ["*"],
+            "revoked": False,
+        }
+    ]
+    result = runner.invoke(
+        app, ["keys", "list"], env={"ASQAV_SESSION_TOKEN": "jwt_x"}
+    )
+    assert result.exit_code == 0, result.output
+    assert "key_1" in result.output
+    assert "sk_live_ab" in result.output
+    assert "active" in result.output
+    assert mock_session.call_args.args[1] == "/keys"
+
+
+@patch("asqav.cli._session_request")
+def test_keys_revoke_calls_delete(mock_session: MagicMock) -> None:
+    """keys revoke --yes DELETEs /keys/{id}."""
+    mock_session.return_value = {"message": "revoked"}
+    result = runner.invoke(
+        app,
+        ["keys", "revoke", "key_1", "--yes"],
+        env={"ASQAV_SESSION_TOKEN": "jwt_x"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "Revoked" in result.output
+    method, path = mock_session.call_args.args[0], mock_session.call_args.args[1]
+    assert method == "DELETE"
+    assert path == "/keys/key_1"
+
+
+# === compliance templates / report / reports ===
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_compliance_templates_lists(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    """compliance templates GETs the templates route and renders ids."""
+    mock_get.return_value = [
+        {"template_id": "eu_ai_act", "framework": "eu_ai_act", "name": "EU AI Act"}
+    ]
+    result = runner.invoke(
+        app, ["compliance", "templates"], env={"ASQAV_API_KEY": "sk_test"}
+    )
+    assert result.exit_code == 0, result.output
+    assert "eu_ai_act" in result.output
+    assert mock_get.call_args.args[0] == "/compliance-reports/templates"
+
+
+@patch("asqav.client._post")
+@patch("asqav.init")
+def test_compliance_report_creates(
+    mock_init: MagicMock, mock_post: MagicMock
+) -> None:
+    """compliance report POSTs the create route with the report_type body."""
+    mock_post.return_value = {
+        "id": "rep_1",
+        "name": "Q2",
+        "framework": "eu_ai_act",
+        "status": "generating",
+    }
+    result = runner.invoke(
+        app,
+        ["compliance", "report", "--report-type", "eu_ai_act", "--name", "Q2"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "rep_1" in result.output
+    called_path = mock_post.call_args.args[0]
+    body = mock_post.call_args.args[1]
+    assert called_path == "/compliance-reports"
+    assert body["report_type"] == "eu_ai_act"
+    assert body["name"] == "Q2"
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_compliance_reports_lists(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    """compliance reports GETs the list route and renders report rows."""
+    mock_get.return_value = {
+        "reports": [
+            {
+                "id": "rep_1",
+                "name": "Q2",
+                "framework": "eu_ai_act",
+                "status": "ready",
+                "record_count": 5,
+            }
+        ],
+        "total": 1,
+    }
+    result = runner.invoke(
+        app,
+        ["compliance", "reports", "--status", "ready"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "rep_1" in result.output
+    assert "ready" in result.output
+    assert "report_status=ready" in mock_get.call_args.args[0]
+
+
+# === observability summary / metrics ===
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_observability_summary(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    """observability summary GETs the summary route and renders totals."""
+    mock_get.return_value = {
+        "total_actions": 12,
+        "total_agents_active": 3,
+        "total_tokens": 4000,
+        "total_cost_usd": 0.42,
+        "avg_latency_ms": 18.5,
+    }
+    result = runner.invoke(
+        app, ["observability", "summary"], env={"ASQAV_API_KEY": "sk_test"}
+    )
+    assert result.exit_code == 0, result.output
+    assert "12" in result.output
+    assert "18.5" in result.output
+    assert mock_get.call_args.args[0] == "/observability/summary"
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_observability_metrics_passes_window(
+    mock_init: MagicMock, mock_get: MagicMock
+) -> None:
+    """observability metrics threads --hours and --window into the query string."""
+    mock_get.return_value = {
+        "metrics": [
+            {
+                "window_start": "2026-06-01T00:00:00Z",
+                "agent_id": "agent_x",
+                "total_actions": 5,
+                "failed_actions": 0,
+                "latency": {"p95_ms": 20.0},
+            }
+        ],
+        "window_type": "1hr",
+        "hours": 24,
+        "count": 1,
+    }
+    result = runner.invoke(
+        app,
+        ["observability", "metrics", "--hours", "48", "--window", "1day"],
+        env={"ASQAV_API_KEY": "sk_test"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "agent_x" in result.output
+    path = mock_get.call_args.args[0]
+    assert "hours=48" in path
+    assert "window_type=1day" in path
+
+
 # === replay-verify ===
 
 

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -12,6 +12,8 @@
  *   asqav budget check / record
  *   asqav approve <session_id> <entity_id>
  *   asqav compliance frameworks / export
+ *   asqav audit-pack verify <bundle>
+ *   asqav org halt / resume <org_id>          (admin, ASQAV_SESSION_TOKEN)
  *
  * Pro-only commands (replay, preflight, budget, approve) and the
  * Business-only `compliance export` are gated client-side via the same
@@ -621,6 +623,66 @@ async function cmdAuditPackExport(args: string[]): Promise<void> {
   }
 }
 
+async function cmdAuditPackVerify(args: string[]): Promise<void> {
+  const [bundlePath] = positional(args);
+  if (!bundlePath) {
+    die("Usage: asqav audit-pack verify <bundle.json|-> [--output text|json]");
+  }
+  const output = parseFlag(args, "output") ?? "text";
+  let bundle: unknown;
+  try {
+    let raw: string;
+    if (bundlePath === "-") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+      raw = Buffer.concat(chunks).toString("utf8");
+    } else {
+      const fs = await import("node:fs/promises");
+      raw = await fs.readFile(bundlePath, "utf8");
+    }
+    bundle = JSON.parse(raw);
+  } catch (err) {
+    die(`Error reading bundle: ${(err as Error).message}`);
+  }
+  ensureApiKey();
+  try {
+    const report = await request<{
+      bundle_signature_valid?: boolean;
+      bundle_digest?: string;
+      receipt_count?: number;
+      report_signature_algorithm?: string;
+      regimes_summary?: Record<string, number>;
+      per_receipt?: Array<{ record_id?: string; signature_valid?: boolean }>;
+    }>("POST", "/audit-pack/verify", { bundle });
+    const sigValid = Boolean(report.bundle_signature_valid);
+    if (output === "json") {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      process.stdout.write(`bundle signature: ${sigValid ? "VALID" : "INVALID"}\n`);
+      process.stdout.write(`bundle_digest:  ${report.bundle_digest ?? "?"}\n`);
+      process.stdout.write(`receipt_count:  ${report.receipt_count ?? "?"}\n`);
+      process.stdout.write(`report_signed:  ${report.report_signature_algorithm ?? "?"}\n`);
+      const regimes = report.regimes_summary ?? {};
+      const regimeKeys = Object.keys(regimes).sort();
+      if (regimeKeys.length > 0) {
+        process.stdout.write(
+          `regimes:        ${regimeKeys.map((k) => `${k}=${regimes[k]}`).join(", ")}\n`,
+        );
+      }
+      const bad = (report.per_receipt ?? []).filter((r) => r.signature_valid === false);
+      if (bad.length > 0) {
+        process.stdout.write(`failed receipts: ${bad.length}\n`);
+        for (const r of bad.slice(0, 10)) {
+          process.stdout.write(`  - ${r.record_id ?? "?"}\n`);
+        }
+      }
+    }
+    if (!sigValid) process.exit(1);
+  } catch (err) {
+    die(`Error verifying audit pack: ${(err as Error).message}`);
+  }
+}
+
 async function cmdAuditPackPolicy(args: string[]): Promise<void> {
   let [digest] = positional(args);
   if (!digest) die("Usage: asqav audit-pack policy <sha256:hex>");
@@ -698,6 +760,87 @@ async function cmdOrgSetComplianceStrict(args: string[]): Promise<void> {
     }
   } catch (err) {
     die(`Error updating organization: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Call an admin/owner route that authenticates with a dashboard JWT.
+ *
+ * The emergency-halt routes resolve the caller via the cloud's
+ * get_current_user dependency (cookie or Authorization: Bearer), not the
+ * X-API-Key an agent key carries. Reads the JWT from ASQAV_SESSION_TOKEN.
+ */
+async function sessionRequest(
+  method: string,
+  path: string,
+  body: Record<string, unknown> = {},
+): Promise<unknown> {
+  const token = process.env.ASQAV_SESSION_TOKEN;
+  if (!token) {
+    die(
+      "Error: ASQAV_SESSION_TOKEN env var is required. This route is admin/owner-scoped " +
+        "and needs a dashboard session token (JWT), not an agent API key.",
+    );
+  }
+  const baseUrl = process.env.ASQAV_API_URL ?? "https://api.asqav.com/api/v1";
+  const url = `${baseUrl.replace(/\/+$/, "")}${path}`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    die(`Network error: ${(err as Error).message}`);
+  }
+  const text = await response.text();
+  if (response.status >= 400) {
+    die(`HTTP ${response.status} from ${path}: ${text}`);
+  }
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function cmdOrgHalt(args: string[]): Promise<void> {
+  const [orgId] = positional(args);
+  if (!orgId) die("Usage: asqav org halt <org_id> [--reason TEXT] [--yes]");
+  if (!hasFlag(args, "yes") && !hasFlag(args, "y")) {
+    die(
+      "Refusing to halt without --yes. While halted, every new sign and countersign " +
+        "fails closed with 403 until you run `asqav org resume`.",
+    );
+  }
+  const reason = parseFlag(args, "reason");
+  const body: Record<string, unknown> = {};
+  if (reason) body.reason = reason;
+  const out = (await sessionRequest("POST", `/orgs/${orgId}/emergency-halt`, body)) as {
+    emergency_halt_at?: string;
+    emergency_halt_reason?: string;
+  } | null;
+  process.stdout.write(`Emergency halt RAISED for org ${orgId}.\n`);
+  if (out?.emergency_halt_at) process.stdout.write(`halted_at: ${out.emergency_halt_at}\n`);
+  if (out?.emergency_halt_reason) process.stdout.write(`reason:    ${out.emergency_halt_reason}\n`);
+}
+
+async function cmdOrgResume(args: string[]): Promise<void> {
+  const [orgId] = positional(args);
+  if (!orgId) die("Usage: asqav org resume <org_id>");
+  const out = (await sessionRequest(
+    "POST",
+    `/orgs/${orgId}/emergency-halt/deactivate`,
+    {},
+  )) as { emergency_halt?: boolean } | null;
+  process.stdout.write(`Emergency halt LIFTED for org ${orgId}. Signing resumes.\n`);
+  if (out && out.emergency_halt === false) {
+    process.stdout.write("server confirms: emergency_halt=false\n");
   }
 }
 
@@ -858,13 +1001,17 @@ Usage:
   asqav compliance frameworks / export                     (Business)
   asqav audit-pack export --start ISO --end ISO --output-file PATH
                           [--organization-id ID] [--no-only-compliance]
+  asqav audit-pack verify <bundle.json|-> [--output text|json]
   asqav audit-pack policy <sha256:hex> [--output text|json]
   asqav payloads erase <signature_id> --yes                P4 right-to-erasure
   asqav org set-compliance-strict <org_id> --enable|--disable
+  asqav org halt <org_id> [--reason TEXT] --yes            kill-switch (ASQAV_SESSION_TOKEN)
+  asqav org resume <org_id>                                lift halt (ASQAV_SESSION_TOKEN)
   asqav keys generate --algorithm ed25519|es256 [--out priv.pem]
   asqav migrate run v3-20|v3-21|v3-22                      X-Maintenance-Key required
 
 Set ASQAV_API_KEY to authenticate. Get a key at https://asqav.com.
+Admin commands (org halt/resume) read a dashboard session token from ASQAV_SESSION_TOKEN.
 `);
 }
 
@@ -922,8 +1069,9 @@ export async function runCli(argv: string[]): Promise<void> {
     case "audit-pack": {
       const [sub, ...rest2] = rest;
       if (sub === "export") return cmdAuditPackExport(rest2);
+      if (sub === "verify") return cmdAuditPackVerify(rest2);
       if (sub === "policy") return cmdAuditPackPolicy(rest2);
-      die("Usage: asqav audit-pack (export | policy <digest>)");
+      die("Usage: asqav audit-pack (export | verify <bundle> | policy <digest>)");
     }
     case "payloads": {
       const [sub, ...rest2] = rest;
@@ -933,7 +1081,9 @@ export async function runCli(argv: string[]): Promise<void> {
     case "org": {
       const [sub, ...rest2] = rest;
       if (sub === "set-compliance-strict") return cmdOrgSetComplianceStrict(rest2);
-      die("Usage: asqav org set-compliance-strict <org_id> --enable|--disable");
+      if (sub === "halt") return cmdOrgHalt(rest2);
+      if (sub === "resume") return cmdOrgResume(rest2);
+      die("Usage: asqav org (set-compliance-strict <org_id> --enable|--disable | halt <org_id> | resume <org_id>)");
     }
     case "keys": {
       const [sub, ...rest2] = rest;


### PR DESCRIPTION
## Summary

Close the highest-value CLI coverage gaps so more of the product is reachable from the terminal. Each command wraps an existing cloud API route; every route was cold-verified against the cloud source before wiring (cloud `file:line` cited below).

## Commands added (Python, `python/src/asqav/cli.py`)

- `asqav audit-pack verify <bundle>` - the verifier path. Posts the bundle to the offline-verify route and prints the signed report; exits non-zero when the bundle signature is invalid.
  - Route: `POST /audit-pack/verify` - `src/asqav_cloud/api/routes/audit_pack.py:763` (request model `AuditPackVerifyRequest` at `:559` wraps the bundle as `{"bundle": ...}`).
- `asqav org halt <org_id>` / `asqav org resume <org_id>` - org-wide emergency kill-switch and its lift.
  - Routes: `POST /orgs/{org_id}/emergency-halt` - `routes/organizations.py:392`; `POST /orgs/{org_id}/emergency-halt/deactivate` - `routes/organizations.py:425`.
- `asqav keys create / list / revoke` - account API key management.
  - Routes: `POST /keys` - `routes/api_keys.py:241`; `GET /keys` - `routes/api_keys.py:209`; `DELETE /keys/{key_id}` - `routes/api_keys.py:397`.
- `asqav compliance templates / report / reports / download` - cloud report generation and PDF download.
  - Routes: `GET /compliance-reports/templates` - `routes/compliance_reports.py:170`; `POST /compliance-reports` - `:191`; `GET /compliance-reports` - `:318`; `GET /compliance-reports/{report_id}/download` - `:377` (streams a PDF, fetched as raw bytes).
- `asqav observability summary / metrics` - read 24h metrics.
  - Routes: `GET /observability/summary` - `routes/observability.py:166`; `GET /observability/metrics` - `routes/observability.py:220` (query params `window_type`, `hours`).

## Auth model note (cold-verify finding)

Two route groups authenticate via the cloud `get_current_user` dependency (`routes/auth.py:354`), which accepts only a dashboard session token (cookie or `Authorization: Bearer <jwt>`), not the `X-API-Key` an agent key carries:

- emergency-halt (`organizations.py:398`)
- account API keys (`api_keys.py:246`)

So `org halt/resume` and `keys create/list/revoke` read the session token from `ASQAV_SESSION_TOKEN` and send it as a Bearer header, failing closed with a clear message when the var is unset. This matches the existing `org set-compliance-strict` command, which calls the same-auth `PATCH /orgs/{org_id}` (`organizations.py:329`). The audit-pack-verify, compliance-report, and observability routes use the `get_api_context` path (`require_scope` / `require_feature` build on it), so those commands reuse the standard X-API-Key client helpers.

## Skipped

- No dedicated observability `coverage` route exists in the cloud, so `observability coverage` was not invented; `summary` and `metrics` are the real read surfaces.

## Parity (TypeScript, `typescript/src/cli.ts`)

The two safety-critical commands are mirrored: `audit-pack verify` and `org halt` / `org resume` (the kill-switch). The remaining Python-only commands (`keys` management, compliance report generation/download, observability) are left for a follow-up; they are read or admin convenience surfaces, not safety-critical, and the TS user keeps the kill-switch.

## Tests

13 new tests in `python/tests/test_cli.py` covering each command, mocking the client helpers (`asqav.client._get` / `_post`) and the session-token helper (`asqav.cli._session_request`) as the existing suite does, including the fail-closed `ASQAV_SESSION_TOKEN`-unset case. Full `test_cli.py` is green (78 passed). `ruff check` on the changed source is clean (the 3 remaining E501s pre-exist on `main` in test fixtures, untouched here).

comment hygiene clean
