### PR TITLE
Release 0.5.9: ship the neutral verifier in the npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [TypeScript 0.5.9] - 2026-06-05
+
 ### Added
 - The neutral verifier is now a published subpath export: `import { verify, ADAPTERS } from "@asqav/sdk/verifier"`. The TypeScript port existed in the package source but was not part of the build entry list, so the published tarball omitted it; it now builds to `dist/verifier/` and ships in the npm package, matching the Python `from asqav.verifier.oracle import verify, ADAPTERS`.
+
+## [Python 0.5.9] - 2026-06-05
 
 ### Fixed
 - The oracle README states the asqav-native scope boundary (signature, chain, and structure-presence axes only; the standalone `verify_receipt` clock-skew and anchor-liveness axes are deliberately omitted by the offline verifier) instead of asserting full parity. The ACTA adapter guards its signature hex decode so a malformed sig fails closed.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.8"
+version = "0.5.9"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -145,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.8"
+__version__ = "0.5.9"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -35,7 +35,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.8";
+export const CLI_VERSION = "0.5.9";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,


### PR DESCRIPTION
## What

Release 0.5.9. Bumps all five version sites together (pyproject, `asqav.__version__`, package.json, package-lock, `CLI_VERSION`) so the recent SDK changes publish to PyPI and npm.

## Included

- The neutral verifier ships in the npm package as the `@asqav/sdk/verifier` subpath export, matching the Python `from asqav.verifier.oracle import verify, ADAPTERS`.
- The oracle README states the asqav-native scope boundary instead of asserting full parity; the ACTA adapter guards its signature hex decode so a malformed sig fails closed; the ACTA interop note acknowledges the draft-farley ecosystem.

## Verification

- All five version sites read 0.5.9.
- Version-consistency tests pass: Python `__version__` matches pyproject; TS `CLI_VERSION` matches package.json.
- Publishing is tag-triggered: PyPI via OIDC trusted publishing, npm via the configured token; the npm build entry now emits `dist/verifier`, so the published tarball carries the verifier.

## Scope

Version bump + changelog only. No code change beyond the already-merged work this release packages.
