### PR TITLE
Correct SDK docs to the two-plan model and drop the dead client-side tier gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+## [0.5.12] - 2026-06-08
+
+Applies to both the Python (`asqav`) and TypeScript (`@asqav/sdk`) packages.
+
+### Fixed
+- The CLI runs every command on the free tier. The client-side tier check that blocked free-tier keys from commands such as `replay`, `preflight`, `budget`, `approve`, `policies`, `webhooks`, and `compliance export` is removed, so a free-tier key reaches the command body and gets the real server response instead of an upgrade message. The Asqav cloud stays the source of truth for what a key may do. This drops the `_require_tier` / `requireTier` gate, the tier-rank table, and the `GET /account` tier lookup from both CLIs.
+
+### Changed
+- The docs describe Asqav's two plans, Free and Enterprise. Free covers 5,000 signatures/month, 10 agents, 10 policies, 3 team members, 30-day retention, and a generous feature set (OpenTimestamps, the MCP server, audit export, framework integrations, content scanning, OpenTelemetry, the Replay API, approvals, governance query and attestation, and 2 compliance reports/month). Enterprise adds RFC 3161 timestamps, SSO/SAML, managed and bring-your-own KMS, SD-JWT selective disclosure, IP allowlists, multi-party quorum signing, quarantine and incident management, a self-hosted signer, and dedicated support. The root, Python, TypeScript, and Chinese READMEs plus the CLI reference are updated to match, and stale tier qualifiers in client docstrings are corrected.
+
 ## [Python 0.5.11] - 2026-06-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -283,9 +283,13 @@ Both SDKs ship to different registries on independent cadences, driven by prefix
 * [asqav-mcp](https://github.com/jagmarques/asqav-mcp): MCP server for Claude Desktop, Claude Code, and Cursor.
 * [asqav-compliance](https://github.com/jagmarques/asqav-compliance): CI/CD compliance scanner.
 
-## Free tier
+## Plans
 
-Get started at no cost. Free includes 50K signatures/month, 20 agents, 10 policies, 3 team members, OpenTimestamps, MCP server, audit export, and framework integrations. Content scanning, OpenTelemetry, and Replay API on Pro. Quarantine, incident management, multi-party signing, compliance reports, and RFC 3161 timestamps on Business. Managed KMS, SSO, IP allowlist, and bring-your-own KMS on Enterprise. See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
+Asqav has two plans: Free and Enterprise.
+
+Free covers 5,000 signatures/month, 10 agents, 10 policies, 3 team members, and 30-day log retention. Most features are included: OpenTimestamps anchoring, the MCP server, audit export, framework integrations, content scanning, OpenTelemetry export, the Replay API, approvals, governance query and attestation, and 2 compliance reports/month.
+
+Enterprise adds RFC 3161 timestamps, SSO/SAML, managed and bring-your-own KMS, SD-JWT selective disclosure, IP allowlists, multi-party quorum signing, quarantine and incident management, a self-hosted signer, and dedicated support. See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
 
 ## Discovery
 

--- a/python/README-ZH.md
+++ b/python/README-ZH.md
@@ -56,21 +56,21 @@ asqav sign --agent-id ID --action-type T --action-json action.json \
            --risk-class high --issuer-id legal:Acme
 asqav agents list / create / revoke
 asqav sessions list / end
-asqav replay <agent_id> <session_id>          # Pro
+asqav replay <agent_id> <session_id>
 asqav replay-verify <agent_id> <session_id> [--strict]   # IETF 链
-asqav preflight <agent_id> <action_type>      # Pro
-asqav budget check / record                   # Pro
-asqav approve <session_id> <entity_id>        # Pro
-asqav compliance frameworks / export          # Business
+asqav preflight <agent_id> <action_type>
+asqav budget check / record
+asqav approve <session_id> <entity_id>
+asqav compliance frameworks / export
 asqav audit-pack export --start ISO --end ISO --output-file bundle.json
 asqav audit-pack policy <sha256:hex>
 asqav payloads erase <signature_id>           # P4：GDPR 删除权
 asqav org set-compliance-strict <org_id> --enable|--disable
 asqav keys generate --algorithm ed25519|es256 [--out priv.pem]
-asqav policies / webhooks list / create / delete   # Pro
+asqav policies / webhooks list / create / delete
 ```
 
-Pro 和 Business 命令在客户端通过 `GET /account` 进行门控，免费套餐 Key 会得到清晰的升级提示，而不是流水线中途的 402。
+以上所有 CLI 命令在免费套餐下均可使用。Asqav 云端是判定 Key 权限的最终依据。
 
 IETF Compliance Receipts profile 相关命令（`sign --compliance-mode`、`audit-pack export`、`audit-pack policy`、`payloads erase`、`replay-verify --strict`、`org set-compliance-strict`）与 SDK 中 `Agent.sign(...)` 和 `verify_compliance_receipt(...)` 的参数一一对应。完整参数说明见 `docs/CLI.md`。
 

--- a/python/README.md
+++ b/python/README.md
@@ -44,22 +44,22 @@ asqav sign --agent-id ID --action-type T --action-json action.json \
            --risk-class high --issuer-id legal:Acme
 asqav agents list / create / revoke
 asqav sessions list / end <session_id>
-asqav replay <agent_id> <session_id>                       # Pro
-asqav replay-verify <agent_id> <session_id> [--strict]     # Pro: IETF chain
-asqav preflight <agent_id> <action_type>                   # Pro
-asqav budget check / record                                # Pro
-asqav approve <session_id> <entity_id>                     # Pro
-asqav compliance frameworks / export                       # Business
+asqav replay <agent_id> <session_id>
+asqav replay-verify <agent_id> <session_id> [--strict]     # IETF chain
+asqav preflight <agent_id> <action_type>
+asqav budget check / record
+asqav approve <session_id> <entity_id>
+asqav compliance frameworks / export
 asqav audit-pack export --start ISO --end ISO --output-file bundle.json
 asqav audit-pack policy <sha256:hex>
 asqav payloads erase <signature_id>                        # P4 right-to-erasure
 asqav org set-compliance-strict <org_id> --enable|--disable
 asqav keys generate --algorithm ed25519|es256 [--out priv.pem]
 asqav migrate run v3-20|v3-21|v3-22                        # X-Maintenance-Key required
-asqav policies / webhooks list / create / delete           # Pro
+asqav policies / webhooks list / create / delete
 ```
 
-Pro and Business commands are gated client-side via `GET /account` so a free-tier key gets a clean upgrade message instead of a mid-pipeline 402. The server is the source of truth; self-hosted deployments without `/account` skip the gate.
+Every command listed here works on the free tier. The Asqav cloud is the source of truth for what your key may do.
 
 ## Data handling modes
 

--- a/python/docs/CLI.md
+++ b/python/docs/CLI.md
@@ -1,6 +1,6 @@
 # `asqav` CLI reference
 
-The `asqav` CLI ships in the `asqav[cli]` extra. Every command wraps a public Python API; the same arguments accepted on the command line work as kwargs on the corresponding SDK call. Pro and Business commands fail with a clean upgrade message when the calling org is below the required tier (gated client-side via `GET /account`; the cloud is the source of truth).
+The `asqav` CLI ships in the `asqav[cli]` extra. Every command wraps a public Python API; the same arguments accepted on the command line work as kwargs on the corresponding SDK call. Every CLI command works on the free tier; the Asqav cloud is the source of truth for what a key may do.
 
 ```bash
 pip install asqav[cli]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.11"
+version = "0.5.12"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -145,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.11"
+__version__ = "0.5.12"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -11,14 +11,14 @@ Commands:
     asqav verify <signature_id>                - Verify a signature (public)
     asqav agents list / create <name> / revoke - Manage agents
     asqav sessions list / end <session_id>     - Manage sessions
-    asqav policies list / create / delete      - Manage org policies (Pro)
-    asqav webhooks list / create / delete      - Manage webhooks (Pro)
+    asqav policies list / create / delete      - Manage org policies
+    asqav webhooks list / create / delete      - Manage webhooks
     asqav replay <agent_id> <session_id>       - Replay a session's audit trail
     asqav preflight <agent_id> <action>        - Pre-flight (revocation + policy)
     asqav budget check / record                - Budget gate / signed spend record
     asqav approve <session_id> <entity_id>     - Sign off a multi-party session
     asqav compliance frameworks / export       - List frameworks / export bundle
-    asqav compliance templates / report / reports / download - Cloud reports (Business+)
+    asqav compliance templates / report / reports / download - Cloud reports
     asqav audit-pack verify <bundle>           - Verify a holder-supplied bundle
     asqav org halt / resume <org_id>           - Org-wide emergency kill-switch (admin)
     asqav keys create / list / revoke          - Account API key management (admin)
@@ -485,7 +485,6 @@ def replay(
             raise typer.Exit(code=1)
 
         _init_sdk()
-        _require_tier("pro")
 
         from asqav import APIError
         from asqav import replay as replay_api
@@ -663,7 +662,6 @@ app.add_typer(policies_app, name="policies")
 def policies_list() -> None:
     """List all org policies."""
     _init_sdk()
-    _require_tier("pro")
     from asqav.client import _get
 
     try:
@@ -694,7 +692,6 @@ def policies_create(
 ) -> None:
     """Create a new policy."""
     _init_sdk()
-    _require_tier("pro")
     from asqav.client import _post
 
     try:
@@ -712,7 +709,6 @@ def policies_create(
 def policies_delete(policy_id: str = typer.Argument(help="Policy ID to delete.")) -> None:
     """Delete a policy."""
     _init_sdk()
-    _require_tier("pro")
     from asqav.client import _delete
 
     try:
@@ -738,7 +734,6 @@ app.add_typer(webhooks_app, name="webhooks")
 def webhooks_list() -> None:
     """List configured webhooks."""
     _init_sdk()
-    _require_tier("pro")
     from asqav.client import _get
 
     try:
@@ -764,7 +759,6 @@ def webhooks_create(
 ) -> None:
     """Create a webhook subscription."""
     _init_sdk()
-    _require_tier("pro")
     from asqav.client import _post
 
     event_list = [e.strip() for e in events.split(",") if e.strip()]
@@ -780,7 +774,6 @@ def webhooks_create(
 def webhooks_delete(webhook_id: str = typer.Argument(help="Webhook ID.")) -> None:
     """Delete a webhook."""
     _init_sdk()
-    _require_tier("pro")
     from asqav.client import _delete
 
     try:
@@ -805,54 +798,6 @@ def _init_sdk() -> None:
         print("Error: ASQAV_API_KEY environment variable required.")
         raise typer.Exit(code=1)
     asqav.init(api_key=api_key)
-
-
-_TIER_RANK = {"free": 0, "pro": 1, "business": 2, "enterprise": 3}
-
-
-def _fetch_account_tier() -> str | None:
-    """Best-effort lookup of the calling org's subscription tier.
-
-    Returns the lowercase tier string, or None when the server does not
-    expose the endpoint (older deployments) or the call fails. Callers
-    treat None as "skip the gate" - the server still enforces.
-    """
-    try:
-        from asqav.client import _get
-    except Exception:
-        return None
-    try:
-        data = _get("/account")
-    except Exception:
-        return None
-    if not isinstance(data, dict):
-        return None
-    tier = data.get("tier")
-    if not isinstance(tier, str) or not tier:
-        return None
-    return tier.lower()
-
-
-def _require_tier(min_tier: str) -> None:
-    """Block the command when the calling org is below ``min_tier``.
-
-    Skips the gate when the /account endpoint is unreachable so older
-    self-hosted deployments stay functional. The server is still the
-    source of truth - this only gives a clean client-side message.
-    """
-    tier = _fetch_account_tier()
-    if tier is None:
-        return
-    have = _TIER_RANK.get(tier, 0)
-    need = _TIER_RANK.get(min_tier.lower(), 0)
-    if have >= need:
-        return
-    print(
-        f"Error: this command requires the {min_tier.title()} tier "
-        f"(current: {tier}). Upgrade at https://asqav.com/pricing.",
-        file=sys.stderr,
-    )
-    raise typer.Exit(code=2)
 
 
 @app.command()
@@ -1102,7 +1047,6 @@ def preflight(
     import json as json_mod
 
     _init_sdk()
-    _require_tier("pro")
     from asqav import Agent, APIError
 
     try:
@@ -1156,7 +1100,6 @@ def budget_check(
     import json as json_mod
 
     _init_sdk()
-    _require_tier("pro")
     from asqav import Agent, BudgetTracker
 
     agent = Agent.get(agent_id)
@@ -1203,7 +1146,6 @@ def budget_record(
     cumulative spend after the record, and the configured limit.
     """
     _init_sdk()
-    _require_tier("pro")
     from asqav import Agent, APIError, BudgetTracker
 
     try:
@@ -1233,7 +1175,6 @@ def approve(
     import json as json_mod
 
     _init_sdk()
-    _require_tier("pro")
     from asqav import APIError, approve_action
 
     try:
@@ -1814,7 +1755,6 @@ def replay_verify_cmd(
     import json as json_mod
 
     _init_sdk()
-    _require_tier("pro")
     from asqav import APIError
     from asqav import replay as replay_api
 
@@ -1973,7 +1913,6 @@ def compliance_export(
     Run 'asqav compliance frameworks' to see valid framework keys.
     """
     _init_sdk()
-    _require_tier("business")
     from asqav import APIError
     from asqav.client import get_session_signatures
     from asqav.compliance import export_bundle
@@ -1997,7 +1936,7 @@ def compliance_export(
 
 @compliance_app.command("templates")
 def compliance_templates() -> None:
-    """List the report templates the cloud can generate (Business+).
+    """List the report templates the cloud can generate.
 
     Calls GET `/compliance-reports/templates`. Use a `template_id` here as
     the `--report-type` for `asqav compliance report`.
@@ -2034,7 +1973,7 @@ def compliance_report(
         "", "--schedule", help="daily|weekly|monthly to recur; omit for one-off."
     ),
 ) -> None:
-    """Generate a compliance report (Business+). Generation runs server-side.
+    """Generate a compliance report. Generation runs server-side.
 
     Calls POST `/compliance-reports`. Returns the report metadata including
     its id and status; poll `asqav compliance reports` until status is
@@ -2076,7 +2015,7 @@ def compliance_reports_list(
     ),
     framework: str = typer.Option("", "--framework", help="Filter by framework key."),
 ) -> None:
-    """List generated compliance reports for the org (Business+).
+    """List generated compliance reports for the org.
 
     Calls GET `/compliance-reports`.
     """
@@ -2117,7 +2056,7 @@ def compliance_download(
         ..., "--output-file", "-o", help="Path to write the report PDF."
     ),
 ) -> None:
-    """Download a ready compliance report PDF (Business+).
+    """Download a ready compliance report PDF.
 
     Calls GET `/compliance-reports/{report_id}/download`, which streams a
     PDF (not JSON). The cloud returns 409 when the report is not yet

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -461,9 +461,9 @@ class SDTokenResponse:
             SD-JWT string with only specified disclosures.
 
         Example:
-            # Full token has: tier, org, capabilities
-            # Present only tier to partner:
-            proof = sd_token.present(["tier"])
+            # Full token has: role, org, capabilities
+            # Present only role to partner:
+            proof = sd_token.present(["role"])
         """
         parts = [self.jwt]
         for claim_name in disclose:
@@ -1558,12 +1558,12 @@ class Agent:
 
         Example:
             sd_token = agent.issue_sd_token(
-                claims={"tier": "pro", "org": "acme"},
-                disclosable=["tier", "org"]
+                claims={"role": "admin", "org": "acme"},
+                disclosable=["role", "org"]
             )
 
-            # Present to partner - only show tier
-            proof = sd_token.present(["tier"])
+            # Present to partner - only show role
+            proof = sd_token.present(["role"])
         """
         data = _post(
             f"/agents/{self.agent_id}/tokens/sd",
@@ -2493,7 +2493,7 @@ class Agent:
         )
 
     def quarantine(self) -> dict[str, Any]:
-        """Block signing and token issuance, keep read + verify. Business+."""
+        """Block signing and token issuance, keep read + verify. Enterprise."""
         return _post(f"/agents/{self.agent_id}/quarantine", {})
 
     def unquarantine(self) -> dict[str, Any]:
@@ -3525,8 +3525,7 @@ def list_rejected_attempts(
 ) -> dict[str, Any]:
     """List rejected sign / verify / replay attempts for the org.
 
-    Pro+ feature. Org-scoped via the API key. Returns the most recent
-    rejections first.
+    Org-scoped via the API key. Returns the most recent rejections first.
     """
     params = [f"hours={hours}", f"limit={limit}", f"offset={offset}"]
     if failure_reason:
@@ -4233,7 +4232,7 @@ def export_audit_json(
     end_date: str | None = None,
     agent_id: str | None = None,
 ) -> dict[str, Any]:
-    """Export signed actions as JSON for audit trail export (Pro+ tier).
+    """Export signed actions as JSON for audit trail export.
 
     Args:
         start_date: Filter by start date (ISO format).
@@ -4263,7 +4262,7 @@ def export_audit_csv(
     end_date: str | None = None,
     agent_id: str | None = None,
 ) -> str:
-    """Export signed actions as CSV for audit trail export (Pro+ tier).
+    """Export signed actions as CSV for audit trail export.
 
     Args:
         start_date: Filter by start date (ISO format).

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -813,33 +813,21 @@ def test_compliance_export_unknown_framework(
     assert "nonexistent" in result.output
 
 
-# === Tier gating ===
-
-
-@patch("asqav.client._get")
-@patch("asqav.init")
-def test_pro_command_blocked_on_free_tier(
-    mock_init: MagicMock, mock_get: MagicMock
-) -> None:
-    """A free-tier API key is blocked at the client when invoking a Pro command."""
-    mock_get.return_value = {"tier": "free", "organization_id": "o", "organization_name": "n"}
-    result = runner.invoke(
-        app,
-        ["preflight", "agt_x", "data:read"],
-        env={"ASQAV_API_KEY": "sk_test"},
-    )
-    assert result.exit_code == 2
-    assert "Pro" in result.output or "Pro" in result.stderr_bytes.decode() if hasattr(result, "stderr_bytes") else True
+# === Free-tier access (every CLI command is free) ===
 
 
 @patch("asqav.Agent.get")
 @patch("asqav.client._get")
 @patch("asqav.init")
-def test_pro_command_runs_on_pro_tier(
+def test_preflight_runs_on_free_tier_without_gate(
     mock_init: MagicMock, mock_get_acc: MagicMock, mock_agent_get: MagicMock,
 ) -> None:
-    """A pro-tier API key passes the gate."""
-    mock_get_acc.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    """A free-tier key runs preflight to completion with no upgrade block.
+
+    The CLI does not gate commands by tier, so a free-tier org reaches the
+    command body. The /account endpoint must not be consulted as a gate.
+    """
+    mock_get_acc.return_value = {"tier": "free", "organization_id": "o", "organization_name": "n"}
     mock_agent = MagicMock()
     mock_agent.preflight.return_value = MagicMock(
         cleared=True, agent_active=True, policy_allowed=True,
@@ -852,45 +840,27 @@ def test_pro_command_runs_on_pro_tier(
         env={"ASQAV_API_KEY": "sk_test"},
     )
     assert result.exit_code == 0
+    assert "Upgrade" not in result.output
+    # The command must not call /account to decide access.
+    for call in mock_get_acc.call_args_list:
+        assert call.args[:1] != ("/account",)
 
 
-@patch("asqav.Agent.get")
 @patch("asqav.client._get")
 @patch("asqav.init")
-def test_business_command_blocked_on_pro_tier(
-    mock_init: MagicMock, mock_get_acc: MagicMock, mock_agent_get: MagicMock,
+def test_policies_list_runs_on_free_tier_without_gate(
+    mock_init: MagicMock, mock_get: MagicMock,
 ) -> None:
-    """A pro-tier key is blocked from a business-only command."""
-    mock_get_acc.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
+    """policies list (a former Pro command) is reachable on the free tier."""
+    mock_get.return_value = []
     result = runner.invoke(
         app,
-        ["compliance", "export",
-         "--session", "sess_a", "--output", "/tmp/x.json"],
-        env={"ASQAV_API_KEY": "sk_test"},
-    )
-    assert result.exit_code == 2
-
-
-@patch("asqav.Agent.get")
-@patch("asqav.client._get")
-@patch("asqav.init")
-def test_unreachable_account_endpoint_does_not_block(
-    mock_init: MagicMock, mock_get_acc: MagicMock, mock_agent_get: MagicMock,
-) -> None:
-    """Older self-hosted deployments without /account stay functional."""
-    mock_get_acc.side_effect = Exception("404 Not Found")
-    mock_agent = MagicMock()
-    mock_agent.preflight.return_value = MagicMock(
-        cleared=True, agent_active=True, policy_allowed=True,
-        reasons=[], explanation="ok",
-    )
-    mock_agent_get.return_value = mock_agent
-    result = runner.invoke(
-        app,
-        ["preflight", "agt_x", "data:read"],
+        ["policies", "list"],
         env={"ASQAV_API_KEY": "sk_test"},
     )
     assert result.exit_code == 0
+    assert "Upgrade" not in result.output
+    mock_get.assert_called_once_with("/policies")
 
 
 # === CLI gap-fill (agents revoke, sessions, policies, webhooks) ===
@@ -999,16 +969,6 @@ def test_webhooks_delete_calls_delete(
     )
     assert result.exit_code == 0
     mock_delete.assert_called_once_with("/webhooks/wh_x")
-
-
-@patch("asqav.client._get")
-@patch("asqav.init")
-def test_policies_blocked_on_free_tier(
-    mock_init: MagicMock, mock_get: MagicMock
-) -> None:
-    mock_get.return_value = {"tier": "free", "organization_id": "o", "organization_name": "n"}
-    result = runner.invoke(app, ["policies", "list"], env={"ASQAV_API_KEY": "sk_test"})
-    assert result.exit_code == 2
 
 
 # === audit-pack export / policy ===

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -45,12 +45,12 @@ asqav sign --agent-id ID --action-type T --action-json action.json \
            # add --no-compliance-mode to opt out of the IETF profile (default is on)
 asqav agents list / create / revoke
 asqav sessions list / end <session_id>
-asqav replay <agent_id> <session_id> [--json]              # Pro
-asqav replay-verify <agent_id> <session_id> [--strict]     # Pro: IETF chain
-asqav preflight <agent_id> <action_type> [--json]          # Pro
-asqav budget check / record                                # Pro
-asqav approve <session_id> <entity_id>                     # Pro
-asqav compliance frameworks / export                       # Business
+asqav replay <agent_id> <session_id> [--json]
+asqav replay-verify <agent_id> <session_id> [--strict]     # IETF chain
+asqav preflight <agent_id> <action_type> [--json]
+asqav budget check / record
+asqav approve <session_id> <entity_id>
+asqav compliance frameworks / export
 asqav audit-pack export --start ISO --end ISO --output-file bundle.json
 asqav audit-pack policy <sha256:hex>
 asqav payloads erase <signature_id> --yes                  # P4 right-to-erasure
@@ -59,7 +59,7 @@ asqav keys generate --algorithm ed25519|es256 [--out priv.bin]
 asqav migrate run v3-20|v3-21|v3-22                        # X-Maintenance-Key required
 ```
 
-Pro and Business commands are gated client-side via `GET /account` so a free-tier key gets a clean upgrade message instead of a mid-pipeline 402. The server is the source of truth; self-hosted deployments without `/account` skip the gate.
+Every command listed here works on the free tier. The Asqav cloud is the source of truth for what your key may do.
 
 ## Data handling modes
 
@@ -230,7 +230,7 @@ Bad input throws `AsqavError` with a verbatim guard message before the HTTP roun
 
 ### Audit Pack export
 
-The SDK exposes the public audit-trail endpoint as `exportAuditJson` for filtered windows of receipts (Pro tier and above):
+The SDK exposes the public audit-trail endpoint as `exportAuditJson` for filtered windows of receipts:
 
 ```ts
 import { exportAuditJson } from "@asqav/sdk";

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -15,10 +15,8 @@
  *   asqav audit-pack verify <bundle>
  *   asqav org halt / resume <org_id>          (admin, ASQAV_SESSION_TOKEN)
  *
- * Pro-only commands (replay, preflight, budget, approve) and the
- * Business-only `compliance export` are gated client-side via the same
- * GET /account endpoint the Python CLI uses; the server is still the
- * source of truth.
+ * Every command here works on the free tier. The server is the source of
+ * truth for what a given key may do.
  */
 
 import {
@@ -35,13 +33,7 @@ import {
   type SignatureResponse,
 } from "./index.js";
 
-export const CLI_VERSION = "0.5.11";
-const TIER_RANK: Record<string, number> = {
-  free: 0,
-  pro: 1,
-  business: 2,
-  enterprise: 3,
-};
+export const CLI_VERSION = "0.5.12";
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`${msg}\n`);
@@ -53,31 +45,6 @@ function ensureApiKey(): void {
     die("Error: ASQAV_API_KEY environment variable required.");
   }
   init({ apiKey: process.env.ASQAV_API_KEY });
-}
-
-async function fetchTier(): Promise<string | null> {
-  try {
-    const data = await request<{ tier?: string }>("GET", "/account");
-    if (data && typeof data.tier === "string" && data.tier.length > 0) {
-      return data.tier.toLowerCase();
-    }
-  } catch {
-    // Older self-hosted deployments without /account; skip the gate.
-  }
-  return null;
-}
-
-async function requireTier(minTier: string): Promise<void> {
-  const tier = await fetchTier();
-  if (tier === null) return;
-  const have = TIER_RANK[tier] ?? 0;
-  const need = TIER_RANK[minTier.toLowerCase()] ?? 0;
-  if (have >= need) return;
-  const titled = minTier.charAt(0).toUpperCase() + minTier.slice(1);
-  die(
-    `Error: this command requires the ${titled} tier (current: ${tier}). Upgrade at https://asqav.com/pricing.`,
-    2,
-  );
 }
 
 function parseFlag(args: string[], name: string): string | undefined {
@@ -236,7 +203,6 @@ async function cmdReplay(args: string[]): Promise<void> {
     die("Usage: asqav replay <agent_id> <session_id> [--json]");
   }
   ensureApiKey();
-  await requireTier("pro");
   try {
     const data = await request<{ steps?: unknown[]; chain_integrity?: boolean }>(
       "GET",
@@ -261,7 +227,6 @@ async function cmdPreflight(args: string[]): Promise<void> {
     die("Usage: asqav preflight <agent_id> <action_type> [--json]");
   }
   ensureApiKey();
-  await requireTier("pro");
   try {
     const agent = await Agent.get(agentId);
     const r = await agent.preflight(actionType);
@@ -287,7 +252,6 @@ async function cmdBudgetCheck(args: string[]): Promise<void> {
     die("Usage: asqav budget check --agent-id <id> --limit N --estimated-cost N [--current-spend N] [--currency USD]");
   }
   ensureApiKey();
-  await requireTier("pro");
   const agent = await Agent.get(agentId);
   const tracker = new BudgetTracker({ agent, limit, currency });
   // Apply existing spend by recording a synthetic priming amount in memory only.
@@ -314,7 +278,6 @@ async function cmdBudgetRecord(args: string[]): Promise<void> {
     die("Usage: asqav budget record --agent-id <id> --action <type> --actual-cost N --limit N [--current-spend N] [--currency USD]");
   }
   ensureApiKey();
-  await requireTier("pro");
   try {
     const agent = await Agent.get(agentId);
     const tracker = new BudgetTracker({ agent, limit, currency });
@@ -334,7 +297,6 @@ async function cmdApprove(args: string[]): Promise<void> {
     die("Usage: asqav approve <session_id> <entity_id> [--json]");
   }
   ensureApiKey();
-  await requireTier("pro");
   try {
     const data = await request<unknown>("POST", `/sessions/${sessionId}/approve`, { entity_id: entityId });
     if (hasFlag(args, "json")) {
@@ -375,7 +337,6 @@ async function cmdComplianceExport(args: string[]): Promise<void> {
     die("Usage: asqav compliance export --session <id> --output <path> [--framework eu_ai_act]");
   }
   ensureApiKey();
-  await requireTier("business");
   try {
     const data = await request<unknown>(
       "GET",
@@ -878,7 +839,6 @@ async function cmdReplayVerify(args: string[]): Promise<void> {
   const strict = hasFlag(args, "strict");
   const output = parseFlag(args, "output") ?? "text";
   ensureApiKey();
-  await requireTier("pro");
   try {
     const data = await request<{
       steps?: Array<{
@@ -993,12 +953,12 @@ Usage:
              [--session-id ID] [--valid-seconds N] [--output text|json]
   asqav agents list / create <name> / revoke <agent_id>
   asqav sessions list / end <session_id>
-  asqav replay <agent_id> <session_id> [--json]            (Pro)
-  asqav replay-verify <agent_id> <session_id> [--strict]   (Pro)  IETF chain
-  asqav preflight <agent_id> <action_type> [--json]        (Pro)
-  asqav budget check / record                              (Pro)
-  asqav approve <session_id> <entity_id>                   (Pro)
-  asqav compliance frameworks / export                     (Business)
+  asqav replay <agent_id> <session_id> [--json]
+  asqav replay-verify <agent_id> <session_id> [--strict]          IETF chain
+  asqav preflight <agent_id> <action_type> [--json]
+  asqav budget check / record
+  asqav approve <session_id> <entity_id>
+  asqav compliance frameworks / export
   asqav audit-pack export --start ISO --end ISO --output-file PATH
                           [--organization-id ID] [--no-only-compliance]
   asqav audit-pack verify <bundle.json|-> [--output text|json]

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -2216,8 +2216,8 @@ export async function postAppliedAttestation(
 }
 
 /** List rejected sign / verify / replay attempts for the caller's
- * org. Pro+ tier. Public verify rejections (org NULL) are filtered out
- * by design - admins query those separately via maintenance. */
+ * org. Public verify rejections (org NULL) are filtered out by design.
+ * Admins query those separately via maintenance. */
 export async function listRejectedAttempts(
   options: ListRejectedAttemptsOptions = {},
 ): Promise<RejectedAttemptList> {

--- a/typescript/tests/cli.test.ts
+++ b/typescript/tests/cli.test.ts
@@ -58,26 +58,9 @@ describe("asqav CLI (TypeScript)", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("blocks Pro command on Free tier (gating)", async () => {
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(
-        jsonResponse({ tier: "free", organization_id: "o", organization_name: "n" }),
-      );
-    try {
-      await runCli(["preflight", "agt_x", "data:read"]);
-    } catch (e) {
-      // exit thrown
-    }
-    expect(output()).toMatch(/Pro tier/);
-    expect(exitSpy).toHaveBeenCalledWith(2);
-  });
-
-  it("allows Pro command on Pro tier", async () => {
-    vi.spyOn(globalThis, "fetch")
-      // /account
-      .mockResolvedValueOnce(
-        jsonResponse({ tier: "pro", organization_id: "o", organization_name: "n" }),
-      )
+  it("runs preflight on the free tier without a tier gate", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
       // Agent.get
       .mockResolvedValueOnce(
         jsonResponse({
@@ -101,36 +84,11 @@ describe("asqav CLI (TypeScript)", () => {
       // CLEARED -> no exit; if BLOCKED -> exit 1. Either way swallowed.
     }
     expect(output()).toMatch(/CLEARED|BLOCKED/);
-  });
-
-  it("skips gating when /account is unreachable (fail-open)", async () => {
-    vi.spyOn(globalThis, "fetch")
-      // /account fails
-      .mockResolvedValueOnce(jsonResponse({ detail: "not found" }, 404))
-      .mockResolvedValueOnce(jsonResponse({ detail: "not found" }, 404))
-      .mockResolvedValueOnce(jsonResponse({ detail: "not found" }, 404))
-      // Agent.get
-      .mockResolvedValueOnce(
-        jsonResponse({
-          agent_id: "agt_x",
-          name: "n",
-          public_key: "pk",
-          key_id: "kid",
-          algorithm: "ml-dsa-65",
-          capabilities: [],
-          created_at: "2026-01-01T00:00:00Z",
-        }),
-      )
-      .mockResolvedValueOnce(jsonResponse({ revoked: false, suspended: false }))
-      .mockResolvedValueOnce(jsonResponse([]));
-
-    try {
-      await runCli(["preflight", "agt_x", "data:read"]);
-    } catch (e) {
-      // ignore exit
-    }
-    // No "Pro tier" gating message
     expect(output()).not.toMatch(/Pro tier/);
+    expect(output()).not.toMatch(/Upgrade/);
+    // No /account call is made as a gate; the first request is Agent.get.
+    const firstUrl = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    expect(firstUrl).not.toContain("/account");
   });
 
   it("compliance frameworks lists static set", async () => {
@@ -438,15 +396,13 @@ describe("asqav CLI (TypeScript)", () => {
   });
 
   it("replay-verify --strict rejects synthetic-shape steps", async () => {
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(jsonResponse({ tier: "pro", organization_id: "o", organization_name: "n" }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          steps: [
-            { signature_id: "sig_1" /* no signed_envelope */ },
-          ],
-        }),
-      );
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        steps: [
+          { signature_id: "sig_1" /* no signed_envelope */ },
+        ],
+      }),
+    );
     try {
       await runCli(["replay-verify", "agt_x", "sess_x", "--strict"]);
     } catch {


### PR DESCRIPTION
The cloud runs two plans, Free and Enterprise. The CLI carried a four-rank client gate that blocked free-plan keys from commands whose features are included in Free (replay, replay-verify, policies, webhooks, preflight, budget, approve, compliance export).

## What changed
- Removed the client-side tier gate and its helpers from the Python and TypeScript CLIs, so the server stays the single source of truth for entitlements.
- Rewrote README, CLI docs, and docstrings to the two-plan feature split: Free includes 5,000 signatures/month, 10 agents, 10 policies, 3 team members, 30-day retention, OpenTimestamps, audit export, content scanning, OpenTelemetry, the Replay API, approvals, governance query and attestation, and 2 compliance reports/month. Enterprise raises the caps and adds timestamp-authority anchoring, SSO/SAML, managed and bring-your-own KMS, SD-JWT, IP allowlist, multi-party quorum, quarantine and incident management, the self-hosted signer, and dedicated support.
- Replaced the gate tests with tests asserting free-plan commands run without a gate.
- Bumped Python and TypeScript to 0.5.12.

Net -172 LOC (dead-code removal). Python 1031 tests and TypeScript 418 tests pass locally.