### PR TITLE
Release 0.5.8: ship the neutral verifier and the Authproof format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [TypeScript 0.5.8] - 2026-06-05
+
+### Added
+- A standalone neutral verifier under `typescript/src/verifier/` that verifies receipts across five formats (Asqav-native, AERF, ACTA, agent-receipts, Authproof) to parity with the Python oracle. Three canonicalisers (`jcs`, `asqavJcs`, `jcsRfc8785`) byte-match the Python ones, Ed25519 and ES256 verify through `node:crypto`, and ML-DSA-65 reports SKIPPED (Node has no primitive), so a post-quantum receipt is INCOMPLETE rather than a false PASS. A gate test reproduces the Python verdict on all conformance vectors, byte-checks the upstream canonicalization vectors, and verifies a receipt minted by the real Authproof SDK.
+- A number-preserving JSON parser so float literals and integers beyond IEEE-754 safe range canonicalise to the exact bytes the producer signed; distinct large integers stay distinct.
+
+## [Python 0.5.8] - 2026-06-05
+
+### Added
+- An Authproof adapter in the verifier oracle (the fifth format): ES256 over the insertion-order JSON of the receipt minus its signature, with the signer key read from the embedded P-256 JWK. New `verify_es256` in `verifier/oracle/crypto.py` wraps the `cryptography` library. A conformance vector minted by the real Authproof SDK gives a cross-implementation interop check.
+- The neutral verifier now ships inside the `asqav` wheel: `from asqav.verifier.oracle import verify, ADAPTERS`. A real Asqav production hash-mode receipt is pinned as a conformance vector that reports INCOMPLETE without the optional `dilithium-py` dependency, proving the post-quantum path is never a false PASS.
+
+### Fixed
+- Malformed signature fields (non-string, non-hex, non-base64) now decode to a verification FAIL across the AERF and Asqav-native compliance paths instead of raising, restoring the never-crash contract.
+
 ## [TypeScript 0.5.7] - 2026-06-02
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.7"
+version = "0.5.8"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -145,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.7"
+__version__ = "0.5.8"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -35,7 +35,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.7";
+export const CLI_VERSION = "0.5.8";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,


### PR DESCRIPTION
## What

Release 0.5.8. Bumps both halves and records the verifier work shipped this cycle in the changelog.

This release makes the neutral verifier usable by third parties for the first time:
- The Authproof adapter (fifth format) plus ES256 in `verifier/oracle/crypto.py`.
- Malformed-signature fail-closed hardening across the AERF and Asqav-native compliance paths.
- The verifier packaged into the `asqav` wheel, so `from asqav.verifier.oracle import verify, ADAPTERS` works after `pip install asqav`.
- A TypeScript verifier port to parity with the Python oracle.

## Publish
After merge, push the Python and TypeScript release tags for this version to trigger the publish workflow (PyPI via trusted publishing, npm via the registry token).
