### PR TITLE
Add a TypeScript port of the neutral verifier oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
             typescript:
               - 'typescript/**'
               - 'conformance/**'
+              # The TS verifier parity gate reads the shared conformance corpus,
+              # so a corpus change must re-run the TS job (not just the Python one).
+              - 'verifier/conformance-vectors/**'
               - '.github/workflows/ci.yml'
             verifier:
               - 'verifier/**'

--- a/typescript/src/verifier/adapter.ts
+++ b/typescript/src/verifier/adapter.ts
@@ -1,0 +1,82 @@
+/**
+ * The format-adapter seam - a port of the Python oracle's `verifier/oracle/adapter.py`.
+ *
+ * Everything format-specific lives behind this seam; everything shared (the JCS
+ * canonicaliser, the Ed25519 / ES256 verify, the SHA-256 chain walk, the vector
+ * runner) is infrastructure the core drives.
+ */
+
+import type { VerifyState } from "./crypto.js";
+
+/** The bytes and metadata needed to check one issuer signature. */
+export interface SignatureMaterial {
+  /** Raw signature bytes (already decoded from hex / base64url / multibase). */
+  sig: Uint8Array;
+  /** Algorithm token routed through `verifySignature`. */
+  alg: string;
+  /** Key identifier used by `resolveKey` to find the public key. */
+  kid: string;
+}
+
+/** The hash-chain linkage for one receipt. */
+export interface ChainStep {
+  /**
+   * The value of the format's previous-hash field, or null when the format omits
+   * it on genesis (AERF) - distinct from an explicit-null genesis.
+   */
+  prevField: string | null;
+  /** True when this receipt declares itself first on its chain. */
+  isGenesis: boolean;
+  /** Recompute the predecessor's chain digest (encodes which bytes the format hashes). */
+  recompute: (predecessor: Record<string, unknown>) => string;
+}
+
+/** `(result, note)` pair returned by structural and extra-axis checks. */
+export type AxisCheck = readonly [VerifyState, string];
+
+/** A named extra axis: `[axisName, result, note]`. */
+export type ExtraAxis = readonly [string, VerifyState, string];
+
+/** Format-shaped key material the runner injects (a JWKS dict, a key map, or null). */
+export type KeyProvider = Record<string, unknown> | null;
+
+/**
+ * One receipt format's binding to the shared verification core. Subclasses
+ * implement the six methods; `name` labels the format in results and the manifest;
+ * `detect` is a cheap structural fingerprint (no crypto).
+ */
+export abstract class FormatAdapter {
+  /** Stable format label surfaced in results and the vector manifest. */
+  abstract readonly name: string;
+
+  /** Cheap structural test: does this adapter own `doc`? No crypto. */
+  abstract detect(doc: Record<string, unknown>): boolean;
+
+  /** Pull the issuer signature bytes plus alg and kid out of `doc`. */
+  abstract extractSignature(doc: Record<string, unknown>): SignatureMaterial;
+
+  /** Return `[publicKeyBytesOrNull, note]` for the receipt's signer. */
+  abstract resolveKey(
+    doc: Record<string, unknown>,
+    keyProvider: KeyProvider,
+  ): readonly [Uint8Array | null, string];
+
+  /** Return the exact bytes the signature covers. */
+  abstract signingInput(doc: Record<string, unknown>): Uint8Array;
+
+  /** Describe how this receipt links to its predecessor. */
+  abstract chainStep(doc: Record<string, unknown>): ChainStep;
+
+  /** Structural check; returns `[result, note]`. */
+  abstract schema(doc: Record<string, unknown>): AxisCheck;
+
+  /**
+   * Format-specific axes beyond structure / issuer-signature / chain. Returns a
+   * list of `[axisName, result, note]`. The default is none; a format whose
+   * verification procedure layers additional REQUIRED checks returns one tuple
+   * per check so a missing-but-required or invalid layer FAILs the verdict.
+   */
+  extraAxes(_doc: Record<string, unknown>, _keyProvider: KeyProvider): ExtraAxis[] {
+    return [];
+  }
+}

--- a/typescript/src/verifier/adapters/acta.ts
+++ b/typescript/src/verifier/adapters/acta.ts
@@ -1,0 +1,142 @@
+/**
+ * ACTA adapter - Ed25519 over the JCS of the payload, signed directly.
+ * A port of the Python oracle's `verifier/oracle/adapters/acta.py`.
+ *
+ * Targets draft-farley-acta-signed-receipts-01. The envelope is
+ * `{payload, signature:{alg, kid, sig}}`; the signature is Ed25519 over the JCS
+ * canonical bytes of the `payload` object, signed DIRECTLY (no pre-hash), with the
+ * sig as a lowercase hex string. The OPTIONAL Commitment Mode is NOT implemented:
+ * a commitment-mode receipt fails the baseline signature check (the honest outcome).
+ *
+ * Asqav-native is a PROFILE of ACTA, so the payloads look identical; the formats
+ * are kept disjoint by the signature encoding (ACTA hex, Asqav-native base64) plus
+ * the Asqav-only `anchors` envelope key.
+ *
+ * The chain field `previousReceiptHash` is SHA-256 of the JCS of the FULL
+ * predecessor receipt INCLUDING its signature.
+ */
+
+import {
+  FormatAdapter,
+  type AxisCheck,
+  type ChainStep,
+  type KeyProvider,
+  type SignatureMaterial,
+} from "../adapter.js";
+import { jcs } from "../canonical.js";
+import { sha256Hex } from "../crypto.js";
+import { b64decode } from "../vrShim.js";
+
+/** True for a non-empty even-length lowercase-hex string (an ACTA signature). */
+export function isLowerHex(s: unknown): boolean {
+  return (
+    typeof s === "string" &&
+    s.length > 0 &&
+    s.length % 2 === 0 &&
+    /^[0-9a-f]+$/.test(s)
+  );
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+export class ActaAdapter extends FormatAdapter {
+  readonly name = "acta";
+
+  detect(doc: Record<string, unknown>): boolean {
+    const payload = doc.payload;
+    const sig = doc.signature;
+    const payloadIsObj = payload !== null && typeof payload === "object" && !Array.isArray(payload);
+    const sigIsObj = sig !== null && typeof sig === "object" && !Array.isArray(sig);
+    if (!payloadIsObj || !sigIsObj) return false;
+    if ("anchors" in doc) return false; // Asqav-native envelope marker; never ACTA.
+    return isLowerHex((sig as Record<string, unknown>).sig);
+  }
+
+  extractSignature(doc: Record<string, unknown>): SignatureMaterial {
+    const sig = asRecord(doc.signature);
+    return {
+      sig: hexToBytes((sig.sig as string) ?? ""),
+      alg: (sig.alg as string) ?? "EdDSA",
+      kid: (sig.kid as string) ?? "",
+    };
+  }
+
+  resolveKey(
+    doc: Record<string, unknown>,
+    keyProvider: KeyProvider,
+  ): readonly [Uint8Array | null, string] {
+    const kid = (asRecord(doc.signature).kid as string) ?? "";
+    const jwkKeys = ((keyProvider?.keys as Array<Record<string, unknown>>) ?? []);
+    for (const jwk of jwkKeys) {
+      if (jwk.kid !== kid) continue;
+      if (jwk.kty !== "OKP" || jwk.crv !== "Ed25519") {
+        return [null, `kid '${kid}' is not an OKP/Ed25519 JWK`];
+      }
+      const raw = b64decode((jwk.x as string) ?? "");
+      if (raw.length !== 32) {
+        return [null, `kid '${kid}' Ed25519 key is ${raw.length} bytes, expected 32`];
+      }
+      return [raw, `resolved kid ${kid} from ACTA JWK Set`];
+    }
+    return [null, `kid '${kid}' not in ACTA JWK Set`];
+  }
+
+  signingInput(doc: Record<string, unknown>): Uint8Array {
+    // Baseline: Ed25519 signs the JCS bytes of the payload directly, no pre-hash.
+    return jcs(asRecord(doc.payload));
+  }
+
+  chainStep(doc: Record<string, unknown>): ChainStep {
+    const payload = asRecord(doc.payload);
+    const prev = payload.previousReceiptHash;
+    const isGenesis = !("previousReceiptHash" in payload);
+    // Chain hash covers the full predecessor receipt, signature included.
+    return {
+      prevField: (prev as string | null) ?? null,
+      isGenesis,
+      recompute: (pred) => sha256Hex(jcs(pred)),
+    };
+  }
+
+  schema(doc: Record<string, unknown>): AxisCheck {
+    const payload = doc.payload;
+    const sig = doc.signature;
+    const payloadIsObj = payload !== null && typeof payload === "object" && !Array.isArray(payload);
+    const sigIsObj = sig !== null && typeof sig === "object" && !Array.isArray(sig);
+    if (!payloadIsObj || !sigIsObj) {
+      return ["FAIL", "ACTA receipt needs object payload and signature"];
+    }
+    const p = payload as Record<string, unknown>;
+    const s = sig as Record<string, unknown>;
+    const missing: string[] = [];
+    for (const f of ["type", "issued_at", "issuer_id"]) {
+      if (!(f in p)) missing.push(f);
+    }
+    for (const f of ["alg", "kid", "sig"]) {
+      if (!(f in s)) missing.push(`signature.${f}`);
+    }
+    if (missing.length > 0) {
+      return ["FAIL", `missing required fields: ${missing.join(",")}`];
+    }
+    if ("previousReceiptHash" in p && p.previousReceiptHash === null) {
+      return ["FAIL", "genesis must omit previousReceiptHash, not set it null"];
+    }
+    if (p.issuer_id !== s.kid) {
+      return ["FAIL", "issuer_id must match signature.kid"];
+    }
+    if (s.alg !== "EdDSA" && s.alg !== "Ed25519") {
+      return ["FAIL", `unsupported ACTA alg ${JSON.stringify(s.alg)}; only EdDSA baseline is implemented`];
+    }
+    return ["PASS", "required fields present; issuer_id matches kid; EdDSA baseline"];
+  }
+}

--- a/typescript/src/verifier/adapters/aerf.ts
+++ b/typescript/src/verifier/adapters/aerf.ts
@@ -1,0 +1,187 @@
+/**
+ * AERF adapter - Ed25519 over RFC 8785 JCS, signed directly (no pre-hash).
+ * A port of the Python oracle's `verifier/oracle/adapters/aerf.py`.
+ *
+ * AERF receipts are a flat object. The signature is Ed25519 over the JCS bytes of
+ * the receipt with the non-payload fields stripped - `signature`, `timestamp`,
+ * `parent_signature`, `parent_key_id`, `log_inclusion_proof` - signed DIRECTLY.
+ *
+ * Chain rule (AERF SPEC): `previous_receipt_hash` is the SHA-256 of the
+ * predecessor's signable payload with the SAME field set stripped (signature
+ * EXCLUDED). Genesis OMITS the field entirely; a present `previous_receipt_hash:
+ * null` is a malformed genesis.
+ *
+ * AERF layers two conditionally-REQUIRED signature checks in `extraAxes`:
+ *   - parent counter-signature: REQUIRED when `impact_tags` is non-empty.
+ *   - PDP binding: REQUIRED when `impact_tags` is non-empty; the PDP key signs
+ *     the canonical tuple `{context_hash_sha256, in_policy, policy_hash}`.
+ */
+
+import {
+  FormatAdapter,
+  type AxisCheck,
+  type ChainStep,
+  type ExtraAxis,
+  type KeyProvider,
+  type SignatureMaterial,
+} from "../adapter.js";
+import { jcs } from "../canonical.js";
+import { FAIL, PASS, SKIPPED, sha256Hex, verifySignature } from "../crypto.js";
+
+/** Fields removed before canonicalising for both the signature and the chain hash. */
+const STRIP = new Set([
+  "signature",
+  "timestamp",
+  "parent_signature",
+  "parent_key_id",
+  "log_inclusion_proof",
+]);
+
+/** Ed25519 SPKI header (12-byte prefix + 32 raw key bytes). */
+const SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+function safeHex(value: unknown): Uint8Array {
+  if (typeof value !== "string") return new Uint8Array(0);
+  if (value.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(value)) return new Uint8Array(0);
+  const out = new Uint8Array(value.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(value.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+function signable(doc: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(doc)) {
+    if (!STRIP.has(k)) out[k] = v;
+  }
+  return out;
+}
+
+/** Return the raw 32-byte key from raw input or an RFC 8410 SPKI value. */
+function rawEd25519(key: Uint8Array): Uint8Array {
+  if (key.length === 44 && Buffer.from(key.slice(0, 12)).equals(SPKI_PREFIX)) {
+    return key.slice(12);
+  }
+  return key;
+}
+
+function resolveRaw(keyProvider: KeyProvider, kid: string): Uint8Array | null {
+  const material = keyProvider?.[kid];
+  if (material === undefined || material === null) return null;
+  return rawEd25519(material instanceof Uint8Array ? material : safeHex(material));
+}
+
+export class AerfAdapter extends FormatAdapter {
+  readonly name = "aerf";
+
+  detect(doc: Record<string, unknown>): boolean {
+    return doc.type === "notarised_evidence" && "evidence_hash_sha512" in doc;
+  }
+
+  extractSignature(doc: Record<string, unknown>): SignatureMaterial {
+    return {
+      sig: safeHex(doc.signature),
+      alg: "Ed25519",
+      kid: (doc.key_id as string) ?? "",
+    };
+  }
+
+  resolveKey(
+    doc: Record<string, unknown>,
+    keyProvider: KeyProvider,
+  ): readonly [Uint8Array | null, string] {
+    const keys = keyProvider ?? {};
+    const kid = (doc.key_id as string) ?? "";
+    const material = keys[kid];
+    if (material === undefined || material === null) {
+      return [null, `key_id '${kid}' not supplied to the key provider`];
+    }
+    const raw = rawEd25519(material instanceof Uint8Array ? material : safeHex(material));
+    return [raw, `resolved key_id ${kid}`];
+  }
+
+  signingInput(doc: Record<string, unknown>): Uint8Array {
+    // AERF signs the JCS canonical bytes of the stripped payload directly.
+    return jcs(signable(doc));
+  }
+
+  chainStep(doc: Record<string, unknown>): ChainStep {
+    const prev = doc.previous_receipt_hash;
+    const isGenesis = !("previous_receipt_hash" in doc);
+    return {
+      prevField: (prev as string | null) ?? null,
+      isGenesis,
+      recompute: (pred) => sha256Hex(jcs(signable(pred))),
+    };
+  }
+
+  schema(doc: Record<string, unknown>): AxisCheck {
+    const required = [
+      "id",
+      "type",
+      "plan_id",
+      "agent",
+      "action",
+      "in_policy",
+      "evidence_hash_sha512",
+      "observed_at",
+      "key_id",
+      "signature",
+    ];
+    const missing = required.filter((f) => !(f in doc));
+    if (missing.length > 0) {
+      return ["FAIL", `missing required fields: ${missing.join(",")}`];
+    }
+    if ("previous_receipt_hash" in doc && doc.previous_receipt_hash === null) {
+      return ["FAIL", "genesis must omit previous_receipt_hash, not set it null"];
+    }
+    return ["PASS", "required fields present; type notarised_evidence"];
+  }
+
+  extraAxes(doc: Record<string, unknown>, keyProvider: KeyProvider): ExtraAxis[] {
+    const axes: ExtraAxis[] = [];
+    const impactTags = doc.impact_tags;
+    const hasImpact = Array.isArray(impactTags) ? impactTags.length > 0 : Boolean(impactTags);
+    if (hasImpact || doc.parent_signature) {
+      axes.push(this.parentAxis(doc, keyProvider, hasImpact));
+    }
+    if (hasImpact || doc.pdp_signature) {
+      axes.push(this.pdpAxis(doc, keyProvider, hasImpact));
+    }
+    return axes;
+  }
+
+  private parentAxis(doc: Record<string, unknown>, keyProvider: KeyProvider, required: boolean): ExtraAxis {
+    const sigHex = doc.parent_signature;
+    if (!sigHex) {
+      if (required) return ["parent_signature", FAIL, "parent_signature absent"];
+      return ["parent_signature", SKIPPED, "no parent_signature on this receipt"];
+    }
+    const pk = resolveRaw(keyProvider, (doc.parent_key_id as string) ?? "");
+    if (pk === null) {
+      return ["parent_signature", SKIPPED, "parent_key_id not supplied to the key provider"];
+    }
+    const { result, note: why } = verifySignature("Ed25519", pk, this.signingInput(doc), safeHex(sigHex));
+    const note = result === PASS ? "parent counter-signature valid" : `parent signature verification FAILED: ${why}`;
+    return ["parent_signature", result, note];
+  }
+
+  private pdpAxis(doc: Record<string, unknown>, keyProvider: KeyProvider, required: boolean): ExtraAxis {
+    const sigHex = doc.pdp_signature;
+    if (!sigHex) {
+      if (required) return ["pdp_signature", FAIL, "pdp_signature absent"];
+      return ["pdp_signature", SKIPPED, "no pdp_signature on this receipt"];
+    }
+    const pk = resolveRaw(keyProvider, (doc.pdp_key_id as string) ?? "");
+    if (pk === null) {
+      return ["pdp_signature", SKIPPED, "pdp_key_id not supplied to the key provider"];
+    }
+    const tupleBytes = jcs({
+      context_hash_sha256: doc.context_hash_sha256 ?? null,
+      in_policy: doc.in_policy ?? null,
+      policy_hash: doc.policy_hash ?? null,
+    });
+    const { result, note: why } = verifySignature("Ed25519", pk, tupleBytes, safeHex(sigHex));
+    const note = result === PASS ? "pdp binding valid" : `pdp signature verification FAILED: ${why}`;
+    return ["pdp_signature", result, note];
+  }
+}

--- a/typescript/src/verifier/adapters/agentreceipts.ts
+++ b/typescript/src/verifier/adapters/agentreceipts.ts
@@ -1,0 +1,152 @@
+/**
+ * agent-receipts adapter - W3C-VC AgentReceipt, Ed25519 over strict RFC 8785 JCS.
+ * A port of the Python oracle's `verifier/oracle/adapters/agentreceipts.py`.
+ *
+ * An AgentReceipt is a W3C Verifiable Credential 2.0 envelope. The signature is
+ * Ed25519 over the strict JCS bytes of the receipt with the `proof` member
+ * removed, signed DIRECTLY. `proof.type` is `Ed25519Signature2020` and
+ * `proof.proofValue` is multibase `u` (base64url, no padding).
+ *
+ * Uses `jcsRfc8785` (UTF-16 key sort, ECMAScript numbers), NOT the AERF/ACTA
+ * `jcs` dialect. The signing key resolves from `proof.verificationMethod` through
+ * the shared DID resolver.
+ *
+ * Chain rule: `credentialSubject.chain.previous_receipt_hash` is `"sha256:"` +
+ * hex(SHA-256(JCS(predecessor without proof))). Genesis carries the field present
+ * and explicitly `null`.
+ */
+
+import {
+  FormatAdapter,
+  type AxisCheck,
+  type ChainStep,
+  type KeyProvider,
+  type SignatureMaterial,
+} from "../adapter.js";
+import { jcsRfc8785 } from "../canonical.js";
+import { sha256Hex } from "../crypto.js";
+import { resolveEd25519Key } from "../did.js";
+
+/** SHA-256 hash prefix the chain field carries before the hex digest. */
+const SHA256_PREFIX = "sha256:";
+
+function signable(doc: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(doc)) {
+    if (k !== "proof") out[k] = v;
+  }
+  return out;
+}
+
+/** Decode a multibase `u` (base64url, no padding) proofValue to raw bytes. */
+function multibaseUDecode(value: string): Uint8Array {
+  if (!value || value[0] !== "u") {
+    throw new Error("proofValue is not multibase 'u' (base64url) encoded");
+  }
+  const body = value.slice(1).replace(/-/g, "+").replace(/_/g, "/");
+  const padded = body + "=".repeat((-body.length % 4 + 4) % 4);
+  return new Uint8Array(Buffer.from(padded, "base64"));
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+function chainOf(doc: Record<string, unknown>): Record<string, unknown> {
+  const sub = doc.credentialSubject;
+  if (sub !== null && typeof sub === "object" && !Array.isArray(sub)) {
+    const chain = (sub as Record<string, unknown>).chain;
+    return asRecord(chain);
+  }
+  return {};
+}
+
+export class AgentReceiptsAdapter extends FormatAdapter {
+  readonly name = "agentreceipts";
+
+  detect(doc: Record<string, unknown>): boolean {
+    const types = doc.type;
+    const proof = doc.proof;
+    if (!Array.isArray(types) || !types.includes("AgentReceipt")) return false;
+    return (
+      proof !== null &&
+      typeof proof === "object" &&
+      !Array.isArray(proof) &&
+      typeof (proof as Record<string, unknown>).proofValue === "string"
+    );
+  }
+
+  extractSignature(doc: Record<string, unknown>): SignatureMaterial {
+    const proof = asRecord(doc.proof);
+    let sig: Uint8Array;
+    try {
+      sig = multibaseUDecode((proof.proofValue as string) ?? "");
+    } catch {
+      sig = new Uint8Array(0);
+    }
+    return { sig, alg: "Ed25519", kid: (proof.verificationMethod as string) ?? "" };
+  }
+
+  resolveKey(
+    doc: Record<string, unknown>,
+    keyProvider: KeyProvider,
+  ): readonly [Uint8Array | null, string] {
+    const kid = (asRecord(doc.proof).verificationMethod as string) ?? "";
+    return resolveEd25519Key(kid, keyProvider);
+  }
+
+  signingInput(doc: Record<string, unknown>): Uint8Array {
+    // Strict-JCS bytes of the receipt minus proof, signed directly (no pre-hash).
+    return jcsRfc8785(signable(doc));
+  }
+
+  chainStep(doc: Record<string, unknown>): ChainStep {
+    const chain = chainOf(doc);
+    const present = "previous_receipt_hash" in chain;
+    const prev = chain.previous_receipt_hash;
+    const isGenesis = present && (prev === null || prev === undefined);
+    return {
+      prevField: (prev as string | null) ?? null,
+      isGenesis,
+      recompute: (pred) => SHA256_PREFIX + sha256Hex(jcsRfc8785(signable(pred))),
+    };
+  }
+
+  schema(doc: Record<string, unknown>): AxisCheck {
+    const required = [
+      "@context",
+      "id",
+      "type",
+      "version",
+      "issuer",
+      "issuanceDate",
+      "credentialSubject",
+      "proof",
+    ];
+    const missing = required.filter((f) => !(f in doc));
+    if (missing.length > 0) {
+      return ["FAIL", `missing required VC fields: ${missing.join(",")}`];
+    }
+    const types = doc.type;
+    if (!Array.isArray(types) || !types.includes("VerifiableCredential") || !types.includes("AgentReceipt")) {
+      return ["FAIL", "type must include VerifiableCredential and AgentReceipt"];
+    }
+    if (asRecord(doc.proof).type !== "Ed25519Signature2020") {
+      return ["FAIL", "proof.type must be Ed25519Signature2020"];
+    }
+    const issuer = doc.issuer;
+    const issuerDid =
+      issuer !== null && typeof issuer === "object" && !Array.isArray(issuer)
+        ? (issuer as Record<string, unknown>).id
+        : issuer;
+    const vmDid = ((asRecord(doc.proof).verificationMethod as string) ?? "").split("#")[0];
+    if (!vmDid || vmDid !== issuerDid) {
+      return ["FAIL", "proof.verificationMethod is not controlled by issuer (signing-key DID != issuer DID)"];
+    }
+    const chain = chainOf(doc);
+    if (!("previous_receipt_hash" in chain)) {
+      return ["FAIL", "chain.previous_receipt_hash must be present (null on genesis), never omitted"];
+    }
+    return ["PASS", "required VC fields present; type AgentReceipt; chain link well-formed"];
+  }
+}

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -1,0 +1,181 @@
+/**
+ * Asqav-native adapter - the existing verify_receipt logic behind the seam.
+ * A port of the Python oracle's `verifier/oracle/adapters/asqav_native.py`.
+ *
+ * Two real Asqav wire shapes route here, kept mutually exclusive at detection:
+ *
+ *   - COMPLIANCE mode: the `{payload, signature, anchors}` envelope whose
+ *     `payload` carries `previousReceiptHash` / `issuer_id`. The signature signs
+ *     the canonical bytes of `payload` DIRECTLY; the chain hash is SHA-256 of the
+ *     predecessor payload's canonical bytes.
+ *   - HASH mode: the default `/sign` output - a FLAT receipt with `mode:"hash"`,
+ *     `payload:null`, a `signature_b64` (or `signature`), and a `hash`. The
+ *     signing input is the flat 11-field object the cloud rebuilds.
+ *
+ * Canonicalisation goes through `asqavJcs`, byte-identical to the cloud's
+ * `verify_receipt.canonical_json`.
+ */
+
+import {
+  FormatAdapter,
+  type AxisCheck,
+  type ChainStep,
+  type KeyProvider,
+  type SignatureMaterial,
+} from "../adapter.js";
+import { asqavJcs } from "../canonical.js";
+import { sha256Hex } from "../crypto.js";
+import { isLowerHex } from "./acta.js";
+import {
+  FIRST_RECEIPT_SEED,
+  b64decode,
+  checkStructure,
+  normaliseEnvelope,
+  resolveKey,
+} from "../vrShim.js";
+
+/** Field set the cloud's hash-mode signer canonicalises (for the structure check). */
+const HASH_MODE_FIELDS = [
+  "v",
+  "mode",
+  "hash",
+  "hash_algo",
+  "metadata",
+  "server_timestamp",
+  "action_id",
+  "agent_id",
+  "org_id",
+  "policy_digest",
+  "policy_decision",
+] as const;
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+/** True for a flat hash-mode signature receipt (mode=hash, null payload, a sig). */
+function isHashMode(doc: Record<string, unknown>): boolean {
+  // Python: mode must be "hash" and payload must be None (null or absent).
+  if (doc.mode !== "hash" || (doc.payload !== null && doc.payload !== undefined)) {
+    return false;
+  }
+  return Boolean(doc.signature_b64 || doc.signature);
+}
+
+/** Normalise to the signed payload regardless of envelope nesting. */
+function payloadOf(doc: Record<string, unknown>): Record<string, unknown> {
+  const env = normaliseEnvelope(doc);
+  const p = env.payload;
+  return isRecord(p) ? p : env;
+}
+
+/** Decode signature material; empty on malformed input so verify FAILs, never crashes. */
+function safeB64(value: unknown): Uint8Array {
+  if (typeof value !== "string") return new Uint8Array(0);
+  try {
+    return b64decode(value);
+  } catch {
+    return new Uint8Array(0);
+  }
+}
+
+export class AsqavNativeAdapter extends FormatAdapter {
+  readonly name = "asqav-native";
+
+  detect(doc: Record<string, unknown>): boolean {
+    if (isHashMode(doc)) return true;
+    const sig = doc.signature;
+    // An ACTA receipt carries a lowercase-hex sig; decline it so the formats stay disjoint.
+    if (isRecord(sig) && isLowerHex(sig.sig)) return false;
+    const payload = doc.payload;
+    if (isRecord(payload) && "previousReceiptHash" in payload) return true;
+    // A bare payload (the conformance-vector shape) is also Asqav-native.
+    return "previousReceiptHash" in doc && "issuer_id" in doc;
+  }
+
+  extractSignature(doc: Record<string, unknown>): SignatureMaterial {
+    if (isHashMode(doc)) {
+      return {
+        sig: safeB64(doc.signature_b64 || doc.signature || ""),
+        alg: (doc.algorithm as string) ?? "ML-DSA-65",
+        kid: (doc.key_id as string) ?? "",
+      };
+    }
+    const env = normaliseEnvelope(doc);
+    let sigObj = env.signature;
+    if (typeof sigObj === "string") {
+      sigObj = { alg: "ML-DSA-65", kid: payloadOf(doc).issuer_id ?? "", sig: sigObj };
+    }
+    const so = isRecord(sigObj) ? sigObj : {};
+    return {
+      sig: safeB64(so.sig ?? ""),
+      alg: (so.alg as string) ?? "ML-DSA-65",
+      kid: (so.kid as string) ?? "",
+    };
+  }
+
+  resolveKey(
+    doc: Record<string, unknown>,
+    keyProvider: KeyProvider,
+  ): readonly [Uint8Array | null, string] {
+    const jwks = keyProvider ?? { keys: [] };
+    const kid = this.extractSignature(doc).kid;
+    const [pk, status] = resolveKey(jwks, kid);
+    if (pk === null) {
+      return [null, `kid '${kid}' not in jwks directory`];
+    }
+    return [pk, `resolved kid ${kid} (status=${status})`];
+  }
+
+  signingInput(doc: Record<string, unknown>): Uint8Array {
+    if (isHashMode(doc)) {
+      return this.hashModeSigningInput(doc);
+    }
+    // Asqav signs the canonical bytes of the payload directly, no pre-hash.
+    return asqavJcs(payloadOf(doc));
+  }
+
+  private hashModeSigningInput(doc: Record<string, unknown>): Uint8Array {
+    const flat = {
+      v: 1,
+      mode: "hash",
+      hash: doc.hash ?? null,
+      hash_algo: doc.hash_algo ?? "sha256",
+      metadata: doc.metadata ?? {},
+      server_timestamp: doc.server_timestamp ?? null,
+      action_id: doc.action_id ?? null,
+      agent_id: doc.agent_id ?? null,
+      org_id: doc.org_id ?? null,
+      policy_digest: doc.policy_digest ?? null,
+      policy_decision: doc.policy_decision ?? null,
+    };
+    return asqavJcs(flat);
+  }
+
+  chainStep(doc: Record<string, unknown>): ChainStep {
+    if (isHashMode(doc)) {
+      // A hash-mode signature receipt carries no in-band chain link of its own.
+      return { prevField: null, isGenesis: true, recompute: () => "" };
+    }
+    const prev = payloadOf(doc).previousReceiptHash;
+    const isGenesis = prev === FIRST_RECEIPT_SEED;
+    return {
+      prevField: (prev as string | null) ?? null,
+      isGenesis,
+      recompute: (pred) => sha256Hex(asqavJcs(payloadOf(pred))),
+    };
+  }
+
+  schema(doc: Record<string, unknown>): AxisCheck {
+    if (isHashMode(doc)) {
+      const missing = HASH_MODE_FIELDS.filter(
+        (f) => (doc[f] === undefined || doc[f] === null) && f !== "policy_digest",
+      );
+      if (missing.length > 0) {
+        return ["FAIL", `hash-mode receipt missing fields: ${missing.join(",")}`];
+      }
+      return ["PASS", "hash-mode signature receipt; required flat fields present"];
+    }
+    return checkStructure(payloadOf(doc));
+  }
+}

--- a/typescript/src/verifier/adapters/authproof.ts
+++ b/typescript/src/verifier/adapters/authproof.ts
@@ -1,0 +1,126 @@
+/**
+ * Authproof adapter - ES256 over insertion-order JSON, key embedded as a JWK.
+ * A port of the Python oracle's `verifier/oracle/adapters/authproof.py`.
+ *
+ * Authproof delegation receipts are signed by the reference JS SDK
+ * (`Commonguy25/authproof-sdk`, `src/authproof.js`), authoritative for the wire
+ * shape. A receipt is a flat object whose signature is ECDSA P-256 / SHA-256 over
+ * `JSON.stringify(receipt-without-signature)` in INSERTION order (not JCS, no
+ * pre-hash). The signature is hex-encoded raw r||s (64 bytes); the signer's public
+ * key is embedded as a P-256 JWK at `signerPublicKey`.
+ *
+ * In TypeScript the signing input is produced with native `JSON.stringify`, which
+ * is exactly what the JS SDK signs - byte-for-byte, no re-derivation.
+ */
+
+import {
+  FormatAdapter,
+  type AxisCheck,
+  type ChainStep,
+  type KeyProvider,
+  type SignatureMaterial,
+} from "../adapter.js";
+
+/** A shipping-SDK delegationId is `auth-<epoch_ms>-<5 base36 chars>`. */
+const DELEGATION_ID = /^auth-\d+-[a-z0-9]{5}$/;
+
+/** Fields the SDK always writes, used for the structural check. */
+const REQUIRED = [
+  "delegationId",
+  "issuedAt",
+  "scope",
+  "boundaries",
+  "timeWindow",
+  "operatorInstructions",
+  "instructionsHash",
+  "signerPublicKey",
+  "signature",
+] as const;
+
+function safeHex(value: unknown): Uint8Array {
+  if (typeof value !== "string") return new Uint8Array(0);
+  if (value.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(value)) return new Uint8Array(0);
+  const out = new Uint8Array(value.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(value.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+function b64url(value: unknown): Uint8Array {
+  if (typeof value !== "string") return new Uint8Array(0);
+  try {
+    const s = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = s + "=".repeat((-s.length % 4 + 4) % 4);
+    return new Uint8Array(Buffer.from(padded, "base64"));
+  } catch {
+    return new Uint8Array(0);
+  }
+}
+
+function isP256Jwk(jwk: unknown): jwk is Record<string, unknown> {
+  return (
+    jwk !== null &&
+    typeof jwk === "object" &&
+    !Array.isArray(jwk) &&
+    (jwk as Record<string, unknown>).kty === "EC" &&
+    (jwk as Record<string, unknown>).crv === "P-256"
+  );
+}
+
+export class AuthproofAdapter extends FormatAdapter {
+  readonly name = "authproof";
+
+  detect(doc: Record<string, unknown>): boolean {
+    const did = doc.delegationId;
+    return (
+      typeof did === "string" &&
+      DELEGATION_ID.test(did) &&
+      "operatorInstructions" in doc &&
+      "instructionsHash" in doc &&
+      isP256Jwk(doc.signerPublicKey) &&
+      typeof doc.signature === "string"
+    );
+  }
+
+  extractSignature(doc: Record<string, unknown>): SignatureMaterial {
+    return { sig: safeHex(doc.signature), alg: "ES256", kid: "" };
+  }
+
+  resolveKey(doc: Record<string, unknown>): readonly [Uint8Array | null, string] {
+    const jwk = doc.signerPublicKey;
+    if (!isP256Jwk(jwk)) {
+      return [null, "signerPublicKey is not a P-256 JWK"];
+    }
+    const x = b64url(jwk.x);
+    const y = b64url(jwk.y);
+    if (x.length !== 32 || y.length !== 32) {
+      return [null, "P-256 JWK coordinates are not 32 bytes each"];
+    }
+    const point = new Uint8Array(65);
+    point[0] = 0x04;
+    point.set(x, 1);
+    point.set(y, 33);
+    return [point, "resolved embedded P-256 JWK"];
+  }
+
+  signingInput(doc: Record<string, unknown>): Uint8Array {
+    // The SDK signs JSON.stringify of the receipt minus `signature`, key order intact.
+    const body: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(doc)) {
+      if (k !== "signature") body[k] = v;
+    }
+    return new TextEncoder().encode(JSON.stringify(body));
+  }
+
+  chainStep(): ChainStep {
+    // The base Authproof receipt carries no in-band chain link of its own.
+    return { prevField: null, isGenesis: true, recompute: () => "" };
+  }
+
+  schema(doc: Record<string, unknown>): AxisCheck {
+    const missing = REQUIRED.filter((f) => doc[f] === undefined || doc[f] === null);
+    if (missing.length > 0) {
+      return ["FAIL", `authproof receipt missing fields: ${missing.join(",")}`];
+    }
+    return ["PASS", "authproof delegation receipt; required fields present"];
+  }
+}

--- a/typescript/src/verifier/canonical.ts
+++ b/typescript/src/verifier/canonical.ts
@@ -1,0 +1,355 @@
+/**
+ * Canonicalization shared across format adapters - a byte-for-byte port of the
+ * Python oracle's `verifier/oracle/canonical.py`.
+ *
+ * Three callable shapes, because three signers disagree on what "JCS" means:
+ *
+ *   - `jcs(obj)`          : NFC-normalised, code-POINT key ordering (Python
+ *                           `sort_keys`), numbers preserved as Python emits them.
+ *                           Matches the AERF / ACTA reference producers.
+ *   - `jcsRfc8785(obj)`   : strict RFC 8785 - UTF-16 code-UNIT key ordering and
+ *                           ECMAScript Number.prototype.toString number output,
+ *                           plus NFC. Byte-matches the agent-receipts upstream
+ *                           canonicalization vectors.
+ *   - `asqavJcs(obj)`     : the Asqav cloud's historical JCS WITHOUT NFC, kept
+ *                           byte-identical to `verify_receipt.canonical_json`.
+ *
+ * Implementation parity notes vs the Python source:
+ *   - Python `sort_keys` sorts by Unicode CODE POINT; JavaScript's default
+ *     `Array.prototype.sort` on strings sorts by UTF-16 CODE UNIT. These differ
+ *     only on supplementary-plane keys. `jcs`/`asqavJcs` therefore sort by code
+ *     point (mirroring Python); `jcsRfc8785` sorts by code unit (RFC 8785).
+ *   - V8's `Number.prototype.toString` already produces the ECMAScript shortest
+ *     round-trip form RFC 8785 mandates; verified byte-equal against the upstream
+ *     number vectors (1e-7, 1e+21, 0.30000000000000004, ...).
+ *   - Python `json.dumps(ensure_ascii=False)` short-escapes \b \t \n \f \r,
+ *     emits other control chars < 0x20 as \u00xx, and passes everything >= 0x20
+ *     (including 0x7f and all non-ASCII) verbatim. `jsonString` reproduces this.
+ *   - Python `json.dumps(allow_nan=False)` rejects NaN/Infinity; we throw too.
+ *   - `jcs`/`asqavJcs` keep numbers as Python emits them. For the integer field
+ *     sets these receipts carry, Python `repr` and V8 `toString` agree; floats
+ *     are out of the Asqav/AERF/ACTA signed scope, so this is exact for the corpus.
+ */
+
+type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * A JSON number that was written as a FLOAT literal (had a `.`, `e`, or `E`).
+ *
+ * JavaScript's `JSON.parse` collapses `500.0` to the integer `500` because
+ * IEEE-754 has no int/float distinction, so the trailing `.0` is lost. Python's
+ * `json.load` keeps it as a `float` and `json.dumps` re-emits `500.0`. The
+ * AERF / ACTA / Asqav `jcs` dialects sign numbers "as the producer emitted them",
+ * so a receipt carrying `500.0` is signed over the bytes `500.0`, not `500`.
+ *
+ * To reproduce those exact bytes, parse receipts with `parseJsonPreservingFloats`
+ * (below), which wraps float literals in this class; the canonicalisers then
+ * re-emit the float form. Integer literals are left as plain `number`.
+ *
+ * Parity scope: the corpus floats are whole-magnitude (`500.0`, `1250.0`), where
+ * Python repr, the AERF Go producer, and this emitter all agree on `<int>.0`.
+ * Exotic floats (e.g. `1e-7` vs Python's `1e-07`) do not occur in any signed
+ * receipt; were they to, the AERF Go producer - not Python repr - is the target.
+ */
+export class RawFloat {
+  constructor(public readonly value: number) {}
+}
+
+function isRawFloat(v: unknown): v is RawFloat {
+  return v instanceof RawFloat;
+}
+
+/**
+ * An integer literal beyond IEEE-754 safe range (|n| > 2^53). JS `JSON.parse`
+ * collapses it to the nearest double, so two distinct integers can read as one
+ * and a tampered receipt could verify. Keeping the exact source digits lets the
+ * Python-dialect canonicalisers emit them verbatim (matching Python's
+ * arbitrary-precision int), closing that false-PASS path.
+ */
+export class RawBigInt {
+  constructor(public readonly source: string) {}
+}
+
+function isRawBigInt(v: unknown): v is RawBigInt {
+  return v instanceof RawBigInt;
+}
+
+/** ECMAScript-shortest decimal of a float, forced to carry a `.0` when whole. */
+function floatToString(n: number): string {
+  if (!Number.isFinite(n)) {
+    throw new Error(`non-finite number not allowed in JCS: ${n}`);
+  }
+  let s = n.toString();
+  // A whole-valued float must keep its decimal point (Python repr(500.0)=="500.0").
+  if (!/[.eE]/.test(s)) s += ".0";
+  return s;
+}
+
+/**
+ * Parse JSON while preserving float literals as `RawFloat` and out-of-safe-range
+ * integers as `RawBigInt`, so the canonicalisers re-emit `500.0` rather than the
+ * collapsed `500` and never let two distinct big integers share one signature.
+ * Mirrors what Python's `json.load` preserves implicitly.
+ *
+ * Hand-rolled recursive descent rather than a `JSON.parse` reviver: the reviver's
+ * raw-literal `context.source` is only available on Node 21.1+, and this package
+ * supports Node 18+. The grammar is RFC 8259 JSON; it is not a lenient parser.
+ */
+export function parseJsonPreservingFloats(text: string): unknown {
+  let i = 0;
+  const ws = () => {
+    while (i < text.length && (text[i] === " " || text[i] === "\t" || text[i] === "\n" || text[i] === "\r")) i++;
+  };
+  const err = (m: string): never => {
+    throw new SyntaxError(`${m} at position ${i}`);
+  };
+  let depth = 0;
+  const value = (): unknown => {
+    ws();
+    const c = text[i];
+    if (c === "{" || c === "[") {
+      if (++depth > 1000) err("maximum nesting depth exceeded");
+      const v = c === "{" ? object() : array();
+      depth--;
+      return v;
+    }
+    if (c === '"') return str();
+    if (c === "-" || (c >= "0" && c <= "9")) return num();
+    if (text.startsWith("true", i)) return (i += 4), true;
+    if (text.startsWith("false", i)) return (i += 5), false;
+    if (text.startsWith("null", i)) return (i += 4), null;
+    return err(`unexpected token ${c ?? "EOF"}`);
+  };
+  const object = (): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+    i++; // {
+    ws();
+    if (text[i] === "}") return i++, out;
+    for (;;) {
+      ws();
+      if (text[i] !== '"') err("expected object key");
+      const k = str();
+      ws();
+      if (text[i++] !== ":") err("expected ':'");
+      out[k] = value();
+      ws();
+      const ch = text[i++];
+      if (ch === "}") return out;
+      if (ch !== ",") err("expected ',' or '}'");
+    }
+  };
+  const array = (): unknown[] => {
+    const out: unknown[] = [];
+    i++; // [
+    ws();
+    if (text[i] === "]") return i++, out;
+    for (;;) {
+      out.push(value());
+      ws();
+      const ch = text[i++];
+      if (ch === "]") return out;
+      if (ch !== ",") err("expected ',' or ']'");
+    }
+  };
+  const str = (): string => {
+    const start = i;
+    i++; // opening quote
+    while (i < text.length) {
+      const c = text[i];
+      if (c === '"') {
+        i++;
+        return JSON.parse(text.slice(start, i)) as string; // reuse the engine for escape handling
+      }
+      if (c === "\\") i += 2;
+      else i++;
+    }
+    return err("unterminated string");
+  };
+  const digit = (): boolean => text[i] >= "0" && text[i] <= "9";
+  const digits = (): void => {
+    while (i < text.length && digit()) i++;
+  };
+  const num = (): RawFloat | RawBigInt | number => {
+    // Strict RFC 8259 number grammar, matching Python json.loads (no leading zero,
+    // a digit required after '.' and after the exponent marker, no bare '-').
+    const start = i;
+    if (text[i] === "-") i++;
+    if (text[i] === "0") i++;
+    else if (text[i] >= "1" && text[i] <= "9") {
+      i++;
+      digits();
+    } else err("invalid number");
+    let isFloat = false;
+    if (text[i] === ".") {
+      isFloat = true;
+      i++;
+      if (!digit()) err("digit expected after decimal point");
+      digits();
+    }
+    if (text[i] === "e" || text[i] === "E") {
+      isFloat = true;
+      i++;
+      if (text[i] === "+" || text[i] === "-") i++;
+      if (!digit()) err("digit expected in exponent");
+      digits();
+    }
+    const lexeme = text.slice(start, i);
+    const parsed = Number(lexeme);
+    if (isFloat) return new RawFloat(parsed);
+    if (!Number.isSafeInteger(parsed)) return new RawBigInt(lexeme);
+    return parsed;
+  };
+  const result = value();
+  ws();
+  if (i !== text.length) err("trailing content after JSON value");
+  return result;
+}
+
+/** Recursively NFC-normalise every string key and value (mirrors `_nfc`). */
+function nfc(obj: unknown): unknown {
+  if (typeof obj === "string") return obj.normalize("NFC");
+  if (isRawFloat(obj) || isRawBigInt(obj)) return obj;
+  if (Array.isArray(obj)) return obj.map(nfc);
+  if (obj !== null && typeof obj === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+      out[(k as string).normalize("NFC")] = nfc(v);
+    }
+    return out;
+  }
+  return obj;
+}
+
+/**
+ * Compare two strings by Unicode CODE POINT (Python `sort_keys` ordering).
+ *
+ * JavaScript string `<` compares by UTF-16 code unit, which differs from code
+ * point on supplementary-plane characters. Iterating with `for...of` yields code
+ * points, so we compare those directly.
+ */
+function compareCodePoints(a: string, b: string): number {
+  const ai = a[Symbol.iterator]();
+  const bi = b[Symbol.iterator]();
+  for (;;) {
+    const an = ai.next();
+    const bn = bi.next();
+    if (an.done && bn.done) return 0;
+    if (an.done) return -1;
+    if (bn.done) return 1;
+    const ac = an.value.codePointAt(0)!;
+    const bc = bn.value.codePointAt(0)!;
+    if (ac !== bc) return ac < bc ? -1 : 1;
+  }
+}
+
+/**
+ * Standard JSON string serialization matching Python `json.dumps(ensure_ascii=False)`.
+ *
+ * Short-escapes \b \t \n \f \r, emits other control chars < 0x20 as \u00xx, and
+ * passes everything else (including 0x7f and all non-ASCII) verbatim. Note `/` is
+ * NOT escaped, matching Python.
+ */
+function jsonString(s: string): string {
+  let out = '"';
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    const ch = s[i];
+    if (ch === '"') {
+      out += '\\"';
+    } else if (ch === "\\") {
+      out += "\\\\";
+    } else if (code === 0x08) {
+      out += "\\b";
+    } else if (code === 0x09) {
+      out += "\\t";
+    } else if (code === 0x0a) {
+      out += "\\n";
+    } else if (code === 0x0c) {
+      out += "\\f";
+    } else if (code === 0x0d) {
+      out += "\\r";
+    } else if (code < 0x20) {
+      out += "\\u" + code.toString(16).padStart(4, "0");
+    } else {
+      out += ch;
+    }
+  }
+  out += '"';
+  return out;
+}
+
+/** ECMAScript Number.prototype.toString form (RFC 8785 number rule). */
+function numberToString(n: number): string {
+  if (!Number.isFinite(n)) {
+    throw new Error(`non-finite number not allowed in JCS: ${n}`);
+  }
+  // Map -0 to "0", as both Python json.dumps and ECMAScript do for the corpus.
+  if (n === 0) return "0";
+  // V8's Number.toString is already the ECMAScript shortest round-trip form,
+  // which is exactly the RFC 8785 number serialisation (verified byte-equal).
+  return n.toString();
+}
+
+/**
+ * Serialise with a chosen key-comparison function.
+ *
+ * `honorFloat` selects the number dialect for `RawFloat` tokens:
+ *   - true  (jcs / asqavJcs, the Python-`json.dumps` dialect): emit the float
+ *     form, e.g. `500.0` (Python `repr(500.0)`).
+ *   - false (jcsRfc8785, strict ECMAScript): collapse a whole-valued float to its
+ *     integer form `500`, matching Python `_number_8785`'s `str(int(value))`.
+ */
+function serialize(
+  value: unknown,
+  keyCompare: (a: string, b: string) => number,
+  honorFloat: boolean,
+): string {
+  if (value === null) return "null";
+  if (value === true) return "true";
+  if (value === false) return "false";
+  if (isRawFloat(value)) return honorFloat ? floatToString(value.value) : numberToString(value.value);
+  // A >2^53 integer: emit the exact source digits in every dialect, matching Python's
+  // `str(int)` (json.dumps and _number_8785 alike). Distinct integers stay distinct, so
+  // a tampered big-int can never collide onto another's bytes and verify.
+  if (isRawBigInt(value)) return value.source;
+  if (typeof value === "number") return numberToString(value);
+  if (typeof value === "string") return jsonString(value);
+  if (Array.isArray(value)) {
+    return "[" + value.map((v) => serialize(v, keyCompare, honorFloat)).join(",") + "]";
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort(keyCompare);
+    const parts: string[] = [];
+    for (const k of keys) {
+      parts.push(jsonString(k) + ":" + serialize(obj[k], keyCompare, honorFloat));
+    }
+    return "{" + parts.join(",") + "}";
+  }
+  throw new TypeError(`unserialisable type in JCS input: ${typeof value}`);
+}
+
+const utf16CompareKeys = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+
+/** AERF/ACTA-dialect JCS: NFC, code-point key sort, numbers as the producer emits them. */
+export function jcs(obj: unknown): Uint8Array {
+  return new TextEncoder().encode(serialize(nfc(obj), compareCodePoints, true));
+}
+
+/** Asqav cloud JCS bytes (no NFC); byte-identical to the cloud signer. */
+export function asqavJcs(obj: unknown): Uint8Array {
+  return new TextEncoder().encode(serialize(obj, compareCodePoints, true));
+}
+
+/** Strict RFC 8785 JCS bytes (UTF-16 code-unit key sort, ECMAScript numbers) with NFC. */
+export function jcsRfc8785(obj: unknown): Uint8Array {
+  return new TextEncoder().encode(serialize(nfc(obj), utf16CompareKeys, false));
+}
+
+export type { JsonValue };

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -1,0 +1,127 @@
+/**
+ * The shared verification core - format detection, dispatch, and the verdict.
+ * A port of the Python oracle's `verifier/oracle/core.py`.
+ *
+ * `verify(doc, ...)` detects the format, then drives the adapter through the
+ * shared axes: structure, signature, chain. It proves only what the bytes prove -
+ * a valid signature over the canonical bytes, a reproducible chain link, and
+ * structural presence at time T. It never attests the behaviour or correctness of
+ * the recorded action.
+ */
+
+import type { FormatAdapter, KeyProvider } from "./adapter.js";
+import { FAIL, PASS, SKIPPED, verifySignature, type VerifyState } from "./crypto.js";
+
+/** One verification axis outcome. */
+export interface AxisResult {
+  /** Which check (structure / signature / chain / extra). */
+  axis: string;
+  /** PASS / FAIL / SKIPPED. */
+  result: VerifyState;
+  /** Human-readable detail for the report. */
+  note: string;
+}
+
+export type Verdict = "PASS" | "FAIL" | "INCOMPLETE";
+
+/** The aggregate outcome of verifying one receipt. */
+export interface VerifyResult {
+  /** The matched adapter name, or "unknown". */
+  fmt: string;
+  axes: AxisResult[];
+  /**
+   * PASS only when every non-skipped axis passed AND the signature was actually
+   * checked; a skipped signature downgrades to INCOMPLETE, never a PASS.
+   */
+  verdict: Verdict;
+}
+
+/** Return the first adapter whose structural fingerprint matches `doc`. */
+export function detect(
+  doc: Record<string, unknown>,
+  adapters: FormatAdapter[],
+): FormatAdapter | null {
+  return adapters.find((a) => a.detect(doc)) ?? null;
+}
+
+function signatureAxis(
+  ad: FormatAdapter,
+  doc: Record<string, unknown>,
+  keyProvider: KeyProvider,
+): AxisResult {
+  const sm = ad.extractSignature(doc);
+  const [pk, note] = ad.resolveKey(doc, keyProvider);
+  if (pk === null) {
+    return { axis: "signature", result: SKIPPED, note: `no key: ${note}` };
+  }
+  const msg = ad.signingInput(doc);
+  const { result, note: why } = verifySignature(sm.alg, pk, msg, sm.sig);
+  return { axis: "signature", result, note: why };
+}
+
+function chainAxis(
+  ad: FormatAdapter,
+  doc: Record<string, unknown>,
+  adapters: FormatAdapter[],
+  predecessor: Record<string, unknown> | null,
+): AxisResult {
+  const step = ad.chainStep(doc);
+  if (step.isGenesis) {
+    return { axis: "chain", result: PASS, note: "genesis receipt (no predecessor link)" };
+  }
+  if (predecessor === null) {
+    return { axis: "chain", result: SKIPPED, note: "no predecessor supplied" };
+  }
+  // A chain link must stay within one format; a cross-format predecessor is not a valid link.
+  const predAd = detect(predecessor, adapters);
+  if (predAd === null || predAd.name !== ad.name) {
+    return { axis: "chain", result: FAIL, note: "predecessor is a different receipt format" };
+  }
+  const actual = step.recompute(predecessor);
+  if (actual === step.prevField) {
+    return { axis: "chain", result: PASS, note: "chain link rederives from predecessor" };
+  }
+  const exp = String(step.prevField).slice(0, 16);
+  return { axis: "chain", result: FAIL, note: `chain break: expected ${exp}.. got ${actual.slice(0, 16)}..` };
+}
+
+/** Verify one parsed receipt and return a structured `VerifyResult`. */
+export function verify(
+  doc: Record<string, unknown>,
+  adapters: FormatAdapter[],
+  keyProvider: KeyProvider = null,
+  predecessor: Record<string, unknown> | null = null,
+): VerifyResult {
+  const ad = detect(doc, adapters);
+  if (ad === null) {
+    return {
+      fmt: "unknown",
+      axes: [{ axis: "structure", result: FAIL, note: "no adapter recognises this receipt" }],
+      verdict: "FAIL",
+    };
+  }
+
+  const [structResult, structNote] = ad.schema(doc);
+  const axes: AxisResult[] = [
+    { axis: "structure", result: structResult, note: structNote },
+    signatureAxis(ad, doc, keyProvider),
+    chainAxis(ad, doc, adapters, predecessor),
+  ];
+  for (const [name, res, note] of ad.extraAxes(doc, keyProvider)) {
+    axes.push({ axis: name, result: res, note });
+  }
+
+  const hasFail = axes.some((a) => a.result === FAIL);
+  // Any skipped axis except a missing-predecessor chain blocks PASS: an unchecked
+  // signature / counter-sign / PDP layer means INCOMPLETE, never a hiding PASS.
+  const blockingSkip = axes.some((a) => a.result === SKIPPED && a.axis !== "chain");
+  let verdict: Verdict;
+  if (hasFail) {
+    verdict = "FAIL";
+  } else if (blockingSkip) {
+    verdict = "INCOMPLETE";
+  } else {
+    verdict = "PASS";
+  }
+  return { fmt: ad.name, axes, verdict };
+}

--- a/typescript/src/verifier/crypto.ts
+++ b/typescript/src/verifier/crypto.ts
@@ -1,0 +1,132 @@
+/**
+ * Signature-verify dispatch shared across format adapters - a port of the Python
+ * oracle's `verifier/oracle/crypto.py`.
+ *
+ * One entry point, `verifySignature(alg, pk, msg, sig)`, returns a 3-state
+ * `{result, note}` where result is `PASS` / `FAIL` / `SKIPPED`, so the oracle
+ * never prints a PASS for a signature it could not actually check.
+ *
+ * Algorithm wiring:
+ *   - `Ed25519` / `EdDSA` : `node:crypto.verify` over a raw 32-byte public key.
+ *   - `ES256`             : ECDSA P-256 / SHA-256 over a 65-byte uncompressed
+ *                           point; signature is the 64-byte raw r||s form
+ *                           (ieee-p1363), which `node:crypto` verifies directly.
+ *   - `ML-DSA-65`         : SKIPPED. Node has no ML-DSA, so the verifier reports
+ *                           it cannot check the post-quantum path - never a
+ *                           false PASS, never a FAIL (mirrors the Python oracle
+ *                           without dilithium-py).
+ *
+ * Malformed key or signature bytes -> FAIL, never throw.
+ */
+
+import { createPublicKey, verify } from "node:crypto";
+
+export const PASS = "PASS";
+export const FAIL = "FAIL";
+export const SKIPPED = "SKIPPED";
+
+export type VerifyState = "PASS" | "FAIL" | "SKIPPED";
+
+export interface VerifyOutcome {
+  result: VerifyState;
+  note: string;
+}
+
+const SPKI_ED25519_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** ML-DSA-65: Node has no implementation, so SKIP - never a false PASS. */
+function verifyMlDsa65(): VerifyOutcome {
+  return {
+    result: SKIPPED,
+    note: "ML-DSA-65 not available in node:crypto; signature axis skipped",
+  };
+}
+
+/** Ed25519 verify over a raw 32-byte public key (RFC 8032). */
+function verifyEd25519(pk: Uint8Array, msg: Uint8Array, sig: Uint8Array): VerifyOutcome {
+  let key;
+  try {
+    if (pk.length !== 32) {
+      return { result: FAIL, note: `bad Ed25519 public key: expected 32 bytes, got ${pk.length}` };
+    }
+    const spki = Buffer.concat([SPKI_ED25519_PREFIX, Buffer.from(pk)]);
+    key = createPublicKey({ key: spki, format: "der", type: "spki" });
+  } catch (exc) {
+    return { result: FAIL, note: `bad Ed25519 public key: ${(exc as Error).message}` };
+  }
+  try {
+    const ok = verify(null, Buffer.from(msg), key, Buffer.from(sig));
+    return ok
+      ? { result: PASS, note: "signature valid" }
+      : { result: FAIL, note: "signature mismatch" };
+  } catch (exc) {
+    return { result: FAIL, note: `verify error: ${(exc as Error).message}` };
+  }
+}
+
+/**
+ * ES256 (ECDSA P-256 over SHA-256) verify.
+ *
+ * The public key is the 65-byte uncompressed point (0x04 || X || Y). The
+ * signature is the 64-byte raw r||s (ieee-p1363) form WebCrypto / JOSE emit,
+ * which `node:crypto.verify` accepts with `dsaEncoding: "ieee-p1363"`.
+ */
+function verifyEs256(pk: Uint8Array, msg: Uint8Array, sig: Uint8Array): VerifyOutcome {
+  let key;
+  try {
+    if (pk.length !== 65 || pk[0] !== 0x04) {
+      return { result: FAIL, note: `bad P-256 public key: expected 65-byte uncompressed point, got ${pk.length}` };
+    }
+    const x = base64url(Buffer.from(pk.slice(1, 33)));
+    const y = base64url(Buffer.from(pk.slice(33, 65)));
+    key = createPublicKey({ key: { kty: "EC", crv: "P-256", x, y }, format: "jwk" });
+  } catch (exc) {
+    return { result: FAIL, note: `bad P-256 public key: ${(exc as Error).message}` };
+  }
+  if (sig.length !== 64) {
+    return { result: FAIL, note: `ES256 signature must be 64-byte raw r||s, got ${sig.length}` };
+  }
+  try {
+    const ok = verify("sha256", Buffer.from(msg), { key, dsaEncoding: "ieee-p1363" }, Buffer.from(sig));
+    return ok
+      ? { result: PASS, note: "signature valid" }
+      : { result: FAIL, note: "signature mismatch" };
+  } catch (exc) {
+    return { result: FAIL, note: `verify error: ${(exc as Error).message}` };
+  }
+}
+
+type Verifier = (pk: Uint8Array, msg: Uint8Array, sig: Uint8Array) => VerifyOutcome;
+
+const DISPATCH: Record<string, Verifier> = {
+  "ML-DSA-65": verifyMlDsa65,
+  ED25519: verifyEd25519,
+  EDDSA: verifyEd25519,
+  ES256: verifyEs256,
+};
+
+/** Dispatch to the algorithm's verifier; SKIP an unsupported alg. */
+export function verifySignature(
+  alg: string,
+  pk: Uint8Array,
+  msg: Uint8Array,
+  sig: Uint8Array,
+): VerifyOutcome {
+  const fn = DISPATCH[(alg || "").toUpperCase()];
+  if (fn === undefined) {
+    const known = Object.keys(DISPATCH).sort().join(", ");
+    return { result: SKIPPED, note: `unsupported alg '${alg}' (oracle checks ${known})` };
+  }
+  return fn(pk, msg, sig);
+}
+
+import { createHash } from "node:crypto";
+
+/** Lowercase hex SHA-256 - the chain primitive every format shares. */
+export function sha256Hex(data: Uint8Array): string {
+  return createHash("sha256").update(Buffer.from(data)).digest("hex");
+}

--- a/typescript/src/verifier/did.ts
+++ b/typescript/src/verifier/did.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared DID resolver - map a verificationMethod DID URL to a raw Ed25519 key.
+ * A port of the Python oracle's `verifier/oracle/did.py`.
+ *
+ * `resolveEd25519Key(didUrl, injected)` returns the raw 32-byte Ed25519 public
+ * key for a signer, or null when it cannot resolve without a network the oracle
+ * is forbidden from touching.
+ *
+ *   - `did:key`  : self-contained. The multibase `z` (base58btc) identifier
+ *                  decodes to a multicodec frame: the two-byte 0xed 0x01 Ed25519
+ *                  prefix followed by the 32 raw key bytes. No network.
+ *   - other      : resolved from an injected `{didOrKid: hexOrRaw}` map. The
+ *                  oracle NEVER fetches a DID document over the network.
+ */
+
+/** Bitcoin base58 alphabet - the base58btc encoding multibase 'z' uses. */
+const B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const B58_INDEX: Record<string, number> = {};
+for (let i = 0; i < B58_ALPHABET.length; i++) B58_INDEX[B58_ALPHABET[i]] = i;
+
+/** Multicodec prefix for an Ed25519 public key (unsigned-varint 0xed01). */
+const ED25519_MULTICODEC = Uint8Array.from([0xed, 0x01]);
+
+/** Decode a base58btc string to bytes, preserving leading-zero bytes as '1's. */
+export function b58btcDecode(text: string): Uint8Array {
+  let num = 0n;
+  for (const ch of text) {
+    const idx = B58_INDEX[ch];
+    if (idx === undefined) throw new Error(`invalid base58btc character: '${ch}'`);
+    num = num * 58n + BigInt(idx);
+  }
+  const bodyBytes: number[] = [];
+  while (num > 0n) {
+    bodyBytes.unshift(Number(num & 0xffn));
+    num >>= 8n;
+  }
+  let pad = 0;
+  for (const ch of text) {
+    if (ch === "1") pad++;
+    else break;
+  }
+  return Uint8Array.from([...new Array(pad).fill(0), ...bodyBytes]);
+}
+
+function startsWith(buf: Uint8Array, prefix: Uint8Array): boolean {
+  if (buf.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (buf[i] !== prefix[i]) return false;
+  }
+  return true;
+}
+
+/** Return the raw 32-byte Ed25519 key from a `did:key` 'z...' identifier, or null. */
+function decodeDidKey(identifier: string): Uint8Array | null {
+  if (!identifier.startsWith("z")) return null;
+  let decoded: Uint8Array;
+  try {
+    decoded = b58btcDecode(identifier.slice(1));
+  } catch {
+    return null;
+  }
+  if (!startsWith(decoded, ED25519_MULTICODEC)) return null;
+  const key = decoded.slice(ED25519_MULTICODEC.length);
+  return key.length === 32 ? key : null;
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0) return null;
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const byte = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) return null;
+    out[i] = byte;
+  }
+  return out;
+}
+
+/** Coerce injected key material (raw bytes or hex string) to raw 32-byte form. */
+function coerceRaw(material: unknown): Uint8Array | null {
+  let raw: Uint8Array | null;
+  if (material instanceof Uint8Array) {
+    raw = material;
+  } else if (typeof material === "string") {
+    raw = hexToBytes(material);
+  } else {
+    return null;
+  }
+  return raw !== null && raw.length === 32 ? raw : null;
+}
+
+/**
+ * Resolve a verificationMethod DID URL to `[rawKeyOrNull, note]`.
+ *
+ * did:key resolves inline; every other method resolves from `injected` keyed by
+ * the full DID URL first, then by the bare DID (fragment stripped). No network.
+ */
+export function resolveEd25519Key(
+  didUrl: string,
+  injected: Record<string, unknown> | null = null,
+): readonly [Uint8Array | null, string] {
+  if (typeof didUrl !== "string" || !didUrl.startsWith("did:")) {
+    return [null, `not a DID URL: '${didUrl}'`];
+  }
+  const bare = didUrl.split("#", 1)[0];
+  if (bare.startsWith("did:key:")) {
+    const key = decodeDidKey(bare.slice("did:key:".length));
+    if (key === null) {
+      return [null, "did:key identifier is not a base58btc Ed25519 multikey"];
+    }
+    return [key, "resolved did:key inline (multicodec ed25519)"];
+  }
+  const keys = injected || {};
+  for (const candidate of [didUrl, bare]) {
+    if (Object.prototype.hasOwnProperty.call(keys, candidate)) {
+      const raw = coerceRaw(keys[candidate]);
+      if (raw === null) {
+        return [null, `injected key for '${candidate}' is not a 32-byte Ed25519 key`];
+      }
+      return [raw, `resolved ${candidate} from injected map`];
+    }
+  }
+  return [null, `no injected key for '${didUrl}' (oracle never fetches a DID document)`];
+}

--- a/typescript/src/verifier/index.ts
+++ b/typescript/src/verifier/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Universal neutral verifier (TypeScript) - verify agent receipts across formats.
+ * A port of the Python oracle at `verifier/oracle/`, to parity with the proven
+ * Python verifier.
+ *
+ * It proves only what a verifier can prove from the bytes: a valid signature over
+ * the canonical bytes, a reproducible hash-chain link, and structural presence at
+ * time T. It never attests behaviour or correctness of the recorded action.
+ *
+ * Public surface:
+ *   - `FormatAdapter` : the 6-method per-format seam.
+ *   - `ADAPTERS`      : ordered registry the dispatcher walks for detection.
+ *   - `verify`        : verify one parsed receipt; returns a `VerifyResult`.
+ *   - canonicalisers, crypto, and the conformance runner.
+ */
+
+import { FormatAdapter } from "./adapter.js";
+import { ActaAdapter } from "./adapters/acta.js";
+import { AerfAdapter } from "./adapters/aerf.js";
+import { AgentReceiptsAdapter } from "./adapters/agentreceipts.js";
+import { AsqavNativeAdapter } from "./adapters/asqavNative.js";
+import { AuthproofAdapter } from "./adapters/authproof.js";
+
+/** Detection fingerprints are mutually exclusive, so registration order is not load-bearing. */
+export const ADAPTERS: FormatAdapter[] = [
+  new AsqavNativeAdapter(),
+  new AerfAdapter(),
+  new ActaAdapter(),
+  new AgentReceiptsAdapter(),
+  new AuthproofAdapter(),
+];
+
+export { FormatAdapter } from "./adapter.js";
+export type {
+  AxisCheck,
+  ChainStep,
+  ExtraAxis,
+  KeyProvider,
+  SignatureMaterial,
+} from "./adapter.js";
+export { ActaAdapter } from "./adapters/acta.js";
+export { AerfAdapter } from "./adapters/aerf.js";
+export { AgentReceiptsAdapter } from "./adapters/agentreceipts.js";
+export { AsqavNativeAdapter } from "./adapters/asqavNative.js";
+export { AuthproofAdapter } from "./adapters/authproof.js";
+export { detect, verify } from "./core.js";
+export type { AxisResult, Verdict, VerifyResult } from "./core.js";
+export { asqavJcs, jcs, jcsRfc8785, parseJsonPreservingFloats, RawFloat } from "./canonical.js";
+export {
+  FAIL,
+  PASS,
+  SKIPPED,
+  sha256Hex,
+  verifySignature,
+  type VerifyOutcome,
+  type VerifyState,
+} from "./crypto.js";
+export { resolveEd25519Key } from "./did.js";
+export {
+  runCorpus,
+  runOne,
+  type VectorOutcome,
+} from "./runner.js";

--- a/typescript/src/verifier/parity-check.ts
+++ b/typescript/src/verifier/parity-check.ts
@@ -1,0 +1,55 @@
+/**
+ * Reproducible equivalence gate - run ALL corpus vectors through the TS verifier
+ * and compare each verdict to the EXPECTED manifest outcome, exactly as the Python
+ * `runner.main()` does. ML-DSA vectors are tolerated as INCOMPLETE->PASS only for
+ * reason_code `signature_skipped_no_dilithium` (Node has no ML-DSA, matching the
+ * Python verifier without dilithium-py).
+ *
+ * Run directly:  node --import tsx typescript/src/verifier/parity-check.ts
+ * or via the test `tests/verifier-parity.test.ts`, which asserts 41/41.
+ */
+
+import { resolve } from "node:path";
+
+import { runCorpus, tolerated, type VectorOutcome } from "./runner.js";
+
+/** Default corpus root: `<repo>/verifier/conformance-vectors`. */
+export function defaultCorpusRoot(): string {
+  // src/verifier -> ../../.. -> repo root -> verifier/conformance-vectors
+  return resolve(__dirname, "..", "..", "..", "verifier", "conformance-vectors");
+}
+
+export interface ParityReport {
+  results: VectorOutcome[];
+  passed: number;
+  total: number;
+  lines: string[];
+}
+
+export function runParity(corpusRoot = defaultCorpusRoot()): ParityReport {
+  const results = runCorpus(corpusRoot);
+  const lines: string[] = [];
+  for (const r of results) {
+    const ok = tolerated(r);
+    const mark = ok ? "ok" : "FAIL";
+    lines.push(`  [${mark.padStart(4)}] ${r.dir.padEnd(38)} expect=${r.expectedOutcome.padEnd(11)} got=${r.actualVerdict}`);
+    if (!ok) lines.push(`         ${r.detail}`);
+  }
+  const passed = results.filter(tolerated).length;
+  lines.push("");
+  lines.push(`  => ${passed}/${results.length} vectors matched expected outcome`);
+  return { results, passed, total: results.length, lines };
+}
+
+function main(): number {
+  // Corpus root from arg / env, else the in-tree default.
+  const root = process.argv[2] || process.env.ASQAV_CORPUS_ROOT || defaultCorpusRoot();
+  const report = runParity(root);
+  for (const line of report.lines) console.log(line);
+  return report.passed === report.total ? 0 : 1;
+}
+
+// Run when invoked as a script (not when imported by the test).
+if (typeof require !== "undefined" && require.main === module) {
+  process.exit(main());
+}

--- a/typescript/src/verifier/runner.ts
+++ b/typescript/src/verifier/runner.ts
@@ -1,0 +1,100 @@
+/**
+ * Conformance-vector runner - drive the oracle over the vector corpus.
+ * A port of the Python oracle's `verifier/oracle/runner.py`.
+ *
+ * The corpus uses the AERF dir-per-vector layout: a top-level `manifest.json`
+ * lists `{dir, format, outcome, reason_code, notes}` and each `<NN-name>/`
+ * directory carries `receipt.json`, an `expected.json`, optional
+ * `predecessor.json`, and optional key material (`jwks.json` for Asqav-native,
+ * `keys.json` for AERF, `acta-keys.json` for ACTA, `did_map.json` for agentreceipts).
+ *
+ * `outcome` maps to the verdict one-for-one (PASS/FAIL/INCOMPLETE). INCOMPLETE
+ * lets the corpus carry a vector whose signature axis cannot be checked (a real
+ * ML-DSA-65 receipt without an ML-DSA library), pinning that the verifier
+ * downgrades rather than false-PASSing.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { ADAPTERS } from "./index.js";
+import { verify, type Verdict } from "./core.js";
+import { parseJsonPreservingFloats } from "./canonical.js";
+import type { KeyProvider } from "./adapter.js";
+
+const OUTCOME_TO_VERDICT: Record<string, Verdict> = {
+  PASS: "PASS",
+  FAIL: "FAIL",
+  INCOMPLETE: "INCOMPLETE",
+};
+
+/** The result of running one corpus vector against the oracle. */
+export interface VectorOutcome {
+  dir: string;
+  expectedOutcome: string;
+  actualVerdict: Verdict | string;
+  ok: boolean;
+  reasonCode: string;
+  detail: string;
+}
+
+interface ManifestEntry {
+  dir: string;
+  format: string;
+  outcome: string;
+  reason_code?: string;
+  notes?: string;
+}
+
+function loadJson(path: string): Record<string, unknown> | null {
+  // Receipts and predecessors are parsed float-preserving so a `500.0` literal
+  // survives to the canonicaliser (JSON.parse otherwise collapses it to `500`).
+  return existsSync(path)
+    ? (parseJsonPreservingFloats(readFileSync(path, "utf-8")) as Record<string, unknown>)
+    : null;
+}
+
+function keyProviderFor(vecDir: string, fmt: string): KeyProvider {
+  if (fmt === "asqav-native") return loadJson(join(vecDir, "jwks.json"));
+  if (fmt === "aerf") return loadJson(join(vecDir, "keys.json"));
+  if (fmt === "acta") return loadJson(join(vecDir, "acta-keys.json"));
+  if (fmt === "agentreceipts") return loadJson(join(vecDir, "did_map.json"));
+  return null;
+}
+
+/** Run a single vector directory and compare against its expected outcome. */
+export function runOne(
+  vecDir: string,
+  fmt: string,
+  expectedOutcome: string,
+  reasonCode = "",
+): VectorOutcome {
+  const receipt = loadJson(join(vecDir, "receipt.json")) ?? {};
+  const predecessor = loadJson(join(vecDir, "predecessor.json"));
+  const keyProvider = keyProviderFor(vecDir, fmt);
+  const result = verify(receipt, ADAPTERS, keyProvider, predecessor);
+
+  const wantVerdict = OUTCOME_TO_VERDICT[expectedOutcome];
+  const ok = wantVerdict !== undefined && result.verdict === wantVerdict;
+  const detail = result.axes.map((a) => `${a.axis}=${a.result}(${a.note})`).join("; ");
+  const name = vecDir.split(/[/\\]/).pop() ?? vecDir;
+  return { dir: name, expectedOutcome, actualVerdict: result.verdict, ok, reasonCode, detail };
+}
+
+/** Run every vector named in `corpusRoot/manifest.json`. */
+export function runCorpus(corpusRoot: string): VectorOutcome[] {
+  const manifest = JSON.parse(readFileSync(join(corpusRoot, "manifest.json"), "utf-8")) as ManifestEntry[];
+  return manifest.map((entry) =>
+    runOne(join(corpusRoot, entry.dir), entry.format, entry.outcome, entry.reason_code ?? ""),
+  );
+}
+
+/** Accept the stronger PASS only for the optional-dep ML-DSA skip vector, never broadly. */
+export function tolerated(outcome: VectorOutcome): boolean {
+  return (
+    outcome.ok ||
+    (outcome.expectedOutcome === "INCOMPLETE" &&
+      outcome.actualVerdict === "PASS" &&
+      outcome.reasonCode === "signature_skipped_no_dilithium")
+  );
+}

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -1,0 +1,106 @@
+/**
+ * A focused port of the standalone `verify_receipt.py` helpers the Asqav-native
+ * and ACTA adapters reuse, so the TS oracle reproduces the same bytes and the
+ * same structure verdict as the Python surface.
+ *
+ * Only the pieces the adapters touch are ported: base64 decoding, envelope
+ * normalisation, the Asqav-native structure check, JWKS key resolution, and the
+ * first-receipt seed constant.
+ */
+
+/** Mirrors `core/integrity.py` FIRST_RECEIPT_SEED (64 zeros). */
+export const FIRST_RECEIPT_SEED = "0".repeat(64);
+
+const REQUIRED_FIELDS = [
+  "type",
+  "issued_at",
+  "issuer_id",
+  "action_ref",
+  "payload_digest",
+  "policy_digest",
+  "previousReceiptHash",
+  "decision",
+] as const;
+
+const ALLOWED_TYPES = new Set([
+  "protectmcp:decision",
+  "protectmcp:restraint",
+  "protectmcp:lifecycle",
+  "protectmcp:lifecycle:configuration_change",
+  "protectmcp:lifecycle:risk_acceptance",
+  "protectmcp:lifecycle:code_authorship",
+  "protectmcp:acknowledgment",
+  "protectmcp:observation",
+  "protectmcp:observation:result_bound",
+]);
+
+/** Decode standard or url-safe base64, padding-tolerant (mirrors `_b64decode`). */
+export function b64decode(value: string): Uint8Array {
+  let s = value.replace(/-/g, "+").replace(/_/g, "/");
+  s += "=".repeat((-s.length % 4 + 4) % 4);
+  return new Uint8Array(Buffer.from(s, "base64"));
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+/**
+ * Remap a hosted /verify response into the canonical 3-key envelope. Already
+ * canonical or non-hosted shapes pass through unchanged (mirrors
+ * `normalise_envelope`).
+ */
+export function normaliseEnvelope(raw: Record<string, unknown>): Record<string, unknown> {
+  const sig = raw.signature;
+  if (isRecord(sig) && isRecord(raw.payload)) {
+    return raw;
+  }
+  const payload = raw.payload;
+  if (!isRecord(payload)) {
+    return raw;
+  }
+  let sigObj = raw.signature_envelope;
+  if (!isRecord(sigObj)) {
+    if (isRecord(sig)) {
+      sigObj = sig;
+    } else {
+      sigObj = {
+        alg: raw.algorithm ?? "ML-DSA-65",
+        kid: payload.issuer_id ?? "",
+        sig: typeof sig === "string" ? sig : "",
+      };
+    }
+  }
+  return {
+    payload,
+    signature: sigObj,
+    anchors: raw.anchors ?? [],
+  };
+}
+
+/** Asqav-native structure check; returns `[result, note]` (mirrors `check_structure`). */
+export function checkStructure(payload: Record<string, unknown>): readonly ["PASS" | "FAIL", string] {
+  const missing = REQUIRED_FIELDS.filter((f) => !(f in payload));
+  if (missing.length > 0) {
+    return ["FAIL", `missing required fields: ${missing.join(",")}`];
+  }
+  const rt = payload.type;
+  if (typeof rt !== "string" || !ALLOWED_TYPES.has(rt)) {
+    return ["FAIL", `type ${JSON.stringify(rt)} outside the allowed namespace`];
+  }
+  return ["PASS", `required fields present; type ${rt}`];
+}
+
+/** Return `[publicKeyBytes, status, alg]` for `kid` from a JWKS dict (mirrors `resolve_key`). */
+export function resolveKey(
+  jwks: Record<string, unknown> | null,
+  kid: string,
+): readonly [Uint8Array | null, string | null, string | null] {
+  const keys = (jwks?.keys as Array<Record<string, unknown>> | undefined) ?? [];
+  for (const k of keys) {
+    if (kid && (kid === k.issuer_id || kid === k.kid)) {
+      return [b64decode(k.public_key as string), (k.status as string) ?? null, (k.alg as string) ?? null];
+    }
+  }
+  return [null, null, null];
+}

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -1,0 +1,168 @@
+/**
+ * THE GATE - the TypeScript verifier must reproduce the proven Python oracle's
+ * verdicts across the whole conformance corpus, byte-match the upstream
+ * canonicalization vectors, and verify the real Authproof receipt.
+ *
+ * These are reproduced artifacts, not assertions: the corpus, the canonicalization
+ * vectors, and the real-SDK receipt are the same files the Python oracle is gated
+ * on.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { asqavJcs, jcsRfc8785, parseJsonPreservingFloats } from "../src/verifier/canonical.js";
+import { verify } from "../src/verifier/core.js";
+import { ADAPTERS } from "../src/verifier/index.js";
+import { runCorpus, tolerated } from "../src/verifier/runner.js";
+
+// typescript/tests -> repo root -> verifier/conformance-vectors
+const CORPUS_ROOT = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
+
+function loadJson(path: string): Record<string, unknown> {
+  // Float-preserving so `500.0` literals survive to the canonicaliser.
+  return parseJsonPreservingFloats(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+describe("verifier parity gate (THE GATE)", () => {
+  it("matches every manifest outcome across all 41 corpus vectors", () => {
+    const results = runCorpus(CORPUS_ROOT);
+    const mismatches = results.filter((r) => !tolerated(r));
+    const passed = results.filter(tolerated).length;
+
+    // Print the same per-vector report the Python runner.main() prints.
+    const report = results
+      .map((r) => {
+        const mark = tolerated(r) ? "ok" : "FAIL";
+        const line = `  [${mark.padStart(4)}] ${r.dir.padEnd(38)} expect=${r.expectedOutcome.padEnd(11)} got=${r.actualVerdict}`;
+        return tolerated(r) ? line : `${line}\n         ${r.detail}`;
+      })
+      .join("\n");
+    // eslint-disable-next-line no-console
+    console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
+
+    expect(results.length).toBe(41);
+    expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
+    expect(passed).toBe(41);
+  });
+});
+
+describe("jcs_rfc8785 byte-parity vs upstream canonicalization vectors", () => {
+  it("byte-matches every upstream canonicalization vector", () => {
+    const path = join(CORPUS_ROOT, "agentreceipts-upstream-interop", "canonicalization_vectors.json");
+    const data = loadJson(path) as { canonicalization_vectors: Array<{ name: string; input: unknown; canonical: string }> };
+    const vectors = data.canonicalization_vectors;
+    const mismatches: Array<{ name: string; want: string; got: string }> = [];
+    for (const v of vectors) {
+      const got = new TextDecoder().decode(jcsRfc8785(v.input));
+      if (got !== v.canonical) mismatches.push({ name: v.name, want: v.canonical, got });
+    }
+    // eslint-disable-next-line no-console
+    console.log(`\n  jcs_rfc8785 byte-parity: ${vectors.length - mismatches.length}/${vectors.length} vectors matched\n`);
+    expect(mismatches, JSON.stringify(mismatches)).toEqual([]);
+    expect(vectors.length).toBeGreaterThanOrEqual(32);
+  });
+});
+
+describe("real Authproof receipt verifies PASS (ES256 path)", () => {
+  it("authproof-01-genesis-real-sdk -> PASS", () => {
+    const dir = join(CORPUS_ROOT, "authproof-01-genesis-real-sdk");
+    const receipt = loadJson(join(dir, "receipt.json"));
+    const result = verify(receipt, ADAPTERS);
+    // eslint-disable-next-line no-console
+    console.log(`\n  authproof-01-genesis-real-sdk: fmt=${result.fmt} verdict=${result.verdict}\n`);
+    expect(result.fmt).toBe("authproof");
+    expect(result.verdict).toBe("PASS");
+  });
+});
+
+describe("canonical-bytes cross-check (TS signing_input sha256 == Python)", () => {
+  // Each TS signing_input sha256 is pinned to the digest the Python oracle's
+  // adapter.signing_input produces for the same receipt, so a canonicaliser drift
+  // on either side breaks this test.
+  const pinned: Record<string, { fmt: string; sha: string }> = {
+    "aerf-01-genesis": {
+      fmt: "aerf",
+      sha: "b0c0ed0d2570cdebb9f87868996497f08747063a2717e5b38db79fae9c87b344",
+    },
+    "acta-01-genesis": {
+      fmt: "acta",
+      sha: "8cc38bc400870eb0ac5491b60468fe3b3f4a13dbe5dce3da0f0952c109de0456",
+    },
+    "agentreceipts-01-didkey-genesis": {
+      fmt: "agentreceipts",
+      sha: "eb5fd119afbd399658e615cd4687c0047c72dd3bb3c59bbf40f69b7a12e66a34",
+    },
+    "asqav-01-genesis-permit": {
+      fmt: "asqav-native",
+      sha: "88051bbc8ba5f41fd1626ade433b923d12ba70a1767201ee78c8b407fc56b580",
+    },
+  };
+  for (const [vec, { fmt, sha }] of Object.entries(pinned)) {
+    it(`TS signing_input byte-matches Python for ${vec}`, () => {
+      const receipt = loadJson(join(CORPUS_ROOT, vec, "receipt.json"));
+      const ad = ADAPTERS.find((a) => a.detect(receipt))!;
+      expect(ad.name).toBe(fmt);
+      const bytes = ad.signingInput(receipt);
+      expect(createHash("sha256").update(Buffer.from(bytes)).digest("hex")).toBe(sha);
+    });
+  }
+});
+
+describe("parseJsonPreservingFloats matches JSON.parse structure (Node 18+ safe)", () => {
+  // The parser is hand-rolled (no Node 21+ reviver context.source); it must agree
+  // with JSON.parse on everything except the deliberate float/big-int preservation.
+  const unwrap = (v: unknown): unknown => {
+    if (v && typeof v === "object" && "value" in v && Object.keys(v).length === 1) return (v as { value: number }).value;
+    if (v && typeof v === "object" && "source" in v && Object.keys(v).length === 1) return Number((v as { source: string }).source);
+    if (Array.isArray(v)) return v.map(unwrap);
+    if (v && typeof v === "object") {
+      return Object.fromEntries(Object.entries(v as Record<string, unknown>).map(([k, x]) => [k, unwrap(x)]));
+    }
+    return v;
+  };
+  const cases = [
+    '{}',
+    '[]',
+    '{"a":1,"b":[true,false,null],"c":{"d":"e"}}',
+    '{"s":"a \\"quoted\\" \\\\ slash \\/ tab\\t newline\\n unicode \\u00e9 \\ud83d\\ude00"}',
+    '{"nested":[[[[1]]]],"mix":[{"x":[2,{"y":3}]}]}',
+    '{"num":[0,-0,1,-1,3.14,-2.5,1e3,1E-3,6.022e23],"big":[12345,9007199254740991]}',
+    '"bare string"',
+    '42',
+    'true',
+    '  {  "spaced"  :  [ 1 , 2 ]  }  ',
+  ];
+  for (const c of cases) {
+    it(`agrees with JSON.parse for ${c.slice(0, 40)}`, () => {
+      expect(unwrap(parseJsonPreservingFloats(c))).toEqual(JSON.parse(c));
+    });
+  }
+  it("rejects malformed JSON, strict RFC 8259 numbers, and over-deep nesting", () => {
+    for (const bad of ['{"a":}', "[1,2", "{} junk", "", "undefined", "[1,,2]", "[1,2,]"]) {
+      expect(() => parseJsonPreservingFloats(bad), bad).toThrow();
+    }
+    // strict number grammar, matching Python json.loads
+    for (const bad of ['{"a":01}', '{"a":5.}', '{"a":.5}', '{"a":-}', '{"a":1e}', '{"a":+5}', '{"a":1.e5}']) {
+      expect(() => parseJsonPreservingFloats(bad), bad).toThrow();
+    }
+    // recursion-depth guard rejects rather than overflowing the stack
+    expect(() => parseJsonPreservingFloats("[".repeat(5000) + "]".repeat(5000))).toThrow();
+  });
+});
+
+describe("integers beyond IEEE-754 safe range stay distinct (no false-PASS)", () => {
+  const dec = new TextDecoder();
+  it("emits the exact source digits in every dialect, matching Python str(int)", () => {
+    const o = parseJsonPreservingFloats('{"n":9007199254740993}');
+    expect(dec.decode(asqavJcs(o))).toBe('{"n":9007199254740993}');
+    expect(dec.decode(jcsRfc8785(o))).toBe('{"n":9007199254740993}');
+  });
+  it("does not collapse 2^53+1 onto 2^53", () => {
+    const a = dec.decode(asqavJcs(parseJsonPreservingFloats('{"n":9007199254740993}')));
+    const b = dec.decode(asqavJcs(parseJsonPreservingFloats('{"n":9007199254740992}')));
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## What

Ports the Python neutral verifier oracle to TypeScript so receipt verification runs in the JS ecosystem to parity, with zero new runtime dependencies.

- Three canonicalisers (`jcs`, `asqavJcs`, `jcsRfc8785`) that byte-match the Python ones, including float literals and integers beyond IEEE-754 safe range, whose exact source digits are preserved so two distinct values never collide onto one signature.
- Ed25519 and ES256 verify via `node:crypto`; ML-DSA-65 reports SKIPPED (Node has no primitive), so an Asqav-native post-quantum receipt is INCOMPLETE, never a false PASS, matching the Python oracle without its optional dep.
- The five adapters, the did:key resolver, the shared verdict logic, and a manifest-driven corpus runner mirror the Python structure.
- The CI typescript paths-filter now also fires on the shared vector corpus so a corpus change re-runs the gate.

## Verification (reproduced gate, not assertions)
- The gate test reproduces the Python verdict on all 41 corpus vectors (41/41), byte-checks the 32 upstream canonicalization vectors (32/32), pins four signing-input sha256 values to the Python oracle's digests, and verifies the real Authproof receipt to PASS.
- All 41 signing inputs are byte-identical between the TS verifier and the Python oracle (independently checked).
- 91-mutation adversarial sweep across all 5 formats: zero false PASS. A tampered big-int field now fails closed.
- `npm run build`, `npm run lint`, `npm test` (409 tests) all green. Reviewer + Devil's Advocate accept.

## Known limitation (fail-closed)
A large whole-magnitude float literal serializes differently between V8 and Python on the Python-repr dialect. It occurs in no signed receipt and only ever causes a signature to FAIL, never to falsely PASS. Tracked for a later float-dialect alignment.
