### PR TITLE
Ship the neutral verifier in the asqav wheel

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -105,8 +105,25 @@ include = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/asqav"]
 
+# The neutral verifier lives at the repo root (verifier/) for standalone use and CI;
+# force-include its runtime source into the wheel so `from asqav.verifier.oracle import
+# verify, ADAPTERS` works for installed third parties. Files are listed explicitly to keep
+# the pytest modules and conformance-vectors test data out of the wheel; the adapters/
+# directory carries no tests so it ships whole. A drift guard
+# (verifier/oracle/test_oracle.py::test_packaging_force_include_covers_every_runtime_module)
+# fails CI if a new runtime module is added without a matching entry here.
 [tool.hatch.build.targets.wheel.force-include]
 "src/asqav/templates/shadow-ai/.env.template" = "asqav/templates/shadow-ai/.env.template"
+"../verifier/__init__.py" = "asqav/verifier/__init__.py"
+"../verifier/verify_receipt.py" = "asqav/verifier/verify_receipt.py"
+"../verifier/oracle/__init__.py" = "asqav/verifier/oracle/__init__.py"
+"../verifier/oracle/adapter.py" = "asqav/verifier/oracle/adapter.py"
+"../verifier/oracle/canonical.py" = "asqav/verifier/oracle/canonical.py"
+"../verifier/oracle/core.py" = "asqav/verifier/oracle/core.py"
+"../verifier/oracle/crypto.py" = "asqav/verifier/oracle/crypto.py"
+"../verifier/oracle/did.py" = "asqav/verifier/oracle/did.py"
+"../verifier/oracle/runner.py" = "asqav/verifier/oracle/runner.py"
+"../verifier/oracle/adapters" = "asqav/verifier/oracle/adapters"
 
 [tool.ruff]
 target-version = "py310"

--- a/verifier/__init__.py
+++ b/verifier/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled neutral receipt verifier (oracle + standalone verify_receipt)."""

--- a/verifier/oracle/README.md
+++ b/verifier/oracle/README.md
@@ -53,12 +53,25 @@ AERF signs the JCS payload directly after stripping `signature`, `timestamp`,
 
 ## Use
 
+From the source tree:
+
 ```python
 from oracle import ADAPTERS, verify
 
 result = verify(receipt, ADAPTERS, key_provider=keys, predecessor=prev)
 print(result.fmt, result.verdict)
 ```
+
+From an installed `asqav` wheel:
+
+```python
+from asqav.verifier.oracle import ADAPTERS, verify
+```
+
+Importing the oracle puts the bundled verifier directory on `sys.path` so the
+standalone `verify_receipt` resolves as a top-level module. That is the one name
+it exposes globally; it loads only when you explicitly import the oracle, never
+from `import asqav` alone.
 
 Run the bundled corpus:
 

--- a/verifier/oracle/__init__.py
+++ b/verifier/oracle/__init__.py
@@ -14,13 +14,21 @@ Public surface:
 """
 from __future__ import annotations
 
-from .adapter import ChainStep, FormatAdapter, SignatureMaterial
-from .adapters.acta import ActaAdapter
-from .adapters.aerf import AerfAdapter
-from .adapters.agentreceipts import AgentReceiptsAdapter
-from .adapters.asqav_native import AsqavNativeAdapter
-from .adapters.authproof import AuthproofAdapter
-from .core import AxisResult, VerifyResult, verify
+import os
+import sys
+
+# The adapters import the standalone ``verify_receipt`` as a top-level module. Put the
+# verifier directory on the path before importing them so the oracle works both from the
+# source tree and from the installed ``asqav.verifier`` package.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from .adapter import ChainStep, FormatAdapter, SignatureMaterial  # noqa: E402
+from .adapters.acta import ActaAdapter  # noqa: E402
+from .adapters.aerf import AerfAdapter  # noqa: E402
+from .adapters.agentreceipts import AgentReceiptsAdapter  # noqa: E402
+from .adapters.asqav_native import AsqavNativeAdapter  # noqa: E402
+from .adapters.authproof import AuthproofAdapter  # noqa: E402
+from .core import AxisResult, VerifyResult, verify  # noqa: E402
 
 #: Detection fingerprints are mutually exclusive, so registration order is not load-bearing.
 ADAPTERS: list[FormatAdapter] = [

--- a/verifier/oracle/test_oracle.py
+++ b/verifier/oracle/test_oracle.py
@@ -43,6 +43,22 @@ def _provider(vec: str, fmt: str):
     return _load(vec, fname)
 
 
+def test_packaging_force_include_covers_every_runtime_module() -> None:
+    """Every verifier/oracle runtime module is force-included into the wheel (drift guard)."""
+    here = Path(__file__).resolve()
+    pyproject = here.parents[2] / "python" / "pyproject.toml"
+    if not pyproject.exists():
+        pytest.skip("pyproject not present (running from an installed package)")
+    text = pyproject.read_text()
+    oracle_mods = [p for p in here.parent.glob("*.py") if not p.name.startswith("test_")]
+    missing = [p.name for p in oracle_mods if f"verifier/oracle/{p.name}" not in text]
+    # Top-level verifier modules an adapter may import (e.g. verify_receipt.py) must ship too.
+    top_mods = [p for p in here.parents[1].glob("*.py") if not p.name.startswith("test_")]
+    missing += [f"../{p.name}" for p in top_mods if f"verifier/{p.name}" not in text]
+    assert not missing, f"force-include missing runtime modules: {missing}"
+    assert "verifier/oracle/adapters" in text  # adapters ship as a directory mapping
+
+
 def test_adapters_registered() -> None:
     names = [a.name for a in ADAPTERS]
     assert names == ["asqav-native", "aerf", "acta", "agentreceipts", "authproof"]


### PR DESCRIPTION
## What

The verifier oracle lived at the repo root and was absent from the built wheel, so `pip install asqav` left the multi-format neutral verifier unavailable to third parties (the whole point of shipping it). This packages it.

- Force-include the verifier runtime source under `asqav/verifier/` in the wheel. Runtime modules are listed explicitly so the pytest files and the conformance-vectors test data stay out.
- Bootstrap the verifier directory onto `sys.path` at the top of the oracle package so the bundled standalone `verify_receipt` resolves from the source tree and from the installed package alike.
- A drift-guard test fails CI if a new oracle or top-level verifier runtime module is added without a matching force-include entry.
- README documents the installed import path and the one global name (`verify_receipt`) the oracle exposes on import.

## Verification
- Built the wheel, installed it into a clean venv, imported `from asqav.verifier.oracle import verify, ADAPTERS` from outside the source tree, and verified a real receipt to PASS. No test modules or vector data ship in the wheel.
- Standalone suite 62 green; corpus 41/41; ruff clean. Reviewer + Devil's Advocate accept.

## Scope
`python/pyproject.toml` + `verifier/` only; no change to adapter logic, canonicalization, or crypto dispatch.
