### PR TITLE
Add an export-only VC envelope shim for EU-lane presentation

### DIFF
--- a/python/src/asqav/verifier/oracle/README.md
+++ b/python/src/asqav/verifier/oracle/README.md
@@ -55,6 +55,24 @@ AERF signs the JCS payload directly after stripping `signature`, `timestamp`,
   embedded as a P-256 JWK. Targets the shipping JS SDK; the bundled draft and the
   repo's Python SDK both diverge (see `conformance-vectors/UPSTREAM.md`).
 
+## VC export shim (export-only, EU-lane presentation)
+
+`asqav.verifier.vc_export.to_vc_envelope(receipt, *, format=None)` presents an Asqav
+receipt in W3C Verifiable Credential 2.0 shape for EU-lane consumers. It is export-only:
+NOT a wire token, NOT a first-class internal type, and NOT a verification path. The
+converter is pure and offline (no signing, no network) and reuses the oracle's detection
+to map each format's action/agent fields into `credentialSubject`.
+
+The proof is Asqav-native, not a standard VC suite. An Asqav receipt is signed over the
+Asqav canonical bytes of its own payload; a registered VC proof signs the VC's own bytes.
+Relabelling the Asqav signature as `Ed25519Signature2020` (or any registered suite) would
+produce a credential a conformant VC verifier rejects, so the export instead emits an
+explicit non-standard `proof.type` of `AsqavReceiptSignature2026` that carries the
+original signature verbatim, its algorithm and key id, and a `signingInputBase64` pointer
+to the exact bytes it covers. A top-level `proofIsAsqavNative: true` marks the boundary.
+Re-checking the proof needs an Asqav-aware verifier; a generic VC verifier MUST decline it.
+This envelope is NOT a standard-suite-signed VC and cannot masquerade as one.
+
 ## Use
 
 From a source checkout or an installed `asqav` distribution:

--- a/python/src/asqav/verifier/vc_export.py
+++ b/python/src/asqav/verifier/vc_export.py
@@ -1,0 +1,241 @@
+"""Export-only shim: an Asqav receipt presented in W3C Verifiable Credential 2.0 shape.
+
+EU-lane presentation. This is NOT a wire token, NOT a first-class internal type, and
+NOT a verification path. ``to_vc_envelope`` maps an Asqav receipt's action/agent fields
+into a VC ``credentialSubject`` so a VC-shaped consumer can read them, but it carries the
+ORIGINAL Asqav signature verbatim - it does not re-sign anything.
+
+WHY THE PROOF CANNOT BE A STANDARD VC SUITE
+-------------------------------------------
+An Asqav receipt is signed with ML-DSA-65 (or Ed25519 / ES256) over the Asqav canonical
+bytes of the *receipt's own* payload. A registered VC proof (``Ed25519Signature2020``,
+``DataIntegrityProof`` with ``eddsa-rdfc-2022``, ...) is a signature over the *VC's* own
+canonical bytes. Those two byte strings differ, so relabelling the Asqav signature as a
+standard suite would produce a credential that any conformant VC verifier would reject -
+a forged-looking VC. To stay honest the export emits an explicit, self-descriptive
+NON-STANDARD proof type (``AsqavReceiptSignature2026``) that:
+
+  - carries the original signature value (base64 / hex) and its algorithm and key id,
+  - points at the EXACT canonical bytes the signature covers (``signingInput``) so an
+    Asqav-aware verifier can re-check, and
+  - never claims to be a registered VC cryptosuite.
+
+A top-level ``proofIsAsqavNative: true`` marker makes the boundary unmistakable: this is
+an Asqav receipt wearing a VC envelope, not a standard-suite-signed VC. Verifying it
+needs an Asqav-aware verifier; a generic VC verifier MUST decline it.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .oracle import ADAPTERS
+
+#: The VC ``@context`` entries - the v2 base plus the Asqav presentation vocabulary.
+VC_V2_CONTEXT = "https://www.w3.org/ns/credentials/v2"
+ASQAV_CONTEXT = "https://asqav.com/context/compliance-receipt/v1"
+
+#: The non-standard, self-descriptive proof type. NOT a registered VC cryptosuite.
+ASQAV_PROOF_TYPE = "AsqavReceiptSignature2026"
+
+#: The credential type pair. Deliberately NOT ``AgentReceipt`` - that token belongs to a
+#: different, standard-suite-signed format and must not be borrowed here.
+VC_CREDENTIAL_TYPE = ["VerifiableCredential", "AsqavComplianceReceipt"]
+
+#: Registered VC proof suites the export must never claim to be (honesty guard reference).
+STANDARD_VC_PROOF_TYPES = frozenset(
+    {
+        "Ed25519Signature2020",
+        "Ed25519Signature2018",
+        "DataIntegrityProof",
+        "JsonWebSignature2020",
+        "EcdsaSecp256k1Signature2019",
+        "BbsBlsSignature2020",
+        "RsaSignature2018",
+    }
+)
+
+
+def _detect_format(receipt: dict) -> str:
+    """Reuse the oracle's detection to label the source format, or ``unknown``."""
+    for adapter in ADAPTERS:
+        try:
+            if adapter.detect(receipt):
+                return adapter.name
+        except Exception:
+            continue
+    return "unknown"
+
+
+def _signing_input_b64(receipt: dict, fmt: str) -> str | None:
+    """Base64 of the exact canonical bytes the source signature covers, if reproducible.
+
+    The oracle's adapter for this format already encodes the signing input rule. Reusing
+    it keeps the pointer honest: it is the same bytes the verifier would re-derive, not a
+    second guess. ``None`` when the format is unknown or the bytes cannot be rebuilt.
+    """
+    import base64
+
+    for adapter in ADAPTERS:
+        if adapter.name != fmt:
+            continue
+        try:
+            return base64.b64encode(adapter.signing_input(receipt)).decode("ascii")
+        except Exception:
+            return None
+    return None
+
+
+def _native_subject(receipt: dict) -> tuple[dict, dict, str | None]:
+    """Map an Asqav-native receipt (compliance or hash mode) to (subject, proofbits, issuer).
+
+    ``proofbits`` is ``{sig, alg, kid}`` pulled verbatim from the source so the proof block
+    preserves the original signature byte-for-byte.
+    """
+    if receipt.get("mode") == "hash" and receipt.get("payload") is None:
+        # Flat hash-mode /sign output.
+        subject = {
+            "agent": {"id": receipt.get("agent_id")},
+            "organization": {"id": receipt.get("org_id")},
+            "action": {
+                "id": receipt.get("action_id"),
+                "contentHash": receipt.get("hash"),
+                "hashAlgorithm": receipt.get("hash_algo"),
+                "timestamp": receipt.get("server_timestamp"),
+            },
+            "policy": {
+                "digest": receipt.get("policy_digest"),
+                "decision": receipt.get("policy_decision"),
+            },
+        }
+        proofbits = {
+            "sig": receipt.get("signature_b64") or receipt.get("signature"),
+            "alg": receipt.get("algorithm", "ML-DSA-65"),
+            "kid": receipt.get("key_id"),
+        }
+        return subject, proofbits, receipt.get("org_id")
+
+    # Compliance-mode envelope: signed payload + signature object.
+    payload = receipt.get("payload") if isinstance(receipt.get("payload"), dict) else receipt
+    sig_obj = receipt.get("signature")
+    if isinstance(sig_obj, dict):
+        proofbits = {"sig": sig_obj.get("sig"), "alg": sig_obj.get("alg"), "kid": sig_obj.get("kid")}
+    else:
+        proofbits = {"sig": sig_obj, "alg": "ML-DSA-65", "kid": payload.get("issuer_id")}
+    subject = {
+        "agent": {"id": payload.get("agent_id")},
+        "action": {
+            "type": payload.get("type"),
+            "reference": payload.get("action_ref"),
+            "toolName": payload.get("tool_name"),
+            "timestamp": payload.get("issued_at"),
+        },
+        "policy": {
+            "digest": payload.get("policy_digest"),
+            "decision": payload.get("decision"),
+        },
+    }
+    return subject, proofbits, payload.get("issuer_id")
+
+
+def _agentreceipts_subject(receipt: dict) -> tuple[dict, dict, str | None]:
+    """Map a W3C-VC AgentReceipt's fields into the Asqav presentation subject + proofbits.
+
+    The source proof is Ed25519 over the receipt's strict-JCS bytes; its ``proofValue`` is
+    carried verbatim. The export still re-labels it Asqav-native, because once the
+    envelope shape changes (type + credentialSubject re-keyed) the original proof no longer
+    verifies as a standard VC over THESE bytes - so presenting it as standard would lie.
+    """
+    sub = receipt.get("credentialSubject", {}) if isinstance(receipt.get("credentialSubject"), dict) else {}
+    proof = receipt.get("proof", {}) if isinstance(receipt.get("proof"), dict) else {}
+    issuer = receipt.get("issuer")
+    issuer_id = issuer.get("id") if isinstance(issuer, dict) else issuer
+    subject = {
+        "principal": sub.get("principal"),
+        "agent": {"id": issuer_id},
+        "action": sub.get("action"),
+        "outcome": sub.get("outcome"),
+        "chain": sub.get("chain"),
+    }
+    proofbits = {
+        "sig": proof.get("proofValue"),
+        "alg": "Ed25519",
+        "kid": proof.get("verificationMethod"),
+        "sourceProofType": proof.get("type"),
+    }
+    return subject, proofbits, issuer_id
+
+
+def _subject_for(receipt: dict, fmt: str) -> tuple[dict, dict, str | None]:
+    if fmt == "agentreceipts":
+        return _agentreceipts_subject(receipt)
+    if fmt == "asqav-native":
+        return _native_subject(receipt)
+    # Best-effort generic mapping for the other oracle formats; the proof still carries the
+    # raw signature and stays non-standard, so no false standard-VC claim is possible.
+    payload = receipt.get("payload") if isinstance(receipt.get("payload"), dict) else receipt
+    sig = receipt.get("signature")
+    if isinstance(sig, dict):
+        proofbits = {"sig": sig.get("sig"), "alg": sig.get("alg"), "kid": sig.get("kid")}
+    else:
+        proofbits = {"sig": sig, "alg": payload.get("alg"), "kid": payload.get("key_id")}
+    subject = {"agent": {"id": payload.get("agent") or payload.get("agent_id")}, "source": payload}
+    return subject, proofbits, payload.get("issuer") or payload.get("issuer_id")
+
+
+def to_vc_envelope(receipt: dict, *, format: str | None = None) -> dict:
+    """Present an Asqav receipt as a W3C Verifiable Credential 2.0 envelope (export only).
+
+    Pure and offline: no signing, no network, no mutation of ``receipt``. The returned
+    credential's ``proof`` is the NON-STANDARD ``AsqavReceiptSignature2026`` carrying the
+    original Asqav signature verbatim and a pointer to the bytes it covers. It is NOT a
+    standard-suite-signed VC and a generic VC verifier MUST decline it.
+
+    Args:
+      receipt: a parsed Asqav (or oracle-recognised) receipt dict.
+      format: optional format hint; when omitted the oracle's detection is reused.
+
+    Returns:
+      A VC 2.0 dict with ``proofIsAsqavNative: True``.
+    """
+    if not isinstance(receipt, dict):
+        raise TypeError("receipt must be a parsed JSON object (dict)")
+
+    fmt = format or _detect_format(receipt)
+    subject, proofbits, issuer_id = _subject_for(receipt, fmt)
+    valid_from = _valid_from(subject)
+
+    proof: dict[str, Any] = {
+        "type": ASQAV_PROOF_TYPE,
+        "proofPurpose": "assertionMethod",
+        "asqavAlgorithm": proofbits.get("alg"),
+        "verificationKeyId": proofbits.get("kid"),
+        "signatureValue": proofbits.get("sig"),
+        "signingInputBase64": _signing_input_b64(receipt, fmt),
+        "sourceFormat": fmt,
+        "note": (
+            "Asqav-native signature over the Asqav canonical bytes of the source receipt; "
+            "re-check requires an Asqav-aware verifier, not a standard VC suite."
+        ),
+    }
+    if proofbits.get("sourceProofType"):
+        proof["sourceProofType"] = proofbits["sourceProofType"]
+
+    envelope: dict[str, Any] = {
+        "@context": [VC_V2_CONTEXT, ASQAV_CONTEXT],
+        "type": list(VC_CREDENTIAL_TYPE),
+        "issuer": {"id": issuer_id} if issuer_id is not None else {},
+        "validFrom": valid_from,
+        "issuanceDate": valid_from,  # carried for VC 1.1 readers; v2 uses validFrom
+        "credentialSubject": subject,
+        "proof": proof,
+        "proofIsAsqavNative": True,
+    }
+    return envelope
+
+
+def _valid_from(subject: dict) -> str | None:
+    """Best-effort issuance timestamp from the mapped action, or ``None``."""
+    action = subject.get("action")
+    if isinstance(action, dict):
+        return action.get("timestamp")
+    return None

--- a/python/tests/test_vc_export.py
+++ b/python/tests/test_vc_export.py
@@ -1,0 +1,181 @@
+"""Export-only VC shim tests - data round-trip + the honesty guard.
+
+The export presents an Asqav receipt in W3C Verifiable Credential 2.0 shape for EU-lane
+consumers. These tests pin two things:
+
+  1. The receipt's key action/agent fields land in the VC ``credentialSubject`` / ``issuer``
+     faithfully, and the original Asqav signature is preserved verbatim in the proof.
+  2. THE HONESTY GUARD: the produced ``proof.type`` is the Asqav non-standard type, never a
+     registered VC suite; and feeding the exported envelope back through the oracle's
+     agentreceipts adapter does NOT yield a false PASS - it is declined / FAILs, because the
+     proof is not a standard VC proof. The export cannot masquerade as a verifiable
+     standard VC.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from asqav.verifier.oracle import ADAPTERS, verify
+from asqav.verifier.oracle.adapters.agentreceipts import AgentReceiptsAdapter
+from asqav.verifier.vc_export import (
+    ASQAV_PROOF_TYPE,
+    STANDARD_VC_PROOF_TYPES,
+    VC_CREDENTIAL_TYPE,
+    to_vc_envelope,
+)
+
+_CORPUS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+
+def _load(vec: str, name: str = "receipt.json") -> dict:
+    return json.loads((_CORPUS / vec / name).read_text())
+
+
+# --- (a) data round-trip ---
+
+
+def test_native_receipt_maps_key_fields_into_credential_subject() -> None:
+    """An Asqav-native compliance receipt maps agent/action/policy + issuer faithfully."""
+    receipt = _load("asqav-01-genesis-permit")
+    vc = to_vc_envelope(receipt)
+
+    assert vc["type"] == VC_CREDENTIAL_TYPE
+    assert vc["@context"][0] == "https://www.w3.org/ns/credentials/v2"
+    assert vc["issuer"]["id"] == receipt["payload"]["issuer_id"]
+    sub = vc["credentialSubject"]
+    assert sub["agent"]["id"] == receipt["payload"]["agent_id"]
+    assert sub["action"]["type"] == receipt["payload"]["type"]
+    assert sub["action"]["reference"] == receipt["payload"]["action_ref"]
+    assert sub["action"]["toolName"] == receipt["payload"]["tool_name"]
+    assert sub["policy"]["decision"] == receipt["payload"]["decision"]
+    assert vc["validFrom"] == receipt["payload"]["issued_at"]
+
+
+def test_agentreceipts_receipt_maps_subject_and_issuer() -> None:
+    """A W3C-VC AgentReceipt input maps its action/principal/chain + issuer into the subject."""
+    receipt = _load("agentreceipts-01-didkey-genesis")
+    vc = to_vc_envelope(receipt)
+
+    assert vc["issuer"]["id"] == receipt["issuer"]["id"]
+    sub = vc["credentialSubject"]
+    assert sub["action"] == receipt["credentialSubject"]["action"]
+    assert sub["principal"] == receipt["credentialSubject"]["principal"]
+    assert sub["outcome"] == receipt["credentialSubject"]["outcome"]
+    assert sub["chain"] == receipt["credentialSubject"]["chain"]
+
+
+def test_export_is_pure_does_not_mutate_input() -> None:
+    """The export never mutates the source receipt."""
+    receipt = _load("asqav-01-genesis-permit")
+    before = json.dumps(receipt, sort_keys=True)
+    to_vc_envelope(receipt)
+    assert json.dumps(receipt, sort_keys=True) == before
+
+
+def test_hash_mode_receipt_exports() -> None:
+    """A flat hash-mode /sign receipt also maps cleanly (agent/org/action/policy)."""
+    receipt = _load("asqav-05-hash-mode-prod")
+    vc = to_vc_envelope(receipt)
+    sub = vc["credentialSubject"]
+    assert sub["agent"]["id"] == receipt["agent_id"]
+    assert sub["organization"]["id"] == receipt["org_id"]
+    assert sub["action"]["contentHash"] == receipt["hash"]
+    assert vc["proof"]["asqavAlgorithm"] == "ML-DSA-65"
+
+
+# --- (c) signature preserved verbatim ---
+
+
+def test_native_signature_preserved_verbatim() -> None:
+    """The original Asqav signature bytes appear unchanged in the proof."""
+    receipt = _load("asqav-01-genesis-permit")
+    vc = to_vc_envelope(receipt)
+    assert vc["proof"]["signatureValue"] == receipt["signature"]["sig"]
+    assert vc["proof"]["verificationKeyId"] == receipt["signature"]["kid"]
+    assert vc["proof"]["asqavAlgorithm"] == receipt["signature"]["alg"]
+
+
+def test_hash_mode_signature_preserved_verbatim() -> None:
+    receipt = _load("asqav-05-hash-mode-prod")
+    vc = to_vc_envelope(receipt)
+    assert vc["proof"]["signatureValue"] == receipt["signature_b64"]
+
+
+def test_agentreceipts_signature_preserved_verbatim() -> None:
+    receipt = _load("agentreceipts-01-didkey-genesis")
+    vc = to_vc_envelope(receipt)
+    assert vc["proof"]["signatureValue"] == receipt["proof"]["proofValue"]
+
+
+def test_signing_input_pointer_matches_oracle_bytes() -> None:
+    """The proof's signingInput pointer is the exact bytes the oracle re-derives."""
+    receipt = _load("asqav-01-genesis-permit")
+    vc = to_vc_envelope(receipt)
+    pointer = base64.b64decode(vc["proof"]["signingInputBase64"])
+    # The asqav-native adapter signs the canonical bytes of the payload directly.
+    from asqav.verifier.oracle.adapters.asqav_native import AsqavNativeAdapter
+
+    assert pointer == AsqavNativeAdapter().signing_input(receipt)
+
+
+# --- (b) THE HONESTY GUARD ---
+
+
+def test_proof_type_is_asqav_native_never_a_standard_vc_suite() -> None:
+    """The proof.type is the Asqav non-standard type and is NOT any registered VC suite."""
+    vecs = ("asqav-01-genesis-permit", "agentreceipts-01-didkey-genesis", "asqav-05-hash-mode-prod")
+    for vec in vecs:
+        vc = to_vc_envelope(_load(vec))
+        assert vc["proof"]["type"] == ASQAV_PROOF_TYPE
+        assert vc["proof"]["type"] not in STANDARD_VC_PROOF_TYPES
+        assert vc["proofIsAsqavNative"] is True
+        # The credential type must not borrow the standard-suite AgentReceipt token.
+        assert "AgentReceipt" not in vc["type"]
+
+
+def test_exported_envelope_does_not_false_pass_the_standard_vc_verifier() -> None:
+    """Feeding the export to the oracle does NOT yield a standard-VC PASS.
+
+    The oracle's agentreceipts adapter verifies a standard ``Ed25519Signature2020`` proof
+    over the VC's own JCS bytes. The export carries an Asqav-native signature over the
+    SOURCE receipt's bytes under a non-standard proof type, so it cannot verify as a
+    standard VC. Prove that twice over:
+
+      - the agentreceipts adapter DECLINES the envelope at detection (it is not an
+        ``AgentReceipt`` and has no standard ``proofValue``), and
+      - the full oracle verdict is never PASS.
+    """
+    for vec in ("asqav-01-genesis-permit", "agentreceipts-01-didkey-genesis"):
+        vc = to_vc_envelope(_load(vec))
+        assert AgentReceiptsAdapter().detect(vc) is False
+        res = verify(vc, ADAPTERS)
+        assert res.verdict != "PASS"
+        assert res.fmt != "agentreceipts"
+
+
+def test_relabelling_export_as_standard_suite_still_cannot_verify() -> None:
+    """Even if an attacker swaps in the standard token, the bytes do not verify as a VC.
+
+    Force the envelope to look like a standard AgentReceipt (borrow the type, move the
+    signature into a ``proofValue`` under ``Ed25519Signature2020``). The Asqav signature
+    covers the SOURCE receipt's canonical bytes, never this VC's JCS bytes, so the standard
+    verifier FAILs the signature - it cannot be made to false-PASS.
+    """
+    receipt = _load("agentreceipts-01-didkey-genesis")
+    vc = to_vc_envelope(receipt)
+    forged = json.loads(json.dumps(vc))
+    forged["type"] = ["VerifiableCredential", "AgentReceipt"]
+    forged["version"] = "0.1.0"
+    forged["id"] = receipt["id"]
+    forged["credentialSubject"] = {"chain": {"previous_receipt_hash": None}}
+    forged["proof"] = {
+        "type": "Ed25519Signature2020",
+        "created": "2026-05-04T12:00:00Z",
+        "verificationMethod": receipt["proof"]["verificationMethod"],
+        "proofPurpose": "assertionMethod",
+        "proofValue": vc["proof"]["signatureValue"],
+    }
+    res = verify(forged, ADAPTERS)
+    assert res.verdict != "PASS"


### PR DESCRIPTION
## What

Adds B1h: an export-only converter from an Asqav receipt to a W3C Verifiable Credential 2.0 envelope, for EU-lane presentation. It is not a wire token, not a first-class type, and it adds no verification path.

`to_vc_envelope(receipt, *, format=None)` is pure and offline. It maps the receipt's agent/action/policy fields into `credentialSubject`, sets `type: ["VerifiableCredential", "AsqavComplianceReceipt"]`, and carries the ORIGINAL Asqav signature in a `proof`.

## Honesty design (why this was gated)

An Asqav signature covers the source receipt's canonical bytes; a standard VC proof signs the VC's own bytes, so the two cannot be relabelled into each other without forging a VC. The export is therefore explicit:
- `proof.type = "AsqavReceiptSignature2026"` — a self-descriptive non-standard type, never `Ed25519Signature2020` or any registered suite. It carries the verbatim signature, the algorithm, the key id, and a pointer to the exact bytes signed.
- `type` deliberately omits `AgentReceipt`, and a top-level `proofIsAsqavNative: true` marks it.
- Result: the oracle declines the exported envelope (`verdict FAIL`, `fmt unknown`) — it cannot be mistaken for a standard-suite-signed VC. A guard test shows that even a forced relabel into a standard suite still fails, because the Asqav signature never covers the VC's own bytes.

## Verification (reproduced)

- `pytest tests/test_vc_export.py` 11 pass (data round-trip for asqav-native + agent-receipts, signature preserved verbatim, signing-input pointer, purity, and the two honesty guards).
- `pytest tests/test_oracle.py` 58 pass (no regression); corpus runner 44/44; ruff clean.

## Scope

One export module + tests + a docs note. Export-only, no verification path, no version bump, no cloud change.
