### PR TITLE
Ship the neutral verifier as the @asqav/sdk/verifier subpath export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+### Added
+- The neutral verifier is now a published subpath export: `import { verify, ADAPTERS } from "@asqav/sdk/verifier"`. The TypeScript port existed in the package source but was not part of the build entry list, so the published tarball omitted it; it now builds to `dist/verifier/` and ships in the npm package, matching the Python `from asqav.verifier.oracle import verify, ADAPTERS`.
+
+### Fixed
+- The oracle README states the asqav-native scope boundary (signature, chain, and structure-presence axes only; the standalone `verify_receipt` clock-skew and anchor-liveness axes are deliberately omitted by the offline verifier) instead of asserting full parity. The ACTA adapter guards its signature hex decode so a malformed sig fails closed.
+
 ## [TypeScript 0.5.8] - 2026-06-05
 
 ### Added

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -278,6 +278,19 @@ try {
 
 `TypeError` is thrown before the HTTP roundtrip for the verbatim rule 8 / 9 / 10 / 11 guards listed above. Catch `TypeError` separately so guard violations surface as developer errors, not API errors.
 
+## Neutral verifier
+
+A standalone offline verifier for agent receipts across formats ships as a subpath export:
+
+```ts
+import { verify, ADAPTERS } from "@asqav/sdk/verifier";
+
+const result = verify(receipt, ADAPTERS, { keyProvider });
+// result.verdict is "PASS", "FAIL", or "INCOMPLETE"
+```
+
+It verifies the issuer signature over the canonical bytes, the hash-chain link, and structural presence across the asqav-native, AERF, ACTA, agent-receipts, and Authproof formats. It never attests the behaviour of the recorded action, and no account is required. Ed25519 and ES256 verify in-process via `node:crypto`; ML-DSA-65 downgrades to `INCOMPLETE` rather than ever returning a false `PASS`. This is the TypeScript port of the Python `asqav.verifier.oracle`, held to verdict parity by a shared conformance corpus.
+
 ## Requirements
 
 Node 20 or newer. Uses the built-in `fetch`. Zero native dependencies; ML-DSA cryptography runs server-side.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -60,6 +60,11 @@
       "types": "./dist/extras/openai-agents.d.ts",
       "import": "./dist/extras/openai-agents.mjs",
       "require": "./dist/extras/openai-agents.js"
+    },
+    "./verifier": {
+      "types": "./dist/verifier/index.d.ts",
+      "import": "./dist/verifier/index.mjs",
+      "require": "./dist/verifier/index.js"
     }
   },
   "files": [
@@ -68,7 +73,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/cli.ts src/extras/index.ts src/extras/vercel-ai.ts src/extras/langchain.ts src/extras/mastra.ts src/extras/openai-agents.ts --format cjs,esm --dts --clean",
+    "build": "tsup src/index.ts src/cli.ts src/extras/index.ts src/extras/vercel-ai.ts src/extras/langchain.ts src/extras/mastra.ts src/extras/openai-agents.ts src/verifier/index.ts --format cjs,esm --dts --clean",
     "test": "vitest run",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
## What

Ships the neutral verifier in the published npm package as a subpath export.

The TypeScript verifier port exists in the package source at `src/verifier/`, held to verdict parity with the Python oracle by a shared conformance corpus. It was not in the tsup build entry list and `src/index.ts` does not re-export it, so the published tarball tree-shook it out and consumers could not import it. The Python `asqav` wheel ships its verifier; the npm package omitted it.

This adds `src/verifier/index.ts` to the build entry list and a `./verifier` export, so:

```ts
import { verify, ADAPTERS } from "@asqav/sdk/verifier";
```

resolves against the published package. The README documents the import and an Unreleased changelog entry records it.

## Verification

- `npm run build` emits `dist/verifier/index.{js,mjs,d.ts,d.mts}`.
- `npm pack --dry-run` lists `dist/verifier/*` in the tarball (was absent).
- The built ESM bundle imports and verifies real receipts end-to-end: an Authproof (ES256) receipt minted by the real Authproof SDK and an agent-receipts (Ed25519 + did:key) receipt both return PASS; ML-DSA-65 returns INCOMPLETE in Node rather than a false PASS.
- Full suite green: `vitest run` -> 32 files, 420 tests pass; the verifier parity suite -> 20 pass.

## Scope

Packaging only: one build-entry addition, one export, README + changelog. No verifier logic change. The version bump and dual-publish ride a later release.
