### PR TITLE
Tighten the oracle scope boundary, ACTA hex guard, and ACTA interop note

### DIFF
--- a/verifier/conformance-vectors/UPSTREAM.md
+++ b/verifier/conformance-vectors/UPSTREAM.md
@@ -71,6 +71,19 @@ draft-nelson text specifies a base64url signature, a content-hash
 sorted-key JSON with snake_case fields. A receipt from either would not verify
 under the JS-SDK rules, and the JS SDK is the published product.
 
+## ACTA
+
+The `acta-*` vectors target draft-farley-acta-signed-receipts (the draft Asqav
+profiles): Ed25519 over the JCS of the `payload`, signed directly, hex sig. The
+four `acta-*` vectors are self-authored and prove self-consistency, not interop.
+An independent draft-farley ecosystem exists - the `@veritasacta/verify` offline
+verifier on npm and the `ScopeBlind/agent-governance-testvectors` shared
+conformance corpus - so bidirectional ACTA interop is a real PENDING step (ingest
+that corpus, and cross-verify our output against that verifier), not yet wired in;
+it is not blocked on the ecosystem existing. The Commitment Mode (signing
+`SHA-256(JCS(payload))`) is intentionally not implemented: a commitment-mode
+receipt FAILs the baseline check, the honest outcome, never a false pass.
+
 ## Outcome mapping
 
 Each upstream vector declares an outcome of `PASS`, `FAIL`, or

--- a/verifier/oracle/README.md
+++ b/verifier/oracle/README.md
@@ -39,9 +39,13 @@ AERF signs the JCS payload directly after stripping `signature`, `timestamp`,
 
 ## Adapters this slice
 
-- **asqav-native** - the existing `verify_receipt` logic behind the seam,
-  behaviour-preserving. ML-DSA-65 over the canonical payload; chain via the
-  all-zero genesis seed.
+- **asqav-native** - the `verify_receipt` signature, chain, and structure-
+  presence axes behind the seam. ML-DSA-65 over the canonical payload; chain via
+  the all-zero genesis seed. Scope boundary: as a standalone offline verifier the
+  oracle runs only those three axes; it does NOT run the standalone
+  `verify_receipt` clock-skew (`issued_at`) or anchor-liveness axes, which need
+  wall-clock freshness and network the oracle deliberately omits. A receipt the
+  oracle PASSes can still fail those two liveness axes at ingestion time.
 - **aerf** - Ed25519 over RFC 8785 JCS, signed directly. Genesis OMITS
   `previous_receipt_hash`; the chain hash EXCLUDES the signature, per the AERF
   spec (the agentmint reference producer includes it; this adapter targets the

--- a/verifier/oracle/adapters/acta.py
+++ b/verifier/oracle/adapters/acta.py
@@ -32,6 +32,16 @@ from ..canonical import jcs
 from ..core import sha256_hex
 
 
+def _safe_hex(value: Any) -> bytes:
+    """Decode a hex string; b'' on any malformed input so verify FAILs, never crashes."""
+    if not isinstance(value, str):
+        return b""
+    try:
+        return bytes.fromhex(value)
+    except ValueError:
+        return b""
+
+
 def _is_lower_hex(s: Any) -> bool:
     """True for a non-empty even-length lowercase-hex string (an ACTA signature).
 
@@ -63,7 +73,7 @@ class ActaAdapter(FormatAdapter):
     def extract_signature(self, doc: dict) -> SignatureMaterial:
         sig = doc.get("signature", {})
         return SignatureMaterial(
-            sig=bytes.fromhex(sig.get("sig", "")),
+            sig=_safe_hex(sig.get("sig", "")),
             alg=sig.get("alg", "EdDSA"),
             kid=sig.get("kid", ""),
         )

--- a/verifier/oracle/test_oracle.py
+++ b/verifier/oracle/test_oracle.py
@@ -261,6 +261,23 @@ def test_acta_commitment_mode_fails_not_false_passes() -> None:
     assert res.axis("signature").result == crypto.FAIL
 
 
+def test_acta_malformed_signature_fails_does_not_crash() -> None:
+    """A malformed ACTA sig fails closed, never raises - at detection and in extract_signature.
+
+    Through the public verify(), a non-hex sig is declined at detection so the verdict
+    is FAIL with no adapter matched. The extract_signature guard is the defense in depth:
+    called directly with a non-hex or non-string sig it returns b'' rather than raising,
+    matching the other adapters.
+    """
+    doc = _load("acta-01-genesis", "receipt.json")
+    for bad in ("zzzz-not-hex", {"k": "v"}, 42, None):
+        forged = json.loads(json.dumps(doc))
+        forged["signature"] = {"sig": bad, "alg": "EdDSA", "kid": "k1"}
+        res = verify(forged, ADAPTERS, key_provider=_acta_keys("acta-01-genesis"))
+        assert res.verdict != "PASS"
+        assert ActaAdapter().extract_signature(forged).sig == b""
+
+
 def test_acta_and_asqav_native_are_mutually_exclusive() -> None:
     """Asqav-native profiles ACTA, so detection must never let both claim one receipt."""
     acta = _load("acta-01-genesis", "receipt.json")


### PR DESCRIPTION
## What

Three audit-driven honesty and robustness fixes to the neutral verifier, no behaviour change to any passing or failing vector.

1. **Oracle scope boundary (README).** The asqav-native adapter runs only the signature, chain, and structure-presence axes. The standalone `verify_receipt` additionally carries a clock-skew (`issued_at`) axis and an anchor-liveness axis, which need wall-clock freshness and network the offline oracle deliberately omits. The README states this boundary so a reader does not assume full parity. A receipt the oracle PASSes can still fail those two liveness axes at ingestion time.

2. **ACTA hex-decode guard.** `ActaAdapter.extract_signature` wraps the signature hex decode so a malformed or non-string sig returns empty bytes and fails closed, matching the AERF / Authproof adapters. Through the public `verify()` a malformed sig is already declined at detection; this is defense in depth for direct callers. A non-regression test pins it.

3. **ACTA interop note (UPSTREAM.md).** Records that the local `acta-*` vectors are self-authored and prove self-consistency, and that an independent draft-farley verifier (`@veritasacta/verify`) and a shared conformance corpus (`ScopeBlind/agent-governance-testvectors`) exist, so bidirectional ACTA interop is a pending wiring step. Cold-verified against the live npm package and GitHub repo.

## Verification

- `python3 -m oracle.runner` -> 41/41 vectors match.
- `pytest verifier/oracle` -> 56 passed (was 55; +1 ACTA guard test).
- `ruff check verifier/oracle` clean.
- A 20k-input fuzz confirmed the hex guard is byte-identical to the raw decode for every non-raising input and returns empty bytes exactly when the raw decode would raise: no verdict can flip.

## Scope

Doc + one defense-in-depth guard + one test. No wire change, no public API change.
