### PR TITLE
Release 0.5.10: restore the sdist and ship ACTA interop, binary, and VC export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [Python 0.5.10] - 2026-06-05
+
+### Fixed
+- The source distribution is restored. The wheel force-included the verifier from outside the build root, which the sdist build could not reach, so the package shipped wheel-only. The verifier runtime now lives under `src/asqav/verifier/`, so `python -m build` produces both a wheel and an sdist again; the conformance corpus stays at the repo root for the TypeScript parity test and the governance corpus URL.
+
+### Added
+- Real third-party ACTA interop. Three draft-farley receipts produced by the ScopeBlind reference issuer are ingested as `acta-up-*` vectors and verify (one tamper is rejected); the external `@veritasacta/verify` accepts our ACTA receipts. The ACTA `schema()` is aligned to the draft-farley conformance spec (the `type` and `issuer_id` Asqav-profile fields become optional; the issuer-binding guard stays conditional).
+- A single-file verifier CLI and binary. `python -m asqav.verifier.oracle <receipt.json>` prints a JSON verdict; a `build-verifier-binary` workflow packages it with `cryptography` and `dilithium-py` into a per-OS single-file binary so a receipt can be verified with no runtime install.
+- An export-only `to_vc_envelope()` shim mapping an Asqav receipt into a W3C Verifiable Credential 2.0 structure for EU-lane presentation. The proof is an explicit Asqav-native type, never a registered VC suite, so it cannot be mistaken for a standard-suite-signed credential.
+
+## [TypeScript 0.5.10] - 2026-06-05
+
+### Added
+- The ACTA adapter is kept at parity with the schema alignment above so the TypeScript verifier matches the 44-vector corpus.
+
 ## [TypeScript 0.5.9] - 2026-06-05
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.9"
+version = "0.5.10"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -145,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.9"
+__version__ = "0.5.10"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -35,7 +35,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.9";
+export const CLI_VERSION = "0.5.10";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,


### PR DESCRIPTION
## What

Release 0.5.10. Bumps all five version sites together so the recent SDK work publishes to PyPI and npm.

## Included

- Restores the Python source distribution (0.5.8/0.5.9 were wheel-only): the verifier runtime moved into `src/asqav/verifier/`, so `python -m build` produces both a wheel and an sdist.
- Real third-party ACTA interop against the ScopeBlind reference corpus, with the ACTA schema aligned to the draft-farley conformance spec.
- A single-file verifier CLI (`python -m asqav.verifier.oracle`) and a per-OS binary build workflow.
- An export-only `to_vc_envelope()` shim for EU-lane presentation, with an explicit Asqav-native proof that cannot be mistaken for a standard signed credential.

## Verification

- All five version sites read 0.5.10; the Python and TypeScript version-consistency tests pass.
- Publishing is tag-triggered: PyPI now ships both wheel and sdist; npm ships the verifier subpath export.

## Scope

Version bump + changelog only.
