### PR TITLE
Remove parenthetical asides from the README and docs prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The agent now has a cryptographic identity, a signed audit trail, and a verifiab
 
 The SDK auto-detects whether you're pointing at the Asqav cloud or a self-hosted deployment, and selects the safer default for each:
 
-- **Cloud (`*.asqav.com`)**: hash-only by default. The SDK builds a fingerprint of your action context, computes a SHA-256 hash locally, and sends only the hash plus a small metadata bag (action_type, agent_id, session_id, model_name, tool_name). Raw prompts and tool arguments stay on your side.
+- **Cloud (`*.asqav.com`)**: hash-only by default. The SDK builds a fingerprint of your action context, computes a SHA-256 hash locally, and sends only the hash plus a small metadata bag of action_type, agent_id, session_id, model_name, and tool_name. Raw prompts and tool arguments stay on your side.
 - **Self-hosted**: full-payload by default. The server can run policy checks, PII redaction, and richer audit. Recommended when you control the deployment.
 
 Override anytime:
@@ -146,13 +146,13 @@ The full reference lives at [asqav.com/docs](https://asqav.com/docs).
 
 ### What's in each SDK
 
-Both SDKs cover the same core surface: agent identity, signed actions, batched signing, policy enforcement, scope tokens, replay, attestations, three-phase signing, and the `user_intent` envelope on `agent.sign(...)` (Ed25519 / ECDSA P-256 / WebAuthn).
+Both SDKs cover the same core surface: agent identity, signed actions, batched signing, policy enforcement, scope tokens, replay, attestations, three-phase signing, and the `user_intent` envelope on `agent.sign(...)`, signed with Ed25519, ECDSA P-256, or WebAuthn.
 
 The Python SDK additionally ships:
 
-- The `asqav` CLI: `quickstart`, `demo`, `verify`, `doctor`, `agents`, `sync`, plus `replay`, `preflight`, `approve`, `budget` (`check`/`record`), and `compliance` (`frameworks`/`export`). See [asqav.com/docs/cli](https://asqav.com/docs/cli).
-- A pytest plugin (`pytest --asqav`) that signs every test result and emits a Merkle-rooted compliance bundle on session finish. See [asqav.com/docs/pytest-plugin](https://asqav.com/docs/pytest-plugin).
-- Native callbacks for LangChain, CrewAI, LiteLLM, Haystack, OpenAI Agents SDK, LlamaIndex, smolagents, DSPy, PydanticAI, Letta, Strands, and Instructor (via the Hooks API).
+- The `asqav` CLI: `quickstart`, `demo`, `verify`, `doctor`, `agents`, `sync`, plus `replay`, `preflight`, `approve`, `budget` with `check` and `record`, and `compliance` with `frameworks` and `export`. See [asqav.com/docs/cli](https://asqav.com/docs/cli).
+- A pytest plugin, enabled with `pytest --asqav`, that signs every test result and emits a Merkle-rooted compliance bundle on session finish. See [asqav.com/docs/pytest-plugin](https://asqav.com/docs/pytest-plugin).
+- Native callbacks for LangChain, CrewAI, LiteLLM, Haystack, OpenAI Agents SDK, LlamaIndex, smolagents, DSPy, PydanticAI, Letta, Strands, and Instructor through the Hooks API.
 - Cookbooks for Streamlit dashboards and Dify workflows under `python/examples/`.
 - Local-mode offline signing with deferred sync.
 
@@ -214,11 +214,11 @@ console.assert(result.verified);
 console.log(result.agentId, result.chainHash);
 ```
 
-Or open the receipt's `verify_url` in a browser. Hashes are reproducible offline from the RFC 8785 (the JSON format spec) payload, so auditors do not need to trust Asqav's servers - the signature speaks for itself.
+Or open the receipt's `verify_url` in a browser. Hashes are reproducible offline from the RFC 8785 payload, the JSON canonicalization format, so auditors do not need to trust Asqav's servers - the signature speaks for itself.
 
 ## Counterparty acknowledgment
 
-When two agents hand off a workflow (A signs an action, B acts on it), the SDK lets B emit a `protectmcp:acknowledgment` receipt that cryptographically binds B's bytes to A's. The bundle carries A's full envelope, B's acknowledgment, and a SHA-256 binding the verifier recomputes offline. A tampered intermediary cannot mutate the bytes without breaking the equality, so a regulator can verify the handoff with one digest comparison.
+When two agents hand off a workflow, where A signs an action and B acts on it, the SDK lets B emit a `protectmcp:acknowledgment` receipt that cryptographically binds B's bytes to A's. The bundle carries A's full envelope, B's acknowledgment, and a SHA-256 binding the verifier recomputes offline. A tampered intermediary cannot mutate the bytes without breaking the equality, so a regulator can verify the handoff with one digest comparison.
 
 Python:
 

--- a/docs/fingerprint-spec.md
+++ b/docs/fingerprint-spec.md
@@ -8,7 +8,7 @@ The output is a string of the form:
 sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
 ```
 
-You send that string as the `hash` field on `/sign`. Asqav signs it with your agent's ML-DSA key and returns a signature. You (or any third party) can later rebuild the fingerprint from the original `(action_type, context)` pair and verify the signature.
+You send that string as the `hash` field on `/sign`. Asqav signs it with your agent's ML-DSA key and returns a signature. You, or any third party, can later rebuild the fingerprint from the original `(action_type, context)` pair and verify the signature.
 
 ## Why a spec at all
 
@@ -33,11 +33,11 @@ def hash_action(action_type: str, context: dict) -> str:
     return "sha256:" + hashlib.sha256(body).hexdigest()
 ```
 
-This is RFC 8785 (the JCS standard) applied to the `{action_type, context}` pair, then SHA-256 over the resulting bytes. Stdlib only, no third-party packages. The output is `sha256:<64 hex chars>`.
+This is RFC 8785, the JCS standard, applied to the `{action_type, context}` pair, then SHA-256 over the resulting bytes. Stdlib only, no third-party packages. The output is `sha256:<64 hex chars>`.
 
 ## Inputs
 
-- **`action_type`**: short string identifying the action (e.g. `"read:data"`, `"api:call"`). The same string you would have sent in full-payload mode.
+- **`action_type`**: short string identifying the action, for example `"read:data"` or `"api:call"`. The same string you would have sent in full-payload mode.
 - **`context`**: the action payload dict. Any JSON-serializable value. May be empty.
 
 The fingerprint is computed over the combined object `{"action_type": ..., "context": ...}`, so `action_type` cannot be tampered with independently of the context bytes.
@@ -46,14 +46,14 @@ The fingerprint is computed over the combined object `{"action_type": ..., "cont
 
 The same rules expressed in any language:
 
-- **Object keys**: sorted lexicographically by Unicode code point (Python's `sorted()` default).
+- **Object keys**: sorted lexicographically by Unicode code point, which is Python's `sorted()` default.
 - **Whitespace**: none, anywhere.
-- **Strings**: emitted verbatim as UTF-8 (no `\uXXXX` escaping for characters above U+001F).
-- **Numbers**: serialized via Python's `json` module rules. Integers as integers (`42`), floats in shortest round-trip form (`1.5`, not `1.50`).
+- **Strings**: emitted verbatim as UTF-8, with no `\uXXXX` escaping for characters above U+001F.
+- **Numbers**: serialized via Python's `json` module rules. Integers stay integers like `42`, and floats use the shortest round-trip form, so `1.5` not `1.50`.
 - **Null / true / false**: lowercase.
 - **Arrays**: order preserved.
 - **Nested objects and arrays**: recurse, same rules.
-- **NaN / Infinity / -Infinity**: rejected (`allow_nan=False`). Filter or convert to `None` before hashing.
+- **NaN / Infinity / -Infinity**: rejected under `allow_nan=False`. Filter or convert to `None` before hashing.
 
 ## Worked example
 
@@ -70,24 +70,24 @@ body = b'{"action_type":"read:data","context":{}}'
 
 See `conformance/vectors.json` for additional worked examples.
 
-## Subtleties (read these)
+## Subtleties worth reading
 
 1. **Float precision**. `0.1 + 0.2 == 0.30000000000000004` in IEEE 754. Python's `json.dumps` emits `0.30000000000000004`. If you want to hash `0.3`, pass `0.3` literally; do not arithmetic to get there. If your domain needs exact decimals, send strings or scaled integers, not floats.
-2. **Unicode normalization**. We do NOT normalize Unicode. `"café"` (single codepoint U+00E9) and `"café"` (e + combining acute) hash differently. If your input might be in either form, NFC-normalize before hashing: `unicodedata.normalize("NFC", s)`.
+2. **Unicode normalization**. We do NOT normalize Unicode. `"café"` as the single codepoint U+00E9 and `"café"` as e plus a combining acute hash differently. If your input might be in either form, NFC-normalize before hashing: `unicodedata.normalize("NFC", s)`.
 3. **Key ordering of nested dicts**. Recursive: every dict at every depth is sorted independently.
-4. **List of dicts**. Lists preserve input order. Each dict inside is formatted in standard form. So `[{"b":1,"a":2},{"a":3}]` becomes `[{"a":2,"b":1},{"a":3}]` (inner keys sorted, outer order preserved).
+4. **List of dicts**. Lists preserve input order. Each dict inside is formatted in standard form. So `[{"b":1,"a":2},{"a":3}]` becomes `[{"a":2,"b":1},{"a":3}]`, with inner keys sorted and outer order preserved.
 5. **Empty values**. `{}` becomes `{}`. `[]` becomes `[]`. Both hash to a stable value.
 6. **`None` / `null`**. Allowed. Serializes as `null`.
 7. **Tuples**. Python tuples serialize as arrays. So `(1,2,3)` and `[1,2,3]` produce the same bytes. If your code relies on the difference, convert to lists first.
 8. **Keys must be strings**. JSON forbids non-string keys. `{1: "x"}` will raise. Convert to `{"1": "x"}` or fail loudly.
 9. **`NaN`, `Infinity`, `-Infinity`**. Rejected by `allow_nan=False`. Filter or convert to `None` before hashing.
 10. **bytes**. Not JSON. Base64-encode and pass as a string.
-11. **datetime / Decimal / UUID**. Not JSON. Convert to string (ISO 8601, str(decimal), str(uuid)) before hashing. Whatever convention you pick, pick it once and stick to it.
-12. **`tool_name` and `model_name`**. These should be static identifiers (e.g. `"database.query"`, `"gpt-4o"`), not user input or PII. The metadata whitelist passes them through unchanged, so a name like `"lookup_user_email_for_alice@example.com"` would land in the audit trail verbatim.
+11. **datetime / Decimal / UUID**. Not JSON. Convert to string before hashing, for example ISO 8601, `str(decimal)`, or `str(uuid)`. Whatever convention you pick, pick it once and stick to it.
+12. **`tool_name` and `model_name`**. These should be static identifiers like `"database.query"` or `"gpt-4o"`, not user input or PII. The metadata whitelist passes them through unchanged, so a name like `"lookup_user_email_for_alice@example.com"` would land in the audit trail verbatim.
 
 ## Cross-language guarantee
 
-Both `asqav` (Python) and `@asqav/sdk` (TypeScript) produce byte-identical output for the same input. The 8 conformance vectors at `conformance/vectors.json` are exercised by CI on both SDKs on every change, so the two stay in lockstep. If you write a verifier in another language, point it at the same vectors first.
+Both `asqav` for Python and `@asqav/sdk` for TypeScript produce byte-identical output for the same input. The 8 conformance vectors at `conformance/vectors.json` are exercised by CI on both SDKs on every change, so the two stay in lockstep. If you write a verifier in another language, point it at the same vectors first.
 
 ## Replay protection
 
@@ -103,9 +103,9 @@ See `conformance/vectors.json`. The hash-mode happy-path vectors (`minimal_read`
 
 ## Versioning
 
-This spec is version 2. The `vectors.json` file declares `version: 2` to align. Hash-mode signing input includes `"v": 1` (the wire version of the signing-input schema, distinct from this spec version), so a future v2 wire format will be distinguishable from v1 in every signature.
+This spec is version 2. The `vectors.json` file declares `version: 2` to align. Hash-mode signing input includes `"v": 1`, the wire version of the signing-input schema, which is distinct from this spec version, so a future v2 wire format will be distinguishable from v1 in every signature.
 
 ## See also
 
-- `conformance/vectors.json` (the test vectors both SDKs pass)
-- README in this repo (mode selection: hash-only vs full-payload)
+- `conformance/vectors.json`, the test vectors both SDKs pass
+- README in this repo, covering mode selection: hash-only vs full-payload

--- a/docs/user-intent.md
+++ b/docs/user-intent.md
@@ -4,7 +4,7 @@ A receipt that says "agent X ran this action" answers half the question. The oth
 
 ## The shape
 
-When you call `agent.sign(...)`, you can attach an optional `user_intent` envelope. The user produces a signature over the bytes they're asserting (typically a digest of action_type plus context plus a fresh nonce). The SDK passes those bytes to the backend verbatim. The backend verifies the signature with the declared algorithm and stores both the agent signature and the user signature on the same record.
+When you call `agent.sign(...)`, you can attach an optional `user_intent` envelope. The user produces a signature over the bytes they're asserting, typically a digest of action_type plus context plus a fresh nonce. The SDK passes those bytes to the backend verbatim. The backend verifies the signature with the declared algorithm and stores both the agent signature and the user signature on the same record.
 
 The envelope:
 
@@ -23,7 +23,7 @@ Supported algorithms today:
 
 - `ed25519` - verified server-side via the cryptography library.
 - `ecdsa-p256` - verified server-side via the cryptography library.
-- `webauthn` - cryptographically verified server-side. `public_key` is a CBOR-encoded COSE credential key (EdDSA or ES256), `signature` is the assertion signature, `signed_message` is the bytes the authenticator signed (per WebAuthn, `authenticatorData || SHA-256(clientDataJSON)`). Higher-level checks (challenge match, RP ID, origin, user-present flag) live with the relying-party front end.
+- `webauthn` - cryptographically verified server-side. `public_key` is a CBOR-encoded COSE credential key, either EdDSA or ES256, `signature` is the assertion signature, and `signed_message` is the bytes the authenticator signed, which per WebAuthn is `authenticatorData || SHA-256(clientDataJSON)`. Higher-level checks such as challenge match, RP ID, origin, and the user-present flag live with the relying-party front end.
 
 If verification fails, the backend returns 400 with `code: USER_INTENT_INVALID` and does not sign over a bogus envelope.
 
@@ -72,7 +72,7 @@ resp = agent.sign(
 assert resp.user_intent_verified is True
 ```
 
-## Browser example with WebAuthn (sketch)
+## Browser example with WebAuthn, a sketch
 
 The actual WebAuthn flow is the customer's responsibility. The sketch below is a starting point:
 
@@ -107,6 +107,6 @@ WebAuthn assertion verification is store-only today. The bytes are persisted on 
 
 ## Roadmap
 
-- WebAuthn assertion verification (parse `authenticatorData` plus `clientDataJSON`, verify against the stored COSE key).
+- WebAuthn assertion verification: parse `authenticatorData` plus `clientDataJSON`, then verify against the stored COSE key.
 - A `verifyUserIntent(signatureId)` helper on both SDKs that re-runs verification against the stored bytes.
 - Optional policy: require `user_intent_verified=true` for specific action_type patterns.

--- a/examples/dify_workflow.md
+++ b/examples/dify_workflow.md
@@ -9,18 +9,18 @@ so any pipeline is portable across runtimes.
 
 ## Install the plugin in Dify
 
-1. Open the Dify Plugin Marketplace (or import from URL).
+1. Open the Dify Plugin Marketplace, or import from URL.
 2. Add the asqav plugin.
 3. Open **Plugin Settings** and enter your credentials:
-   - **asqav API Key** (`sk_...`) - get one at <https://cloud.asqav.com>
-   - **Agent ID** (`agent_...`) - create with `asqav agents create my-agent`
+   - **asqav API Key**, in the form `sk_...` - get one at <https://cloud.asqav.com>
+   - **Agent ID**, in the form `agent_...` - create with `asqav agents create my-agent`
      or via the dashboard.
 
 ## Wire up a workflow
 
 A typical workflow puts the Sign Action tool right after the LLM step that
 decides what to do, and the Verify Signature tool wherever a downstream step
-(or auditor) needs to confirm the action ran as recorded.
+or auditor needs to confirm the action ran as recorded.
 
 ```
 [User input] -> [LLM: choose tool] -> [Sign Action] -> [Execute tool] -> [Output]
@@ -70,9 +70,9 @@ asqav verify sig_a1b2c3
 
 ## Bundle a workflow run for an auditor
 
-Group every signature from a Dify workflow run under one `session_id` (the
-plugin accepts `context.session_id`, or use the same value across all Sign
-Action calls). Then export the bundle from the SDK or CLI:
+Group every signature from a Dify workflow run under one `session_id`. The
+plugin accepts `context.session_id`, or you can use the same value across all
+Sign Action calls. Then export the bundle from the SDK or CLI:
 
 ```bash
 asqav compliance export --session sess_dify_run_42 --output run-42.json
@@ -91,7 +91,7 @@ for the programmatic equivalent.
 - Bulk batch signing is not exposed by the plugin yet. Use the SDK's
   `agent.sign_batch(...)` for high-volume runs.
 - The plugin does not yet drive the multi-party countersigning flow
-  (`co_signers`). For that, call `agent.sign(..., co_signers=[...])` from the
+  via `co_signers`. For that, call `agent.sign(..., co_signers=[...])` from the
   SDK.
 
 ## Links

--- a/github-action/README.md
+++ b/github-action/README.md
@@ -4,15 +4,15 @@ Sign an Asqav code-authorship receipt from a CI run. On every pull request this
 action records who authored a code change and signs that record with ML-DSA-65
 (FIPS 204) server-side, then writes it out as an in-toto Statement.
 
-## What it proves (and what it does not)
+## What it proves and what it does not
 
 This action signs a small, honest set of facts:
 
-- a change existed (the diff between a base commit and the head commit, captured
-  as a SHA-256 digest),
-- that change was key-authored (the Asqav agent key signed the record),
-- the record was chained at time T (the receipt is hash-chained and timestamped
-  by Asqav).
+- a change existed, namely the diff between a base commit and the head commit,
+  captured as a SHA-256 digest,
+- that change was key-authored, since the Asqav agent key signed the record,
+- the record was chained at time T, as the receipt is hash-chained and
+  timestamped by Asqav.
 
 It does not verify the code, does not re-run the diff, does not resolve the
 refs, and does not attest the model. The author identity, the tool, and any
@@ -63,11 +63,11 @@ base commit must be present in the checkout.
 
 | Input            | Required | Default          | Description |
 | ---------------- | -------- | ---------------- | ----------- |
-| `asqav-api-key`  | yes      |                  | Asqav API key (`sk_...`). Pass via a repository secret. |
+| `asqav-api-key`  | yes      |                  | Asqav API key in the form `sk_...`. Pass via a repository secret. |
 | `asqav-agent-id` | yes      |                  | Asqav agent id whose key signs the receipt. |
 | `change-class`   | no       | `write`          | One of `read`, `write`, `delete`, `execute`, `deploy`. |
-| `model-id`       | no       | (empty)          | Producer-asserted model id. Recorded, never verified. |
-| `model-version`  | no       | (empty)          | Producer-asserted model version. Recorded, never verified. |
+| `model-id`       | no       | empty            | Producer-asserted model id. Recorded, never verified. |
+| `model-version`  | no       | empty            | Producer-asserted model version. Recorded, never verified. |
 | `tool`           | no       | `github-actions` | Producer-asserted authoring tool label. |
 
 ## Outputs
@@ -90,8 +90,8 @@ The action reads the git context from the GitHub Actions environment:
 
 It then calls `agent.sign(...)` with
 `receipt_type="protectmcp:lifecycle:code_authorship"`, `compliance_mode=True`,
-and `policy_decision="none"` (a code-authorship receipt records no policy
-evaluation, so it signs under the no-policy opt-out).
+and `policy_decision="none"`, since a code-authorship receipt records no policy
+evaluation and signs under the no-policy opt-out.
 
 ## in-toto interop
 

--- a/python/README-ZH.md
+++ b/python/README-ZH.md
@@ -43,7 +43,7 @@ print(sig.previous_receipt_hash)  # 64 位 hex；每个 Agent 的首条记录为
 print(sig.verification_url)
 ```
 
-每次签名默认会生成一份符合 IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) 的 Compliance Receipt：ML-DSA-65（FIPS 204）签名、链式哈希、保留的 `policy_digest`、fail-closed 时间戳锚定，以及一个公开的验证 URL。如需关闭，请传入 `compliance_mode=False`。
+每次签名默认会生成一份符合 IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) 的 Compliance Receipt：基于 FIPS 204 的 ML-DSA-65 签名、链式哈希、保留的 `policy_digest`、fail-closed 时间戳锚定，以及一个公开的验证 URL。如需关闭，请传入 `compliance_mode=False`。
 
 ## CLI
 
@@ -72,18 +72,18 @@ asqav policies / webhooks list / create / delete
 
 以上所有 CLI 命令在免费套餐下均可使用。Asqav 云端是判定 Key 权限的最终依据。
 
-IETF Compliance Receipts profile 相关命令（`sign --compliance-mode`、`audit-pack export`、`audit-pack policy`、`payloads erase`、`replay-verify --strict`、`org set-compliance-strict`）与 SDK 中 `Agent.sign(...)` 和 `verify_compliance_receipt(...)` 的参数一一对应。完整参数说明见 `docs/CLI.md`。
+IETF Compliance Receipts profile 相关命令，包括 `sign --compliance-mode`、`audit-pack export`、`audit-pack policy`、`payloads erase`、`replay-verify --strict` 和 `org set-compliance-strict`，与 SDK 中 `Agent.sign(...)` 和 `verify_compliance_receipt(...)` 的参数一一对应。完整参数说明见 `docs/CLI.md`。
 
 ## 路线图
 
 Asqav 当前已上线的六项能力：
 
-- 云端 hash-only 模式 - 已上线（`*.asqav.com` 默认开启）。
-- 自托管签名器（split-trust）- 已上线。
-- 自带 KMS（AWS KMS / GCP KMS）- 已上线，Enterprise 层级。
-- 客户自有存储 - 已上线（自托管；relay payload 白名单在代码中强制）。
-- SCITT / COSE_Sign1 收据导出 - 已上线（公开端点 `GET /api/v1/signatures/{id}/cose` 返回 `application/cose`）。
-- 气隙 / 本地部署模式 - 已上线（离线 license + 零出网，详见后端仓库 `docs/airgapped-mode.md`）。
+- 云端 hash-only 模式 - 已上线，`*.asqav.com` 默认开启。
+- 自托管签名器，采用 split-trust - 已上线。
+- 自带 KMS，支持 AWS KMS 或 GCP KMS - 已上线，Enterprise 层级。
+- 客户自有存储 - 已上线，自托管；relay payload 白名单在代码中强制。
+- SCITT / COSE_Sign1 收据导出 - 已上线，公开端点 `GET /api/v1/signatures/{id}/cose` 返回 `application/cose`。
+- 气隙 / 本地部署模式 - 已上线，离线 license + 零出网，详见后端仓库 `docs/airgapped-mode.md`。
 
 最新特性见文档站 <https://asqav.com/docs>。
 
@@ -91,7 +91,7 @@ Asqav 当前已上线的六项能力：
 
 Asqav 的合规凭证基于 IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/)，profile 了上游 [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/)，并绑定了 EU AI Act 第 12、26 条以及 DORA 第 17 条。
 
-## Compliance Receipts（IETF profile）
+## Compliance Receipts：IETF profile
 
 Compliance Receipts 是 SDK 的默认模式。每次 `agent.sign(...)` 都会生成一份符合 [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) 的凭证：ML-DSA-65 签名、RFC 3161 + OpenTimestamps 锚点、保留的 `policy_digest`、哈希链 `previousReceiptHash`。如需旧版结构，传入 `compliance_mode=False`。
 
@@ -101,12 +101,12 @@ Compliance Receipts 是 SDK 的默认模式。每次 `agent.sign(...)` 都会生
 - `risk_class` - 受控词汇：`unacceptable | high | limited | minimal | gpai | low | medium | unknown`。
 - `iteration_id` - 逻辑任务 id，与 session 区分。
 - `sandbox_state` - 高风险门控用的 `enabled | disabled | unavailable`。
-- `incident_class` - DORA / NYDFS / CIRCIA token（可为数组）。
-- `issuer_id` - LEI（ISO 17442）、EIN、CIK，或非 LEI 部署方的 W3C DID。
+- `incident_class` - DORA / NYDFS / CIRCIA token，也可为数组。
+- `issuer_id` - 符合 ISO 17442 的 LEI、EIN、CIK，或非 LEI 部署方的 W3C DID。
 
 ### Audit Pack 导出
 
-云端会对一段时间窗内的收据签发一份 Compliance Audit Pack（对应 IETF -03 第 7 节）。SDK 提供封装：
+云端会对一段时间窗内的收据签发一份 Compliance Audit Pack，对应 IETF -03 第 7 节。SDK 提供封装：
 
 ```python
 pack = asqav.fetch_audit_pack(start="2026-05-01T00:00Z", end="2026-06-01T00:00Z")
@@ -118,9 +118,9 @@ print(pack["algorithm_registry_version"]) # 签发时锚定的算法注册表版
 
 气隙场景请改用 `asqav.export_bundle(signatures, framework="dora")`：它在内存中对收据列表计算 Merkle 根，不调用云端。只要云端可达，请优先用 `fetch_audit_pack`，因为只有云端签名才能给审计方一份防篡改的清单。
 
-本地侧的基础校验（必填字段是否存在、命名空间、300 秒时钟偏差边界、前驱重派生）通过 `asqav.verify_compliance_receipt(envelope, predecessor_envelope=...)` 提供。权威验证方仍是云端，该 helper 仅作便利。
+本地侧的基础校验通过 `asqav.verify_compliance_receipt(envelope, predecessor_envelope=...)` 提供，涵盖必填字段是否存在、命名空间、300 秒时钟偏差边界以及前驱重派生。权威验证方仍是云端，该 helper 仅作便利。
 
-按 profile 第 10.8 节的算法敏捷性，可用算法通过 `asqav.SUPPORTED_ALGORITHMS` 暴露。`Agent.create(...)` 可传入 `algorithm="ed25519"` 或 `"es256"` 用于经典（非 ML-DSA）身份，或用 `asqav.generate_local_keypair("ed25519")` 进行离线场景。
+按 profile 第 10.8 节的算法敏捷性，可用算法通过 `asqav.SUPPORTED_ALGORITHMS` 暴露。`Agent.create(...)` 可传入 `algorithm="ed25519"` 或 `"es256"` 用于经典身份，即非 ML-DSA 身份，或用 `asqav.generate_local_keypair("ed25519")` 进行离线场景。
 
 ## 文档
 

--- a/python/README.md
+++ b/python/README.md
@@ -65,7 +65,7 @@ Every command listed here works on the free tier. The Asqav cloud is the source 
 
 The SDK auto-detects whether you're pointing at the Asqav cloud or a self-hosted deployment and selects the safer default for each:
 
-- **Cloud (`*.asqav.com`)**: hash-only by default. The SDK builds a fingerprint of your action context, computes a SHA-256 hash locally, and sends only the hash plus a small metadata bag (`action_type`, `agent_id`, `session_id`, `model_name`, `tool_name`). Raw prompts and tool arguments stay on your side.
+- **Cloud (`*.asqav.com`)**: hash-only by default. The SDK builds a fingerprint of your action context, computes a SHA-256 hash locally, and sends only the hash plus a small metadata bag of `action_type`, `agent_id`, `session_id`, `model_name`, and `tool_name`. Raw prompts and tool arguments stay on your side.
 - **Self-hosted**: full-payload by default. The server can run policy checks, PII redaction, and richer audit. Recommended when you control the deployment.
 
 Override anytime:
@@ -76,24 +76,24 @@ asqav.init(api_key="...", base_url="https://api.asqav.com", mode="hash-only")
 
 The fingerprint format is sorted JSON with no whitespace per JCS, hashed with SHA-256. See `docs/fingerprint-spec.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
 
-## Compliance receipts (IETF profile)
+## Compliance receipts: the IETF profile
 
 Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 signature, JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `compliance_mode=False` if you want the older shape.
 
 The envelope extensions most callers reach for:
 
-- `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:lifecycle:configuration_change`, `protectmcp:acknowledgment`, `protectmcp:observation`, or `protectmcp:observation:result_bound` (observation receipts that bind tool output via `result_digest`).
+- `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:lifecycle:configuration_change`, `protectmcp:acknowledgment`, `protectmcp:observation`, or `protectmcp:observation:result_bound`, which is an observation receipt that binds tool output via `result_digest`.
 - `risk_class` - controlled vocabulary: `low | medium | high | unknown`.
 - `iteration_id` - logical task id, distinct from session.
 - `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
-- `incident_class` - DORA / NYDFS / CIRCIA token (or array of tokens).
-- `issuer_id` - LEI (ISO 17442), EIN, CIK, or a W3C DID for non-LEI deployers.
+- `incident_class` - DORA / NYDFS / CIRCIA token, or an array of tokens.
+- `issuer_id` - LEI per ISO 17442, EIN, CIK, or a W3C DID for non-LEI deployers.
 
-### Shadow AI capture (passive_telemetry)
+### Shadow AI capture with passive_telemetry
 
-Two `receipt_type` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action; `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block (SIEM forwarder, browser extension in observe-only mode, NetFlow-style proxy with no enforcement hook).
+Two `receipt_type` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action; `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block, such as a SIEM forwarder, a browser extension in observe-only mode, or a NetFlow-style proxy with no enforcement hook.
 
-Set `capture_topology='passive_telemetry'` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `capture_topology='passive_telemetry'` receipt MUST use `receipt_type='protectmcp:observation'`. Any other receipt_type paired with `passive_telemetry` (`:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, `:acknowledgment`) raises `ValueError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :<offending> (rule 8)` message before the HTTP roundtrip (see `false_attestation_guard` in `python/src/asqav/client.py`).
+Set `capture_topology='passive_telemetry'` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `capture_topology='passive_telemetry'` receipt MUST use `receipt_type='protectmcp:observation'`. Any other receipt_type paired with `passive_telemetry`, namely `:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, or `:acknowledgment`, raises `ValueError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :<offending> (rule 8)` message before the HTTP roundtrip. The guard lives as `false_attestation_guard` in `python/src/asqav/client.py`.
 
 ```python
 sig = agent.sign(
@@ -107,9 +107,9 @@ sig = agent.sign(
 
 `capture_topology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `ebpf_observer`, and `mcp_proxy`; only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
 
-### Configuration change receipts (rule 9)
+### Configuration change receipts, rule 9
 
-A `receipt_type='protectmcp:lifecycle:configuration_change'` receipt declares the agent's runtime configuration was mutated. The SDK pre-flights the Asqav cloud's rule 9 cross-field gate (NSA CSI U/OO/6030316-26 alignment): the receipt MUST carry `config_manifest_digest`. Omitting it raises `ValueError` with the verbatim `false_attestation_guard: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (rule 9)` message before the HTTP roundtrip.
+A `receipt_type='protectmcp:lifecycle:configuration_change'` receipt declares the agent's runtime configuration was mutated. The SDK pre-flights the Asqav cloud's rule 9 cross-field gate for NSA CSI U/OO/6030316-26 alignment: the receipt MUST carry `config_manifest_digest`. Omitting it raises `ValueError` with the verbatim `false_attestation_guard: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (rule 9)` message before the HTTP roundtrip.
 
 ```python
 sig = agent.sign(
@@ -122,13 +122,13 @@ sig = agent.sign(
 )
 ```
 
-### Expiry precedence (rule 10)
+### Expiry precedence, rule 10
 
-`valid_seconds` (legacy, server computes `valid_until = signed_at + valid_seconds`) and `expires_at` (caller-supplied horizon) are mutually exclusive. Pass exactly one of the two: `valid_seconds=3600` for "expire one hour after signing", or `expires_at="2026-06-01T00:00:00Z"` for an explicit horizon. Passing both raises `ValueError` with the verbatim `expiry_collision_guard: pass either valid_seconds or expires_at, not both (rule 10)` message before the HTTP roundtrip. Passing neither falls back to the server-side default (`valid_seconds=86400`).
+The legacy `valid_seconds`, where the server computes `valid_until = signed_at + valid_seconds`, and the caller-supplied horizon `expires_at` are mutually exclusive. Pass exactly one of the two: `valid_seconds=3600` for "expire one hour after signing", or `expires_at="2026-06-01T00:00:00Z"` for an explicit horizon. Passing both raises `ValueError` with the verbatim `expiry_collision_guard: pass either valid_seconds or expires_at, not both (rule 10)` message before the HTTP roundtrip. Passing neither falls back to the server-side default of `valid_seconds=86400`.
 
-### Digest format (rule 11)
+### Digest format, rule 11
 
-Every caller-supplied self-describing digest field (`config_manifest_digest`, `cve_inventory_digest`, `executable_hash`, `sbom_digest`) MUST match the regex `^sha256:[a-f0-9]{64}$`. `tool_fingerprint` is the exception: it uses the cloud wire form of 32 bare lowercase hex chars (SHA-256[:32], `^[0-9a-f]{32}$`, no `sha256:` prefix); anything else raises `ValueError` with the verbatim `tool_fingerprint_not_32_hex_chars: must be 32 lowercase hex chars (SHA-256[:32]).` guard. The two URL pointer fields (`slsa_provenance_pointer`, `supply_chain_pointer`) MUST start with `http://` or `https://`. Anything else raises `ValueError` with a verbatim guard message before the HTTP roundtrip. To avoid wire drift, use the SDK's deterministic helpers (each is byte-deterministic under JCS):
+Every caller-supplied self-describing digest field, namely `config_manifest_digest`, `cve_inventory_digest`, `executable_hash`, and `sbom_digest`, MUST match the regex `^sha256:[a-f0-9]{64}$`. `tool_fingerprint` is the exception: it uses the cloud wire form of 32 bare lowercase hex chars, SHA-256[:32], matching `^[0-9a-f]{32}$` with no `sha256:` prefix; anything else raises `ValueError` with the verbatim `tool_fingerprint_not_32_hex_chars: must be 32 lowercase hex chars (SHA-256[:32]).` guard. The two URL pointer fields `slsa_provenance_pointer` and `supply_chain_pointer` MUST start with `http://` or `https://`. Anything else raises `ValueError` with a verbatim guard message before the HTTP roundtrip. To avoid wire drift, use the SDK's deterministic helpers, each byte-deterministic under JCS:
 
 ```python
 from asqav.client import (
@@ -147,9 +147,9 @@ cve = _compute_cve_inventory_digest([{"id": "CVE-2026-0001", "severity": "high"}
 Six wire fields on `agent.sign(...)` carry the NSA CSI U/OO/6030316-26 alignment for MCP server lifecycle and tool output binding:
 
 - `result_digest` - `sha256:<hex>` of the tool output, binds the receipt to a specific result. See <https://www.asqav.com/docs/result-digest>.
-- `expires_at` - explicit ISO-8601 (or POSIX) validity horizon. Converted client-side to `valid_seconds` and sent as a duration, since the cloud owns absolute time-binding. Mutually exclusive with `valid_seconds`. See <https://www.asqav.com/docs/expires-at>.
+- `expires_at` - explicit ISO-8601 or POSIX validity horizon. Converted client-side to `valid_seconds` and sent as a duration, since the cloud owns absolute time-binding. Mutually exclusive with `valid_seconds`. See <https://www.asqav.com/docs/expires-at>.
 - `nonce` - 12 random bytes auto-generated when omitted; cloud rejects duplicates inside the validity window. See <https://www.asqav.com/docs/nonce>.
-- `tool_fingerprint` - 32 bare lowercase hex chars (SHA-256[:32]) over `{tool_name, schema}`, auto-derived when `tool_name` + `tool_schema` are present. See <https://www.asqav.com/docs/tool-fingerprint>.
+- `tool_fingerprint` - 32 bare lowercase hex chars, SHA-256[:32], over `{tool_name, schema}`, auto-derived when `tool_name` + `tool_schema` are present. See <https://www.asqav.com/docs/tool-fingerprint>.
 - `config_manifest_digest` - `sha256:<hex>` of the agent's runtime configuration snapshot. Required on configuration_change receipts. See <https://www.asqav.com/docs/config-manifest-digest>.
 - `cve_inventory_digest` - `sha256:<hex>` over the CVE snapshot at sign time. See <https://www.asqav.com/docs/cve-inventory-digest>.
 
@@ -178,17 +178,17 @@ sig = agent.sign(
 
 See <https://www.asqav.com/docs/executable-hash-and-sbom-provenance>.
 
-## Threat-framework mappings (optional)
+## Optional threat-framework mappings
 
 Seven optional wire fields let a caller pin the receipt to industry threat-and-control taxonomies. Each list is caller-supplied and Asqav-preserved verbatim; the cloud sets `framework_mappings_self_declared=true` on the receipt whenever any of the six list fields is populated, so verifiers can tell self-declared classifications apart from cloud-verified ones.
 
-- `mitre_techniques` - list of MITRE ATT&CK technique ids (e.g. `["T1059", "T1078"]`).
-- `mitre_atlas` - list of MITRE ATLAS ids for AI-system threats (e.g. `["AML.T0051"]`).
-- `owasp_llm_top10` - list of OWASP Top 10 for LLM ids (e.g. `["LLM01", "LLM02"]`).
-- `nist_ai_rmf` - list of NIST AI RMF function ids (e.g. `["GOVERN-1.1", "MEASURE-2.7"]`).
-- `iso_42001` - list of ISO/IEC 42001 control ids (e.g. `["A.6.2.6"]`).
-- `eu_ai_act_articles` - list of EU AI Act article ids (e.g. `["Article-12", "Article-15"]`).
-- `rfc3161_timestamp` - caller-supplied base64-encoded RFC 3161 TimeStampResp (DER).
+- `mitre_techniques` - list of MITRE ATT&CK technique ids, for example `["T1059", "T1078"]`.
+- `mitre_atlas` - list of MITRE ATLAS ids for AI-system threats, for example `["AML.T0051"]`.
+- `owasp_llm_top10` - list of OWASP Top 10 for LLM ids, for example `["LLM01", "LLM02"]`.
+- `nist_ai_rmf` - list of NIST AI RMF function ids, for example `["GOVERN-1.1", "MEASURE-2.7"]`.
+- `iso_42001` - list of ISO/IEC 42001 control ids, for example `["A.6.2.6"]`.
+- `eu_ai_act_articles` - list of EU AI Act article ids, for example `["Article-12", "Article-15"]`.
+- `rfc3161_timestamp` - caller-supplied base64-encoded RFC 3161 TimeStampResp in DER.
 
 ```python
 sig = agent.sign(
@@ -202,11 +202,11 @@ sig = agent.sign(
 )
 ```
 
-Each list must be a non-empty list of strings, each entry up to 128 characters; empty lists, non-string entries, or oversize entries raise `ValueError` with verbatim guard messages (`<field>_must_be_non_empty_list`, `<field>_entry_invalid`) and skip the HTTP roundtrip. The `rfc3161_timestamp` must be valid base64 or raises `rfc3161_timestamp_not_base64`.
+Each list must be a non-empty list of strings, each entry up to 128 characters; empty lists, non-string entries, or oversize entries raise `ValueError` with the verbatim guard messages `<field>_must_be_non_empty_list` or `<field>_entry_invalid` and skip the HTTP roundtrip. The `rfc3161_timestamp` must be valid base64 or raises `rfc3161_timestamp_not_base64`.
 
 See <https://www.asqav.com/docs/threat-framework-mapping>.
 
-## Witness policy (optional)
+## Optional witness policy
 
 `witness_policy` lets a caller declare an N-of-M durable-anchoring quorum on the receipt. The receipt reaches `witness_quorum_met` only when `required` witnesses hold a real inclusion proof.
 
@@ -224,7 +224,7 @@ sig = agent.sign(
 )
 ```
 
-Bad input raises `ValueError` with a verbatim guard message before the HTTP roundtrip: `witness_policy_unknown_witness` (e.g. `rekor`), `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, or `witness_policy_duplicate_witness`. Omit the field for today's behaviour.
+Bad input raises `ValueError` with a verbatim guard message before the HTTP roundtrip: `witness_policy_unknown_witness` for an entry like `rekor`, `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, or `witness_policy_duplicate_witness`. Omit the field for today's behaviour.
 
 ### Audit Pack export
 
@@ -240,7 +240,7 @@ print(pack["algorithm_registry_version"]) # registry version pinned at issuance
 
 `asqav.export_bundle(signatures, framework="dora")` is the offline alternative for air-gapped flows: it computes a Merkle root over an in-memory list of receipts without calling the cloud. Use `fetch_audit_pack` whenever the cloud is reachable, since only the cloud signature gives the auditor a tamper-evident manifest.
 
-Local-side sanity checks (presence of REQUIRED fields, namespace, 300s skew bound, predecessor rederivation) are available as `asqav.verify_compliance_receipt(envelope, predecessor_envelope=...)`. The cloud is the authoritative verifier; this helper is a convenience.
+Local-side sanity checks, covering presence of REQUIRED fields, namespace, the 300s skew bound, and predecessor rederivation, are available as `asqav.verify_compliance_receipt(envelope, predecessor_envelope=...)`. The cloud is the authoritative verifier; this helper is a convenience.
 
 Algorithm agility is exposed via `asqav.SUPPORTED_ALGORITHMS`. Pass `algorithm="ed25519"` or `"es256"` to `Agent.create(...)` for non-post-quantum identities, or `asqav.generate_local_keypair("ed25519")` for offline scenarios.
 
@@ -259,7 +259,7 @@ Cookbooks for FastAPI middleware, AutoGen, and reasoning-trace capture live unde
 
 ## Errors
 
-All raised exceptions extend `AsqavError`. `AuthenticationError` (401), `RateLimitError` (429), and `APIError` (with `status_code`) are exported for fine-grained handling:
+All raised exceptions extend `AsqavError`. `AuthenticationError` for 401, `RateLimitError` for 429, and `APIError` carrying `status_code` are exported for fine-grained handling:
 
 ```python
 from asqav import AsqavError, AuthenticationError, RateLimitError, APIError
@@ -292,8 +292,8 @@ Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-
 What ships on Asqav today. Each item is available on `main`:
 
 - Hash-only mode for cloud - default for `*.asqav.com`.
-- Self-hosted signer (split-trust) - compose file in the Asqav backend repo.
-- Bring-your-own KMS (AWS KMS / GCP KMS) - Enterprise tier.
+- Self-hosted signer with split-trust - compose file in the Asqav backend repo.
+- Bring-your-own KMS for AWS KMS or GCP KMS - Enterprise tier.
 - Customer-owned storage - self-hosted; relay payload allowlist enforced in code.
 - SCITT / COSE_Sign1 receipt export - public `GET /api/v1/signatures/{id}/cose` returns `application/cose`.
 - Air-gapped / on-prem mode - offline license + zero-egress; see the backend repo `docs/airgapped-mode.md`.

--- a/python/docs/CLI.md
+++ b/python/docs/CLI.md
@@ -17,7 +17,7 @@ Public, no API key required. Prints the verification outcome plus the IETF Compl
 asqav verify sig_abc123 --output json
 ```
 
-## Compliance Receipts (IETF profile)
+## Compliance Receipts: the IETF profile
 
 ### `asqav sign`
 
@@ -41,7 +41,7 @@ Flags:
 
 | Flag | SDK kwarg | Notes |
 | --- | --- | --- |
-| `--action-id` | `_action_id` (in context) | Stable client-side action id; cloud allocates one when empty. |
+| `--action-id` | `_action_id`, in context | Stable client-side action id; cloud allocates one when empty. |
 | `--action-type` | `action_type` | Required. |
 | `--compliance-mode/--no-compliance-mode` | `compliance_mode` | Default false. |
 | `--action-ref` | `action_ref` | `sha256:<hex>`; auto-derived from `--action-json` when missing. |
@@ -49,7 +49,7 @@ Flags:
 | `--sandbox-state` | `sandbox_state` | `enabled|disabled|unavailable`. |
 | `--iteration-id` | `iteration_id` | Distinct from session_id. |
 | `--risk-class` | `risk_class` | `low|medium|high|unknown`. |
-| `--incident-class` | `incident_class` | Canonical 6-value Annex II field 3.23 list (JC 2024-33, 17 July 2024) |
+| `--incident-class` | `incident_class` | Canonical 6-value Annex II field 3.23 list, per JC 2024-33, 17 July 2024 |
 | `--issuer-id` | `issuer_id` | Overrides server resolution. |
 | `--receipt-type` | `receipt_type` | `protectmcp:decision|protectmcp:restraint|protectmcp:lifecycle`. Default `protectmcp:decision`. |
 | `--reason` | `reason` | Required when `--policy-decision` is `deny|rate_limit`. |
@@ -57,8 +57,8 @@ Flags:
 | `--algorithm` | `algorithm` | Cloud uses the agent's algorithm; CLI warns on mismatch. |
 | `--session-id` | `agent._session_id` | Bind the record to an existing session. |
 | `--valid-seconds` | `valid_seconds` | Validity window. |
-| `--policy-artefact <path|->` | `_policy_artefact` (in context) | Cloud stores; receipt's `policy_digest` is its content hash. |
-| `--output` | n/a | `text` (default) or `json`. |
+| `--policy-artefact <path|->` | `_policy_artefact`, in context | Cloud stores; receipt's `policy_digest` is its content hash. |
+| `--output` | n/a | `text` by default, or `json`. |
 
 ### `asqav audit-pack export`
 
@@ -74,7 +74,7 @@ asqav audit-pack export \
 
 ### `asqav audit-pack policy <digest>`
 
-Resolves a `policy_digest` to the retained policy artefact JSON. Accepts either `sha256:<64-hex>` or a bare 64-hex string (the prefix is added).
+Resolves a `policy_digest` to the retained policy artefact JSON. Accepts either `sha256:<64-hex>` or a bare 64-hex string, where the prefix is added for you.
 
 ```bash
 asqav audit-pack policy a3f6...c91d --output text
@@ -82,7 +82,7 @@ asqav audit-pack policy a3f6...c91d --output text
 
 ### `asqav replay-verify <agent_id> <session_id> [--strict]`
 
-Re-derives the IETF chain over `sha256(canonical_json(signed_envelope))`. With `--strict` rejects any step that lacks a cloud-emitted `signed_envelope` (synthetic fallback shape cannot prove byte-level integrity).
+Re-derives the IETF chain over `sha256(canonical_json(signed_envelope))`. With `--strict` rejects any step that lacks a cloud-emitted `signed_envelope`, since the synthetic fallback shape cannot prove byte-level integrity.
 
 ```bash
 asqav replay-verify agt_x7y8z9 sess_abc --strict --output json
@@ -90,7 +90,7 @@ asqav replay-verify agt_x7y8z9 sess_abc --strict --output json
 
 ### `asqav payloads erase <signature_id>`
 
-Right-to-erasure (P4). Calls `DELETE /signatures/payloads/{signature_id}`. Idempotent; the signature, chain hash, and anchors stay intact so the receipt remains verifiable.
+Right-to-erasure under P4. Calls `DELETE /signatures/payloads/{signature_id}`. Idempotent; the signature, chain hash, and anchors stay intact so the receipt remains verifiable.
 
 ```bash
 asqav payloads erase sig_abc123 --yes
@@ -98,7 +98,7 @@ asqav payloads erase sig_abc123 --yes
 
 ### `asqav org set-compliance-strict <org_id> --enable|--disable`
 
-Toggles per-org `compliance_mode_strict` (M-NEW-1). When enabled, the cloud rejects any sign request that is not flagged `compliance_mode=true` with HTTP 412.
+Toggles the per-org `compliance_mode_strict` flag from M-NEW-1. When enabled, the cloud rejects any sign request that is not flagged `compliance_mode=true` with HTTP 412.
 
 ```bash
 asqav org set-compliance-strict org_abc --enable
@@ -106,7 +106,7 @@ asqav org set-compliance-strict org_abc --enable
 
 ### `asqav keys generate --algorithm <ml-dsa-65|ed25519|es256>`
 
-Generates a local keypair for offline / air-gapped flows. Ed25519 and ES256 emit PKCS#8 PEM. ML-DSA-65 raises a clear error pointing at `asqav agents create` (server-side keygen).
+Generates a local keypair for offline / air-gapped flows. Ed25519 and ES256 emit PKCS#8 PEM. ML-DSA-65 raises a clear error pointing at `asqav agents create` for server-side keygen.
 
 ```bash
 asqav keys generate --algorithm ed25519 --out priv.pem
@@ -126,4 +126,4 @@ ASQAV_MAINTENANCE_KEY=mk_... asqav migrate run v3-20
 | --- | --- |
 | v3-20 | IETF profile schema additions on `signature_records` + `policy_artefacts` table. |
 | v3-21 | Partial unique index defending the IETF receipt chain against forks. |
-| v3-22 | `organizations.compliance_mode_strict` boolean (M-NEW-1). |
+| v3-22 | `organizations.compliance_mode_strict` boolean from M-NEW-1. |

--- a/python/docs/self-hosted-signer.md
+++ b/python/docs/self-hosted-signer.md
@@ -6,9 +6,9 @@ the container boundary. Only signature digests, signature bytes,
 timestamps, and structural metadata ever leave your network. This is
 the split-trust deployment model.
 
-For the full reference (architecture diagram, environment contract,
-upstream relay semantics, QTSP / RFC 3161 wiring), see the cloud-side
-doc: https://www.asqav.com/docs/self-hosted-signer
+For the full reference, covering the architecture diagram, environment
+contract, upstream relay semantics, and QTSP / RFC 3161 wiring, see the
+cloud-side doc: https://www.asqav.com/docs/self-hosted-signer
 
 ## When to pick this mode
 
@@ -42,8 +42,8 @@ docker compose -f docker-compose.signer.yml up -d
 ```
 
 The signer exposes the Asqav API surface on port `8000` inside the
-compose network. Front it with your own ingress (Traefik, nginx,
-Caddy, ALB) and terminate TLS there. The signer container does not
+compose network. Front it with your own ingress such as Traefik, nginx,
+Caddy, or ALB, and terminate TLS there. The signer container does not
 ship a TLS terminator.
 
 ## Point the SDK at your signer
@@ -85,9 +85,9 @@ client.configure(
 
 | Boundary | What enters | What leaves |
 | --- | --- | --- |
-| Agent host | `action_type`, full context (prompt, tool args) | nothing |
+| Agent host | `action_type`, full context such as prompt and tool args | nothing |
 | Signer container | the above | `signature_id`, signature bytes, hash chain, timestamp, structural metadata |
-| Upstream relay (optional) | digest + signature + timestamp + metadata | none of the raw context |
+| Upstream relay, optional | digest + signature + timestamp + metadata | none of the raw context |
 
 The agent's prompt and tool arguments never cross the signer
 boundary on the wire. If you also enable the optional upstream relay
@@ -123,7 +123,7 @@ asqav verify --pack ./compliance-bundle.json
 ```
 
 The same audit-pack also feeds the IETF Compliance Receipts profile
-(`draft-marques-asqav-compliance-receipts`), so third-party
+under `draft-marques-asqav-compliance-receipts`, so third-party
 verifiers can consume it without an Asqav SDK.
 
 ## Troubleshooting

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -76,24 +76,24 @@ await init({ apiKey: "...", baseUrl: "https://api.asqav.com", mode: "hash-only" 
 
 The fingerprint format is sorted JSON with no whitespace per JCS, hashed with SHA-256. See `docs/fingerprint-spec.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
 
-## Compliance receipts (IETF profile)
+## Compliance receipts: the IETF profile
 
 Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 signature, JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `complianceMode: false` if you want the older shape.
 
-The envelope extensions most callers reach for (camelCase on the SDK, snake_case on the JSON wire):
+The envelope extensions most callers reach for, camelCase on the SDK and snake_case on the JSON wire:
 
-- `receiptType` -> `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:lifecycle:configuration_change`, `protectmcp:acknowledgment`, `protectmcp:observation`, or `protectmcp:observation:result_bound` (observation receipts that bind tool output via `resultDigest`).
+- `receiptType` -> `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:lifecycle:configuration_change`, `protectmcp:acknowledgment`, `protectmcp:observation`, or `protectmcp:observation:result_bound`, which is an observation receipt that binds tool output via `resultDigest`.
 - `riskClass` -> `risk_class` - controlled vocabulary: `low | medium | high | unknown`.
 - `iterationId` -> `iteration_id` - logical task id, distinct from session.
 - `sandboxState` -> `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
-- `incidentClass` -> `incident_class` - DORA / NYDFS / CIRCIA token (or array of tokens).
-- `issuerId` -> `issuer_id` - LEI (ISO 17442), EIN, CIK, or a W3C DID for non-LEI deployers.
+- `incidentClass` -> `incident_class` - DORA / NYDFS / CIRCIA token, or an array of tokens.
+- `issuerId` -> `issuer_id` - LEI per ISO 17442, EIN, CIK, or a W3C DID for non-LEI deployers.
 
-### Shadow AI capture (passive_telemetry)
+### Shadow AI capture with passive_telemetry
 
-Two `receiptType` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action; `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block (SIEM forwarder, browser extension in observe-only mode, NetFlow-style proxy with no enforcement hook).
+Two `receiptType` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action; `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block, such as a SIEM forwarder, a browser extension in observe-only mode, or a NetFlow-style proxy with no enforcement hook.
 
-Set `captureTopology: "passive_telemetry"` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `captureTopology: "passive_telemetry"` receipt MUST use `receiptType: "protectmcp:observation"`. Any other receiptType paired with `passive_telemetry` (`:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, `:acknowledgment`) throws `AsqavError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :<offending> (rule 8)` message before the HTTP roundtrip (see `false_attestation_guard` in `typescript/src/index.ts`).
+Set `captureTopology: "passive_telemetry"` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `captureTopology: "passive_telemetry"` receipt MUST use `receiptType: "protectmcp:observation"`. Any other receiptType paired with `passive_telemetry`, namely `:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, or `:acknowledgment`, throws `AsqavError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :<offending> (rule 8)` message before the HTTP roundtrip. The guard lives as `false_attestation_guard` in `typescript/src/index.ts`.
 
 ```ts
 const sig = await agent.sign({
@@ -107,9 +107,9 @@ const sig = await agent.sign({
 
 `captureTopology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `ebpf_observer`, and `mcp_proxy`; only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
 
-### Configuration change receipts (rule 9)
+### Configuration change receipts, rule 9
 
-A `receiptType: "protectmcp:lifecycle:configuration_change"` receipt declares the agent's runtime configuration was mutated. The SDK pre-flights the Asqav cloud's rule 9 cross-field gate (NSA CSI U/OO/6030316-26 alignment): the receipt MUST carry `configManifestDigest`. Omitting it throws `AsqavError` with the verbatim `false_attestation_guard: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (rule 9)` message before the HTTP roundtrip.
+A `receiptType: "protectmcp:lifecycle:configuration_change"` receipt declares the agent's runtime configuration was mutated. The SDK pre-flights the Asqav cloud's rule 9 cross-field gate for NSA CSI U/OO/6030316-26 alignment: the receipt MUST carry `configManifestDigest`. Omitting it throws `AsqavError` with the verbatim `false_attestation_guard: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (rule 9)` message before the HTTP roundtrip.
 
 ```ts
 const sig = await agent.sign({
@@ -122,13 +122,13 @@ const sig = await agent.sign({
 });
 ```
 
-### Expiry precedence (rule 10)
+### Expiry precedence, rule 10
 
-`validSeconds` (legacy, server computes `valid_until = signed_at + valid_seconds`) and `expiresAt` (caller-supplied horizon) are mutually exclusive. Pass exactly one of the two: `validSeconds: 3600` for "expire one hour after signing", or `expiresAt: "2026-06-01T00:00:00Z"` for an explicit horizon. Passing both throws `AsqavError` with the verbatim `expiry_collision_guard: pass either valid_seconds or expires_at, not both (rule 10)` message before the HTTP roundtrip. Passing neither falls back to the server-side default (`valid_seconds=86400`).
+The legacy `validSeconds`, where the server computes `valid_until = signed_at + valid_seconds`, and the caller-supplied horizon `expiresAt` are mutually exclusive. Pass exactly one of the two: `validSeconds: 3600` for "expire one hour after signing", or `expiresAt: "2026-06-01T00:00:00Z"` for an explicit horizon. Passing both throws `AsqavError` with the verbatim `expiry_collision_guard: pass either valid_seconds or expires_at, not both (rule 10)` message before the HTTP roundtrip. Passing neither falls back to the server-side default of `valid_seconds=86400`.
 
-### Digest format (rule 11)
+### Digest format, rule 11
 
-Every caller-supplied self-describing digest field (`configManifestDigest`, `cveInventoryDigest`, `executableHash`, `sbomDigest`) MUST match the regex `^sha256:[a-f0-9]{64}$`. `toolFingerprint` is the exception: it uses the cloud wire form of 32 bare lowercase hex chars (SHA-256[:32], `^[0-9a-f]{32}$`, no `sha256:` prefix); anything else throws `AsqavError` with the verbatim `tool_fingerprint_not_32_hex_chars: must be 32 lowercase hex chars (SHA-256[:32]).` message before the HTTP roundtrip. To avoid wire drift, use the SDK's deterministic helpers (each is byte-deterministic under JCS):
+Every caller-supplied self-describing digest field, namely `configManifestDigest`, `cveInventoryDigest`, `executableHash`, and `sbomDigest`, MUST match the regex `^sha256:[a-f0-9]{64}$`. `toolFingerprint` is the exception: it uses the cloud wire form of 32 bare lowercase hex chars, SHA-256[:32], matching `^[0-9a-f]{32}$` with no `sha256:` prefix; anything else throws `AsqavError` with the verbatim `tool_fingerprint_not_32_hex_chars: must be 32 lowercase hex chars (SHA-256[:32]).` message before the HTTP roundtrip. To avoid wire drift, use the SDK's deterministic helpers, each byte-deterministic under JCS:
 
 ```ts
 import {
@@ -147,9 +147,9 @@ const cve = computeCveInventoryDigest([{ id: "CVE-2026-0001", severity: "high" }
 Six wire fields on `agent.sign(...)` carry the NSA CSI U/OO/6030316-26 alignment for MCP server lifecycle and tool output binding:
 
 - `resultDigest` - `sha256:<hex>` of the tool output, binds the receipt to a specific result. See <https://www.asqav.com/docs/result-digest>.
-- `expiresAt` - explicit ISO-8601 (or POSIX) validity horizon. Converted client-side to `validSeconds` and sent as a duration, since the cloud owns absolute time-binding. Mutually exclusive with `validSeconds`. See <https://www.asqav.com/docs/expires-at>.
+- `expiresAt` - explicit ISO-8601 or POSIX validity horizon. Converted client-side to `validSeconds` and sent as a duration, since the cloud owns absolute time-binding. Mutually exclusive with `validSeconds`. See <https://www.asqav.com/docs/expires-at>.
 - `nonce` - 12 random bytes auto-generated when omitted; cloud rejects duplicates inside the validity window. See <https://www.asqav.com/docs/nonce>.
-- `toolFingerprint` - 32 bare lowercase hex chars (SHA-256[:32]) over `{tool_name, schema}`, auto-derived when `toolName` + `toolSchema` are present. See <https://www.asqav.com/docs/tool-fingerprint>.
+- `toolFingerprint` - 32 bare lowercase hex chars, SHA-256[:32], over `{tool_name, schema}`, auto-derived when `toolName` + `toolSchema` are present. See <https://www.asqav.com/docs/tool-fingerprint>.
 - `configManifestDigest` - `sha256:<hex>` of the agent's runtime configuration snapshot. Required on configuration_change receipts. See <https://www.asqav.com/docs/config-manifest-digest>.
 - `cveInventoryDigest` - `sha256:<hex>` over the CVE snapshot at sign time. See <https://www.asqav.com/docs/cve-inventory-digest>.
 
@@ -180,17 +180,17 @@ const receipt = await agent.sign({
 
 See <https://www.asqav.com/docs/executable-hash-and-sbom-provenance> for the field semantics and a worked policy example.
 
-## Threat-framework mappings (optional)
+## Optional threat-framework mappings
 
 Seven optional wire fields let a caller pin the receipt to industry threat-and-control taxonomies. Each list is caller-supplied and Asqav-preserved verbatim; the cloud sets `framework_mappings_self_declared=true` on the receipt whenever any of the six list fields is populated, so verifiers can tell self-declared classifications apart from cloud-verified ones.
 
-- `mitreTechniques` - list of MITRE ATT&CK technique ids (e.g. `["T1059", "T1078"]`).
-- `mitreAtlas` - list of MITRE ATLAS ids for AI-system threats (e.g. `["AML.T0051"]`).
-- `owaspLlmTop10` - list of OWASP Top 10 for LLM ids (e.g. `["LLM01", "LLM02"]`).
-- `nistAiRmf` - list of NIST AI RMF function ids (e.g. `["GOVERN-1.1", "MEASURE-2.7"]`).
-- `iso42001` - list of ISO/IEC 42001 control ids (e.g. `["A.6.2.6"]`).
-- `euAiActArticles` - list of EU AI Act article ids (e.g. `["Article-12", "Article-15"]`).
-- `rfc3161Timestamp` - caller-supplied base64-encoded RFC 3161 TimeStampResp (DER).
+- `mitreTechniques` - list of MITRE ATT&CK technique ids, for example `["T1059", "T1078"]`.
+- `mitreAtlas` - list of MITRE ATLAS ids for AI-system threats, for example `["AML.T0051"]`.
+- `owaspLlmTop10` - list of OWASP Top 10 for LLM ids, for example `["LLM01", "LLM02"]`.
+- `nistAiRmf` - list of NIST AI RMF function ids, for example `["GOVERN-1.1", "MEASURE-2.7"]`.
+- `iso42001` - list of ISO/IEC 42001 control ids, for example `["A.6.2.6"]`.
+- `euAiActArticles` - list of EU AI Act article ids, for example `["Article-12", "Article-15"]`.
+- `rfc3161Timestamp` - caller-supplied base64-encoded RFC 3161 TimeStampResp in DER.
 
 ```ts
 const receipt = await agent.sign({
@@ -204,11 +204,11 @@ const receipt = await agent.sign({
 });
 ```
 
-Each list must be a non-empty array of strings, each entry up to 128 characters; empty arrays, non-string entries, or oversize entries throw `AsqavError` with verbatim guard messages (`<field>_must_be_non_empty_list`, `<field>_entry_invalid`) and skip the HTTP roundtrip. The `rfc3161Timestamp` must be valid base64 or throws `rfc3161_timestamp_not_base64`. Camel-case props project onto snake_case wire keys via the SDK's `IETF_OPTIONAL_FIELD_MAP`.
+Each list must be a non-empty array of strings, each entry up to 128 characters; empty arrays, non-string entries, or oversize entries throw `AsqavError` with the verbatim guard messages `<field>_must_be_non_empty_list` or `<field>_entry_invalid` and skip the HTTP roundtrip. The `rfc3161Timestamp` must be valid base64 or throws `rfc3161_timestamp_not_base64`. Camel-case props project onto snake_case wire keys via the SDK's `IETF_OPTIONAL_FIELD_MAP`.
 
 See <https://www.asqav.com/docs/threat-framework-mapping>.
 
-## Witness policy (optional)
+## Optional witness policy
 
 `witnessPolicy` lets a caller declare an N-of-M durable-anchoring quorum on the receipt. The receipt reaches `witness_quorum_met` only when `required` witnesses hold a real inclusion proof. It projects onto the snake_case `witness_policy` wire key via the SDK's `IETF_OPTIONAL_FIELD_MAP`.
 
@@ -226,7 +226,7 @@ const sig = await agent.sign({
 });
 ```
 
-Bad input throws `AsqavError` with a verbatim guard message before the HTTP roundtrip: `witness_policy_unknown_witness` (e.g. `rekor`), `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, or `witness_policy_duplicate_witness`. Omit the field for today's behaviour.
+Bad input throws `AsqavError` with a verbatim guard message before the HTTP roundtrip: `witness_policy_unknown_witness` for an entry like `rekor`, `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, or `witness_policy_duplicate_witness`. Omit the field for today's behaviour.
 
 ### Audit Pack export
 
@@ -245,23 +245,23 @@ console.log(bundle.records.length, bundle.bundleDigest);
 
 For offline chain verification, `verifyChain(records)` walks an ordered list of signed envelopes for one agent and re-derives each `previous_receipt_hash`. The first record's seed is `"0".repeat(64)`. The cloud is the authoritative verifier; this helper is a convenience.
 
-Algorithm agility is exposed via `SUPPORTED_ALGORITHMS`. Pass `algorithm: "ed25519"` or `"es256"` to `Agent.create(...)` for non-post-quantum identities, or `generateKeypair("ed25519")` for offline scenarios. ES256 signatures emit in IEEE-P1363 (raw r||s) form so they match the cloud verifier byte-for-byte.
+Algorithm agility is exposed via `SUPPORTED_ALGORITHMS`. Pass `algorithm: "ed25519"` or `"es256"` to `Agent.create(...)` for non-post-quantum identities, or `generateKeypair("ed25519")` for offline scenarios. ES256 signatures emit in IEEE-P1363 raw r||s form so they match the cloud verifier byte-for-byte.
 
 ## Integrations
 
 The SDK ships native callbacks and adapters for common agent frameworks:
 
-- **Vercel AI SDK** - import `createAsqavExporter` from `@asqav/sdk/extras/vercel-ai`, pass to `experimental_telemetry: { tracer }`. Every span (text generation, tool calls, embeddings) becomes a signed Asqav action.
+- **Vercel AI SDK** - import `createAsqavExporter` from `@asqav/sdk/extras/vercel-ai`, pass to `experimental_telemetry: { tracer }`. Every span becomes a signed Asqav action, whether text generation, a tool call, or an embedding.
 - **LangChain.js** - import `AsqavCallbackHandler` from `@asqav/sdk/extras/langchain`, construct via `await AsqavCallbackHandler.create({ agent })` then pass to `callbacks: [handler]`. Requires `@langchain/core` as a peer dep.
 - **Mastra** - import `AsqavMastraHook` from `@asqav/sdk/extras/mastra`, attach via `await new AsqavMastraHook({ agent }).attach(mastraAgent)`. Requires `@mastra/core` as a peer dep.
 - **OpenAI Agents JS** - import `AsqavOpenAIAgentsAdapter` from `@asqav/sdk/extras/openai-agents`, wrap individual tools via `new AsqavOpenAIAgentsAdapter({ agent }).wrapTool(tool)`. Each invocation signs `tool:start` / `tool:end` / `tool:error`. Requires `@openai/agents` as a peer dep.
-- **CrewAI**, **LiteLLM**, **LlamaIndex**, **Haystack** - same pattern via the Hooks API (Python SDK has the richer ecosystem; see <https://asqav.com/docs/integrations> for parity status).
+- **CrewAI**, **LiteLLM**, **LlamaIndex**, **Haystack** - same pattern via the Hooks API. The Python SDK has the richer ecosystem; see <https://asqav.com/docs/integrations> for parity status.
 
 Span names are mapped to Asqav action types: `ai.generateText` -> `ai:completion`, `ai.streamText` -> `ai:completion_stream`, `ai.toolCall` -> `ai:tool_call`, errors -> `ai:error`. Signing is fire-and-forget and never blocks generation; failures log a warning instead of throwing.
 
 ## Errors
 
-All thrown errors extend `AsqavError`. `AuthenticationError` (401), `RateLimitError` (429), and `APIError` (with `statusCode`) are exported for fine-grained handling:
+All thrown errors extend `AsqavError`. `AuthenticationError` for 401, `RateLimitError` for 429, and `APIError` carrying `statusCode` are exported for fine-grained handling:
 
 ```ts
 import { AsqavError, AuthenticationError, RateLimitError, APIError } from "@asqav/sdk";
@@ -304,8 +304,8 @@ Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-
 What ships on Asqav today. Each item is available on `main`:
 
 - Hash-only mode for cloud - default for `*.asqav.com`.
-- Self-hosted signer (split-trust) - compose file in the Asqav backend repo.
-- Bring-your-own KMS (AWS KMS / GCP KMS) - Enterprise tier.
+- Self-hosted signer with split-trust - compose file in the Asqav backend repo.
+- Bring-your-own KMS for AWS KMS or GCP KMS - Enterprise tier.
 - Customer-owned storage - self-hosted; relay payload allowlist enforced in code.
 - SCITT / COSE_Sign1 receipt export - public `GET /api/v1/signatures/{id}/cose` returns `application/cose`.
 - Air-gapped / on-prem mode - offline license + zero-egress; see the backend repo `docs/airgapped-mode.md`.


### PR DESCRIPTION
Reworded parenthetical asides in the README, CLI docs, and reference docs into clean clauses, for readability. Prose only: inline code, CLI examples, markdown links, version strings, and the verbatim guard-message bytes are untouched. Version unchanged at 0.5.12.