### PR TITLE
Fail closed on malformed receipt signatures and pin the prod hash-mode vector

### DIFF
--- a/verifier/conformance-vectors/README.md
+++ b/verifier/conformance-vectors/README.md
@@ -18,9 +18,13 @@ manifest.json                  array of {dir, format, outcome, reason_code, note
   did_map.json                 (agentreceipts) {did: ed25519_pubkey_hex} for did:agent / did:web
 ```
 
-`outcome` is `PASS` or `FAIL`; the runner maps it to the oracle verdict and
-asserts equality. `reason_code` follows the shared taxonomy (`issuer_signature`,
-`chain`, `schema`, `key`).
+`outcome` is `PASS`, `FAIL`, or `INCOMPLETE`; the runner maps it one-for-one to
+the oracle verdict and asserts equality. `INCOMPLETE` carries a vector whose
+signature axis cannot be checked in the CI environment (for example a real
+ML-DSA-65 prod receipt when `dilithium-py` is absent), pinning that the verifier
+downgrades to INCOMPLETE rather than emitting a false PASS. `reason_code` follows
+the shared taxonomy (`issuer_signature`, `chain`, `schema`, `key`,
+`signature_skipped_no_dilithium`).
 
 ## Run
 
@@ -34,6 +38,11 @@ python -m oracle.runner          # from the verifier/ directory
   chain link), Ed25519-signed so the signature axis verifies without the
   post-quantum dependency.
 - `asqav-04-tamper-sig` - decision flipped after signing; signature fails.
+- `asqav-05-hash-mode-prod` - a real default-mode prod `/sign` receipt (ML-DSA-65).
+  The reconstructed signing input byte-matches the prod-signed message and the
+  signature verifies with `dilithium-py`; absent that optional dep the signature
+  axis SKIPs, so the outcome is `INCOMPLETE`. Guards the production hash-mode path
+  against a false PASS on the post-quantum signature the CI base cannot check.
 - `aerf-01..02` - valid AERF receipts (genesis, chain link). Genesis omits
   `previous_receipt_hash`; the chain hash excludes the signature, per the AERF
   spec.

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -28,6 +28,13 @@
     "notes": "decision flipped after signing; signature no longer matches the canonical payload."
   },
   {
+    "dir": "asqav-05-hash-mode-prod",
+    "format": "asqav-native",
+    "outcome": "INCOMPLETE",
+    "reason_code": "signature_skipped_no_dilithium",
+    "notes": "Real default-mode prod /sign receipt; the reconstructed signing input byte-matches the prod-signed message and ML-DSA-65 verifies with dilithium-py. Absent that optional dep the signature axis SKIPs, so the verdict is INCOMPLETE, proving the verifier never false-PASSes the post-quantum path it cannot check."
+  },
+  {
     "dir": "aerf-01-genesis",
     "format": "aerf",
     "outcome": "PASS",

--- a/verifier/oracle/adapters/aerf.py
+++ b/verifier/oracle/adapters/aerf.py
@@ -44,6 +44,16 @@ _STRIP = ("signature", "timestamp", "parent_signature", "parent_key_id", "log_in
 _SPKI_PREFIX = bytes.fromhex("302a300506032b6570032100")
 
 
+def _safe_hex(value: Any) -> bytes:
+    """Decode a hex string; b'' on any malformed input so verify FAILs, never crashes."""
+    if not isinstance(value, str):
+        return b""
+    try:
+        return bytes.fromhex(value)
+    except ValueError:
+        return b""
+
+
 def _signable(doc: dict) -> dict:
     return {k: v for k, v in doc.items() if k not in _STRIP}
 
@@ -60,7 +70,7 @@ def _resolve_raw(key_provider: Any, kid: str) -> bytes | None:
     material = (key_provider or {}).get(kid)
     if material is None:
         return None
-    return _raw_ed25519(material if isinstance(material, bytes) else bytes.fromhex(material))
+    return _raw_ed25519(material if isinstance(material, bytes) else _safe_hex(material))
 
 
 class AerfAdapter(FormatAdapter):
@@ -73,7 +83,7 @@ class AerfAdapter(FormatAdapter):
 
     def extract_signature(self, doc: dict) -> SignatureMaterial:
         return SignatureMaterial(
-            sig=bytes.fromhex(doc.get("signature", "")),
+            sig=_safe_hex(doc.get("signature", "")),
             alg="Ed25519",
             kid=doc.get("key_id", ""),
         )
@@ -84,7 +94,7 @@ class AerfAdapter(FormatAdapter):
         material = keys.get(kid)
         if material is None:
             return None, f"key_id {kid!r} not supplied to the key provider"
-        raw = _raw_ed25519(material if isinstance(material, bytes) else bytes.fromhex(material))
+        raw = _raw_ed25519(material if isinstance(material, bytes) else _safe_hex(material))
         return raw, f"resolved key_id {kid}"
 
     def signing_input(self, doc: dict) -> bytes:
@@ -139,7 +149,7 @@ class AerfAdapter(FormatAdapter):
         pk = _resolve_raw(key_provider, doc.get("parent_key_id", ""))
         if pk is None:
             return ("parent_signature", SKIPPED, "parent_key_id not supplied to the key provider")
-        res, why = verify_signature("Ed25519", pk, self.signing_input(doc), bytes.fromhex(sig_hex))
+        res, why = verify_signature("Ed25519", pk, self.signing_input(doc), _safe_hex(sig_hex))
         note = "parent counter-signature valid" if res == PASS else f"parent signature verification FAILED: {why}"
         return ("parent_signature", res, note)
 
@@ -159,6 +169,6 @@ class AerfAdapter(FormatAdapter):
                 "policy_hash": doc.get("policy_hash"),
             }
         )
-        res, why = verify_signature("Ed25519", pk, tuple_bytes, bytes.fromhex(sig_hex))
+        res, why = verify_signature("Ed25519", pk, tuple_bytes, _safe_hex(sig_hex))
         note = "pdp binding valid" if res == PASS else f"pdp signature verification FAILED: {why}"
         return ("pdp_signature", res, note)

--- a/verifier/oracle/adapters/asqav_native.py
+++ b/verifier/oracle/adapters/asqav_native.py
@@ -101,7 +101,7 @@ class AsqavNativeAdapter(FormatAdapter):
         if isinstance(sig_obj, str):
             sig_obj = {"alg": "ML-DSA-65", "kid": _payload(doc).get("issuer_id", ""), "sig": sig_obj}
         return SignatureMaterial(
-            sig=_vr._b64decode(sig_obj.get("sig", "")),
+            sig=_safe_b64(sig_obj.get("sig", "")),
             alg=sig_obj.get("alg", "ML-DSA-65"),
             kid=sig_obj.get("kid", ""),
         )

--- a/verifier/oracle/runner.py
+++ b/verifier/oracle/runner.py
@@ -6,9 +6,11 @@ The corpus uses the AERF dir-per-vector layout as a superset: a top-level
 ``predecessor.json`` for chain vectors, and optional key material (``jwks.json``
 for Asqav-native, ``keys.json`` mapping key_id->hex for AERF).
 
-``outcome`` is mapped to the oracle verdict: PASS -> verdict PASS, FAIL -> verdict
-FAIL. ``run_corpus`` returns one ``VectorOutcome`` per vector so callers (pytest
-or the CLI) can assert pass/fail counts.
+``outcome`` maps to the verdict one-for-one (PASS/FAIL/INCOMPLETE). INCOMPLETE
+lets the corpus carry a vector whose signature axis cannot be checked in CI (a
+real ML-DSA-65 prod receipt without dilithium-py), pinning that the verifier
+downgrades rather than false-PASSing. ``run_corpus`` returns one ``VectorOutcome``
+per vector so callers can assert counts.
 """
 from __future__ import annotations
 
@@ -20,7 +22,7 @@ from . import ADAPTERS
 from .core import verify
 
 #: manifest outcome token -> the VerifyResult.verdict it must produce.
-_OUTCOME_TO_VERDICT = {"PASS": "PASS", "FAIL": "FAIL"}
+_OUTCOME_TO_VERDICT = {"PASS": "PASS", "FAIL": "FAIL", "INCOMPLETE": "INCOMPLETE"}
 
 
 @dataclass(frozen=True)
@@ -29,9 +31,10 @@ class VectorOutcome:
 
     Fields:
       dir: the vector directory name.
-      expected_outcome: the manifest's PASS / FAIL outcome.
+      expected_outcome: the manifest's PASS / FAIL / INCOMPLETE outcome.
       actual_verdict: the oracle's PASS / FAIL / INCOMPLETE verdict.
       ok: True when the actual verdict matches the expected outcome.
+      reason_code: the manifest reason_code for this vector.
       detail: per-axis notes for a failing match.
     """
 
@@ -39,6 +42,7 @@ class VectorOutcome:
     expected_outcome: str
     actual_verdict: str
     ok: bool
+    reason_code: str
     detail: str
 
 
@@ -59,7 +63,7 @@ def _key_provider(vec_dir: Path, fmt: str):
     return None
 
 
-def run_one(vec_dir: Path, fmt: str, expected_outcome: str) -> VectorOutcome:
+def run_one(vec_dir: Path, fmt: str, expected_outcome: str, reason_code: str = "") -> VectorOutcome:
     """Run a single vector directory and compare against its expected outcome."""
     receipt = _load(vec_dir / "receipt.json")
     predecessor = _load(vec_dir / "predecessor.json")
@@ -69,7 +73,7 @@ def run_one(vec_dir: Path, fmt: str, expected_outcome: str) -> VectorOutcome:
     want_verdict = _OUTCOME_TO_VERDICT.get(expected_outcome)
     ok = want_verdict is not None and result.verdict == want_verdict
     detail = "; ".join(f"{a.axis}={a.result}({a.note})" for a in result.axes)
-    return VectorOutcome(vec_dir.name, expected_outcome, result.verdict, ok, detail)
+    return VectorOutcome(vec_dir.name, expected_outcome, result.verdict, ok, reason_code, detail)
 
 
 def run_corpus(corpus_root: Path) -> list[VectorOutcome]:
@@ -78,9 +82,18 @@ def run_corpus(corpus_root: Path) -> list[VectorOutcome]:
     out = []
     for entry in manifest:
         out.append(
-            run_one(corpus_root / entry["dir"], entry["format"], entry["outcome"])
+            run_one(corpus_root / entry["dir"], entry["format"], entry["outcome"], entry.get("reason_code", ""))
         )
     return out
+
+
+def _tolerated(outcome: VectorOutcome) -> bool:
+    """Accept the stronger PASS only for the optional-dep ML-DSA skip vector, never broadly."""
+    return outcome.ok or (
+        outcome.expected_outcome == "INCOMPLETE"
+        and outcome.actual_verdict == "PASS"
+        and outcome.reason_code == "signature_skipped_no_dilithium"
+    )
 
 
 def main() -> int:
@@ -88,11 +101,11 @@ def main() -> int:
     root = Path(__file__).resolve().parent.parent / "conformance-vectors"
     results = run_corpus(root)
     for r in results:
-        mark = "ok" if r.ok else "FAIL"
+        mark = "ok" if _tolerated(r) else "FAIL"
         print(f"  [{mark:>4}] {r.dir:<28} expect={r.expected_outcome:<5} got={r.actual_verdict}")
-        if not r.ok:
+        if not _tolerated(r):
             print(f"         {r.detail}")
-    passed = sum(1 for r in results if r.ok)
+    passed = sum(1 for r in results if _tolerated(r))
     print(f"\n  => {passed}/{len(results)} vectors matched expected outcome")
     return 0 if passed == len(results) else 1
 

--- a/verifier/oracle/test_oracle.py
+++ b/verifier/oracle/test_oracle.py
@@ -22,6 +22,7 @@ from oracle import ADAPTERS, crypto, verify  # noqa: E402
 from oracle.adapters.aerf import AerfAdapter  # noqa: E402
 from oracle.adapters.agentreceipts import AgentReceiptsAdapter  # noqa: E402
 from oracle.adapters.asqav_native import AsqavNativeAdapter  # noqa: E402
+from oracle.runner import main as runner_main  # noqa: E402
 from oracle.runner import run_corpus  # noqa: E402
 
 _CORPUS = Path(_VERIFIER) / "conformance-vectors"
@@ -175,11 +176,29 @@ def test_signature_skips_downgrade_to_incomplete() -> None:
 
 
 @requires_ed25519
+def test_runner_main_reports_all_green(capsys) -> None:
+    """The CLI entrypoint runs the corpus, tolerates the optional-dep vector, exits 0."""
+    rc = runner_main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "vectors matched expected outcome" in out
+    assert "[FAIL]" not in out
+
+
+@requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 37
-    failures = [r for r in results if not r.ok]
-    assert not failures, f"corpus mismatches: {[(r.dir, r.actual_verdict) for r in failures]}"
+    assert len(results) == 38
+    # The optional-dep ML-DSA vector returns the stronger PASS when dilithium-py is present.
+    def _tol(r):
+        return r.ok or (
+            r.expected_outcome == "INCOMPLETE"
+            and r.actual_verdict == "PASS"
+            and r.reason_code == "signature_skipped_no_dilithium"
+        )
+
+    failures = [(r.dir, r.actual_verdict) for r in results if not _tol(r)]
+    assert not failures, f"corpus mismatches: {failures}"
 
 
 # --- ACTA adapter + cross-format confusion ---
@@ -564,3 +583,35 @@ def test_hash_mode_malformed_signature_fails_does_not_crash() -> None:
         forged["signature"] = bad
         res = verify(forged, ADAPTERS, key_provider=_provider("asqav-05-hash-mode-prod", "asqav-native"))
         assert res.verdict != "PASS"
+
+
+def test_compliance_envelope_malformed_signature_fails_does_not_crash() -> None:
+    """A malformed Asqav compliance-envelope signature decodes to b'' and FAILs, never raises."""
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    for bad in ({"k": "v"}, 999, None, "not base64 @@@"):
+        forged = json.loads(json.dumps(doc))
+        forged["signature"]["sig"] = bad
+        res = verify(forged, ADAPTERS, key_provider=_provider("asqav-01-genesis-permit", "asqav-native"))
+        assert res.verdict != "PASS"
+
+
+def test_aerf_malformed_signature_fails_does_not_crash() -> None:
+    """A malformed AERF signature (non-hex or non-string) decodes to b'' and FAILs, never raises."""
+    doc = _load("aerf-01-genesis", "receipt.json")
+    for bad in ("zzzz-not-hex", {"k": "v"}, 42, None):
+        forged = json.loads(json.dumps(doc))
+        forged["signature"] = bad
+        res = verify(forged, ADAPTERS, key_provider=_provider("aerf-01-genesis", "aerf"))
+        assert res.verdict != "PASS"
+
+
+def test_aerf_malformed_parent_pdp_signature_fails_does_not_crash() -> None:
+    """Malformed AERF parent/pdp counter-signatures decode to b'' and FAIL, never raise."""
+    vec = "aerf-up-06-impact-with-parent-sig"
+    doc = _load(vec, "receipt.json")
+    for field in ("parent_signature", "pdp_signature"):
+        for bad in ("zz", "abc", "not-hex"):
+            forged = json.loads(json.dumps(doc))
+            forged[field] = bad
+            res = verify(forged, ADAPTERS, key_provider=_provider(vec, "aerf"))
+            assert res.verdict != "PASS"


### PR DESCRIPTION
## What

Two hardening fixes to the neutral verifier oracle, surfaced by re-deriving the merged adapters against a real production receipt.

### 1. Malformed signatures fail closed
The AERF adapter (issuer, parent counter-sign, and PDP axes) and the Asqav-native compliance envelope decoded the signature field with a raw hex/base64 call that raised on a non-string or non-hex value. A hostile or buggy producer could crash the verifier process instead of getting a FAIL. Both paths route through the same safe-decode helper the hash-mode branch uses, returning empty bytes so the signature axis FAILs. No forged input ever verified, so soundness was intact; this restores the documented never-crash contract. Three negative tests pin the behaviour across both adapters.

### 2. The corpus runner can carry an INCOMPLETE-expected vector
The outcome map gained an INCOMPLETE row and a real default-mode production `/sign` receipt (ML-DSA-65) is wired into the manifest. Without the optional `dilithium-py` dependency the signature axis skips, so the verdict is INCOMPLETE, pinning that the verifier downgrades rather than emitting a false PASS on a post-quantum signature the CI base cannot check. With the dependency installed the receipt verifies to PASS; the runner accepts that stronger verdict only for this one `reason_code`, keeping strict matching everywhere else.

## Verification
- Full oracle suite green with and without `dilithium-py` (49 tests, both environments).
- `ruff check verifier/oracle` clean; dead-code scan clean.
- CRAP at most 7 on every changed function (threshold 30).
- The reconstructed signing input byte-matches the production-signed message, and the production signature verifies with `dilithium-py` installed.

## Scope
Six files under `verifier/`; no change to canonicalization, detection routing, or the crypto dispatch.
