### PR TITLE
feat(github-action): risk-acceptance receipt action with mint and audit modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       typescript: ${{ steps.filter.outputs.typescript }}
       verifier: ${{ steps.filter.outputs.verifier }}
+      actions: ${{ steps.filter.outputs.actions }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -32,6 +33,10 @@ jobs:
             verifier:
               - 'python/src/asqav/verifier/**'
               - 'verifier/conformance-vectors/**'
+              - '.github/workflows/ci.yml'
+            actions:
+              - 'github-action/**'
+              - 'github-action-risk-acceptance/**'
               - '.github/workflows/ci.yml'
 
   python:
@@ -87,10 +92,23 @@ jobs:
       - run: ruff check python/src/asqav/verifier
       - run: PYTHONPATH=python/src pytest python/tests/test_oracle.py python/tests/test_verify_receipt.py -v --tb=short
 
+  actions:
+    needs: changes
+    if: needs.changes.outputs.actions == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest ruff
+      - run: ruff check github-action github-action-risk-acceptance
+      - run: pytest github-action github-action-risk-acceptance -v --tb=short
+
   ci-ok:
     # Single required status check for branch protection.
     # Passes when matrix jobs succeeded OR were skipped (no relevant changes).
-    needs: [python, typescript, verifier]
+    needs: [python, typescript, verifier, actions]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -98,6 +116,8 @@ jobs:
           echo "python=${{ needs.python.result }}"
           echo "typescript=${{ needs.typescript.result }}"
           echo "verifier=${{ needs.verifier.result }}"
+          echo "actions=${{ needs.actions.result }}"
           [[ "${{ needs.python.result }}"     =~ ^(success|skipped)$ ]] || exit 1
           [[ "${{ needs.typescript.result }}" =~ ^(success|skipped)$ ]] || exit 1
           [[ "${{ needs.verifier.result }}"   =~ ^(success|skipped)$ ]] || exit 1
+          [[ "${{ needs.actions.result }}"    =~ ^(success|skipped)$ ]] || exit 1

--- a/github-action-risk-acceptance/README.md
+++ b/github-action-risk-acceptance/README.md
@@ -112,13 +112,19 @@ The manifest lists the receipt ids your suppressions rely on, one per line
 (`#` comments allowed), or as a JSON array, or as `{"receipts": [...]}`.
 
 The audit fetches each receipt through the public verify endpoint and fails
-when any referenced receipt is missing, fails verification, is expired
-(evaluated server-side against the receipt's `valid_until`), carries a
-receipt type other than `protectmcp:lifecycle:risk_acceptance`, or is named
-in the `supersedes` field of another receipt in the manifest. Supersession is
-evaluated client-side across the fetched set, so keep both the old and the
-new receipt id in the manifest during a handover if you want the audit to
-flag the old one.
+when any referenced receipt is missing, fails verification, or is expired
+(evaluated server-side against the receipt's `valid_until`). Two more checks
+read the receipt payload and run only when the verify endpoint returns one:
+a receipt type other than `protectmcp:lifecycle:risk_acceptance` fails the
+audit, and a receipt named in the `supersedes` field of another receipt in
+the manifest fails as superseded (evaluated client-side across the fetched
+set, so keep both the old and the new id in the manifest during a handover).
+
+Hash-mode receipts, the SDK default against the Asqav cloud, return no
+payload on the public verify surface. For those the audit emits a prominent
+warning marking the type and supersession checks NOT EVALUABLE and does not
+fail on them; enforcement there rests on the existence, signature, and
+expiry checks alone.
 
 ## Inputs
 

--- a/github-action-risk-acceptance/README.md
+++ b/github-action-risk-acceptance/README.md
@@ -1,0 +1,159 @@
+# Asqav Risk-Acceptance Receipt Action
+
+Mint a signed Asqav risk-acceptance receipt from CI when an exception pull
+request is approved, and audit your scanner suppressions against the receipts
+that back them. Signing is ML-DSA-65 (FIPS 204) server-side. Receipts support
+recordkeeping obligations around security exceptions, with a built-in expiry
+so an acceptance can never quietly become permanent.
+
+## What it proves and what it does not
+
+Mint mode signs a small, honest set of facts:
+
+- a scanner finding existed, captured as the SARIF file's SHA-256 digest and
+  the finding reference,
+- a named approver accepted the risk for a named initiator, read from the PR
+  approval event,
+- the acceptance was recorded and key-signed at a point in time with a
+  declared expiry.
+
+It does not verify the finding, does not re-run the scanner, and does not
+attest the GitHub identities. The approver login (the approving reviewer, or
+the merging user on a merged pull request) and the initiator login (the PR
+author) are producer-asserted and recorded, never verified by Asqav. The
+SARIF file is digested on the runner and never uploaded.
+
+## The expiry loop
+
+Every acceptance carries an expiry. When it lapses, the audit mode fails the
+CI run, the team removes the suppression, and the scanner flags the finding
+again. The risk gets re-decided instead of forgotten:
+
+1. Scanner flags a finding. The team decides to accept the risk for 90 days.
+2. An exception PR adds the suppression. On approval, mint mode signs the
+   acceptance with `expires: 90d` and the receipt id goes into the
+   suppression manifest.
+3. A scheduled workflow runs audit mode against the manifest. While the
+   receipt is valid, the audit passes.
+4. After 90 days the receipt expires, the audit exits nonzero, the
+   suppression is removed, and the scanner re-flags the finding. Accepting it
+   again means minting a new receipt, with `supersedes` pointing at the old
+   one.
+
+## Usage: mint on exception-PR approval
+
+```yaml
+name: risk-acceptance
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  mint:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run security scanner
+        run: my-scanner --output results.sarif
+
+      - name: Mint Asqav risk-acceptance receipt
+        id: asqav
+        uses: jagmarques/asqav-sdk/github-action-risk-acceptance@main
+        with:
+          asqav-api-key: ${{ secrets.ASQAV_API_KEY }}
+          asqav-agent-id: ${{ secrets.ASQAV_AGENT_ID }}
+          sarif-file: results.sarif
+          finding-id: "py/sql-injection:4f2a91c0"
+          reason: "Input reaches a parameterized query, compensating control reviewed"
+          expires: 90d
+
+      - name: Show receipt
+        run: |
+          echo "signature: ${{ steps.asqav.outputs.signature-id }}"
+          echo "verify:    ${{ steps.asqav.outputs.verification-url }}"
+```
+
+The approver is read from `github.event.review.user.login` and the initiator
+from the PR author. On a merged `pull_request` event the merging user is
+recorded as the approver instead.
+
+## Usage: audit the suppression manifest
+
+```yaml
+name: suppression-audit
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Audit risk-acceptance receipts
+        uses: jagmarques/asqav-sdk/github-action-risk-acceptance@main
+        with:
+          mode: audit
+          asqav-api-key: ${{ secrets.ASQAV_API_KEY }}
+          suppression-manifest: .security/suppressions.txt
+```
+
+The manifest lists the receipt ids your suppressions rely on, one per line
+(`#` comments allowed), or as a JSON array, or as `{"receipts": [...]}`.
+
+The audit fetches each receipt through the public verify endpoint and fails
+when any referenced receipt is missing, fails verification, is expired
+(evaluated server-side against the receipt's `valid_until`), carries a
+receipt type other than `protectmcp:lifecycle:risk_acceptance`, or is named
+in the `supersedes` field of another receipt in the manifest. Supersession is
+evaluated client-side across the fetched set, so keep both the old and the
+new receipt id in the manifest during a handover if you want the audit to
+flag the old one.
+
+## Inputs
+
+| Input                  | Required          | Default | Description |
+| ---------------------- | ----------------- | ------- | ----------- |
+| `mode`                 | no                | `mint`  | `mint` or `audit`. |
+| `asqav-api-key`        | yes               |         | Asqav API key in the form `sk_...`. Pass via a repository secret. |
+| `asqav-agent-id`       | mint              |         | Asqav agent id whose key signs the receipt. |
+| `sarif-file`           | mint              |         | Path to the SARIF file containing the flagged finding. Digested, never uploaded. |
+| `finding-id`           | mint              |         | The SARIF ruleId plus fingerprint the exception covers. Recorded as `finding_ref`. |
+| `reason`               | mint              |         | Why the risk is accepted. Recorded as `acceptance_reason`. |
+| `expires`              | mint              |         | Duration (`90d`, `12h`, `30m`, `3600s`, `2w`) or ISO date. Converted to `valid_seconds`. |
+| `supersedes`           | no                |         | Signature id of the acceptance this one replaces. |
+| `risk-snapshot-json`   | no                |         | JSON object of producer-asserted third-party risk signals, passed through unmodified. |
+| `suppression-manifest` | audit             |         | Path to the manifest of receipt ids. |
+
+## Outputs
+
+| Output             | Description |
+| ------------------ | ----------- |
+| `signature-id`     | Asqav signature id of the signed receipt (mint mode). |
+| `verification-url` | Public URL to verify the signed receipt (mint mode). |
+
+## How the receipt is derived
+
+Mint mode calls `agent.sign(...)` with
+`receipt_type="protectmcp:lifecycle:risk_acceptance"`, `compliance_mode=True`,
+and `policy_decision="none"`, since a risk-acceptance receipt records a human
+decision, not a policy evaluation. The field map:
+
+- `approver_id` from the approving reviewer's login,
+- `initiator_id` from the PR author's login,
+- `acceptance_reason` from `reason`,
+- `accepted_at` from the review's `submitted_at`,
+- `finding_ref` from `finding-id`,
+- `sarif_digest` = `sha256:` + SHA-256 of the SARIF file bytes,
+- `supersedes` and `risk_snapshot` passed through when provided,
+- `valid_seconds` from `expires`.

--- a/github-action-risk-acceptance/action.yml
+++ b/github-action-risk-acceptance/action.yml
@@ -1,0 +1,94 @@
+name: "Asqav Risk-Acceptance Receipt"
+description: >-
+  Mint a signed Asqav risk-acceptance receipt from CI when an exception pull
+  request is approved (approver and initiator read from the PR event,
+  producer-asserted), or audit a suppression manifest against the receipts it
+  references. Signing is ML-DSA-65 server-side.
+author: "Asqav"
+branding:
+  icon: "shield"
+  color: "blue"
+
+inputs:
+  mode:
+    description: "Action mode: mint | audit."
+    required: false
+    default: "mint"
+  asqav-api-key:
+    description: "Asqav API key (sk_...). Pass via a repository secret."
+    required: true
+  asqav-agent-id:
+    description: "Asqav agent id whose key signs the receipt. Required for mint mode."
+    required: false
+    default: ""
+  sarif-file:
+    description: "Path to the SARIF file containing the flagged finding. Digested, never uploaded."
+    required: false
+    default: ""
+  finding-id:
+    description: "The SARIF ruleId plus fingerprint the exception covers. Recorded as finding_ref."
+    required: false
+    default: ""
+  reason:
+    description: "Why the risk is accepted. Recorded as acceptance_reason."
+    required: false
+    default: ""
+  expires:
+    description: >-
+      How long the acceptance is valid: a duration like 90d, 12h, 30m, 3600s,
+      or an ISO date like 2026-09-01. Converted to valid_seconds.
+    required: false
+    default: ""
+  supersedes:
+    description: "Optional signature id of the prior risk-acceptance receipt this one replaces."
+    required: false
+    default: ""
+  risk-snapshot-json:
+    description: >-
+      Optional JSON object of producer-asserted third-party risk signals
+      (snapshot_at required, snapshot_source required with any numeric).
+      Passed through unmodified; the SDK validates the shape.
+    required: false
+    default: ""
+  suppression-manifest:
+    description: >-
+      Audit mode: path to a manifest of receipt ids the scanner suppressions
+      rely on. One id per line, or a JSON array, or {"receipts": [...]}.
+    required: false
+    default: ""
+
+outputs:
+  signature-id:
+    description: "The Asqav signature id of the signed risk-acceptance receipt."
+    value: ${{ steps.run.outputs.signature-id }}
+  verification-url:
+    description: "Public URL to verify the signed receipt."
+    value: ${{ steps.run.outputs.verification-url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install Asqav SDK
+      shell: bash
+      run: python -m pip install --upgrade "asqav>=0.5.7"
+
+    - name: Run risk-acceptance action
+      id: run
+      shell: bash
+      env:
+        ASQAV_MODE: ${{ inputs.mode }}
+        ASQAV_API_KEY: ${{ inputs.asqav-api-key }}
+        ASQAV_AGENT_ID: ${{ inputs.asqav-agent-id }}
+        ASQAV_SARIF_FILE: ${{ inputs.sarif-file }}
+        ASQAV_FINDING_ID: ${{ inputs.finding-id }}
+        ASQAV_REASON: ${{ inputs.reason }}
+        ASQAV_EXPIRES: ${{ inputs.expires }}
+        ASQAV_SUPERSEDES: ${{ inputs.supersedes }}
+        ASQAV_RISK_SNAPSHOT_JSON: ${{ inputs.risk-snapshot-json }}
+        ASQAV_SUPPRESSION_MANIFEST: ${{ inputs.suppression-manifest }}
+      run: python "${{ github.action_path }}/risk_acceptance.py"

--- a/github-action-risk-acceptance/action.yml
+++ b/github-action-risk-acceptance/action.yml
@@ -75,7 +75,7 @@ runs:
 
     - name: Install Asqav SDK
       shell: bash
-      run: python -m pip install --upgrade "asqav>=0.5.7"
+      run: python -m pip install --upgrade "asqav>=0.5.7,<0.6"
 
     - name: Run risk-acceptance action
       id: run

--- a/github-action-risk-acceptance/risk_acceptance.py
+++ b/github-action-risk-acceptance/risk_acceptance.py
@@ -12,11 +12,14 @@ declared expiry, nothing more.
 
 Audit mode fetches each receipt id named in a suppression manifest via the
 public verify endpoint and exits nonzero when any referenced receipt is
-missing, fails verification, is expired (server-evaluated valid_until), or is
-superseded by another receipt fetched in the same run. Supersession is
-detected client-side from the `supersedes` field on the fetched receipts, so
-the audit works against the live verify endpoint alone with no list endpoint
-required.
+missing, fails verification, or is expired (server-evaluated valid_until).
+The receipt-type and supersession checks read the receipt payload, and the
+public verify surface returns no payload for hash-mode receipts (the SDK
+default against the Asqav cloud). For those receipts the audit emits a
+prominent warning marking both checks NOT EVALUABLE instead of skipping them
+without a trace. When the payload is present, a wrong receipt_type fails the
+audit and supersession is detected client-side from the `supersedes` field
+across the fetched set, with no list endpoint required.
 """
 
 from __future__ import annotations
@@ -33,6 +36,13 @@ from typing import Any
 RECEIPT_TYPE = "protectmcp:lifecycle:risk_acceptance"
 #: validation_label the cloud verify cascade emits for a lapsed valid_until.
 EXPIRED_LABEL = "signature_expired"
+#: warning text for receipts whose payload the verify surface does not return.
+NOT_EVALUABLE_MSG = (
+    "receipt_type and supersedes are NOT EVALUABLE from the public verify "
+    "surface for hash-mode receipts (no payload returned). The signature, "
+    "expiry, and existence checks still apply; the audit cannot confirm this "
+    "receipt's type or whether another receipt supersedes it."
+)
 
 _DURATION_RE = re.compile(r"^(\d+)\s*([smhdw]?)$", re.IGNORECASE)
 _DURATION_UNITS = {"": 1, "s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
@@ -257,16 +267,21 @@ def _fetch_receipt(signature_id: str) -> dict[str, Any] | None:
     }
 
 
-def evaluate_audit(receipts: dict[str, dict[str, Any] | None]) -> list[str]:
-    """Return the list of audit failures for the fetched manifest receipts.
+def evaluate_audit(
+    receipts: dict[str, dict[str, Any] | None]
+) -> tuple[list[str], list[str]]:
+    """Return (failures, warnings) for the fetched manifest receipts.
 
     A manifest id fails when the receipt is missing, fails verification, is
-    expired (the server-evaluated validation_label), references a receipt type
-    other than risk_acceptance, or is named in the `supersedes` field of
-    another fetched receipt. Supersession is evaluated client-side across the
-    fetched set, on the payload's `supersedes` value.
+    expired (the server-evaluated validation_label), carries a payload with a
+    receipt type other than risk_acceptance, or is named in the `supersedes`
+    field of another fetched receipt. The type and supersession checks read
+    the payload; a receipt fetched with payload=None (hash-mode receipts
+    return none) gets a warning marking those checks NOT EVALUABLE rather
+    than a quiet pass.
     """
     failures: list[str] = []
+    warnings: list[str] = []
     superseded_by: dict[str, str] = {}
     for sig_id, rec in receipts.items():
         if rec is None or not rec.get("payload"):
@@ -285,7 +300,9 @@ def evaluate_audit(receipts: dict[str, dict[str, Any] | None]) -> list[str]:
         elif not rec.get("verified"):
             failures.append(f"{sig_id}: failed verification (validation_label={label}).")
         payload = rec.get("payload")
-        if payload is not None:
+        if payload is None:
+            warnings.append(f"{sig_id}: {NOT_EVALUABLE_MSG}")
+        else:
             rtype = payload.get("receipt_type")
             if rtype != RECEIPT_TYPE:
                 failures.append(
@@ -293,11 +310,11 @@ def evaluate_audit(receipts: dict[str, dict[str, Any] | None]) -> list[str]:
                 )
         if sig_id in superseded_by:
             failures.append(f"{sig_id}: superseded by {superseded_by[sig_id]}.")
-    return failures
+    return failures, warnings
 
 
-def audit(*, api_key: str, manifest_path: str) -> list[str]:
-    """Run the audit: fetch every manifest receipt, evaluate, return failures."""
+def audit(*, api_key: str, manifest_path: str) -> tuple[list[str], list[str]]:
+    """Fetch every manifest receipt, evaluate, return (failures, warnings)."""
     import asqav
 
     asqav.init(api_key=api_key)
@@ -365,10 +382,13 @@ def _main_audit() -> int:
         )
         return 2
     try:
-        failures = audit(api_key=api_key, manifest_path=manifest_path)
+        failures, warnings = audit(api_key=api_key, manifest_path=manifest_path)
     except Exception as exc:  # noqa: BLE001 - surface any failure to the runner
         print(f"ERROR auditing suppression manifest: {exc}", file=sys.stderr)
         return 1
+    for line in warnings:
+        print(f"::warning::{line}")
+        print(f"WARNING {line}", file=sys.stderr)
     if failures:
         for line in failures:
             print(f"FAIL {line}", file=sys.stderr)
@@ -379,7 +399,14 @@ def _main_audit() -> int:
             file=sys.stderr,
         )
         return 1
-    print("All manifest receipts verified, unexpired, and unsuperseded.")
+    if warnings:
+        print(
+            "All evaluable checks passed: every manifest receipt verified "
+            f"and unexpired. receipt_type and supersedes were NOT EVALUABLE "
+            f"for {len(warnings)} hash-mode receipt(s), see warnings above."
+        )
+    else:
+        print("All manifest receipts verified, unexpired, and unsuperseded.")
     return 0
 
 

--- a/github-action-risk-acceptance/risk_acceptance.py
+++ b/github-action-risk-acceptance/risk_acceptance.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Mint or audit Asqav risk-acceptance receipts from a GitHub Actions run.
+
+Honest scope: mint mode signs what the runner can see (a SHA-256 digest of the
+SARIF file, the finding reference, the acceptance reason, and a validity
+window) plus the identities the PR event reports. The approver is the
+approving reviewer's login from `github.event.review` (or the merging user on
+a merged pull_request event) and the initiator is the PR author's login; both
+are producer-asserted and recorded, never verified by Asqav. The receipt
+proves the acceptance was recorded and key-signed at a point in time with a
+declared expiry, nothing more.
+
+Audit mode fetches each receipt id named in a suppression manifest via the
+public verify endpoint and exits nonzero when any referenced receipt is
+missing, fails verification, is expired (server-evaluated valid_until), or is
+superseded by another receipt fetched in the same run. Supersession is
+detected client-side from the `supersedes` field on the fetched receipts, so
+the audit works against the live verify endpoint alone with no list endpoint
+required.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+RECEIPT_TYPE = "protectmcp:lifecycle:risk_acceptance"
+#: validation_label the cloud verify cascade emits for a lapsed valid_until.
+EXPIRED_LABEL = "signature_expired"
+
+_DURATION_RE = re.compile(r"^(\d+)\s*([smhdw]?)$", re.IGNORECASE)
+_DURATION_UNITS = {"": 1, "s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+
+
+@dataclass
+class ApprovalContext:
+    """The PR-approval facts the receipt binds to, read from the event payload.
+
+    All identities are producer-asserted GitHub logins; Asqav records them and
+    never verifies them.
+    """
+
+    approver: str
+    initiator: str | None
+    accepted_at: str | None
+    approval_ref: str | None
+
+
+def parse_expires(value: str, *, now: datetime | None = None) -> int:
+    """Convert the `expires` input into valid_seconds.
+
+    Accepts a duration (90d, 12h, 30m, 3600s, 2w, or a bare integer of
+    seconds) or an ISO 8601 date / datetime, which is converted to the number
+    of seconds between now and that instant. Raises ValueError on a malformed
+    value or a non-future date so the action fails clean instead of minting an
+    already-expired acceptance.
+    """
+    value = value.strip()
+    if not value:
+        raise ValueError("expires is required: pass a duration (90d) or an ISO date.")
+    m = _DURATION_RE.match(value)
+    if m:
+        seconds = int(m.group(1)) * _DURATION_UNITS[m.group(2).lower()]
+        if seconds <= 0:
+            raise ValueError(f"expires must be a positive duration (got: {value!r}).")
+        return seconds
+    try:
+        target = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"expires is neither a duration nor an ISO date (got: {value!r})."
+        ) from exc
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    seconds = int((target - now).total_seconds())
+    if seconds <= 0:
+        raise ValueError(f"expires date must be in the future (got: {value!r}).")
+    return seconds
+
+
+def compute_sarif_digest(path: str) -> str:
+    """Return `sha256:` + SHA-256 of the SARIF file bytes.
+
+    The digest is an existence proof of the exact scanner output the
+    acceptance was minted against; the file itself never leaves the runner.
+    """
+    with open(path, "rb") as fh:
+        digest = hashlib.sha256(fh.read()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def read_approval_context(event: dict[str, Any] | None = None) -> ApprovalContext:
+    """Derive approver and initiator from the GitHub event payload.
+
+    approver   <- review.user.login (pull_request_review event), else
+                  pull_request.merged_by.login (merged pull_request event)
+    initiator  <- pull_request.user.login (the PR author)
+    accepted_at<- review.submitted_at when present
+    approval_ref <- the review html_url, else the PR html_url
+
+    Raises ValueError when no approver can be derived, because a
+    risk-acceptance receipt without an approver is rejected by the SDK.
+    """
+    if event is None:
+        event = {}
+        event_path = os.environ.get("GITHUB_EVENT_PATH")
+        if event_path and os.path.exists(event_path):
+            try:
+                with open(event_path, encoding="utf-8") as fh:
+                    event = json.load(fh)
+            except (OSError, ValueError):
+                event = {}
+
+    review = event.get("review") or {}
+    pr = event.get("pull_request") or {}
+
+    approver = (review.get("user") or {}).get("login")
+    if not approver:
+        approver = (pr.get("merged_by") or {}).get("login")
+    if not approver:
+        raise ValueError(
+            "no approver in the event payload: run this action on a "
+            "pull_request_review (submitted) event or a merged pull_request "
+            "event so the approving login is present."
+        )
+
+    initiator = (pr.get("user") or {}).get("login") or None
+    accepted_at = review.get("submitted_at") or None
+    approval_ref = review.get("html_url") or pr.get("html_url") or None
+    return ApprovalContext(
+        approver=approver,
+        initiator=initiator,
+        accepted_at=accepted_at,
+        approval_ref=approval_ref,
+    )
+
+
+def _write_github_output(values: dict[str, str]) -> None:
+    """Append key=value lines to $GITHUB_OUTPUT if it is set."""
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    with open(out_path, "a", encoding="utf-8") as fh:
+        for key, value in values.items():
+            fh.write(f"{key}={value}\n")
+
+
+def mint(
+    *,
+    api_key: str,
+    agent_id: str,
+    reason: str,
+    finding_id: str,
+    sarif_digest: str,
+    valid_seconds: int,
+    supersedes: str | None,
+    risk_snapshot: dict[str, Any] | None,
+    approval: ApprovalContext,
+) -> dict[str, str]:
+    """Sign the risk-acceptance receipt and return the GitHub outputs.
+
+    The sign call mirrors the SDK risk-acceptance guards: the extension fields
+    are fenced to receipt_type=protectmcp:lifecycle:risk_acceptance, require
+    compliance_mode=True, and sign under policy_decision='none' because the
+    receipt records no policy evaluation.
+    """
+    import asqav
+
+    asqav.init(api_key=api_key)
+    agent = asqav.Agent.get(agent_id)
+
+    response = agent.sign(
+        "security:risk_acceptance",
+        receipt_type=RECEIPT_TYPE,
+        compliance_mode=True,
+        policy_decision="none",
+        approver_id=approval.approver,
+        initiator_id=approval.initiator,
+        acceptance_reason=reason,
+        accepted_at=approval.accepted_at,
+        supersedes=supersedes,
+        sarif_digest=sarif_digest,
+        finding_ref=finding_id,
+        approval_ref=approval.approval_ref,
+        risk_snapshot=risk_snapshot,
+        valid_seconds=valid_seconds,
+    )
+
+    print(f"Signed risk-acceptance receipt: {response.signature_id}")
+    print(f"Verify at: {response.verification_url}")
+
+    outputs = {
+        "signature-id": response.signature_id,
+        "verification-url": response.verification_url,
+    }
+    _write_github_output(outputs)
+    return outputs
+
+
+def parse_manifest(text: str) -> list[str]:
+    """Parse a suppression manifest into a list of receipt ids.
+
+    Accepts a JSON array, a JSON object with a `receipts` key, or plain text
+    with one id per line (blank lines and `#` comments skipped). Raises
+    ValueError on an empty result so an empty manifest never passes silently.
+    """
+    text = text.strip()
+    ids: list[str] = []
+    if text.startswith("[") or text.startswith("{"):
+        data = json.loads(text)
+        if isinstance(data, dict):
+            data = data.get("receipts")
+        if not isinstance(data, list):
+            raise ValueError(
+                "JSON manifest must be an array of ids or {\"receipts\": [...]}."
+            )
+        ids = [str(x).strip() for x in data if str(x).strip()]
+    else:
+        for line in text.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                ids.append(line)
+    if not ids:
+        raise ValueError("suppression manifest contains no receipt ids.")
+    return ids
+
+
+def _fetch_receipt(signature_id: str) -> dict[str, Any] | None:
+    """Fetch one receipt via the public verify endpoint.
+
+    Returns a plain dict with the axes the audit consumes, or None when the
+    receipt does not exist. Network and API failures propagate so the audit
+    fails loud rather than passing on missing data.
+    """
+    import asqav
+    from asqav import APIError
+
+    try:
+        result = asqav.verify_signature(signature_id)
+    except APIError as exc:
+        if exc.status_code == 404:
+            return None
+        raise
+    detail = result.verification_detail
+    return {
+        "signature_id": result.signature_id,
+        "verified": result.verified,
+        "validation_label": detail.validation_label if detail else None,
+        "payload": result.payload if isinstance(result.payload, dict) else None,
+    }
+
+
+def evaluate_audit(receipts: dict[str, dict[str, Any] | None]) -> list[str]:
+    """Return the list of audit failures for the fetched manifest receipts.
+
+    A manifest id fails when the receipt is missing, fails verification, is
+    expired (the server-evaluated validation_label), references a receipt type
+    other than risk_acceptance, or is named in the `supersedes` field of
+    another fetched receipt. Supersession is evaluated client-side across the
+    fetched set, on the payload's `supersedes` value.
+    """
+    failures: list[str] = []
+    superseded_by: dict[str, str] = {}
+    for sig_id, rec in receipts.items():
+        if rec is None or not rec.get("payload"):
+            continue
+        target = rec["payload"].get("supersedes")
+        if isinstance(target, str) and target:
+            superseded_by[target] = sig_id
+
+    for sig_id, rec in receipts.items():
+        if rec is None:
+            failures.append(f"{sig_id}: receipt not found.")
+            continue
+        label = rec.get("validation_label")
+        if label == EXPIRED_LABEL:
+            failures.append(f"{sig_id}: expired (validation_label={label}).")
+        elif not rec.get("verified"):
+            failures.append(f"{sig_id}: failed verification (validation_label={label}).")
+        payload = rec.get("payload")
+        if payload is not None:
+            rtype = payload.get("receipt_type")
+            if rtype != RECEIPT_TYPE:
+                failures.append(
+                    f"{sig_id}: receipt_type is {rtype!r}, expected {RECEIPT_TYPE}."
+                )
+        if sig_id in superseded_by:
+            failures.append(f"{sig_id}: superseded by {superseded_by[sig_id]}.")
+    return failures
+
+
+def audit(*, api_key: str, manifest_path: str) -> list[str]:
+    """Run the audit: fetch every manifest receipt, evaluate, return failures."""
+    import asqav
+
+    asqav.init(api_key=api_key)
+    with open(manifest_path, encoding="utf-8") as fh:
+        ids = parse_manifest(fh.read())
+    receipts = {sig_id: _fetch_receipt(sig_id) for sig_id in ids}
+    return evaluate_audit(receipts)
+
+
+def _main_mint() -> int:
+    api_key = os.environ.get("ASQAV_API_KEY", "")
+    agent_id = os.environ.get("ASQAV_AGENT_ID", "")
+    reason = os.environ.get("ASQAV_REASON", "").strip()
+    finding_id = os.environ.get("ASQAV_FINDING_ID", "").strip()
+    sarif_file = os.environ.get("ASQAV_SARIF_FILE", "").strip()
+    expires = os.environ.get("ASQAV_EXPIRES", "").strip()
+    supersedes = os.environ.get("ASQAV_SUPERSEDES", "").strip() or None
+    snapshot_raw = os.environ.get("ASQAV_RISK_SNAPSHOT_JSON", "").strip()
+
+    missing = [
+        name
+        for name, value in (
+            ("asqav-api-key", api_key),
+            ("asqav-agent-id", agent_id),
+            ("reason", reason),
+            ("finding-id", finding_id),
+            ("sarif-file", sarif_file),
+            ("expires", expires),
+        )
+        if not value
+    ]
+    if missing:
+        print(f"ERROR: mint mode requires inputs: {', '.join(missing)}.", file=sys.stderr)
+        return 2
+
+    try:
+        valid_seconds = parse_expires(expires)
+        sarif_digest = compute_sarif_digest(sarif_file)
+        risk_snapshot = json.loads(snapshot_raw) if snapshot_raw else None
+        approval = read_approval_context()
+        mint(
+            api_key=api_key,
+            agent_id=agent_id,
+            reason=reason,
+            finding_id=finding_id,
+            sarif_digest=sarif_digest,
+            valid_seconds=valid_seconds,
+            supersedes=supersedes,
+            risk_snapshot=risk_snapshot,
+            approval=approval,
+        )
+    except Exception as exc:  # noqa: BLE001 - surface any failure to the runner
+        print(f"ERROR minting risk-acceptance receipt: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _main_audit() -> int:
+    api_key = os.environ.get("ASQAV_API_KEY", "")
+    manifest_path = os.environ.get("ASQAV_SUPPRESSION_MANIFEST", "").strip()
+    if not api_key or not manifest_path:
+        print(
+            "ERROR: audit mode requires asqav-api-key and suppression-manifest.",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        failures = audit(api_key=api_key, manifest_path=manifest_path)
+    except Exception as exc:  # noqa: BLE001 - surface any failure to the runner
+        print(f"ERROR auditing suppression manifest: {exc}", file=sys.stderr)
+        return 1
+    if failures:
+        for line in failures:
+            print(f"FAIL {line}", file=sys.stderr)
+        print(
+            f"{len(failures)} suppression(s) rest on an expired, superseded, "
+            "or invalid risk-acceptance receipt. Remove the suppression or "
+            "mint a new acceptance.",
+            file=sys.stderr,
+        )
+        return 1
+    print("All manifest receipts verified, unexpired, and unsuperseded.")
+    return 0
+
+
+def main() -> int:
+    mode = os.environ.get("ASQAV_MODE", "mint").strip().lower()
+    if mode == "mint":
+        return _main_mint()
+    if mode == "audit":
+        return _main_audit()
+    print(f"ERROR: unknown mode {mode!r} (expected mint or audit).", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/github-action-risk-acceptance/test_risk_acceptance.py
+++ b/github-action-risk-acceptance/test_risk_acceptance.py
@@ -8,7 +8,8 @@ tests cover the load-bearing pieces of the action:
 3. approver and initiator extraction from the event payload.
 4. the mint sign call invariants (receipt type, compliance mode, field map).
 5. manifest parsing and the client-side audit filter (expired, superseded,
-   missing, wrong type).
+   missing, wrong type, and the NOT EVALUABLE warning for hash-mode
+   receipts that return payload=None).
 """
 
 import hashlib
@@ -223,18 +224,28 @@ def _ok_receipt(sig_id, **payload_extra):
     }
 
 
+def _hash_mode_receipt(sig_id, verified=True, validation_label="fully_verified"):
+    return {
+        "signature_id": sig_id,
+        "verified": verified,
+        "validation_label": validation_label,
+        "payload": None,
+    }
+
+
 def test_audit_passes_valid_receipts():
     receipts = {"sig_a": _ok_receipt("sig_a"), "sig_b": _ok_receipt("sig_b")}
-    assert mod.evaluate_audit(receipts) == []
+    assert mod.evaluate_audit(receipts) == ([], [])
 
 
 def test_audit_fails_expired_receipt():
     rec = _ok_receipt("sig_a")
     rec["validation_label"] = mod.EXPIRED_LABEL
     rec["verified"] = False
-    failures = mod.evaluate_audit({"sig_a": rec})
+    failures, warnings = mod.evaluate_audit({"sig_a": rec})
     assert len(failures) == 1
     assert "expired" in failures[0]
+    assert warnings == []
 
 
 def test_audit_fails_superseded_receipt():
@@ -242,27 +253,70 @@ def test_audit_fails_superseded_receipt():
         "sig_old": _ok_receipt("sig_old"),
         "sig_new": _ok_receipt("sig_new", supersedes="sig_old"),
     }
-    failures = mod.evaluate_audit(receipts)
+    failures, warnings = mod.evaluate_audit(receipts)
     assert failures == ["sig_old: superseded by sig_new."]
+    assert warnings == []
 
 
 def test_audit_fails_missing_receipt():
-    failures = mod.evaluate_audit({"sig_gone": None})
+    failures, warnings = mod.evaluate_audit({"sig_gone": None})
     assert failures == ["sig_gone: receipt not found."]
+    assert warnings == []
 
 
 def test_audit_fails_wrong_receipt_type():
     rec = _ok_receipt("sig_a")
     rec["payload"]["receipt_type"] = "protectmcp:lifecycle:code_authorship"
-    failures = mod.evaluate_audit({"sig_a": rec})
+    failures, warnings = mod.evaluate_audit({"sig_a": rec})
     assert len(failures) == 1
     assert "receipt_type" in failures[0]
+    assert warnings == []
 
 
 def test_audit_unverified_receipt_fails():
     rec = _ok_receipt("sig_a")
     rec["verified"] = False
     rec["validation_label"] = "signature_invalid"
-    failures = mod.evaluate_audit({"sig_a": rec})
+    failures, warnings = mod.evaluate_audit({"sig_a": rec})
     assert len(failures) == 1
     assert "failed verification" in failures[0]
+    assert warnings == []
+
+
+def test_audit_hash_mode_payload_none_warns_not_evaluable():
+    failures, warnings = mod.evaluate_audit({"sig_a": _hash_mode_receipt("sig_a")})
+    assert failures == []
+    assert len(warnings) == 1
+    assert warnings[0].startswith("sig_a: ")
+    assert "NOT EVALUABLE" in warnings[0]
+    assert "hash-mode" in warnings[0]
+
+
+def test_audit_hash_mode_warning_does_not_mask_expiry():
+    rec = _hash_mode_receipt(
+        "sig_a", verified=False, validation_label=mod.EXPIRED_LABEL
+    )
+    failures, warnings = mod.evaluate_audit({"sig_a": rec})
+    assert len(failures) == 1
+    assert "expired" in failures[0]
+    assert len(warnings) == 1
+    assert "NOT EVALUABLE" in warnings[0]
+
+
+def test_main_audit_surfaces_warning_and_exits_zero(monkeypatch, capsys, tmp_path):
+    manifest = tmp_path / "suppressions.txt"
+    manifest.write_text("sig_a\n")
+    monkeypatch.setenv("ASQAV_MODE", "audit")
+    monkeypatch.setenv("ASQAV_API_KEY", "sk_test")
+    monkeypatch.setenv("ASQAV_SUPPRESSION_MANIFEST", str(manifest))
+    monkeypatch.setattr(
+        mod, "audit", lambda **kw: ([], [f"sig_a: {mod.NOT_EVALUABLE_MSG}"])
+    )
+
+    rc = mod.main()
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "::warning::sig_a:" in captured.out
+    assert "NOT EVALUABLE" in captured.err
+    assert "NOT EVALUABLE for 1 hash-mode receipt(s)" in captured.out

--- a/github-action-risk-acceptance/test_risk_acceptance.py
+++ b/github-action-risk-acceptance/test_risk_acceptance.py
@@ -1,0 +1,268 @@
+"""Pure unit tests for the risk-acceptance action.
+
+No network, no real Asqav API. The SDK sign and verify calls are mocked. These
+tests cover the load-bearing pieces of the action:
+
+1. expires parsing (durations and ISO dates to valid_seconds).
+2. sarif_digest computation (wire form).
+3. approver and initiator extraction from the event payload.
+4. the mint sign call invariants (receipt type, compliance mode, field map).
+5. manifest parsing and the client-side audit filter (expired, superseded,
+   missing, wrong type).
+"""
+
+import hashlib
+import json
+import sys
+import types
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import risk_acceptance as mod  # noqa: E402
+
+
+# --- expires parsing -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("90d", 90 * 86400),
+        ("12h", 12 * 3600),
+        ("30m", 30 * 60),
+        ("3600s", 3600),
+        ("2w", 2 * 604800),
+        ("7200", 7200),
+    ],
+)
+def test_parse_expires_durations(value, expected):
+    assert mod.parse_expires(value) == expected
+
+
+def test_parse_expires_iso_date_converts_to_seconds():
+    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    assert mod.parse_expires("2026-06-02", now=now) == 86400
+
+
+@pytest.mark.parametrize("value", ["", "soon", "-5d", "0d", "2020-01-01"])
+def test_parse_expires_rejects_bad_values(value):
+    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    with pytest.raises(ValueError):
+        mod.parse_expires(value, now=now)
+
+
+# --- sarif digest --------------------------------------------------------------
+
+
+def test_sarif_digest_is_sha256_wire_form(tmp_path):
+    sarif = tmp_path / "scan.sarif"
+    sarif.write_bytes(b'{"runs": []}')
+    expected = "sha256:" + hashlib.sha256(b'{"runs": []}').hexdigest()
+    assert mod.compute_sarif_digest(str(sarif)) == expected
+
+
+# --- approval context extraction ------------------------------------------------
+
+
+def test_approval_from_review_event():
+    event = {
+        "review": {
+            "user": {"login": "sec-reviewer"},
+            "submitted_at": "2026-06-09T10:00:00Z",
+            "html_url": "https://github.com/o/r/pull/7#pullrequestreview-1",
+        },
+        "pull_request": {
+            "user": {"login": "pr-author"},
+            "html_url": "https://github.com/o/r/pull/7",
+        },
+    }
+    ctx = mod.read_approval_context(event)
+    assert ctx.approver == "sec-reviewer"
+    assert ctx.initiator == "pr-author"
+    assert ctx.accepted_at == "2026-06-09T10:00:00Z"
+    assert ctx.approval_ref == "https://github.com/o/r/pull/7#pullrequestreview-1"
+
+
+def test_approval_from_merged_pull_request_event():
+    event = {
+        "pull_request": {
+            "user": {"login": "pr-author"},
+            "merged_by": {"login": "merger"},
+            "html_url": "https://github.com/o/r/pull/8",
+        },
+    }
+    ctx = mod.read_approval_context(event)
+    assert ctx.approver == "merger"
+    assert ctx.initiator == "pr-author"
+    assert ctx.accepted_at is None
+    assert ctx.approval_ref == "https://github.com/o/r/pull/8"
+
+
+def test_approval_missing_approver_raises():
+    with pytest.raises(ValueError):
+        mod.read_approval_context({"pull_request": {"user": {"login": "x"}}})
+
+
+# --- mint sign call with a mocked SDK -------------------------------------------
+
+
+@dataclass
+class _FakeResponse:
+    signature_id: str = "sig_ra"
+    verification_url: str = "https://asqav.com/v/sig_ra"
+
+
+def _install_fake_asqav(monkeypatch, captured):
+    fake = types.ModuleType("asqav")
+
+    def fake_init(api_key=None, **kwargs):
+        captured["api_key"] = api_key
+
+    class FakeAgent:
+        def __init__(self, agent_id):
+            self.agent_id = agent_id
+
+        @classmethod
+        def get(cls, agent_id):
+            captured["agent_id"] = agent_id
+            return cls(agent_id)
+
+        def sign(self, action_type, **kwargs):
+            captured["action_type"] = action_type
+            captured["sign_kwargs"] = kwargs
+            return _FakeResponse()
+
+    class FakeAPIError(Exception):
+        def __init__(self, message, status_code=None):
+            super().__init__(message)
+            self.status_code = status_code
+
+    fake.init = fake_init
+    fake.Agent = FakeAgent
+    fake.APIError = FakeAPIError
+    monkeypatch.setitem(sys.modules, "asqav", fake)
+    return fake
+
+
+def test_mint_passes_risk_acceptance_fields(monkeypatch):
+    captured = {}
+    _install_fake_asqav(monkeypatch, captured)
+    approval = mod.ApprovalContext(
+        approver="sec-reviewer",
+        initiator="pr-author",
+        accepted_at="2026-06-09T10:00:00Z",
+        approval_ref="https://github.com/o/r/pull/7",
+    )
+
+    outputs = mod.mint(
+        api_key="sk_test",
+        agent_id="agent-1",
+        reason="compensating control in place",
+        finding_id="py/sql-injection:fp-123",
+        sarif_digest="sha256:" + "a" * 64,
+        valid_seconds=90 * 86400,
+        supersedes="sig_old",
+        risk_snapshot={"snapshot_at": "2026-06-09T09:00:00Z"},
+        approval=approval,
+    )
+
+    kwargs = captured["sign_kwargs"]
+    assert kwargs["receipt_type"] == mod.RECEIPT_TYPE
+    assert kwargs["compliance_mode"] is True
+    assert kwargs["policy_decision"] == "none"
+    assert kwargs["approver_id"] == "sec-reviewer"
+    assert kwargs["initiator_id"] == "pr-author"
+    assert kwargs["acceptance_reason"] == "compensating control in place"
+    assert kwargs["accepted_at"] == "2026-06-09T10:00:00Z"
+    assert kwargs["supersedes"] == "sig_old"
+    assert kwargs["sarif_digest"] == "sha256:" + "a" * 64
+    assert kwargs["finding_ref"] == "py/sql-injection:fp-123"
+    assert kwargs["approval_ref"] == "https://github.com/o/r/pull/7"
+    assert kwargs["risk_snapshot"] == {"snapshot_at": "2026-06-09T09:00:00Z"}
+    assert kwargs["valid_seconds"] == 90 * 86400
+    assert outputs["signature-id"] == "sig_ra"
+    assert outputs["verification-url"] == "https://asqav.com/v/sig_ra"
+
+
+# --- manifest parsing ------------------------------------------------------------
+
+
+def test_parse_manifest_plain_lines():
+    text = "# suppressions\nsig_a\n\nsig_b\n"
+    assert mod.parse_manifest(text) == ["sig_a", "sig_b"]
+
+
+def test_parse_manifest_json_array():
+    assert mod.parse_manifest(json.dumps(["sig_a", "sig_b"])) == ["sig_a", "sig_b"]
+
+
+def test_parse_manifest_json_object():
+    assert mod.parse_manifest(json.dumps({"receipts": ["sig_a"]})) == ["sig_a"]
+
+
+def test_parse_manifest_empty_raises():
+    with pytest.raises(ValueError):
+        mod.parse_manifest("\n# nothing\n")
+
+
+# --- client-side audit filter -----------------------------------------------------
+
+
+def _ok_receipt(sig_id, **payload_extra):
+    payload = {"receipt_type": mod.RECEIPT_TYPE, **payload_extra}
+    return {
+        "signature_id": sig_id,
+        "verified": True,
+        "validation_label": "fully_verified",
+        "payload": payload,
+    }
+
+
+def test_audit_passes_valid_receipts():
+    receipts = {"sig_a": _ok_receipt("sig_a"), "sig_b": _ok_receipt("sig_b")}
+    assert mod.evaluate_audit(receipts) == []
+
+
+def test_audit_fails_expired_receipt():
+    rec = _ok_receipt("sig_a")
+    rec["validation_label"] = mod.EXPIRED_LABEL
+    rec["verified"] = False
+    failures = mod.evaluate_audit({"sig_a": rec})
+    assert len(failures) == 1
+    assert "expired" in failures[0]
+
+
+def test_audit_fails_superseded_receipt():
+    receipts = {
+        "sig_old": _ok_receipt("sig_old"),
+        "sig_new": _ok_receipt("sig_new", supersedes="sig_old"),
+    }
+    failures = mod.evaluate_audit(receipts)
+    assert failures == ["sig_old: superseded by sig_new."]
+
+
+def test_audit_fails_missing_receipt():
+    failures = mod.evaluate_audit({"sig_gone": None})
+    assert failures == ["sig_gone: receipt not found."]
+
+
+def test_audit_fails_wrong_receipt_type():
+    rec = _ok_receipt("sig_a")
+    rec["payload"]["receipt_type"] = "protectmcp:lifecycle:code_authorship"
+    failures = mod.evaluate_audit({"sig_a": rec})
+    assert len(failures) == 1
+    assert "receipt_type" in failures[0]
+
+
+def test_audit_unverified_receipt_fails():
+    rec = _ok_receipt("sig_a")
+    rec["verified"] = False
+    rec["validation_label"] = "signature_invalid"
+    failures = mod.evaluate_audit({"sig_a": rec})
+    assert len(failures) == 1
+    assert "failed verification" in failures[0]


### PR DESCRIPTION
## Summary

Adds a sibling composite action `github-action-risk-acceptance/` with two modes.

Mint mode signs a risk-acceptance receipt (`receipt_type=protectmcp:lifecycle:risk_acceptance`, `compliance_mode=True`, `policy_decision="none"`) when an exception PR is approved. The approver is the approving reviewer login from `github.event.review` (or the merging user on a merged pull_request event) and the initiator is the PR author login, both producer-asserted from the event payload and never verified. The SARIF file is digested on the runner (`sarif_digest` = sha256 wire form) and never uploaded. `expires` (duration or ISO date) converts to `valid_seconds`.

Audit mode reads a suppression manifest of receipt ids, fetches each via the public verify endpoint, and exits nonzero when any referenced receipt is missing, fails verification, is expired (server-evaluated validation label), carries another receipt type, or is named in the `supersedes` field of another fetched receipt. The expired and superseded filters run client-side over the fetched set, so the audit works against the live verify endpoint alone with no list endpoint required.

CI gains an `actions` job (ruff + pytest over both action dirs) wired into `ci-ok`, so a PR touching only the action subtrees exercises its own code rather than skipping every matrix job.

## THREAT_MODEL

- New attack surface: a CI-minted acceptance could claim a policy evaluation or an Asqav-verified approver identity it does not have.
- Existing guard: the SDK risk-acceptance guards fence the fields to the risk_acceptance receipt type, require approver_id + acceptance_reason + compliance_mode, and force policy_decision none, so the receipt records a human decision and never a policy evaluation; identities stay producer-asserted by construction.
- New tests: unit tests assert the sign call carries exactly those invariants, plus negative tests for missing approver, malformed expires, expired, superseded, missing, and wrong-type receipts in audit mode.
- Trust boundary: unchanged. The action is a producer-side consumer of the existing sign and verify endpoints, adds no server-side path.

## Tests

35 passed locally (`pytest github-action github-action-risk-acceptance`), ruff clean on both action dirs.

comment hygiene clean
