### PR TITLE
Build the asqav wheel directly so the bundled verifier ships

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,12 @@ jobs:
         with:
           python-version: '3.12'
       - run: pip install build
-      - run: python -m build
+        # Build the wheel directly from the source tree, not via an sdist round-trip:
+        # the wheel force-includes the verifier from ../verifier (outside python/), a
+        # path that does not exist inside an unpacked sdist. The package is pure Python,
+        # so the wheel is universal. A follow-up can relocate the verifier under
+        # src/asqav to restore the sdist.
+      - run: python -m build --wheel
         working-directory: python
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION

The publish build ran an sdist round-trip, but the wheel force-includes the
verifier from ../verifier (outside the python package dir), a path absent inside
an unpacked sdist, so the wheel build failed. The package is pure Python, so a
directly-built wheel is universal. A follow-up can relocate the verifier under
src/asqav to restore the source distribution.