### PR TITLE
Tighten comments and remove dead code (asqav-sdk)

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -2774,7 +2774,6 @@ def init(
     )
     _org_salt = org_salt
 
-    # Initialize HTTP client
     if _HTTPX_AVAILABLE:
         _client = httpx.Client(
             base_url=_api_base,
@@ -3385,10 +3384,7 @@ def verify_compliance_receipt(
             if not outcome.valid:
                 errors.append(f"counterparty_binding_{outcome.label}")
 
-    # authorized_under_mandate is server-built; recognise it structurally and
-    # reject a present-but-malformed attestation (lockstep with the cloud
-    # false_mandate_attestation_guard). verified=true is self-declared issuer
-    # authority, never Asqav-verified third-party authorization.
+    # Reject a malformed authorized_under_mandate (lockstep with false_mandate_attestation_guard).
     if isinstance(_payload, dict):
         _aum = _payload.get("authorized_under_mandate")
         if _aum is not None:
@@ -3403,12 +3399,7 @@ def verify_compliance_receipt(
             ):
                 errors.append("false_mandate_attestation_guard")
 
-    # controls_evaluated is server-built; recognise it structurally and reject a
-    # present-but-malformed block (lockstep with the cloud
-    # false_control_attestation_guard, conformance.py:_check_controls_evaluated).
-    # A populated control proves provenance: quorum.fired needs a 64-hex
-    # attestation_hash; policy.evaluated needs matched_count >= 1. An unknown key
-    # or a type mismatch is a forged attestation; an absent key is honest silence.
+    # Reject a malformed controls_evaluated (lockstep with false_control_attestation_guard).
     if isinstance(_payload, dict):
         _ce = _payload.get("controls_evaluated")
         if _ce is not None:

--- a/python/src/asqav/verifier/oracle/adapters/acta.py
+++ b/python/src/asqav/verifier/oracle/adapters/acta.py
@@ -111,20 +111,14 @@ class ActaAdapter(FormatAdapter):
         sig = doc.get("signature")
         if not isinstance(payload, dict) or not isinstance(sig, dict):
             return "FAIL", "ACTA receipt needs object payload and signature"
-        # draft-farley conformance mandates a temporal anchor plus the signature
-        # triple; `type`/`issuer_id` are Asqav-profile fields, OPTIONAL upstream
-        # (the ScopeBlind reference producers emit `issuer`, not `issuer_id`, and
-        # omit `type`), so requiring them would reject conformant third-party
-        # receipts whose signatures genuinely verify.
+        # Require only the temporal anchor + signature triple; `type`/`issuer_id` are OPTIONAL Asqav-profile fields.
         missing = [f for f in ("issued_at",) if f not in payload]
         missing += [f"signature.{f}" for f in ("alg", "kid", "sig") if f not in sig]
         if missing:
             return "FAIL", f"missing required fields: {','.join(missing)}"
         if "previousReceiptHash" in payload and payload["previousReceiptHash"] is None:
             return "FAIL", "genesis must omit previousReceiptHash, not set it null"
-        # False-attestation guard: when the Asqav-profile `issuer_id` is present it
-        # MUST match the signing kid. Absent it, there is nothing to contradict, so
-        # the check is conditional rather than a hard requirement.
+        # False-attestation guard: when `issuer_id` is present it must match the signing kid.
         if "issuer_id" in payload and payload["issuer_id"] != sig.get("kid"):
             return "FAIL", "issuer_id must match signature.kid"
         # Bind alg to the EdDSA baseline; reject registry algs this verifier does not check.

--- a/typescript/src/extras/langchain.ts
+++ b/typescript/src/extras/langchain.ts
@@ -60,9 +60,7 @@ function truncate(s: string, max = MAX_PREVIEW): string {
  */
 async function loadBase(): Promise<BaseCallbackHandlerCtor> {
   try {
-    // Dynamic specifier: the peer is optional, declared in package.json
-    // peerDependenciesMeta. ts-ignore avoids hard-failing the type-check
-    // for installs without @langchain/core.
+    // Dynamic specifier: the peer is optional (package.json peerDependenciesMeta).
     // @ts-ignore optional peer dependency
     const mod = (await import("@langchain/core/callbacks/base")) as unknown;
     const ctor = (mod as { BaseCallbackHandler?: BaseCallbackHandlerCtor })

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1139,12 +1139,7 @@ function validateSignOptions(options: SignOptions, complianceMode: boolean): voi
       );
     }
   }
-  // Threat-framework taxonomy validators. Lockstep with the cloud
-  // SignRequest cross-field validator: lists must be non-empty
-  // arrays of strings (each entry up to 128 chars); rfc3161Timestamp
-  // must be valid base64. Verbatim guard tokens kept in sync with
-  // the cloud and Python SDK so SDK errors round-trip through the
-  // conformance vectors.
+  // Threat-framework taxonomy validators; verbatim guard tokens kept in lockstep with the cloud SignRequest validator.
   const _taxonomyChecks: Array<[string, string[] | undefined]> = [
     ["mitre_techniques", options.mitreTechniques],
     ["mitre_atlas", options.mitreAtlas],

--- a/typescript/src/verifier/adapters/acta.ts
+++ b/typescript/src/verifier/adapters/acta.ts
@@ -119,11 +119,7 @@ export class ActaAdapter extends FormatAdapter {
     const p = payload as Record<string, unknown>;
     const s = sig as Record<string, unknown>;
     const missing: string[] = [];
-    // draft-farley conformance mandates a temporal anchor plus the signature
-    // triple; `type`/`issuer_id` are Asqav-profile fields, OPTIONAL upstream (the
-    // ScopeBlind reference producers emit `issuer`, not `issuer_id`, and omit
-    // `type`), so requiring them would reject conformant third-party receipts
-    // whose signatures genuinely verify.
+    // Require only the temporal anchor + signature triple; `type`/`issuer_id` are OPTIONAL Asqav-profile fields.
     for (const f of ["issued_at"]) {
       if (!(f in p)) missing.push(f);
     }

--- a/typescript/src/verifier/canonical.ts
+++ b/typescript/src/verifier/canonical.ts
@@ -314,9 +314,7 @@ function serialize(
   if (value === true) return "true";
   if (value === false) return "false";
   if (isRawFloat(value)) return honorFloat ? floatToString(value.value) : numberToString(value.value);
-  // A >2^53 integer: emit the exact source digits in every dialect, matching Python's
-  // `str(int)` (json.dumps and _number_8785 alike). Distinct integers stay distinct, so
-  // a tampered big-int can never collide onto another's bytes and verify.
+  // A >2^53 integer: emit exact source digits in every dialect, matching Python's str(int), so distinct ints stay distinct.
   if (isRawBigInt(value)) return value.source;
   if (typeof value === "number") return numberToString(value);
   if (typeof value === "string") return jsonString(value);


### PR DESCRIPTION
Code-hygiene pass: condense standalone multi-line comment blocks to single-line WHY-only comments, and drop one comment that restated the code beneath it.

Touched (comments only, no logic or signature change):
- python client.py: two attestation-guard comment blocks condensed; dropped a redundant comment above the HTTP client construction
- python verifier acta adapter: two comment blocks condensed
- typescript index.ts: taxonomy validators comment block condensed
- typescript verifier acta adapter + canonical.ts: comment blocks condensed
- typescript langchain extra: optional-peer import comment condensed

No dead code met the zero-caller bar this pass, so none was removed. No literals repeated across 3+ sites, so nothing was tokenized.

Local checks run: ruff check (clean on both changed python files), python ast.parse on changed python files, tsc --noEmit (clean). Full test suite not run on darwin.

Draft on purpose; not for merge.