### PR TITLE
Release 0.5.11: ship the offline-verify cryptography dependency fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [Python 0.5.11] - 2026-06-05
+
+### Fixed
+- The `verify` extra now installs `cryptography` alongside `dilithium-py`, so an offline `pip install asqav[verify]` can check the Ed25519 and ES256 signature axes. Without it those signatures downgraded to INCOMPLETE (a fail-safe, never a false PASS) and the common offline-verify case did not work out of the box.
+- The VC export envelope keeps its validity date for third-party ACTA receipts: `validFrom` now falls back to the source payload `issued_at` when no mapped action timestamp is present.
+
 ## [Python 0.5.10] - 2026-06-05
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.10"
+version = "0.5.11"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -145,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.10"
+__version__ = "0.5.11"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -35,7 +35,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.10";
+export const CLI_VERSION = "0.5.11";
 const TIER_RANK: Record<string, number> = {
   free: 0,
   pro: 1,


### PR DESCRIPTION
## What

Release 0.5.11, a patch that fixes the offline-verify experience.

- The `verify` extra installs `cryptography` alongside `dilithium-py`, so `pip install asqav[verify]` can check the Ed25519 and ES256 axes offline. In 0.5.10 the extra carried only `dilithium-py`, so those signatures downgraded to INCOMPLETE (a fail-safe, never a false PASS) and a clean offline install left them unchecked out of the box.
- The VC export keeps its validity date for third-party ACTA receipts (`validFrom` falls back to the source `issued_at`).

## Verification

- All five version sites read 0.5.11; the Python and TypeScript version-consistency tests pass.
- Dual-publish PyPI + npm; PyPI continues to ship both wheel and sdist.
