### PR TITLE
Close three polish gaps from the final verifier validation sweep

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,9 +51,10 @@ dependencies = []
 [project.optional-dependencies]
 httpx = ["httpx>=0.24.0"]
 # Standalone receipt verifier (verifier/verify_receipt.py). Pure-python FIPS 204
-# ML-DSA-65 so a buyer can verify a receipt offline without liboqs. Optional:
-# the main SDK defers signature crypto to the cloud and never imports this.
-verify = ["dilithium-py>=1.0.0"]
+# ML-DSA-65 so a buyer can verify a receipt offline without liboqs. cryptography
+# carries the Ed25519 and ES256 axes; without it those signatures downgrade to
+# INCOMPLETE rather than verifying. The main SDK defers signing to the cloud.
+verify = ["dilithium-py>=1.0.0", "cryptography>=42"]
 cli = ["typer>=0.12.0", "httpx>=0.24.0"]
 langchain = ["langchain-core>=0.2.0"]
 crewai = ["crewai>=0.41.0"]

--- a/python/src/asqav/verifier/vc_export.py
+++ b/python/src/asqav/verifier/vc_export.py
@@ -234,8 +234,13 @@ def to_vc_envelope(receipt: dict, *, format: str | None = None) -> dict:
 
 
 def _valid_from(subject: dict) -> str | None:
-    """Best-effort issuance timestamp from the mapped action, or ``None``."""
+    """Best-effort issuance timestamp from the mapped action or source payload, or ``None``."""
     action = subject.get("action")
-    if isinstance(action, dict):
+    if isinstance(action, dict) and action.get("timestamp"):
         return action.get("timestamp")
+    source = subject.get("source")
+    if isinstance(source, dict):
+        for key in ("issued_at", "issuanceDate", "timestamp", "validFrom"):
+            if source.get(key):
+                return source[key]
     return None

--- a/python/tests/test_vc_export.py
+++ b/python/tests/test_vc_export.py
@@ -179,3 +179,11 @@ def test_relabelling_export_as_standard_suite_still_cannot_verify() -> None:
     }
     res = verify(forged, ADAPTERS)
     assert res.verdict != "PASS"
+
+
+def test_upstream_acta_receipt_carries_validfrom_from_issued_at() -> None:
+    """A third-party ACTA receipt maps payload.issued_at into the VC validFrom."""
+    receipt = _load("acta-up-01-a2a-trusted-attestation")
+    vc = to_vc_envelope(receipt)
+    assert vc["validFrom"] == receipt["payload"]["issued_at"]
+    assert vc["issuanceDate"] == vc["validFrom"]

--- a/typescript/src/verifier/parity-check.ts
+++ b/typescript/src/verifier/parity-check.ts
@@ -6,7 +6,7 @@
  * Python verifier without dilithium-py).
  *
  * Run directly:  node --import tsx typescript/src/verifier/parity-check.ts
- * or via the test `tests/verifier-parity.test.ts`, which asserts 41/41.
+ * or via the test `tests/verifier-parity.test.ts`, which asserts 44/44.
  */
 
 import { resolve } from "node:path";


### PR DESCRIPTION
## What

Closes three minor gaps the final final validation sweep found. No soundness impact.

1. **`cryptography` added to the `verify` extra.** The extra carried only `dilithium-py` (ML-DSA), so an offline `pip install asqav[verify]` could not check the Ed25519 or ES256 axes and downgraded them to INCOMPLETE. Adding `cryptography>=42` lets a verify-only install check those signatures. The fail-safe was correct (no false PASS); this makes the common case work out of the box.
2. **VC export keeps its validity date for third-party ACTA receipts.** `_valid_from` read only a mapped `action.timestamp`, so a ScopeBlind ACTA receipt (whose `payload.issued_at` lands under the generic `source` mapping) produced `validFrom: null`. It now falls back to the source payload's `issued_at`. Presentation-only; the proof was already carried verbatim.
3. **A verifier parity-check comment** updated to the current 44-vector count.

## Verification (reproduced)

- VC export on `acta-up-01` now yields `validFrom: 2026-04-18T12:00:00Z`; native receipts unchanged. A new test pins it.
- `pytest tests/test_vc_export.py tests/test_oracle.py` 69 pass; corpus runner 44/44; ruff clean.

## Scope

One packaging line, one presentation fallback, one comment, one test. No version bump.
