### PR TITLE
Add the agent-receipts W3C-VC adapter, a DID resolver, and strict JCS

### DIFF
--- a/verifier/conformance-vectors/README.md
+++ b/verifier/conformance-vectors/README.md
@@ -14,6 +14,8 @@ manifest.json                  array of {dir, format, outcome, reason_code, note
   predecessor.json             (chain vectors only) the prior receipt
   jwks.json                    (asqav-native) issuer key directory
   keys.json                    (aerf) {key_id: ed25519_pubkey_hex}
+  acta-keys.json               (acta) JWKS-shaped key set
+  did_map.json                 (agentreceipts) {did: ed25519_pubkey_hex} for did:agent / did:web
 ```
 
 `outcome` is `PASS` or `FAIL`; the runner maps it to the oracle verdict and
@@ -37,6 +39,19 @@ python -m oracle.runner          # from the verifier/ directory
   spec.
 - `aerf-03-tamper-evidence` - action mutated after signing; signature fails.
 - `aerf-04-tamper-chain` - `previous_receipt_hash` mutated; chain fails.
+- `acta-01..05` - ACTA genesis, chain link, tampered signature, and an
+  unsupported commitment-mode receipt that fails the baseline verifier.
+- `aerf-up-*` - upstream-derived AERF vectors (see `UPSTREAM.md`).
+- `agentreceipts-01..06` - W3C-VC AgentReceipt: did:key genesis (key resolves
+  inline), chain link, tampered payload, tampered proofValue, a genesis missing
+  `previous_receipt_hash` (malformed), and a wrong-DID signature mismatch.
+- `agentreceipts-up-*` - upstream agent-receipts vectors (six malformed
+  single-field mutations, a tampered chain, and two upstream-keypair PASS
+  cases). See `UPSTREAM.md`.
 
 The keys are generated from fixed seeds so the vectors are reproducible. AERF
 public keys are derived per spec as the first 16 hex of `SHA-256(pubkey)`.
+AgentReceipt did:key receipts need no key file - the resolver decodes the key
+from the `did:key` identifier; did:agent / did:web vectors carry `did_map.json`.
+Vector provenance, the upstream commit SHAs, and the re-signing of the
+agent-receipts PASS vectors with the upstream keypair are recorded in `UPSTREAM.md`.

--- a/verifier/conformance-vectors/UPSTREAM.md
+++ b/verifier/conformance-vectors/UPSTREAM.md
@@ -4,6 +4,47 @@ The `aerf-up-*` vector directories are derived from the AERF conformance
 corpus at <https://github.com/aerf-spec/aerf>, cloned at commit
 `59fce60fe30bde35318812f502a55ab4bace4650`.
 
+The `agentreceipts-up-*` vector directories and the vendored interop files
+under `agentreceipts-upstream-interop/` are derived from the agent-receipts
+corpus at <https://github.com/agent-receipts/ar>, cloned at commit
+`16772507e6d00b1dfea6f079ea0e0980d324993f`. The repository code (including
+`cross-sdk-tests/`) is licensed Apache-2.0 and the protocol spec under `spec/`
+(including the did:key vectors) is licensed MIT.
+
+`agentreceipts-upstream-interop/canonicalization_vectors.json` is reproduced
+verbatim from `cross-sdk-tests/canonicalization_vectors.json`; our
+`jcs_rfc8785` canonicaliser must produce byte-identical output for every one of
+its 32 `canonicalization_vectors` entries, asserted directly in the oracle test
+suite. `agentreceipts-upstream-interop/did_key_vectors.json` is reproduced from
+`spec/test-vectors/did-key/vectors.json`; the shared DID resolver decodes each
+to the expected raw Ed25519 key.
+
+The `agentreceipts-up-*` FAIL directories reproduce the six single-field
+mutations from `cross-sdk-tests/malformed_vectors.json` (receipts every SDK MUST
+reject) plus the tampered middle-chain receipt. The valid `agentreceipts-up-00`
+and `-up-08` directories re-sign that corpus's base receipt with the corpus's
+own Ed25519 keypair over `jcs_rfc8785` bytes, so the PASS vectors carry a real
+upstream-keypair signature rather than a self-authored one.
+
+The agent-receipts spec example receipts under `spec/examples/` are NOT ingested:
+they use `did:agent:` identifiers with no published key and carry placeholder
+`previous_receipt_hash` values, so they are documentation illustrations rather
+than cryptographically verifiable vectors.
+
+INTEROP FINDING (canonicalization dialect divergence). Both AERF SPEC.md and the
+agent-receipts spec cite "full RFC 8785 (JCS)", but their reference producers
+disagree on number serialisation and key ordering. The AERF Go canonicaliser
+(`verifiers/go/internal/aerf/canonical.go`) writes numbers via `json.Number`
+verbatim and sorts keys with `sort.Strings` (UTF-8 byte order), so an AERF
+receipt carrying `1250.0` is signed over the bytes `1250.0`. The agent-receipts
+producers sign true RFC 8785, where the same value canonicalises to `1250`. The
+two are not byte-compatible, so the oracle keeps two canonicalisers: `jcs` (the
+AERF/ACTA dialect, numbers as Python emits them) and `jcs_rfc8785` (strict RFC
+8785, used only by the agent-receipts adapter). This was verified directly:
+the upstream AERF signature on `vectors/01-genesis-happy-path` verifies under the
+verbatim-number canonicaliser and fails under the strict one, while all 32
+agent-receipts canonicalization vectors byte-match only under the strict one.
+
 The upstream code and vector data are licensed Apache-2.0; the upstream
 prose is licensed CC-BY. The receipt artifacts and public keys are
 reproduced from that corpus. Each upstream public key (SPKI PEM) is

--- a/verifier/conformance-vectors/agentreceipts-01-didkey-genesis/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-01-didkey-genesis/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "did:key genesis; key resolves inline, signature verifies, previous_receipt_hash explicit null."
+}

--- a/verifier/conformance-vectors/agentreceipts-01-didkey-genesis/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-01-didkey-genesis/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:11111111-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+  },
+  "issuanceDate": "2026-05-04T12:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_00000000-0000-0000-0000-000000000001",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-05-04T12:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_didkey_demo"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-05-04T12:00:00Z",
+    "verificationMethod": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "u0RGtoFwGVVgZ-t0mwsvN5ikthL-eMOswR2UnMuAbMrCO48kBPHlWrDR21sF4LWMV1Ng7VDRzOp5c3xTMFwXIDA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-02-didkey-chain-link/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-02-didkey-chain-link/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Successor links via sha256:hex(JCS(predecessor without proof)); signature verifies."
+}

--- a/verifier/conformance-vectors/agentreceipts-02-didkey-chain-link/predecessor.json
+++ b/verifier/conformance-vectors/agentreceipts-02-didkey-chain-link/predecessor.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:11111111-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+  },
+  "issuanceDate": "2026-05-04T12:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_00000000-0000-0000-0000-000000000001",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-05-04T12:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_didkey_demo"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-05-04T12:00:00Z",
+    "verificationMethod": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "u0RGtoFwGVVgZ-t0mwsvN5ikthL-eMOswR2UnMuAbMrCO48kBPHlWrDR21sF4LWMV1Ng7VDRzOp5c3xTMFwXIDA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-02-didkey-chain-link/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-02-didkey-chain-link/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:11111111-0000-4000-8000-000000000002",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+  },
+  "issuanceDate": "2026-05-04T12:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_00000000-0000-0000-0000-000000000002",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-05-04T12:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 2,
+      "previous_receipt_hash": "sha256:eb5fd119afbd399658e615cd4687c0047c72dd3bb3c59bbf40f69b7a12e66a34",
+      "chain_id": "chain_didkey_demo"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-05-04T12:00:00Z",
+    "verificationMethod": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "unHhQNS8kbyy35I-whv226R5Q0r6PMuFfqF6_PBX4IP2Xt6ySyeu_cE2U33ynoSpTByKIrPSs1L09W62U_sxKBQ"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-03-tamper-payload/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-03-tamper-payload/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "action.type mutated after signing; canonical bytes no longer match the signature."
+}

--- a/verifier/conformance-vectors/agentreceipts-03-tamper-payload/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-03-tamper-payload/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:11111111-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+  },
+  "issuanceDate": "2026-05-04T12:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_00000000-0000-0000-0000-000000000001",
+      "type": "financial.payment.initiate",
+      "risk_level": "low",
+      "timestamp": "2026-05-04T12:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_didkey_demo"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-05-04T12:00:00Z",
+    "verificationMethod": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "u0RGtoFwGVVgZ-t0mwsvN5ikthL-eMOswR2UnMuAbMrCO48kBPHlWrDR21sF4LWMV1Ng7VDRzOp5c3xTMFwXIDA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-04-tamper-proofvalue/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-04-tamper-proofvalue/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Single proofValue byte flipped; Ed25519 verification fails."
+}

--- a/verifier/conformance-vectors/agentreceipts-04-tamper-proofvalue/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-04-tamper-proofvalue/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:11111111-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+  },
+  "issuanceDate": "2026-05-04T12:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_00000000-0000-0000-0000-000000000001",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-05-04T12:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_didkey_demo"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-05-04T12:00:00Z",
+    "verificationMethod": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "u0BGtoFwGVVgZ-t0mwsvN5ikthL-eMOswR2UnMuAbMrCO48kBPHlWrDR21sF4LWMV1Ng7VDRzOp5c3xTMFwXIDA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-05-genesis-missing-prev-hash/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-05-genesis-missing-prev-hash/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "schema",
+  "notes": "previous_receipt_hash omitted; spec requires it present (null on genesis), so the receipt is malformed."
+}

--- a/verifier/conformance-vectors/agentreceipts-05-genesis-missing-prev-hash/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-05-genesis-missing-prev-hash/receipt.json
@@ -1,0 +1,41 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:11111111-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+  },
+  "issuanceDate": "2026-05-04T12:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_00000000-0000-0000-0000-000000000001",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-05-04T12:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "chain_id": "chain_didkey_demo"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-05-04T12:00:00Z",
+    "verificationMethod": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "u0RGtoFwGVVgZ-t0mwsvN5ikthL-eMOswR2UnMuAbMrCO48kBPHlWrDR21sF4LWMV1Ng7VDRzOp5c3xTMFwXIDA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-06-wrong-key/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-06-wrong-key/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:impersonator-001": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737"
+}

--- a/verifier/conformance-vectors/agentreceipts-06-wrong-key/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-06-wrong-key/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "verificationMethod resolves (via the injected map) to a different valid Ed25519 key than the signer; signature fails."
+}

--- a/verifier/conformance-vectors/agentreceipts-06-wrong-key/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-06-wrong-key/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:11111111-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.1.0",
+  "issuer": {
+    "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+  },
+  "issuanceDate": "2026-05-04T12:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_00000000-0000-0000-0000-000000000001",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-05-04T12:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_didkey_demo"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-05-04T12:00:00Z",
+    "verificationMethod": "did:agent:impersonator-001#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "u0RGtoFwGVVgZ-t0mwsvN5ikthL-eMOswR2UnMuAbMrCO48kBPHlWrDR21sF4LWMV1Ng7VDRzOp5c3xTMFwXIDA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-00-valid-resigned/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-up-00-valid-resigned/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:malformed-test": "64cce1d90b5dc7fa78d16957843fa02a66930efdeb2c69ba4de63b4ec2542924"
+}

--- a/verifier/conformance-vectors/agentreceipts-up-00-valid-resigned/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-00-valid-resigned/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Upstream malformed-corpus base receipt re-signed cleanly with the upstream keypair; signature verifies over jcs_rfc8785 bytes."
+}

--- a/verifier/conformance-vectors/agentreceipts-up-00-valid-resigned/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-up-00-valid-resigned/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_1",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_malformed_base"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "uRO9fTNL12Fwdz4M5pDcRP3P6msLELGTTt4EmVZfmWvq1zjemjZ-VA_4Hk6F6944UPW5aMLGZvonhiGt3SpS-BA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-01-wrong-proof-type/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-up-01-wrong-proof-type/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:malformed-test": "64cce1d90b5dc7fa78d16957843fa02a66930efdeb2c69ba4de63b4ec2542924"
+}

--- a/verifier/conformance-vectors/agentreceipts-up-01-wrong-proof-type/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-01-wrong-proof-type/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "schema",
+  "notes": "Upstream malformed vector: proof.type is not Ed25519Signature2020."
+}

--- a/verifier/conformance-vectors/agentreceipts-up-01-wrong-proof-type/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-up-01-wrong-proof-type/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_1",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_malformed_base"
+    }
+  },
+  "proof": {
+    "type": "RsaSignature2018",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "uRO9fTNL12Fwdz4M5pDcRP3P6msLELGTTt4EmVZfmWvq1zjemjZ-VA_4Hk6F6944UPW5aMLGZvonhiGt3SpS-BA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-02-mutated-action-type/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-up-02-mutated-action-type/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:malformed-test": "64cce1d90b5dc7fa78d16957843fa02a66930efdeb2c69ba4de63b4ec2542924"
+}

--- a/verifier/conformance-vectors/agentreceipts-up-02-mutated-action-type/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-02-mutated-action-type/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Upstream malformed vector: action.type mutated after signing."
+}

--- a/verifier/conformance-vectors/agentreceipts-up-02-mutated-action-type/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-up-02-mutated-action-type/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_1",
+      "type": "filesystem.file.delete",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_malformed_base"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "uRO9fTNL12Fwdz4M5pDcRP3P6msLELGTTt4EmVZfmWvq1zjemjZ-VA_4Hk6F6944UPW5aMLGZvonhiGt3SpS-BA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-03-mutated-principal-id/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-up-03-mutated-principal-id/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:malformed-test": "64cce1d90b5dc7fa78d16957843fa02a66930efdeb2c69ba4de63b4ec2542924"
+}

--- a/verifier/conformance-vectors/agentreceipts-up-03-mutated-principal-id/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-03-mutated-principal-id/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Upstream malformed vector: principal.id mutated after signing."
+}

--- a/verifier/conformance-vectors/agentreceipts-up-03-mutated-principal-id/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-up-03-mutated-principal-id/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:attacker"
+    },
+    "action": {
+      "id": "act_malformed_1",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_malformed_base"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "uRO9fTNL12Fwdz4M5pDcRP3P6msLELGTTt4EmVZfmWvq1zjemjZ-VA_4Hk6F6944UPW5aMLGZvonhiGt3SpS-BA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-04-truncated-proof-value/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-up-04-truncated-proof-value/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:malformed-test": "64cce1d90b5dc7fa78d16957843fa02a66930efdeb2c69ba4de63b4ec2542924"
+}

--- a/verifier/conformance-vectors/agentreceipts-up-04-truncated-proof-value/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-04-truncated-proof-value/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Upstream malformed vector: proofValue truncated to its multibase prefix; empty signature bytes."
+}

--- a/verifier/conformance-vectors/agentreceipts-up-04-truncated-proof-value/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-up-04-truncated-proof-value/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_1",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_malformed_base"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "u"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-05-wrong-multibase-prefix/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-up-05-wrong-multibase-prefix/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:malformed-test": "64cce1d90b5dc7fa78d16957843fa02a66930efdeb2c69ba4de63b4ec2542924"
+}

--- a/verifier/conformance-vectors/agentreceipts-up-05-wrong-multibase-prefix/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-05-wrong-multibase-prefix/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Upstream malformed vector: proofValue uses base58 'z' not base64url 'u'; signature bytes do not decode to the real signature."
+}

--- a/verifier/conformance-vectors/agentreceipts-up-05-wrong-multibase-prefix/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-up-05-wrong-multibase-prefix/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_1",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_malformed_base"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "zRO9fTNL12Fwdz4M5pDcRP3P6msLELGTTt4EmVZfmWvq1zjemjZ-VA_4Hk6F6944UPW5aMLGZvonhiGt3SpS-BA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-06-flipped-proof-byte/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-up-06-flipped-proof-byte/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:malformed-test": "64cce1d90b5dc7fa78d16957843fa02a66930efdeb2c69ba4de63b4ec2542924"
+}

--- a/verifier/conformance-vectors/agentreceipts-up-06-flipped-proof-byte/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-06-flipped-proof-byte/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Upstream malformed vector: Single proofValue byte mutated; Ed25519 verification fails."
+}

--- a/verifier/conformance-vectors/agentreceipts-up-06-flipped-proof-byte/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-up-06-flipped-proof-byte/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_1",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_malformed_base"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "uRO9fTNL12Fwdz4M5pDcRP3P6msLELGTTt4EmVZfmWvA1zjemjZ-VA_4Hk6F6944UPW5aMLGZvonhiGt3SpS-BA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:malformed-test": "64cce1d90b5dc7fa78d16957843fa02a66930efdeb2c69ba4de63b4ec2542924"
+}

--- a/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Upstream tampered-chain vector: the middle receipt was mutated after signing, so its own issuer signature no longer matches; ingested against its valid predecessor."
+}

--- a/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/predecessor.json
+++ b/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/predecessor.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000002",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_chain_1",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_malformed_broken"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "uWqWcwnOxoEseswFFMXvs58wqKJ78hrS8SIerNbTE0aqohzyEz6PoDbWl25sO3ZADaOIroWSPWWIa2jSf3G5KBA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000003",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_chain_2",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 2,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_malformed_broken"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "uihZNOWwBp_IbPaC8XReZsuwoF-WG3CI6GR1np1WFc2wxM76d1yVZburVt_U31P0cNIy-gvhQW-yCnthDxd8zDQ"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/did_map.json
+++ b/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/did_map.json
@@ -1,0 +1,3 @@
+{
+  "did:agent:malformed-test": "64cce1d90b5dc7fa78d16957843fa02a66930efdeb2c69ba4de63b4ec2542924"
+}

--- a/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "agentreceipts",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Successor signed with the upstream keypair; previous_receipt_hash rederives from sha256:hex(JCS(genesis without proof))."
+}

--- a/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/predecessor.json
+++ b/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/predecessor.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-000000000001",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_1",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 1,
+      "previous_receipt_hash": null,
+      "chain_id": "chain_up_demo"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "u5j6QA1qApds9FMpyHHBxX5MXILmcV9J4fcfteuJ4CtJqjOvXWNIJK9GYTmjhjPGQkPtR7VpsldBt_BBrqldaBg"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/receipt.json
+++ b/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/receipt.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://agentreceipts.ai/context/v1"
+  ],
+  "id": "urn:receipt:00000000-0000-4000-8000-0000000000a2",
+  "type": [
+    "VerifiableCredential",
+    "AgentReceipt"
+  ],
+  "version": "0.2.0",
+  "issuer": {
+    "id": "did:agent:malformed-test"
+  },
+  "issuanceDate": "2026-04-22T00:00:00Z",
+  "credentialSubject": {
+    "principal": {
+      "id": "did:user:alice"
+    },
+    "action": {
+      "id": "act_malformed_1",
+      "type": "filesystem.file.read",
+      "risk_level": "low",
+      "timestamp": "2026-04-22T00:00:00Z"
+    },
+    "outcome": {
+      "status": "success"
+    },
+    "chain": {
+      "sequence": 2,
+      "previous_receipt_hash": "sha256:1b1d7634b8d2168c41446baf4b9ecb38ff52776b5de42c86db84965e7b0aa38b",
+      "chain_id": "chain_up_demo"
+    }
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-04-22T00:00:00Z",
+    "verificationMethod": "did:agent:malformed-test#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "uhtPZ85g5HlNTnvbmwsVnnHfO_epRfe8ZAJARrLWr0cSeIMS414J0mdSaGlWLQuKZ3ZhqoepMkP4ROHN8suPmCA"
+  }
+}

--- a/verifier/conformance-vectors/agentreceipts-upstream-interop/canonicalization_vectors.json
+++ b/verifier/conformance-vectors/agentreceipts-upstream-interop/canonicalization_vectors.json
@@ -1,0 +1,523 @@
+{
+  "$comment": "Cross-SDK canonicalisation test vectors for ADR-0009. Each vector under canonicalization_vectors asserts that SDK.canonicalize(input) produces canonical byte-for-byte. Each vector under receipt_hash_vectors asserts that SDK.hashReceipt(receipt) produces expectedHash; these vectors exercise the Rule 2 null-normalisation in addition to the raw canonicaliser. NOTE: the `receipt` field on some vectors intentionally carries schema-INVALID caller input (e.g. optional fields set to null) in order to exercise the SDK's pre-serialization normalisation sweep; such vectors are marked `preNormalizationInput: true`. They are not conformant receipts and must never be emitted as-is. All strings are UTF-8.",
+  "schemaVersion": "0.2.1",
+  "adr": "docs/adr/0009-canonicalization-and-schema-consistency.md",
+
+  "canonicalization_vectors": [
+    {
+      "name": "empty_object",
+      "rule": "baseline",
+      "description": "Empty object serialises to {}.",
+      "input": {},
+      "canonical": "{}"
+    },
+    {
+      "name": "empty_array",
+      "rule": "baseline",
+      "description": "Empty array serialises to [].",
+      "input": [],
+      "canonical": "[]"
+    },
+    {
+      "name": "sort_ascii",
+      "rule": "rule1_key_sort",
+      "description": "ASCII key order — baseline.",
+      "input": { "b": 1, "a": 2, "c": 3 },
+      "canonical": "{\"a\":2,\"b\":1,\"c\":3}"
+    },
+    {
+      "name": "sort_ascii_nested",
+      "rule": "rule1_key_sort",
+      "description": "Recursive key sort at all depths.",
+      "input": { "b": { "z": 1, "a": 2 }, "a": 3 },
+      "canonical": "{\"a\":3,\"b\":{\"a\":2,\"z\":1}}"
+    },
+    {
+      "name": "sort_bmp_at_ascii_boundary",
+      "rule": "rule1_key_sort",
+      "description": "U+007F (DEL) vs U+0080 (C1 control) — both below the UTF-16-LE byte-order bug threshold; catches the Go UTF-8-byte-sort bug (#82) since the UTF-8 encoding of U+0080 is 0xC2 0x80 (two bytes, leading 0xC2), whereas 0x7F is one byte (0x7F). Sort by UTF-16 code units: 0x007F < 0x0080.",
+      "input": { "\u0080": 2, "\u007f": 1 },
+      "canonical": "{\"\u007f\":1,\"\u0080\":2}"
+    },
+    {
+      "name": "sort_bmp_above_00ff",
+      "rule": "rule1_key_sort",
+      "description": "U+00FF (ÿ) vs U+0100 (Ā) — catches the Python UTF-16-LE byte-order bug (#86). UTF-16-LE bytes: 0xFF 0x00 vs 0x00 0x01 → byte sort puts 0x00 0x01 (Ā) first, which is WRONG. UTF-16 code-unit sort: 0x00FF < 0x0100 → ÿ first, which is correct.",
+      "input": { "\u0100": 2, "\u00ff": 1 },
+      "canonical": "{\"\u00ff\":1,\"\u0100\":2}"
+    },
+    {
+      "name": "sort_supplementary_plane",
+      "rule": "rule1_key_sort",
+      "description": "🎉 (U+1F389) vs private-use U+E000. Code-point sort would put U+E000 < U+1F389 — wrong. UTF-16 sort: 🎉 encodes as surrogate pair 0xD83C 0xDF89, so the first code unit is 0xD83C which is less than 0xE000 → 🎉 sorts first.",
+      "input": { "\ue000": 1, "\ud83c\udf89": 2 },
+      "canonical": "{\"\ud83c\udf89\":2,\"\ue000\":1}"
+    },
+    {
+      "name": "parameters_disclosure_multikey_sort",
+      "rule": "rule1_key_sort",
+      "description": "Pins the canonical form of an action.parameters_disclosure map (ADR-0012 Phase A) with two keys. The field is a plain string\u2192string map and flows through the same canonicaliser as every other map, so this is a key-sort vector rather than a parameters_disclosure-specific rule. Input has insertion order user\u2192command; canonical output sorts to command\u2192user.",
+      "input": { "user": "ci", "command": "echo build" },
+      "canonical": "{\"command\":\"echo build\",\"user\":\"ci\"}",
+      "expectedHash": "sha256:c998221c9390ec1796069faaf6c8890b70ad6693bb3b01c4d01e7a84edcf5d24"
+    },
+    {
+      "name": "number_zero",
+      "rule": "rule4_numbers",
+      "description": "Positive zero.",
+      "input": 0,
+      "canonical": "0"
+    },
+    {
+      "name": "number_negative_zero",
+      "rule": "rule4_numbers",
+      "description": "-0 must serialise as 0 per RFC 8785. This vector uses JSON -0.0 (rather than -0) so standard decoders preserve IEEE 754 negative zero without requiring harness special-casing: Python json.loads, JavaScript JSON.parse, and Go json.Unmarshal into float64/interface{} all round-trip -0.0 as a float with a negative sign bit.",
+      "input": -0.0,
+      "canonical": "0"
+    },
+    {
+      "name": "number_integer_positive",
+      "rule": "rule4_numbers",
+      "description": "Integer value encoded as a number.",
+      "input": 42,
+      "canonical": "42"
+    },
+    {
+      "name": "number_integer_negative",
+      "rule": "rule4_numbers",
+      "description": "Negative integer.",
+      "input": -42,
+      "canonical": "-42"
+    },
+    {
+      "name": "number_simple_decimal",
+      "rule": "rule4_numbers",
+      "description": "Exact binary fraction — same repr across all SDKs.",
+      "input": 0.5,
+      "canonical": "0.5"
+    },
+    {
+      "name": "number_shortest_repr",
+      "rule": "rule4_numbers",
+      "description": "0.1 has no exact binary representation; ES6 Number.toString returns the shortest decimal that round-trips (0.1).",
+      "input": 0.1,
+      "canonical": "0.1"
+    },
+    {
+      "name": "number_fp_addition",
+      "rule": "rule4_numbers",
+      "description": "0.1 + 0.2 = 0.30000000000000004 under IEEE 754 double. Tests the shortest-round-trippable rule at full precision.",
+      "input": 0.30000000000000004,
+      "canonical": "0.30000000000000004"
+    },
+    {
+      "name": "number_small_exp_boundary_fixed",
+      "rule": "rule4_numbers",
+      "description": "1e-6 renders as fixed notation (0.000001) per ES6.",
+      "input": 1e-6,
+      "canonical": "0.000001"
+    },
+    {
+      "name": "number_small_exp_boundary_exp",
+      "rule": "rule4_numbers",
+      "description": "1e-7 crosses the ES6 exponential threshold (exp < -6) and renders as 1e-7 — NOT 1e-07, 0.0000001, or 1E-7. Pins sign and digit formatting.",
+      "input": 1e-7,
+      "canonical": "1e-7"
+    },
+    {
+      "name": "number_large_exp_boundary_fixed",
+      "rule": "rule4_numbers",
+      "description": "1e20 is at the boundary where ES6 still uses fixed notation (exp < 21).",
+      "input": 1e20,
+      "canonical": "100000000000000000000"
+    },
+    {
+      "name": "number_large_exp_boundary_exp",
+      "rule": "rule4_numbers",
+      "description": "1e21 crosses the ES6 exponential threshold and renders as 1e+21. The + is mandatory (not just 1e21).",
+      "input": 1e21,
+      "canonical": "1e+21"
+    },
+    {
+      "name": "number_2_to_53",
+      "rule": "rule4_numbers",
+      "description": "2^53 = 9007199254740992 is exactly representable in IEEE 754 and appears as an integer.",
+      "input": 9007199254740992,
+      "canonical": "9007199254740992"
+    },
+
+    {
+      "name": "string_empty",
+      "rule": "rule4_strings",
+      "description": "Empty string.",
+      "input": "",
+      "canonical": "\"\""
+    },
+    {
+      "name": "string_simple_ascii",
+      "rule": "rule4_strings",
+      "description": "Plain ASCII string.",
+      "input": "hello",
+      "canonical": "\"hello\""
+    },
+    {
+      "name": "string_escape_quote_and_backslash",
+      "rule": "rule4_strings",
+      "description": "Mandatory RFC 8259 escapes: \\\" and \\\\.",
+      "input": "a\"b\\c",
+      "canonical": "\"a\\\"b\\\\c\""
+    },
+    {
+      "name": "string_escape_control_chars",
+      "rule": "rule4_strings",
+      "description": "Control chars escape as per ES6 JSON.stringify: \\b, \\f, \\n, \\r, \\t for the named ones; \\u00XX for the rest. Pins specifically that U+0001 uses \\u0001 lowercase hex.",
+      "input": "\u0001\b\t\n\f\r",
+      "canonical": "\"\\u0001\\b\\t\\n\\f\\r\""
+    },
+    {
+      "name": "string_no_html_escape",
+      "rule": "rule4_strings",
+      "description": "Chars that Go's default json.Marshal HTML-escapes (<, >, &) MUST be emitted verbatim per RFC 8785. Catches the Go HTML-escape divergence (discovered during ADR-0009 review).",
+      "input": "<a href=\"x\">&amp;</a>",
+      "canonical": "\"<a href=\\\"x\\\">&amp;</a>\""
+    },
+    {
+      "name": "string_no_u2028_escape",
+      "rule": "rule4_strings",
+      "description": "U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are valid JSON chars per RFC 8259 and RFC 8785 — emitted verbatim, NOT escaped. ES5 JSON.stringify escaped them; ES6+ does not. SDKs must track the ES6 behaviour.",
+      "input": "\u2028\u2029",
+      "canonical": "\"\u2028\u2029\""
+    },
+    {
+      "name": "string_bmp_non_ascii",
+      "rule": "rule4_strings",
+      "description": "Non-ASCII BMP chars are emitted verbatim (UTF-8 encoded in output), not escaped.",
+      "input": "ÿĀ",
+      "canonical": "\"ÿĀ\""
+    },
+    {
+      "name": "string_supplementary_plane",
+      "rule": "rule4_strings",
+      "description": "Supplementary-plane char emitted verbatim as the UTF-8 byte sequence for U+1F389 (F0 9F 8E 89).",
+      "input": "\ud83c\udf89",
+      "canonical": "\"\ud83c\udf89\""
+    },
+    {
+      "name": "bool_and_null",
+      "rule": "baseline",
+      "description": "Literals.",
+      "input": [true, false, null],
+      "canonical": "[true,false,null]"
+    },
+    {
+      "name": "deep_nesting",
+      "rule": "baseline",
+      "description": "Ten-level nesting of objects and arrays, pinning that recursion works end-to-end.",
+      "input": {
+        "a": { "b": { "c": { "d": { "e": { "f": { "g": { "h": { "i": { "j": 1 } } } } } } } } }
+      },
+      "canonical": "{\"a\":{\"b\":{\"c\":{\"d\":{\"e\":{\"f\":{\"g\":{\"h\":{\"i\":{\"j\":1}}}}}}}}}}"
+    },
+    {
+      "name": "parameters_hash_ascii",
+      "rule": "rule4_parameters_hash",
+      "description": "mcp-proxy's parameters_hash must use RFC 8785 (#118). ASCII-only baseline: SHA-256 of the canonical bytes equals a known value. Note: ASCII cannot distinguish a conformant RFC 8785 canonicaliser from Go's `json.Marshal` shortcut — both sort ASCII keys identically. This vector only asserts parity with the known canonical bytes; the `parameters_hash_supplementary_vs_bmp` vector is what actually catches the Go bug. SDKs compute canonical bytes of `input` and assert `expectedHash` = sha256(canonical).",
+      "input": { "b": 2, "a": 1 },
+      "canonical": "{\"a\":1,\"b\":2}",
+      "expectedHash": "sha256:43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777"
+    },
+    {
+      "name": "parameters_hash_supplementary_vs_bmp",
+      "rule": "rule4_parameters_hash",
+      "description": "Supplementary-plane key (🎉, U+1F389) vs BMP key (U+E000). This pair genuinely diverges between UTF-8 byte sort and UTF-16 code-unit sort — it is the vector that catches Go's `json.Marshal` shortcut (#118). UTF-16 code-unit sort: 🎉's first code unit is 0xD83C < 0xE000, so 🎉 sorts first (RFC 8785 — correct). UTF-8 byte sort: 🎉 = F0 9F 8E 89 vs U+E000 = EE 80 80 — EE < F0, so U+E000 would sort first (Go's default — wrong). The canonical bytes and hash below commit to the RFC 8785 order.",
+      "input": { "\ue000": 1, "\ud83c\udf89": 2 },
+      "canonical": "{\"\ud83c\udf89\":2,\"\ue000\":1}",
+      "expectedHash": "sha256:772daaff8804fe0809691758cfc856914d39056ead9a8934756d84be94ddc55f"
+    }
+  ],
+
+  "receipt_hash_vectors": [
+    {
+      "name": "receipt_all_optional_absent",
+      "rule": "rule2_null_optional_absent",
+      "description": "A v0.2.1 receipt with no optional fields present. Canonical form is the minimum-size receipt; signature verifies. Serves as the baseline against which 'optional-null' vectors are compared.",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000001",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.2.1",
+        "issuer": { "id": "did:agent:test" },
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000001",
+            "type": "filesystem.file.read",
+            "risk_level": "low",
+            "timestamp": "2026-04-22T00:00:00Z"
+          },
+          "outcome": { "status": "success" },
+          "chain": {
+            "sequence": 1,
+            "previous_receipt_hash": null,
+            "chain_id": "chain_test"
+          }
+        }
+      },
+      "expectedHash": "sha256:dc9a49a55e1d163b6cd72865a401fccd5af41358c2c769a27ca11fd348f51887"
+    },
+    {
+      "name": "receipt_optional_null_becomes_absent",
+      "rule": "rule2_null_optional_absent",
+      "preNormalizationInput": true,
+      "description": "INTENTIONALLY SCHEMA-INVALID caller input. The receipt below sets optional fields (action.trusted_timestamp, outcome.error) to null, which the tightened 0.2.1 schema forbids. It is never emitted on the wire — it only exists to exercise the SDK's pre-serialization normalisation sweep. The post-sweep canonicaliser MUST normalise null-valued optional fields to absent before hashing; the resulting canonical bytes MUST be identical to receipt_all_optional_absent. Pre-sweep Python does this (exclude_none); pre-sweep TS would include the null, producing a different hash — this vector catches that regression.",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000001",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.2.1",
+        "issuer": { "id": "did:agent:test" },
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000001",
+            "type": "filesystem.file.read",
+            "risk_level": "low",
+            "timestamp": "2026-04-22T00:00:00Z",
+            "trusted_timestamp": null
+          },
+          "outcome": { "status": "success", "error": null },
+          "chain": {
+            "sequence": 1,
+            "previous_receipt_hash": null,
+            "chain_id": "chain_test"
+          }
+        }
+      },
+      "expectedHash": "SAME_AS_receipt_all_optional_absent"
+    },
+    {
+      "name": "receipt_parameters_disclosure_null_becomes_absent",
+      "rule": "rule2_null_optional_absent",
+      "preNormalizationInput": true,
+      "description": "INTENTIONALLY SCHEMA-INVALID caller input. action.parameters_disclosure is set to null, which the 0.2.1 schema (and ADR-0012 Phase A) forbids. The post-sweep canonicaliser MUST normalise null-valued optional fields to absent before hashing; the resulting canonical bytes MUST be identical to receipt_all_optional_absent. Mirrors receipt_optional_null_becomes_absent for the parameters_disclosure field specifically (regression test for ADR-0012 rollout).",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000001",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.2.1",
+        "issuer": { "id": "did:agent:test" },
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000001",
+            "type": "filesystem.file.read",
+            "risk_level": "low",
+            "parameters_disclosure": null,
+            "timestamp": "2026-04-22T00:00:00Z"
+          },
+          "outcome": { "status": "success" },
+          "chain": {
+            "sequence": 1,
+            "previous_receipt_hash": null,
+            "chain_id": "chain_test"
+          }
+        }
+      },
+      "expectedHash": "SAME_AS_receipt_all_optional_absent"
+    },
+    {
+      "name": "receipt_required_null_preserved",
+      "rule": "rule2_null_required_preserved",
+      "description": "previous_receipt_hash is required-nullable; when null it MUST appear as \"previous_receipt_hash\":null in the canonical bytes. This vector is identical to receipt_all_optional_absent — included separately to document the required-nullable rule explicitly and pin a regression test against an SDK that accidentally drops it.",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000001",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.2.1",
+        "issuer": { "id": "did:agent:test" },
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000001",
+            "type": "filesystem.file.read",
+            "risk_level": "low",
+            "timestamp": "2026-04-22T00:00:00Z"
+          },
+          "outcome": { "status": "success" },
+          "chain": {
+            "sequence": 1,
+            "previous_receipt_hash": null,
+            "chain_id": "chain_test"
+          }
+        }
+      },
+      "mustContainSubstring": "\"previous_receipt_hash\":null",
+      "expectedHash": "SAME_AS_receipt_all_optional_absent"
+    },
+    {
+      "name": "receipt_non_ascii_resource",
+      "rule": "rule1_key_sort_in_receipt",
+      "description": "credentialSubject.action.target.resource contains non-ASCII Unicode (literal UTF-8, no escaping). Exercises the key-sort rule at the receipt level — the other keys are ASCII but the SDK's canonicaliser must preserve this string verbatim and sort surrounding keys correctly.",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000002",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.2.1",
+        "issuer": { "id": "did:agent:test" },
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000002",
+            "type": "filesystem.file.read",
+            "risk_level": "low",
+            "target": { "system": "local", "resource": "/tmp/αβγ-🎉.txt" },
+            "timestamp": "2026-04-22T00:00:00Z"
+          },
+          "outcome": { "status": "success" },
+          "chain": {
+            "sequence": 1,
+            "previous_receipt_hash": null,
+            "chain_id": "chain_test"
+          }
+        }
+      },
+      "expectedHash": "sha256:5cc599ef311452c60a89bb2f039ad9b66dd41655352b64f85c3a3498e35b09fd"
+    },
+    {
+      "name": "receipt_html_chars_in_resource",
+      "rule": "rule4_strings_no_html_escape",
+      "description": "credentialSubject.action.target.resource contains <, >, & — MUST NOT be HTML-escaped. Catches the Go json.Marshal HTML-escape bug (Rule 4 bonus).",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000003",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.2.1",
+        "issuer": { "id": "did:agent:test" },
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000003",
+            "type": "http.request",
+            "risk_level": "low",
+            "target": { "system": "web", "resource": "https://example.com/?a=1&b=2&c=<x>" },
+            "timestamp": "2026-04-22T00:00:00Z"
+          },
+          "outcome": { "status": "success" },
+          "chain": {
+            "sequence": 1,
+            "previous_receipt_hash": null,
+            "chain_id": "chain_test"
+          }
+        }
+      },
+      "mustContainSubstring": "?a=1&b=2&c=<x>",
+      "expectedHash": "sha256:a22ce79feffb1707ea33cd67bf5e4deabedded574b7f3ed169b2e57568ca2849"
+    },
+    {
+      "name": "receipt_all_optional_present",
+      "rule": "rule2_optional_present_is_emitted",
+      "description": "A v0.2.1 receipt with every currently-defined optional field populated with a non-null value. Pins the canonical form of the 'maximal' receipt. Compare against receipt_all_optional_absent to confirm each optional field contributes a unique canonical-byte sequence.",
+      "receipt": {
+        "@context": [
+          "https://www.w3.org/ns/credentials/v2",
+          "https://agentreceipts.ai/context/v1"
+        ],
+        "id": "urn:receipt:00000000-0000-0000-0000-000000000004",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "0.2.1",
+        "issuer": {
+          "id": "did:agent:test",
+          "type": "AIAgent",
+          "name": "TestAgent",
+          "operator": { "id": "did:org:test", "name": "TestOrg" },
+          "model": "claude-opus-4-7",
+          "session_id": "sess-001"
+        },
+        "issuanceDate": "2026-04-22T00:00:00Z",
+        "credentialSubject": {
+          "principal": { "id": "did:user:test", "type": "HumanPrincipal" },
+          "action": {
+            "id": "act_00000000-0000-0000-0000-000000000004",
+            "type": "filesystem.file.read",
+            "tool_name": "Read",
+            "risk_level": "low",
+            "target": { "system": "local", "resource": "/tmp/x.txt" },
+            "parameters_hash": "sha256:43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777",
+            "parameters_disclosure": { "command": "echo build", "user": "ci" },
+            "timestamp": "2026-04-22T00:00:00Z"
+          },
+          "intent": {
+            "conversation_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "prompt_preview": "Read /tmp/x.txt",
+            "prompt_preview_truncated": false,
+            "reasoning_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          "outcome": {
+            "status": "success",
+            "reversible": true,
+            "reversal_method": "fs:none",
+            "reversal_window_seconds": 0,
+            "state_change": {
+              "before_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+              "after_hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            },
+            "response_hash": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+          },
+          "authorization": {
+            "scopes": ["fs:read:/tmp"],
+            "granted_at": "2026-04-22T00:00:00Z",
+            "expires_at": "2026-04-23T00:00:00Z",
+            "grant_ref": "grant-001"
+          },
+          "chain": {
+            "sequence": 2,
+            "previous_receipt_hash": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "chain_id": "chain_test",
+            "terminal": true
+          }
+        }
+      },
+      "expectedHash": "sha256:9e43a72dab99b0104bfdd05cebe473281fdc84153a30841d2ea044ab991c1e29"
+    },
+    {
+      "name": "receipt_signature_preservation_legacy_0_2_0",
+      "rule": "signature_preservation",
+      "description": "The three-receipt terminalChain from cross-sdk-tests/v020_vectors.json was signed under the pre-sweep (0.2.0) canonicaliser. Running the post-sweep canonicaliser on the same unsigned bytes MUST produce identical canonical output, and the existing proof.proofValue MUST still verify. This is the signature-preservation invariant from ADR-0009 §4. Implementation: this vector reuses the v020 fixtures by reference; the test harness loads both files and asserts round-trip equality.",
+      "receiptsFrom": "cross-sdk-tests/v020_vectors.json#/terminalChain/receipts",
+      "invariant": "post-sweep canonicalize(unsigned(r)) == pre-sweep canonical bytes; verifySignature(r) == true"
+    }
+  ],
+
+  "notes_for_implementers": [
+    "All strings in this file are UTF-8. JSON unicode escapes (\\uXXXX) are equivalent to their literal characters after parsing — SDK test harnesses should parse the file with any standard JSON parser and compare bytes post-parse.",
+    "Fields marked expectedHash: 'SAME_AS_receipt_all_optional_absent' assert equality with the baseline vector; the test harness does not need a literal value, only the invariant.",
+    "Fields marked mustContainSubstring assert a substring appears in the canonical output — useful when the full canonical is verbose but one specific byte sequence is the thing being tested (e.g., that Go does not HTML-escape < and >).",
+    "Vectors marked preNormalizationInput: true carry schema-invalid caller input on purpose — they test the SDK's pre-serialization null→absent sweep. Do NOT attempt to schema-validate these `receipt` payloads; canonicalise and hash them and assert the invariant.",
+    "The number vectors rely on language-native IEEE 754 double-precision arithmetic. Each SDK should construct the test value from its numeric literal exactly as written in the input field; some JSON parsers may not round-trip -0 through JSON.parse, so implementations should hard-code -0 when the vector name is number_negative_zero rather than parsing it from this file.",
+    "The legacy 0.2.0 terminalChain in cross-sdk-tests/v020_vectors.json stays as-is (signature-preservation proof). New vectors added to v020_vectors.json (e.g. parametersDisclosureReceipt) and to this file use schemaVersion 0.2.1."
+  ]
+}

--- a/verifier/conformance-vectors/agentreceipts-upstream-interop/did_key_vectors.json
+++ b/verifier/conformance-vectors/agentreceipts-upstream-interop/did_key_vectors.json
@@ -1,0 +1,91 @@
+{
+  "$comment": "did:key v0.7 resolution test vectors for Agent Receipts. Each vector pins the wire-shape mapping from a 32-byte Ed25519 public key (RFC 8032 §5.1.5) to (a) the did:key identifier and (b) the resolved DID Document with a single Multikey verification method. See docs/adr/0007-did-method-strategy.md (Implementation spec — did:key v0.7 wire format) for the normative algorithm. Vectors use deterministic public keys taken from RFC 8032 §7.1 and the W3C did:key registry so reviewers can reproduce them without re-running an SDK. These are static expected outputs; wiring them into SDK test suites is a later track.",
+  "spec_version": "did:key v0.7",
+  "adr": "docs/adr/0007-did-method-strategy.md",
+  "multicodec_prefix_hex": "ed01",
+  "multibase_prefix": "z",
+  "multibase_encoding": "base58btc",
+  "vectors": [
+    {
+      "name": "vector-1-rfc8032-test-1",
+      "source": "RFC 8032 §7.1, TEST 1 (secret key 9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60).",
+      "public_key_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "did": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+      "did_document": {
+        "@context": [
+          "https://www.w3.org/ns/did/v1",
+          "https://w3id.org/security/multikey/v1"
+        ],
+        "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+        "verificationMethod": [
+          {
+            "id": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+            "type": "Multikey",
+            "controller": "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw",
+            "publicKeyMultibase": "z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+          }
+        ],
+        "authentication": [
+          "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+        ],
+        "assertionMethod": [
+          "did:key:z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw#z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw"
+        ]
+      }
+    },
+    {
+      "name": "vector-2-rfc8032-test-2",
+      "source": "RFC 8032 §7.1, TEST 2 (secret key 4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb).",
+      "public_key_hex": "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+      "did": "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT",
+      "did_document": {
+        "@context": [
+          "https://www.w3.org/ns/did/v1",
+          "https://w3id.org/security/multikey/v1"
+        ],
+        "id": "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT",
+        "verificationMethod": [
+          {
+            "id": "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT#z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT",
+            "type": "Multikey",
+            "controller": "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT",
+            "publicKeyMultibase": "z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT"
+          }
+        ],
+        "authentication": [
+          "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT#z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT"
+        ],
+        "assertionMethod": [
+          "did:key:z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT#z6MkiaMbhXHNA4eJVCCj8dbzKzTgYDKf6crKgHVHid1F1WCT"
+        ]
+      }
+    },
+    {
+      "name": "vector-3-w3c-did-key-registry-example",
+      "source": "W3C did:key Method Specification, Example 1 (Ed25519). Public key 3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29; matches the registry's canonical reference identifier.",
+      "public_key_hex": "3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29",
+      "did": "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+      "did_document": {
+        "@context": [
+          "https://www.w3.org/ns/did/v1",
+          "https://w3id.org/security/multikey/v1"
+        ],
+        "id": "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+        "verificationMethod": [
+          {
+            "id": "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp#z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+            "type": "Multikey",
+            "controller": "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+            "publicKeyMultibase": "z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp"
+          }
+        ],
+        "authentication": [
+          "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp#z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp"
+        ],
+        "assertionMethod": [
+          "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp#z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp"
+        ]
+      }
+    }
+  ]
+}

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -152,5 +152,110 @@
     "outcome": "PASS",
     "reason_code": "",
     "notes": "Upstream documents this as a residual: all three signers (issuer, parent, PDP) saw the same poisoned upstream context and signed honestly, so every signature verifies. The receipt records what was attested, not whether the context was sound; our verifier reaches the same PASS the upstream verifier does. Mapped to PASS because every signature genuinely verifies, not a relabel."
+  },
+  {
+    "dir": "agentreceipts-01-didkey-genesis",
+    "format": "agentreceipts",
+    "outcome": "PASS",
+    "reason_code": "",
+    "notes": "did:key genesis; key resolves inline, signature verifies, previous_receipt_hash explicit null."
+  },
+  {
+    "dir": "agentreceipts-02-didkey-chain-link",
+    "format": "agentreceipts",
+    "outcome": "PASS",
+    "reason_code": "",
+    "notes": "Successor links via sha256:hex(JCS(predecessor without proof)); signature verifies."
+  },
+  {
+    "dir": "agentreceipts-03-tamper-payload",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "action.type mutated after signing; canonical bytes no longer match the signature."
+  },
+  {
+    "dir": "agentreceipts-04-tamper-proofvalue",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Single proofValue byte flipped; Ed25519 verification fails."
+  },
+  {
+    "dir": "agentreceipts-05-genesis-missing-prev-hash",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "schema",
+    "notes": "previous_receipt_hash omitted; spec requires it present (null on genesis), so the receipt is malformed."
+  },
+  {
+    "dir": "agentreceipts-06-wrong-key",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "verificationMethod resolves (via the injected map) to a different valid Ed25519 key than the signer; signature fails."
+  },
+  {
+    "dir": "agentreceipts-up-00-valid-resigned",
+    "format": "agentreceipts",
+    "outcome": "PASS",
+    "reason_code": "",
+    "notes": "Upstream malformed-corpus base receipt re-signed cleanly with the upstream keypair; signature verifies over jcs_rfc8785 bytes."
+  },
+  {
+    "dir": "agentreceipts-up-01-wrong-proof-type",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "schema",
+    "notes": "Upstream malformed vector: proof.type is not Ed25519Signature2020."
+  },
+  {
+    "dir": "agentreceipts-up-02-mutated-action-type",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Upstream malformed vector: action.type mutated after signing."
+  },
+  {
+    "dir": "agentreceipts-up-03-mutated-principal-id",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Upstream malformed vector: principal.id mutated after signing."
+  },
+  {
+    "dir": "agentreceipts-up-04-truncated-proof-value",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Upstream malformed vector: proofValue truncated to its multibase prefix; empty signature bytes."
+  },
+  {
+    "dir": "agentreceipts-up-05-wrong-multibase-prefix",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Upstream malformed vector: proofValue uses base58 'z' not base64url 'u'; signature bytes do not decode to the real signature."
+  },
+  {
+    "dir": "agentreceipts-up-06-flipped-proof-byte",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Upstream malformed vector: Single proofValue byte mutated; Ed25519 verification fails."
+  },
+  {
+    "dir": "agentreceipts-up-07-tampered-mid-chain",
+    "format": "agentreceipts",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Upstream tampered-chain vector: the middle receipt was mutated after signing, so its own issuer signature no longer matches; ingested against its valid predecessor."
+  },
+  {
+    "dir": "agentreceipts-up-08-valid-chain-link",
+    "format": "agentreceipts",
+    "outcome": "PASS",
+    "reason_code": "",
+    "notes": "Successor signed with the upstream keypair; previous_receipt_hash rederives from sha256:hex(JCS(genesis without proof))."
   }
 ]

--- a/verifier/oracle/__init__.py
+++ b/verifier/oracle/__init__.py
@@ -17,16 +17,23 @@ from __future__ import annotations
 from .adapter import ChainStep, FormatAdapter, SignatureMaterial
 from .adapters.acta import ActaAdapter
 from .adapters.aerf import AerfAdapter
+from .adapters.agentreceipts import AgentReceiptsAdapter
 from .adapters.asqav_native import AsqavNativeAdapter
 from .core import AxisResult, VerifyResult, verify
 
 #: Detection fingerprints are mutually exclusive, so registration order is not load-bearing.
-ADAPTERS: list[FormatAdapter] = [AsqavNativeAdapter(), AerfAdapter(), ActaAdapter()]
+ADAPTERS: list[FormatAdapter] = [
+    AsqavNativeAdapter(),
+    AerfAdapter(),
+    ActaAdapter(),
+    AgentReceiptsAdapter(),
+]
 
 __all__ = [
     "ADAPTERS",
     "ActaAdapter",
     "AerfAdapter",
+    "AgentReceiptsAdapter",
     "AsqavNativeAdapter",
     "AxisResult",
     "ChainStep",

--- a/verifier/oracle/adapters/agentreceipts.py
+++ b/verifier/oracle/adapters/agentreceipts.py
@@ -1,0 +1,106 @@
+"""agent-receipts adapter - W3C-VC AgentReceipt, Ed25519 over strict RFC 8785 JCS.
+
+An AgentReceipt is a W3C Verifiable Credential 2.0 envelope: top-level ``@context``,
+``id``, ``type`` (``["VerifiableCredential", "AgentReceipt"]``), ``issuer``,
+``issuanceDate``, ``credentialSubject``, and a ``proof``. The signature is Ed25519
+over the strict JCS bytes of the receipt with the ``proof`` member removed, signed
+DIRECTLY (no pre-hash) per the agent-receipts signing rule. The ``proof.type`` is
+``Ed25519Signature2020`` and ``proof.proofValue`` is multibase ``u`` (base64url, no
+padding).
+
+This adapter uses ``jcs_rfc8785`` (UTF-16 key sort, ECMAScript numbers), NOT the
+AERF/ACTA ``jcs`` dialect: the agent-receipts producers sign true strict-JCS bytes and
+the upstream canonicalization vectors pin that. The signing key is resolved from
+``proof.verificationMethod`` through the shared DID resolver - did:key inline, every
+other method from an injected map (the oracle never fetches a DID document).
+
+Chain rule: ``credentialSubject.chain.previous_receipt_hash`` is ``"sha256:"`` +
+hex(SHA-256(JCS(predecessor without proof))). Genesis carries the field present and
+explicitly ``null`` (the field MUST always be present; ``null`` is not the same as
+omitting it) - the opposite of the AERF omit-on-genesis rule.
+"""
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from ..adapter import ChainStep, FormatAdapter, SignatureMaterial
+from ..canonical import jcs_rfc8785
+from ..core import sha256_hex
+from ..did import resolve_ed25519_key
+
+#: SHA-256 hash prefix the chain field carries before the hex digest.
+_SHA256_PREFIX = "sha256:"
+
+
+def _signable(doc: dict) -> dict:
+    """The receipt with ``proof`` removed - the exact object the signature covers."""
+    return {k: v for k, v in doc.items() if k != "proof"}
+
+
+def _multibase_u_decode(value: str) -> bytes:
+    """Decode a multibase ``u`` (base64url, no padding) proofValue to raw bytes."""
+    if not value or value[0] != "u":
+        raise ValueError("proofValue is not multibase 'u' (base64url) encoded")
+    body = value[1:]
+    return base64.urlsafe_b64decode(body + "=" * (-len(body) % 4))
+
+
+def _chain(doc: dict) -> dict:
+    sub = doc.get("credentialSubject")
+    return sub.get("chain", {}) if isinstance(sub, dict) else {}
+
+
+class AgentReceiptsAdapter(FormatAdapter):
+    """agent-receipts AgentReceipt - Ed25519 over strict RFC 8785 JCS, proof excluded."""
+
+    name = "agentreceipts"
+
+    def detect(self, doc: dict) -> bool:
+        types = doc.get("type")
+        proof = doc.get("proof")
+        if not isinstance(types, list) or "AgentReceipt" not in types:
+            return False
+        return isinstance(proof, dict) and isinstance(proof.get("proofValue"), str)
+
+    def extract_signature(self, doc: dict) -> SignatureMaterial:
+        proof = doc.get("proof", {})
+        try:
+            sig = _multibase_u_decode(proof.get("proofValue", ""))
+        except (ValueError, base64.binascii.Error):
+            sig = b""
+        return SignatureMaterial(sig=sig, alg="Ed25519", kid=proof.get("verificationMethod", ""))
+
+    def resolve_key(self, doc: dict, key_provider: Any) -> tuple[bytes | None, str]:
+        kid = doc.get("proof", {}).get("verificationMethod", "")
+        return resolve_ed25519_key(kid, key_provider)
+
+    def signing_input(self, doc: dict) -> bytes:
+        # Strict-JCS bytes of the receipt minus proof, signed directly (no pre-hash).
+        return jcs_rfc8785(_signable(doc))
+
+    def chain_step(self, doc: dict) -> ChainStep:
+        chain = _chain(doc)
+        present = "previous_receipt_hash" in chain
+        prev = chain.get("previous_receipt_hash")
+        is_genesis = present and prev is None
+        return ChainStep(
+            prev_field=prev,
+            is_genesis=is_genesis,
+            recompute=lambda pred: _SHA256_PREFIX + sha256_hex(jcs_rfc8785(_signable(pred))),
+        )
+
+    def schema(self, doc: dict) -> tuple[str, str]:
+        required = ("@context", "id", "type", "issuer", "issuanceDate", "credentialSubject", "proof")
+        missing = [f for f in required if f not in doc]
+        if missing:
+            return "FAIL", f"missing required VC fields: {','.join(missing)}"
+        types = doc.get("type")
+        if not isinstance(types, list) or "VerifiableCredential" not in types or "AgentReceipt" not in types:
+            return "FAIL", "type must include VerifiableCredential and AgentReceipt"
+        if doc.get("proof", {}).get("type") != "Ed25519Signature2020":
+            return "FAIL", "proof.type must be Ed25519Signature2020"
+        chain = _chain(doc)
+        if "previous_receipt_hash" not in chain:
+            return "FAIL", "chain.previous_receipt_hash must be present (null on genesis), never omitted"
+        return "PASS", "required VC fields present; type AgentReceipt; chain link well-formed"

--- a/verifier/oracle/adapters/agentreceipts.py
+++ b/verifier/oracle/adapters/agentreceipts.py
@@ -100,6 +100,12 @@ class AgentReceiptsAdapter(FormatAdapter):
             return "FAIL", "type must include VerifiableCredential and AgentReceipt"
         if doc.get("proof", {}).get("type") != "Ed25519Signature2020":
             return "FAIL", "proof.type must be Ed25519Signature2020"
+        issuer = doc.get("issuer")
+        issuer_did = issuer.get("id") if isinstance(issuer, dict) else issuer
+        vm_did = doc.get("proof", {}).get("verificationMethod", "").split("#")[0]
+        if not vm_did or vm_did != issuer_did:
+            # did:key carries its key in-receipt; bind to issuer or anyone self-signs as a victim
+            return "FAIL", "proof.verificationMethod is not controlled by issuer (signing-key DID != issuer DID)"
         chain = _chain(doc)
         if "previous_receipt_hash" not in chain:
             return "FAIL", "chain.previous_receipt_hash must be present (null on genesis), never omitted"

--- a/verifier/oracle/canonical.py
+++ b/verifier/oracle/canonical.py
@@ -1,16 +1,33 @@
 """Canonicalization shared across format adapters.
 
-Two callable shapes, one code path:
-  - ``jcs(obj)``        : RFC 8785 JCS with NFC normalisation of every string,
-                          for formats that mandate full RFC 8785 (AERF, ACTA, VC).
-  - ``asqav_jcs(obj)``  : the Asqav cloud's historical JCS WITHOUT NFC, kept
-                          byte-identical to ``verify_receipt.canonical_json`` so
-                          the native adapter reproduces exactly what the cloud
-                          signed.
+Three callable shapes, because three signers disagree on what "JCS" means:
 
-GAP NOTE: the cloud's canonicaliser predates the NFC requirement and does not
-normalise strings; ``asqav_jcs`` mirrors that on purpose. ``jcs`` is the spec
-form. ASCII-only payloads (the common case) produce identical bytes either way.
+  - ``jcs(obj)``         : NFC-normalised, Python ``sort_keys`` (Unicode code
+                           point) ordering, numbers preserved as Python emits
+                           them. This matches the AERF and ACTA reference
+                           producers, whose Go canonicaliser writes numbers
+                           verbatim and sorts keys byte-wise. For their ASCII
+                           field set the code-point order equals the byte order,
+                           so this reproduces exactly the bytes those producers
+                           signed.
+  - ``jcs_rfc8785(obj)`` : strict RFC 8785 - UTF-16 code-unit key ordering and
+                           ECMAScript ``Number.prototype.toString`` number output,
+                           plus NFC. This is what the agent-receipts producers
+                           sign, and it byte-matches the agent-receipts upstream
+                           canonicalization vectors. The two diverge from ``jcs``
+                           on supplementary-plane keys and on non-integral or
+                           large-magnitude numbers.
+  - ``asqav_jcs(obj)``   : the Asqav cloud's historical JCS WITHOUT NFC, kept
+                           byte-identical to ``verify_receipt.canonical_json`` so
+                           the native adapter reproduces exactly what the cloud
+                           signed.
+
+INTEROP NOTE: AERF SPEC.md §5.1 and the agent-receipts spec both cite "full RFC
+8785 (JCS)", but the AERF Go reference (``verifiers/go/internal/aerf/canonical.go``)
+preserves numbers via ``json.Number`` verbatim and sorts with ``sort.Strings``
+(UTF-8 byte order), so an AERF receipt carrying ``1250.0`` is signed over the
+bytes ``1250.0``, not the RFC 8785 ``1250``. ``jcs`` therefore deliberately keeps
+the AERF dialect; only the agent-receipts adapter uses ``jcs_rfc8785``.
 """
 from __future__ import annotations
 
@@ -30,21 +47,86 @@ def _nfc(obj: Any) -> Any:
     return obj
 
 
-def _dump(obj: Any) -> bytes:
-    return json.dumps(
-        obj,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-        allow_nan=False,
-    ).encode("utf-8")
-
-
 def jcs(obj: Any) -> bytes:
-    """RFC 8785 JCS bytes with NFC string normalisation."""
-    return _dump(_nfc(obj))
+    """AERF/ACTA-dialect JCS: NFC, code-point key sort, numbers as Python emits them."""
+    return json.dumps(
+        _nfc(obj), sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
 
 
 def asqav_jcs(obj: Any) -> bytes:
     """Asqav cloud JCS bytes (no NFC); byte-identical to the cloud signer."""
-    return _dump(obj)
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+
+
+def jcs_rfc8785(obj: Any) -> bytes:
+    """Strict RFC 8785 JCS bytes (UTF-16 key sort, ECMAScript numbers) with NFC."""
+    return _serialize_8785(_nfc(obj)).encode("utf-8")
+
+
+def _utf16_key(key: str) -> tuple[int, ...]:
+    """UTF-16 BE code-unit sequence for ``key`` - the RFC 8785 key-ordering key."""
+    raw = key.encode("utf-16-be")
+    return tuple(int.from_bytes(raw[i : i + 2], "big") for i in range(0, len(raw), 2))
+
+
+def _number_8785(value: float) -> str:
+    """ECMAScript ``Number.prototype.toString`` form of a JSON number (RFC 8785)."""
+    if value != value or value in (float("inf"), float("-inf")):
+        raise ValueError(f"non-finite number not allowed in JCS: {value!r}")
+    if isinstance(value, int):
+        return str(value)
+    if value == int(value) and abs(value) < 1e21:
+        return str(int(value))  # ECMAScript renders -0.0 and 5.0 as 0 and 5
+    return _ecma_float(float(value))
+
+
+def _ecma_float(value: float) -> str:
+    """Non-integral float as ECMA-262 6.1.6.1.20 Number-to-String (shortest round-trip)."""
+    sign = "-" if value < 0 else ""
+    s, exp = _shortest_digits(abs(value))
+    k = len(s)
+    n = exp + k  # decimal point sits after digit n; ECMAScript chooses fixed vs exponential by n
+    if k <= n <= 21:
+        return f"{sign}{s}{'0' * (n - k)}"
+    if 0 < n <= 21:
+        return f"{sign}{s[:n]}.{s[n:]}"
+    if -6 < n <= 0:
+        return f"{sign}0.{'0' * -n}{s}"
+    tail = s[0] if k == 1 else f"{s[0]}.{s[1:]}"
+    return f"{sign}{tail}e{'+' if n - 1 >= 0 else '-'}{abs(n - 1)}"
+
+
+def _shortest_digits(value: float) -> tuple[str, int]:
+    """Return (digit string with no trailing zeros, base-10 exponent) for a positive float."""
+    mantissa, _, exp = repr(value).partition("e")
+    exponent = int(exp) if exp else 0
+    if "." in mantissa:
+        whole, frac = mantissa.split(".")
+        exponent -= len(frac)
+        mantissa = whole + frac
+    digits = mantissa.lstrip("0") or "0"
+    stripped = digits.rstrip("0")
+    if stripped:
+        exponent += len(digits) - len(stripped)
+        digits = stripped
+    return digits, exponent
+
+
+def _serialize_8785(obj: Any) -> str:
+    """RFC 8785 serialisation: UTF-16 sorted keys, ECMAScript numbers, minimal strings."""
+    if obj is None or isinstance(obj, bool):
+        return json.dumps(obj)
+    if isinstance(obj, (int, float)):
+        return _number_8785(obj)
+    if isinstance(obj, str):
+        return json.dumps(obj, ensure_ascii=False)
+    if isinstance(obj, list):
+        return "[" + ",".join(_serialize_8785(v) for v in obj) + "]"
+    if isinstance(obj, dict):
+        items = sorted(obj.items(), key=lambda kv: _utf16_key(kv[0]))
+        body = ",".join(json.dumps(k, ensure_ascii=False) + ":" + _serialize_8785(v) for k, v in items)
+        return "{" + body + "}"
+    raise TypeError(f"unserialisable type in JCS input: {type(obj).__name__}")

--- a/verifier/oracle/did.py
+++ b/verifier/oracle/did.py
@@ -1,0 +1,92 @@
+"""Shared DID resolver - map a verificationMethod DID URL to a raw Ed25519 key.
+
+``resolve_ed25519_key(did_url, injected)`` returns the raw 32-byte Ed25519 public
+key for a signer, or None when it cannot resolve without a network the oracle is
+forbidden from touching. Two methods are supported:
+
+  - ``did:key`` - self-contained. The multibase ``z`` (base58btc) identifier
+    decodes to a multicodec frame: the two-byte ``0xed 0x01`` Ed25519 prefix
+    followed by the 32 raw key bytes. No network, no injected map needed.
+  - ``did:agent`` / ``did:web`` (and any other method) - resolved from an injected
+    ``{did_or_kid: hex_or_raw}`` map the caller supplies. The oracle NEVER fetches
+    a DID document over the network; an unmapped DID returns None.
+
+This resolver is adapter-agnostic so a later ERC-8004 / DID hook reuses it. base58
+is an encoding, not crypto, so the base58btc decoder is implemented here and pinned
+by a unit test against the upstream did:key reference vectors; the Ed25519 verify
+itself stays in ``crypto.py`` behind the ``cryptography`` library.
+"""
+from __future__ import annotations
+
+#: Bitcoin base58 alphabet - the base58btc encoding multibase 'z' uses.
+_B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+_B58_INDEX = {ch: i for i, ch in enumerate(_B58_ALPHABET)}
+
+#: Multicodec prefix for an Ed25519 public key (unsigned-varint 0xed01).
+_ED25519_MULTICODEC = b"\xed\x01"
+
+
+def b58btc_decode(text: str) -> bytes:
+    """Decode a base58btc string to bytes, preserving leading-zero bytes as '1's."""
+    num = 0
+    for ch in text:
+        if ch not in _B58_INDEX:
+            raise ValueError(f"invalid base58btc character: {ch!r}")
+        num = num * 58 + _B58_INDEX[ch]
+    body = num.to_bytes((num.bit_length() + 7) // 8, "big") if num else b""
+    pad = len(text) - len(text.lstrip("1"))
+    return b"\x00" * pad + body
+
+
+def _decode_did_key(identifier: str) -> bytes | None:
+    """Return the raw 32-byte Ed25519 key from a ``did:key`` 'z...' identifier."""
+    if not identifier.startswith("z"):
+        return None  # multibase base58btc is the only did:key form this resolver decodes
+    try:
+        decoded = b58btc_decode(identifier[1:])
+    except ValueError:
+        return None
+    if not decoded.startswith(_ED25519_MULTICODEC):
+        return None  # not an Ed25519 did:key (e.g. did:key for a different curve)
+    key = decoded[len(_ED25519_MULTICODEC) :]
+    return key if len(key) == 32 else None
+
+
+def _coerce_raw(material: object) -> bytes | None:
+    """Coerce injected key material (raw bytes or hex string) to raw 32-byte form."""
+    if isinstance(material, bytes):
+        raw = material
+    elif isinstance(material, str):
+        try:
+            raw = bytes.fromhex(material)
+        except ValueError:
+            return None
+    else:
+        return None
+    return raw if len(raw) == 32 else None
+
+
+def resolve_ed25519_key(
+    did_url: str, injected: dict | None = None
+) -> tuple[bytes | None, str]:
+    """Resolve a verificationMethod DID URL to ``(raw_key_or_None, note)``.
+
+    did:key resolves inline; every other method resolves from ``injected`` keyed by
+    the full DID URL first, then by the bare DID (fragment stripped). No network.
+    """
+    if not isinstance(did_url, str) or not did_url.startswith("did:"):
+        return None, f"not a DID URL: {did_url!r}"
+    bare = did_url.split("#", 1)[0]
+    if bare.startswith("did:key:"):
+        key = _decode_did_key(bare[len("did:key:") :])
+        if key is None:
+            return None, "did:key identifier is not a base58btc Ed25519 multikey"
+        return key, "resolved did:key inline (multicodec ed25519)"
+    keys = injected or {}
+    for candidate in (did_url, bare):
+        if candidate in keys:
+            raw = _coerce_raw(keys[candidate])
+            if raw is None:
+                return None, f"injected key for {candidate!r} is not a 32-byte Ed25519 key"
+            return raw, f"resolved {candidate} from injected map"
+    return None, f"no injected key for {did_url!r} (oracle never fetches a DID document)"

--- a/verifier/oracle/runner.py
+++ b/verifier/oracle/runner.py
@@ -53,6 +53,9 @@ def _key_provider(vec_dir: Path, fmt: str):
         return _load(vec_dir / "keys.json")
     if fmt == "acta":
         return _load(vec_dir / "acta-keys.json")
+    if fmt == "agentreceipts":
+        # did:key receipts self-resolve (no file); did:agent/web carry an injected map.
+        return _load(vec_dir / "did_map.json")
     return None
 
 

--- a/verifier/oracle/test_oracle.py
+++ b/verifier/oracle/test_oracle.py
@@ -417,6 +417,28 @@ def test_agentreceipts_tampered_proofvalue_fails_signature() -> None:
     assert res.axis("signature").result == crypto.FAIL
 
 
+@requires_ed25519
+def test_agentreceipts_issuer_must_control_signing_key_no_impersonation() -> None:
+    """An attacker's valid signature under a key the issuer does not control must not verify."""
+    from base64 import urlsafe_b64encode
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    sk = Ed25519PrivateKey.generate()
+    pk = sk.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    vm = "did:web:attacker.example#key-1"
+    forged = json.loads(json.dumps(_ar("agentreceipts-01-didkey-genesis")))
+    forged["issuer"] = {"id": "did:web:victim.example"}
+    forged["proof"]["verificationMethod"] = vm
+    sig = sk.sign(AgentReceiptsAdapter().signing_input(forged))
+    forged["proof"]["proofValue"] = "u" + urlsafe_b64encode(sig).decode().rstrip("=")
+    res = verify(forged, ADAPTERS, key_provider={vm: pk.hex()})
+    assert res.axis("signature").result == crypto.PASS  # the attacker's signature is cryptographically valid
+    assert res.axis("structure").result == crypto.FAIL  # but the signing-key DID is not the issuer
+    assert res.verdict == "FAIL"
+
+
 def test_agentreceipts_genesis_explicit_null_is_genesis_missing_field_is_malformed() -> None:
     """Genesis carries previous_receipt_hash present and null; omitting it is malformed."""
     genesis = _ar("agentreceipts-01-didkey-genesis")

--- a/verifier/oracle/test_oracle.py
+++ b/verifier/oracle/test_oracle.py
@@ -20,6 +20,7 @@ sys.path.insert(0, _VERIFIER)
 
 from oracle import ADAPTERS, crypto, verify  # noqa: E402
 from oracle.adapters.aerf import AerfAdapter  # noqa: E402
+from oracle.adapters.agentreceipts import AgentReceiptsAdapter  # noqa: E402
 from oracle.adapters.asqav_native import AsqavNativeAdapter  # noqa: E402
 from oracle.runner import run_corpus  # noqa: E402
 
@@ -43,7 +44,7 @@ def _provider(vec: str, fmt: str):
 
 def test_adapters_registered() -> None:
     names = [a.name for a in ADAPTERS]
-    assert names == ["asqav-native", "aerf", "acta"]
+    assert names == ["asqav-native", "aerf", "acta", "agentreceipts"]
 
 
 def test_detection_picks_the_right_adapter() -> None:
@@ -176,7 +177,7 @@ def test_signature_skips_downgrade_to_incomplete() -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 22
+    assert len(results) == 37
     failures = [r for r in results if not r.ok]
     assert not failures, f"corpus mismatches: {[(r.dir, r.actual_verdict) for r in failures]}"
 
@@ -351,12 +352,132 @@ def test_nfc_canonicalization_edge() -> None:
     assert verify(tampered, ADAPTERS, key_provider=provider).axis("signature").result == crypto.FAIL
 
 
-def test_three_way_format_exclusion() -> None:
-    """Each adapter detects only its own receipt, giving a clean 3x3 detection diagonal."""
+def test_four_way_format_exclusion() -> None:
+    """Each adapter detects only its own receipt, giving a clean 4x4 detection diagonal."""
     native = _load("asqav-01-genesis-permit", "receipt.json")
     aerf = _load("aerf-01-genesis", "receipt.json")
     acta = _load("acta-01-genesis", "receipt.json")
-    a, e, c = AsqavNativeAdapter(), AerfAdapter(), ActaAdapter()
-    assert (a.detect(native), e.detect(native), c.detect(native)) == (True, False, False)
-    assert (a.detect(aerf), e.detect(aerf), c.detect(aerf)) == (False, True, False)
-    assert (a.detect(acta), e.detect(acta), c.detect(acta)) == (False, False, True)
+    ar = _load("agentreceipts-01-didkey-genesis", "receipt.json")
+    a, e, c, g = AsqavNativeAdapter(), AerfAdapter(), ActaAdapter(), AgentReceiptsAdapter()
+    assert (a.detect(native), e.detect(native), c.detect(native), g.detect(native)) == (True, False, False, False)
+    assert (a.detect(aerf), e.detect(aerf), c.detect(aerf), g.detect(aerf)) == (False, True, False, False)
+    assert (a.detect(acta), e.detect(acta), c.detect(acta), g.detect(acta)) == (False, False, True, False)
+    assert (a.detect(ar), e.detect(ar), c.detect(ar), g.detect(ar)) == (False, False, False, True)
+
+
+# --- agent-receipts adapter (W3C-VC AgentReceipt) + upstream interop ---
+
+from oracle.canonical import jcs_rfc8785  # noqa: E402
+from oracle.did import b58btc_decode, resolve_ed25519_key  # noqa: E402
+
+_INTEROP = _CORPUS / "agentreceipts-upstream-interop"
+
+
+def _ar(vec: str, name: str = "receipt.json") -> dict:
+    return _load(vec, name)
+
+
+def _ar_provider(vec: str):
+    path = _CORPUS / vec / "did_map.json"
+    return json.loads(path.read_text()) if path.exists() else None
+
+
+@requires_ed25519
+def test_agentreceipts_didkey_genesis_passes() -> None:
+    """A did:key genesis verifies: the key resolves inline and the signature checks."""
+    doc = _ar("agentreceipts-01-didkey-genesis")
+    res = verify(doc, ADAPTERS)
+    assert res.fmt == "agentreceipts"
+    assert res.verdict == "PASS"
+    assert res.axis("signature").result == crypto.PASS
+
+
+@requires_ed25519
+def test_agentreceipts_chain_link_passes() -> None:
+    doc = _ar("agentreceipts-02-didkey-chain-link")
+    pred = _ar("agentreceipts-02-didkey-chain-link", "predecessor.json")
+    res = verify(doc, ADAPTERS, predecessor=pred)
+    assert res.verdict == "PASS"
+    assert res.axis("chain").result == crypto.PASS
+
+
+@requires_ed25519
+def test_agentreceipts_tampered_payload_fails_signature() -> None:
+    doc = _ar("agentreceipts-03-tamper-payload")
+    res = verify(doc, ADAPTERS)
+    assert res.verdict == "FAIL"
+    assert res.axis("signature").result == crypto.FAIL
+
+
+@requires_ed25519
+def test_agentreceipts_tampered_proofvalue_fails_signature() -> None:
+    doc = _ar("agentreceipts-04-tamper-proofvalue")
+    res = verify(doc, ADAPTERS)
+    assert res.verdict == "FAIL"
+    assert res.axis("signature").result == crypto.FAIL
+
+
+def test_agentreceipts_genesis_explicit_null_is_genesis_missing_field_is_malformed() -> None:
+    """Genesis carries previous_receipt_hash present and null; omitting it is malformed."""
+    genesis = _ar("agentreceipts-01-didkey-genesis")
+    ad = AgentReceiptsAdapter()
+    assert ad.chain_step(genesis).is_genesis is True
+    assert ad.schema(genesis)[0] == crypto.PASS
+
+    missing = _ar("agentreceipts-05-genesis-missing-prev-hash")
+    assert ad.schema(missing)[0] == crypto.FAIL
+    assert verify(missing, ADAPTERS).verdict == "FAIL"
+
+
+@requires_ed25519
+def test_agentreceipts_wrong_did_fails_signature() -> None:
+    """A verificationMethod resolved to a different key cannot verify the signature."""
+    doc = _ar("agentreceipts-06-wrong-key")
+    res = verify(doc, ADAPTERS, key_provider=_ar_provider("agentreceipts-06-wrong-key"))
+    assert res.fmt == "agentreceipts"
+    assert res.verdict == "FAIL"
+    assert res.axis("signature").result == crypto.FAIL
+
+
+@requires_ed25519
+def test_agentreceipts_upstream_valid_resigned_passes() -> None:
+    """The upstream malformed-corpus base receipt, re-signed clean with the upstream key."""
+    doc = _ar("agentreceipts-up-00-valid-resigned")
+    res = verify(doc, ADAPTERS, key_provider=_ar_provider("agentreceipts-up-00-valid-resigned"))
+    assert res.verdict == "PASS"
+    assert res.axis("signature").result == crypto.PASS
+
+
+def test_jcs_rfc8785_byte_matches_upstream_canonicalization_vectors() -> None:
+    """Gold interop: our jcs_rfc8785 output must byte-equal every upstream canonical form."""
+    path = _INTEROP / "canonicalization_vectors.json"
+    if not path.exists():
+        pytest.skip("upstream canonicalization vectors not vendored")
+    data = json.loads(path.read_text())
+    mismatches = []
+    for v in data["canonicalization_vectors"]:
+        got = jcs_rfc8785(v["input"]).decode("utf-8")
+        if got != v["canonical"]:
+            mismatches.append((v["name"], v["canonical"], got))
+    assert not mismatches, f"JCS interop mismatches vs upstream: {mismatches}"
+
+
+def test_didkey_resolver_decodes_upstream_did_key_vectors() -> None:
+    """The shared DID resolver decodes each upstream did:key to its expected raw key."""
+    path = _INTEROP / "did_key_vectors.json"
+    if not path.exists():
+        pytest.skip("upstream did:key vectors not vendored")
+    data = json.loads(path.read_text())
+    for v in data["vectors"]:
+        did = v["did"]
+        raw, _note = resolve_ed25519_key(did + "#" + did.split(":")[-1])
+        assert raw is not None, f"{v['name']} did not resolve"
+        assert raw.hex() == v["public_key_hex"], f"{v['name']} key mismatch"
+
+
+def test_b58btc_decode_known_value() -> None:
+    """base58btc decodes a known multikey frame: 0xed01 prefix + 32 key bytes."""
+    # did:key vector-1 identifier without the multibase 'z' prefix.
+    decoded = b58btc_decode("6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw")
+    assert decoded[:2] == b"\xed\x01"
+    assert decoded[2:].hex() == "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"


### PR DESCRIPTION
Adds a fourth oracle adapter for the agent-receipts AgentReceipt format (a W3C Verifiable Credential envelope), a shared DID resolver, and the upstream interop corpus.

The adapter verifies Ed25519 over the JCS canonical bytes of the receipt with the proof removed, decodes the multibase proofValue, and rederives the chain hash over the predecessor with its proof removed (genesis carries an explicit null, the opposite of AERF's omit-on-genesis). Keys resolve through a new shared DID resolver: did:key is decoded inline (multibase base58btc identifier, Ed25519 multicodec prefix, raw 32-byte key), did:agent and did:web through an injected map with no live fetch. A later DID hook reuses the resolver.

Interop finding (lesson learned, surfaced not silenced): ingesting the upstream corpus showed the existing canonicaliser is the AERF / ACTA dialect (numbers as Python emits them, code-point key sort) and is NOT byte-identical to the agent-receipts producers, even though both specs cite the same standard. Rather than change the bytes the AERF and ACTA adapters verify, this adds a strict jcs_rfc8785 (UTF-16 key order, ECMAScript number output) used only by the agent-receipts adapter. Its output byte-matches all 32 upstream canonicalization vectors, asserted directly. Both canonicalisers and the divergence are documented in UPSTREAM.md.

THREAT_MODEL:
- New attack surface: a new verify path for a VC-shaped format whose key arrives through a DID, plus a second canonicaliser.
- Existing guard: none; this is a new adapter and a new resolver.
- New tests asserting the guards: tampered payload and tampered proofValue FAIL, wrong DID FAIL, the canonicaliser must byte-match the 32 upstream canonicalization vectors, the resolver must decode the upstream did:key vectors, the six upstream malformed receipts must be rejected, and the cross-format exclusion test now covers all four formats (no receipt claimed by more than one adapter).
- Trust boundary: a verifier can false-pass a forged receipt if the canonicaliser or resolver is wrong; mitigated by the upstream-keypair-signed PASS vectors and the byte-match assertion (independent ground truth, not self-authored).

The two transparency-log vectors remain deferred. 39 oracle tests pass; corpus is 37 vectors; ruff clean.
