### PR TITLE
Harden the verifier CLI and fix the npm verify example

### DIFF
--- a/python/src/asqav/verifier/oracle/__main__.py
+++ b/python/src/asqav/verifier/oracle/__main__.py
@@ -36,7 +36,16 @@ _EXIT = {"PASS": 0, "FAIL": 1, "INCOMPLETE": 2}
 def _load(path: str | None) -> dict | None:
     if not path:
         return None
-    return json.loads(Path(path).read_text())
+    try:
+        text = Path(path).read_text()
+    except OSError as exc:
+        print(f"asqav-verify: cannot read {path}: {exc.strerror or exc}", file=sys.stderr)
+        raise SystemExit(2) from None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        print(f"asqav-verify: {path} is not valid JSON: {exc}", file=sys.stderr)
+        raise SystemExit(2) from None
 
 
 def run(receipt_path: str, keys_path: str | None, predecessor_path: str | None) -> int:

--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -51,6 +51,10 @@ class VerifyResult:
 
 def detect(doc: dict, adapters: list[FormatAdapter]) -> FormatAdapter | None:
     """Return the first adapter whose structural fingerprint matches ``doc``."""
+    if not isinstance(doc, dict):
+        # A non-object receipt (array, string, number, null) matches no format;
+        # the adapters assume a dict, so guard here rather than crash in detect().
+        return None
     return next((a for a in adapters if a.detect(doc)), None)
 
 

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -745,3 +745,13 @@ def test_es256_malformed_key_and_sig_fail_closed() -> None:
     assert crypto.verify_es256(b"\x00" * 10, b"m", b"\x00" * 64)[0] == crypto.FAIL
     pk = AuthproofAdapter().resolve_key(_authproof_receipt(), None)[0]
     assert crypto.verify_es256(pk, b"m", b"\x00" * 10)[0] == crypto.FAIL
+
+
+def test_non_dict_receipt_fails_closed_never_crashes() -> None:
+    """A non-object receipt (array/string/scalar) matches no format and FAILs, never crashes."""
+    from asqav.verifier.oracle.core import detect
+
+    for bad in ([1, 2, 3], "a-string", 42, None, True):
+        assert detect(bad, ADAPTERS) is None
+        res = verify(bad, ADAPTERS)
+        assert res.verdict != "PASS"

--- a/typescript/LICENSE
+++ b/typescript/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Asqav
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -285,7 +285,7 @@ A standalone offline verifier for agent receipts across formats ships as a subpa
 ```ts
 import { verify, ADAPTERS } from "@asqav/sdk/verifier";
 
-const result = verify(receipt, ADAPTERS, { keyProvider });
+const result = verify(receipt, ADAPTERS, keyProvider);
 // result.verdict is "PASS", "FAIL", or "INCOMPLETE"
 ```
 


### PR DESCRIPTION
## What

Fixes three edge defects the second validation sweep found against the published 0.5.11 (none security: no forged receipt ever passed; the verifier core is unchanged).

1. **CLI fails clean instead of leaking tracebacks.** `python -m asqav.verifier.oracle` on a missing file, an empty file, non-JSON garbage, or a JSON array printed a raw Python traceback. The file load now prints a clean message and exits nonzero, and `detect()` guards a non-object receipt (array/scalar) so it fails closed instead of raising in an adapter. Fail-closed on the security axis was already true; this adds fail-clean on the robustness axis, matching the TypeScript verifier.
2. **npm README verify example corrected.** The snippet passed the key provider as `{ keyProvider }`; the real signature takes it positionally, so the example returned INCOMPLETE rather than the documented PASS. Now `verify(receipt, ADAPTERS, keyProvider)`.
3. **LICENSE ships in the npm package.** `package.json` listed it in `files` but the tarball omitted it (no `typescript/LICENSE`); added.

## Verification (reproduced)

- CLI: JSON array -> clean FAIL verdict (exit 1, no traceback); empty/missing file -> clean message (exit 2); a valid receipt still PASSes.
- `detect()` returns no match and `verify()` returns non-PASS for array/string/number/null/bool, no crash; a regression test pins it.
- `pytest tests/test_oracle.py tests/test_vc_export.py` 70 pass; ruff clean on the verifier source.

## Scope

CLI robustness + one README line + a LICENSE file + a test. No verifier logic change, no version bump (rides the next release per the publish-discipline rule).
