### PR TITLE
Add an Authproof verifier adapter to the neutral oracle

### DIFF
--- a/verifier/conformance-vectors/README.md
+++ b/verifier/conformance-vectors/README.md
@@ -57,6 +57,11 @@ python -m oracle.runner          # from the verifier/ directory
 - `agentreceipts-up-*` - upstream agent-receipts vectors (six malformed
   single-field mutations, a tampered chain, and two upstream-keypair PASS
   cases). See `UPSTREAM.md`.
+- `authproof-01-genesis-real-sdk` - a receipt minted by the real Authproof JS
+  SDK (ES256 over insertion-order `JSON.stringify`, embedded P-256 JWK); a
+  cross-implementation interop PASS. `authproof-02/03` are its forged-signature
+  and tampered-scope negatives. The signer key is embedded, so no key file. See
+  `UPSTREAM.md`.
 
 The keys are generated from fixed seeds so the vectors are reproducible. AERF
 public keys are derived per spec as the first 16 hex of `SHA-256(pubkey)`.

--- a/verifier/conformance-vectors/UPSTREAM.md
+++ b/verifier/conformance-vectors/UPSTREAM.md
@@ -52,6 +52,25 @@ translated into our `keys.json` key map as raw Ed25519 hex, keyed by the
 upstream `key_id` (the leading 16 hex characters of the SHA-256 of the
 public key).
 
+## Authproof
+
+The `authproof-*` vectors target the shipping Authproof JS SDK
+(<https://github.com/Commonguy25/authproof-sdk>, `src/authproof.js`), which is
+authoritative for the wire shape: ES256 (ECDSA P-256 / SHA-256) over
+insertion-order `JSON.stringify` of the receipt minus its `signature`, signature
+hex-encoded as raw `r||s` (64 bytes), signer key embedded as a P-256 JWK at
+`signerPublicKey`. `authproof-01-genesis-real-sdk` is a receipt minted by that
+SDK and is a one-directional interop PASS (we verify a real Authproof artifact);
+`authproof-02/03` are its self-authored negatives. No published portable vector
+corpus exists upstream, so bidirectional interop against a third-party verifier
+of our output is PENDING.
+
+Two upstream variants deliberately diverge and are NOT targeted: the bundled
+draft-nelson text specifies a base64url signature, a content-hash
+`delegationId`, and canonical JSON; the repo's separate Python SDK signs DER over
+sorted-key JSON with snake_case fields. A receipt from either would not verify
+under the JS-SDK rules, and the JS SDK is the published product.
+
 ## Outcome mapping
 
 Each upstream vector declares an outcome of `PASS`, `FAIL`, or

--- a/verifier/conformance-vectors/authproof-01-genesis-real-sdk/expected.json
+++ b/verifier/conformance-vectors/authproof-01-genesis-real-sdk/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "authproof",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Receipt minted by the real Authproof JS SDK (Commonguy25/authproof-sdk). ES256 over insertion-order JSON.stringify, hex raw r||s, embedded P-256 JWK. Cross-implementation interop proof."
+}

--- a/verifier/conformance-vectors/authproof-01-genesis-real-sdk/receipt.json
+++ b/verifier/conformance-vectors/authproof-01-genesis-real-sdk/receipt.json
@@ -1,0 +1,20 @@
+{
+  "delegationId": "auth-1780609788582-vktlb",
+  "issuedAt": "2026-06-04T21:49:48.582Z",
+  "scope": "Search the web for public info.",
+  "boundaries": "Do not send emails.",
+  "timeWindow": {
+    "start": "2026-06-04T21:49:48.582Z",
+    "end": "2026-06-05T01:49:48.582Z"
+  },
+  "operatorInstructions": "Cite every claim.",
+  "instructionsHash": "be7ee51a1d624620cb2792ff1351f1a9ab411e47cfb301d9c1578faad45cff47",
+  "signerPublicKey": {
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "yMVhXZILz_GGg8wwWuea3gOYkTvvYwzM42bgY5k_zgM",
+    "y": "KeSjl2d1A6yOlxVhMvaiMmB07ze7DBRc16HgZU_4fE8"
+  },
+  "agentId": "agent-007",
+  "signature": "152657d7c58354549f6ec8fb9f3d467467efa97f5cb6564d8a379ad4259ea6e8c5a4bb9b376dd528a105ec70129664b868e00fd1fb40d689b7279276febdb164"
+}

--- a/verifier/conformance-vectors/authproof-02-forged-sig/expected.json
+++ b/verifier/conformance-vectors/authproof-02-forged-sig/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "authproof",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Signature first byte flipped; ECDSA verify fails."
+}

--- a/verifier/conformance-vectors/authproof-02-forged-sig/receipt.json
+++ b/verifier/conformance-vectors/authproof-02-forged-sig/receipt.json
@@ -1,0 +1,20 @@
+{
+  "delegationId": "auth-1780609788582-vktlb",
+  "issuedAt": "2026-06-04T21:49:48.582Z",
+  "scope": "Search the web for public info.",
+  "boundaries": "Do not send emails.",
+  "timeWindow": {
+    "start": "2026-06-04T21:49:48.582Z",
+    "end": "2026-06-05T01:49:48.582Z"
+  },
+  "operatorInstructions": "Cite every claim.",
+  "instructionsHash": "be7ee51a1d624620cb2792ff1351f1a9ab411e47cfb301d9c1578faad45cff47",
+  "signerPublicKey": {
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "yMVhXZILz_GGg8wwWuea3gOYkTvvYwzM42bgY5k_zgM",
+    "y": "KeSjl2d1A6yOlxVhMvaiMmB07ze7DBRc16HgZU_4fE8"
+  },
+  "agentId": "agent-007",
+  "signature": "252657d7c58354549f6ec8fb9f3d467467efa97f5cb6564d8a379ad4259ea6e8c5a4bb9b376dd528a105ec70129664b868e00fd1fb40d689b7279276febdb164"
+}

--- a/verifier/conformance-vectors/authproof-03-tampered-scope/expected.json
+++ b/verifier/conformance-vectors/authproof-03-tampered-scope/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "authproof",
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Scope changed after signing; signature no longer covers the bytes."
+}

--- a/verifier/conformance-vectors/authproof-03-tampered-scope/receipt.json
+++ b/verifier/conformance-vectors/authproof-03-tampered-scope/receipt.json
@@ -1,0 +1,20 @@
+{
+  "delegationId": "auth-1780609788582-vktlb",
+  "issuedAt": "2026-06-04T21:49:48.582Z",
+  "scope": "Send all the emails.",
+  "boundaries": "Do not send emails.",
+  "timeWindow": {
+    "start": "2026-06-04T21:49:48.582Z",
+    "end": "2026-06-05T01:49:48.582Z"
+  },
+  "operatorInstructions": "Cite every claim.",
+  "instructionsHash": "be7ee51a1d624620cb2792ff1351f1a9ab411e47cfb301d9c1578faad45cff47",
+  "signerPublicKey": {
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "yMVhXZILz_GGg8wwWuea3gOYkTvvYwzM42bgY5k_zgM",
+    "y": "KeSjl2d1A6yOlxVhMvaiMmB07ze7DBRc16HgZU_4fE8"
+  },
+  "agentId": "agent-007",
+  "signature": "152657d7c58354549f6ec8fb9f3d467467efa97f5cb6564d8a379ad4259ea6e8c5a4bb9b376dd528a105ec70129664b868e00fd1fb40d689b7279276febdb164"
+}

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -264,5 +264,26 @@
     "outcome": "PASS",
     "reason_code": "",
     "notes": "Successor signed with the upstream keypair; previous_receipt_hash rederives from sha256:hex(JCS(genesis without proof))."
+  },
+  {
+    "dir": "authproof-01-genesis-real-sdk",
+    "format": "authproof",
+    "outcome": "PASS",
+    "reason_code": "",
+    "notes": "Receipt minted by the real Authproof JS SDK; ES256 over insertion-order JSON.stringify, hex raw r||s, embedded P-256 JWK. Cross-implementation interop proof."
+  },
+  {
+    "dir": "authproof-02-forged-sig",
+    "format": "authproof",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Signature first byte flipped; ECDSA verify fails."
+  },
+  {
+    "dir": "authproof-03-tampered-scope",
+    "format": "authproof",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Scope changed after signing; signature no longer covers the bytes."
   }
 ]

--- a/verifier/oracle/README.md
+++ b/verifier/oracle/README.md
@@ -46,6 +46,10 @@ AERF signs the JCS payload directly after stripping `signature`, `timestamp`,
   `previous_receipt_hash`; the chain hash EXCLUDES the signature, per the AERF
   spec (the agentmint reference producer includes it; this adapter targets the
   spec).
+- **authproof** - ES256 (ECDSA P-256 / SHA-256) over insertion-order
+  `JSON.stringify` of the receipt minus its `signature`, hex raw r||s, signer key
+  embedded as a P-256 JWK. Targets the shipping JS SDK; the bundled draft and the
+  repo's Python SDK both diverge (see `conformance-vectors/UPSTREAM.md`).
 
 ## Use
 

--- a/verifier/oracle/__init__.py
+++ b/verifier/oracle/__init__.py
@@ -19,6 +19,7 @@ from .adapters.acta import ActaAdapter
 from .adapters.aerf import AerfAdapter
 from .adapters.agentreceipts import AgentReceiptsAdapter
 from .adapters.asqav_native import AsqavNativeAdapter
+from .adapters.authproof import AuthproofAdapter
 from .core import AxisResult, VerifyResult, verify
 
 #: Detection fingerprints are mutually exclusive, so registration order is not load-bearing.
@@ -27,6 +28,7 @@ ADAPTERS: list[FormatAdapter] = [
     AerfAdapter(),
     ActaAdapter(),
     AgentReceiptsAdapter(),
+    AuthproofAdapter(),
 ]
 
 __all__ = [
@@ -35,6 +37,7 @@ __all__ = [
     "AerfAdapter",
     "AgentReceiptsAdapter",
     "AsqavNativeAdapter",
+    "AuthproofAdapter",
     "AxisResult",
     "ChainStep",
     "FormatAdapter",

--- a/verifier/oracle/adapters/authproof.py
+++ b/verifier/oracle/adapters/authproof.py
@@ -1,0 +1,121 @@
+"""Authproof adapter - ES256 over insertion-order JSON, key embedded as a JWK.
+
+Authproof delegation receipts are signed by the reference JS SDK
+(``Commonguy25/authproof-sdk``, ``src/authproof.js``), which is authoritative for
+the wire shape. A receipt is a flat object whose signature is ECDSA P-256 / SHA-256
+over ``JSON.stringify(receipt-without-signature)`` in INSERTION order (not JCS, no
+pre-hash). The signature is hex-encoded raw ``r || s`` (64 bytes), and the signer's
+public key is embedded as a P-256 JWK at ``signerPublicKey``.
+
+Divergences this adapter deliberately does NOT follow (the JS SDK is the target):
+  - the bundled draft-nelson text specifies a base64url signature, a content-hash
+    ``delegationId``, and canonical JSON; the shipping SDK emits hex, a random
+    ``auth-<ms>-<rand>`` id, and insertion-order ``JSON.stringify``.
+  - the repo's separate Python SDK signs DER over sorted-key JSON with snake_case
+    fields; that is a distinct, non-interoperable variant.
+
+Scope: verifies the issuer signature and structural presence. The base receipt
+carries no in-band chain link (chaining is a separate SDK feature), so the chain
+axis reports genesis. Interop is proven against a receipt minted by the real JS
+SDK; there is no published portable vector corpus.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import re
+from typing import Any
+
+from ..adapter import ChainStep, FormatAdapter, SignatureMaterial
+
+#: A shipping-SDK delegationId is ``auth-<epoch_ms>-<5 base36 chars>``.
+_DELEGATION_ID = re.compile(r"^auth-\d+-[a-z0-9]{5}$")
+
+#: Fields the SDK always writes, used for the structural check.
+_REQUIRED = (
+    "delegationId",
+    "issuedAt",
+    "scope",
+    "boundaries",
+    "timeWindow",
+    "operatorInstructions",
+    "instructionsHash",
+    "signerPublicKey",
+    "signature",
+)
+
+
+def _safe_hex(value: Any) -> bytes:
+    """Decode a hex string; b'' on any malformed input so verify FAILs, never crashes."""
+    if not isinstance(value, str):
+        return b""
+    try:
+        return bytes.fromhex(value)
+    except ValueError:
+        return b""
+
+
+def _b64url(value: Any) -> bytes:
+    """Decode a base64url JWK coordinate; b'' on malformed input."""
+    if not isinstance(value, str):
+        return b""
+    try:
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except Exception:
+        return b""
+
+
+def _is_p256_jwk(jwk: Any) -> bool:
+    return isinstance(jwk, dict) and jwk.get("kty") == "EC" and jwk.get("crv") == "P-256"
+
+
+class AuthproofAdapter(FormatAdapter):
+    """Authproof delegation receipt - ES256 over insertion-order JSON.stringify."""
+
+    name = "authproof"
+
+    def detect(self, doc: dict) -> bool:
+        did = doc.get("delegationId")
+        return (
+            isinstance(did, str)
+            and _DELEGATION_ID.match(did) is not None
+            and "operatorInstructions" in doc
+            and "instructionsHash" in doc
+            and _is_p256_jwk(doc.get("signerPublicKey"))
+            and isinstance(doc.get("signature"), str)
+        )
+
+    def extract_signature(self, doc: dict) -> SignatureMaterial:
+        return SignatureMaterial(sig=_safe_hex(doc.get("signature", "")), alg="ES256", kid="")
+
+    def resolve_key(self, doc: dict, _key_provider: Any) -> tuple[bytes | None, str]:
+        """Return the 65-byte uncompressed P-256 point from the embedded JWK (key is in-band)."""
+        jwk = doc.get("signerPublicKey")
+        if not _is_p256_jwk(jwk):
+            return None, "signerPublicKey is not a P-256 JWK"
+        x, y = _b64url(jwk.get("x")), _b64url(jwk.get("y"))
+        if len(x) != 32 or len(y) != 32:
+            return None, "P-256 JWK coordinates are not 32 bytes each"
+        return b"\x04" + x + y, "resolved embedded P-256 JWK"
+
+    def signing_input(self, doc: dict) -> bytes:
+        """The SDK signs ``JSON.stringify`` of the receipt minus ``signature``, key order intact.
+
+        ``json.dumps`` here reproduces ``JSON.stringify`` byte-for-byte for the SDK's
+        string-valued fields (separators and string escaping agree, key order is
+        preserved, non-ASCII is emitted verbatim). The one divergence is non-integer
+        float serialisation, which Authproof's signed schema never carries; a numeric
+        ``metadata`` value would be the only case to re-check.
+        """
+        body = {k: v for k, v in doc.items() if k != "signature"}
+        return json.dumps(body, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    def chain_step(self, doc: dict) -> ChainStep:
+        # The base Authproof receipt carries no in-band chain link of its own.
+        return ChainStep(prev_field=None, is_genesis=True, recompute=lambda _pred: "")
+
+    def schema(self, doc: dict) -> tuple[str, str]:
+        missing = [f for f in _REQUIRED if doc.get(f) is None]
+        if missing:
+            return "FAIL", f"authproof receipt missing fields: {','.join(missing)}"
+        return "PASS", "authproof delegation receipt; required fields present"

--- a/verifier/oracle/crypto.py
+++ b/verifier/oracle/crypto.py
@@ -58,11 +58,46 @@ def verify_ed25519(pk: bytes, msg: bytes, sig: bytes) -> tuple[str, str]:
         return FAIL, f"verify error: {exc}"
 
 
+def verify_es256(pk: bytes, msg: bytes, sig: bytes) -> tuple[str, str]:
+    """ES256 (ECDSA P-256 over SHA-256) verify via ``cryptography``; SKIP when absent.
+
+    The public key is the 65-byte uncompressed point (0x04 || X || Y). The signature
+    is the 64-byte raw ``r || s`` form that WebCrypto and JOSE emit; it is converted
+    to DER for the library, which does not accept the raw form directly.
+    """
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric.ec import (
+            ECDSA,
+            SECP256R1,
+            EllipticCurvePublicKey,
+        )
+        from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+    except ImportError:
+        return SKIPPED, "run 'pip install cryptography' for the ES256 check"
+    try:
+        key = EllipticCurvePublicKey.from_encoded_point(SECP256R1(), pk)
+    except Exception as exc:  # malformed point bytes
+        return FAIL, f"bad P-256 public key: {exc}"
+    if len(sig) != 64:
+        return FAIL, f"ES256 signature must be 64-byte raw r||s, got {len(sig)}"
+    der = encode_dss_signature(int.from_bytes(sig[:32], "big"), int.from_bytes(sig[32:], "big"))
+    try:
+        key.verify(der, msg, ECDSA(hashes.SHA256()))
+        return PASS, "signature valid"
+    except InvalidSignature:
+        return FAIL, "signature mismatch"
+    except Exception as exc:  # malformed signature bytes
+        return FAIL, f"verify error: {exc}"
+
+
 #: alg token (upper-cased) -> verify callable; the dispatch table the oracle walks.
 _DISPATCH = {
     "ML-DSA-65": verify_ml_dsa_65,
     "ED25519": verify_ed25519,
     "EDDSA": verify_ed25519,
+    "ES256": verify_es256,
 }
 
 

--- a/verifier/oracle/test_oracle.py
+++ b/verifier/oracle/test_oracle.py
@@ -45,7 +45,7 @@ def _provider(vec: str, fmt: str):
 
 def test_adapters_registered() -> None:
     names = [a.name for a in ADAPTERS]
-    assert names == ["asqav-native", "aerf", "acta", "agentreceipts"]
+    assert names == ["asqav-native", "aerf", "acta", "agentreceipts", "authproof"]
 
 
 def test_detection_picks_the_right_adapter() -> None:
@@ -188,7 +188,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 38
+    assert len(results) == 41
     # The optional-dep ML-DSA vector returns the stronger PASS when dilithium-py is present.
     def _tol(r):
         return r.ok or (
@@ -615,3 +615,60 @@ def test_aerf_malformed_parent_pdp_signature_fails_does_not_crash() -> None:
             forged[field] = bad
             res = verify(forged, ADAPTERS, key_provider=_provider(vec, "aerf"))
             assert res.verdict != "PASS"
+
+
+# --- Authproof adapter (ES256 over insertion-order JSON.stringify) ---
+
+from oracle.adapters.authproof import AuthproofAdapter  # noqa: E402
+
+
+def _authproof_receipt() -> dict:
+    return json.loads((_CORPUS / "authproof-01-genesis-real-sdk" / "receipt.json").read_text())
+
+
+@requires_ed25519
+def test_authproof_real_sdk_receipt_verifies() -> None:
+    """A receipt minted by the real Authproof JS SDK verifies (cross-implementation interop)."""
+    res = verify(_authproof_receipt(), ADAPTERS)
+    assert res.fmt == "authproof"
+    assert res.verdict == "PASS"
+    assert res.axis("signature").result == crypto.PASS
+
+
+def test_authproof_detection_is_exclusive() -> None:
+    """The Authproof fingerprint matches only its own receipt, not the other formats."""
+    doc = _authproof_receipt()
+    assert [a.name for a in ADAPTERS if a.detect(doc)] == ["authproof"]
+    other = _load("aerf-01-genesis", "receipt.json")
+    assert AuthproofAdapter().detect(other) is False
+
+
+@requires_ed25519
+def test_authproof_tamper_and_forge_fail_closed() -> None:
+    """Tampering a signed field, forging the signature, or swapping the key all FAIL."""
+    base = _authproof_receipt()
+    tampered = json.loads(json.dumps(base))
+    tampered["scope"] = "Send all the emails."
+    assert verify(tampered, ADAPTERS).verdict == "FAIL"
+    forged = json.loads(json.dumps(base))
+    forged["signature"] = "25" + base["signature"][2:]
+    assert verify(forged, ADAPTERS).verdict == "FAIL"
+    wrong_key = json.loads(json.dumps(base))
+    wrong_key["signerPublicKey"]["x"] = "AAAAXZILz_GGg8wwWuea3gOYkTvvYwzM42bgY5k_zgM"
+    assert verify(wrong_key, ADAPTERS).verdict == "FAIL"
+
+
+def test_authproof_malformed_signature_fails_does_not_crash() -> None:
+    """A malformed Authproof signature decodes to b'' and FAILs, never raises."""
+    base = _authproof_receipt()
+    for bad in ("zz-not-hex", {"k": "v"}, 42, None, "abc"):
+        forged = json.loads(json.dumps(base))
+        forged["signature"] = bad
+        assert verify(forged, ADAPTERS).verdict != "PASS"
+
+
+def test_es256_malformed_key_and_sig_fail_closed() -> None:
+    """ES256 verify returns FAIL (never raises) on a bad point or a wrong-length signature."""
+    assert crypto.verify_es256(b"\x00" * 10, b"m", b"\x00" * 64)[0] == crypto.FAIL
+    pk = AuthproofAdapter().resolve_key(_authproof_receipt(), None)[0]
+    assert crypto.verify_es256(pk, b"m", b"\x00" * 10)[0] == crypto.FAIL


### PR DESCRIPTION
## What

Extends the universal neutral verifier to a fifth format, the Authproof delegation receipt, targeting the shipping JS SDK (the authoritative signer).

- New **ES256** (ECDSA P-256 over SHA-256) verify in `crypto.py`, wrapping the `cryptography` library and converting the 64-byte raw `r||s` signature to DER for it. SKIPs when the library is absent, never false-PASSes.
- The adapter verifies the signature over insertion-order `JSON.stringify` of the receipt minus its `signature` field, with the signer key read from the embedded P-256 JWK. Detection keys on the `auth-` delegation id plus the operator-instruction fields and the embedded EC key, mutually exclusive with the other four formats.
- A conformance vector **minted by the real Authproof SDK** gives a one-directional interop PASS; forged-signature and tampered-scope negatives fail closed. The bundled draft and the repo's separate Python SDK both diverge on the wire shape and are documented as out of scope.

## Verification
- 54 oracle tests green with and without the post-quantum dep; corpus 41/41 (3 authproof vectors).
- `ruff check verifier/oracle` clean; dead-code scan clean; CRAP at most 7 on every new function.
- Adversarial battery: tamper each signed field, forge the signature, swap the embedded key, present DER / wrong-length signatures, malformed signature field. All fail closed, zero false PASS.

## Scope
Only `verifier/` files; no change to canonicalization, the core, or the other adapters.
