### PR TITLE
fix: send a real User-Agent on every SDK request, fail-clean verifier on null payload, doctor edge probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follo
 
 ## [Unreleased]
 
+### Fixed
+- Every HTTP request from both SDK halves now sends a real `User-Agent` (`asqav-python/<version> (+https://www.asqav.com)` and `asqav-js/<version>`). The api.asqav.com edge rejects anonymous default agents with a 403 (Cloudflare error 1010), which made a fresh install's first sign call fail with a bare "HTTP Error 403: Forbidden". Covers the Python urllib and httpx transports (client, async client, CLI, compliance export, standalone verifier) and the TypeScript fetch transport; in browsers, where fetch forbids setting `User-Agent`, the header is skipped so bundles keep working.
+- The standalone receipt verifier no longer crashes with an `AttributeError` when the hosted `/verify/{id}` response carries `payload: null`. It now prints a readable "receipt payload not available from this surface" message and exits with the INCOMPLETE code (2).
+- `asqav doctor` probes the API edge with the SDK `User-Agent` and fails loudly when the edge blocks or cannot reach the client, instead of printing "All checks passed" while every sign call 403s.
+
 ## [0.5.12] - 2026-06-08
 
 Applies to both the Python (`asqav`) and TypeScript (`@asqav/sdk`) packages.

--- a/python/src/asqav/_useragent.py
+++ b/python/src/asqav/_useragent.py
@@ -1,0 +1,27 @@
+"""Shared User-Agent for every outbound HTTP call the SDK makes.
+
+The api.asqav.com edge runs a Cloudflare browser-integrity check that
+rejects the bare ``Python-urllib/x.y`` default with a 403 (error 1010),
+so every request must identify itself with a real product token.
+"""
+
+from __future__ import annotations
+
+
+def _sdk_version() -> str:
+    """Resolve the installed package version without importing the package."""
+    try:
+        from importlib.metadata import version
+
+        return version("asqav")
+    except Exception:
+        # Source checkout without installed dist metadata.
+        try:
+            from asqav import __version__
+
+            return __version__
+        except Exception:
+            return "unknown"
+
+
+USER_AGENT = f"asqav-python/{_sdk_version()} (+https://www.asqav.com)"

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from ._useragent import USER_AGENT
 from .client import (
     APIError,
     AsqavError,
@@ -76,7 +77,7 @@ async def _async_get(path: str) -> dict[str, Any]:
 
     async with httpx.AsyncClient(
         base_url=api_base,
-        headers={"X-API-Key": api_key},
+        headers={"X-API-Key": api_key, "User-Agent": USER_AGENT},
         timeout=30.0,
     ) as client:
         response = await client.get(path)
@@ -94,7 +95,7 @@ async def _async_post(path: str, data: dict[str, Any]) -> dict[str, Any]:
 
     async with httpx.AsyncClient(
         base_url=api_base,
-        headers={"X-API-Key": api_key},
+        headers={"X-API-Key": api_key, "User-Agent": USER_AGENT},
         timeout=30.0,
     ) as client:
         response = await client.post(path, json=data)
@@ -112,7 +113,7 @@ async def _async_patch(path: str, data: dict[str, Any]) -> dict[str, Any]:
 
     async with httpx.AsyncClient(
         base_url=api_base,
-        headers={"X-API-Key": api_key},
+        headers={"X-API-Key": api_key, "User-Agent": USER_AGENT},
         timeout=30.0,
     ) as client:
         response = await client.patch(path, json=data)
@@ -337,7 +338,7 @@ class AsyncAgent:
         api_base, _ = _get_config()
         url = f"{api_base}/verify/{signature_id}"
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=30.0) as client:
             response = await client.get(url)
             if response.status_code == 404:
                 raise APIError("Signature not found", 404)

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -42,6 +42,7 @@ except ImportError:
     sys.exit(1)
 
 from asqav import __version__
+from asqav._useragent import USER_AGENT
 
 app = typer.Typer(
     name="asqav",
@@ -988,7 +989,48 @@ def doctor() -> None:
             + "  API reachable (no key)"
         )
 
-    # Check 3: SDK version
+    # Check 3: API edge accepts this client (catches the Cloudflare
+    # browser-integrity 403/1010 block that fails sign calls while the
+    # key-authenticated health check above still looks fine).
+    import urllib.error
+    import urllib.request
+
+    from asqav import client as _client_mod
+
+    edge_url = _client_mod._api_base.rstrip("/") + "/health"
+    edge_req = urllib.request.Request(
+        edge_url, headers={"User-Agent": USER_AGENT}, method="GET"
+    )
+    try:
+        with urllib.request.urlopen(edge_req, timeout=10):
+            pass
+        typer.echo(
+            typer.style("PASS", fg=typer.colors.GREEN, bold=True)
+            + "  API edge accepts this client (sign path reachable)"
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code == 403:
+            typer.echo(
+                typer.style("FAIL", fg=typer.colors.RED, bold=True)
+                + "  API edge BLOCKED this client (HTTP 403). Sign calls will "
+                "fail. The edge firewall rejected this client; upgrade the "
+                "asqav package (older versions sent a blocked User-Agent) or "
+                "check your network/proxy."
+            )
+        else:
+            typer.echo(
+                typer.style("FAIL", fg=typer.colors.RED, bold=True)
+                + f"  API edge returned HTTP {exc.code} on {edge_url}"
+            )
+        all_ok = False
+    except Exception as exc:
+        typer.echo(
+            typer.style("FAIL", fg=typer.colors.RED, bold=True)
+            + f"  API edge unreachable: {exc}"
+        )
+        all_ok = False
+
+    # Check 4: SDK version
     typer.echo(
         typer.style("INFO", fg=typer.colors.BLUE, bold=True)
         + f"  SDK version: {__version__}"
@@ -1477,6 +1519,7 @@ def _session_request(
         headers={
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
         },
         data=body if method in {"POST", "PATCH", "PUT", "DELETE"} else None,
     )
@@ -1866,6 +1909,7 @@ def migrate_run(
             "X-API-Key": api_key,
             "X-Maintenance-Key": maintenance_key,
             "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
         },
         data=b"{}",
     )
@@ -2076,7 +2120,7 @@ def compliance_download(
     req = urllib.request.Request(
         url,
         method="GET",
-        headers={"X-API-Key": _client_mod._api_key or ""},
+        headers={"X-API-Key": _client_mod._api_key or "", "User-Agent": USER_AGENT},
     )
     try:
         with urllib.request.urlopen(req, timeout=60) as resp:
@@ -2468,7 +2512,7 @@ def shadow_ai_status(
 
     def _probe(label: str, url: str) -> bool:
         try:
-            resp = httpx.get(url, timeout=5.0)
+            resp = httpx.get(url, headers={"User-Agent": USER_AGENT}, timeout=5.0)
         except httpx.HTTPError as exc:
             print(f"{label}: unreachable ({exc.__class__.__name__})")
             return False

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from .phases import PhaseChain
     from .scope import ScopeToken
 
+from ._useragent import USER_AGENT
 from .patterns import resolve_pattern
 from .retry import with_retry
 
@@ -926,7 +927,7 @@ def flush_spans() -> None:
         req = urllib.request.Request(
             _otel_endpoint,
             data=json.dumps(payload).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", "User-Agent": USER_AGENT},
             method="POST",
         )
         urllib.request.urlopen(req, timeout=5)
@@ -2777,7 +2778,7 @@ def init(
     if _HTTPX_AVAILABLE:
         _client = httpx.Client(
             base_url=_api_base,
-            headers={"X-API-Key": _api_key},
+            headers={"X-API-Key": _api_key, "User-Agent": USER_AGENT},
             timeout=30.0,
         )
 
@@ -2896,6 +2897,7 @@ def _urllib_request(
     headers = {
         "X-API-Key": _api_key,
         "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
     }
 
     body = json.dumps(data).encode("utf-8") if data else None
@@ -3164,7 +3166,7 @@ def verify_signature(signature_id: str) -> VerificationResponse:
 
     # Use httpx if available (better SSL handling)
     if _HTTPX_AVAILABLE:
-        response = httpx.get(url, timeout=30.0)
+        response = httpx.get(url, headers={"User-Agent": USER_AGENT}, timeout=30.0)
         if response.status_code == 404:
             raise APIError("Signature not found", 404)
         if response.status_code >= 400:
@@ -3177,7 +3179,8 @@ def verify_signature(signature_id: str) -> VerificationResponse:
         import urllib.request
 
         try:
-            with urllib.request.urlopen(url, timeout=30) as response:
+            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(req, timeout=30) as response:
                 data = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
             if e.code == 404:
@@ -4288,6 +4291,7 @@ def export_audit_csv(
         url = urljoin(_api_base, path)
         headers = {
             "Authorization": f"Bearer {_api_key}",
+            "User-Agent": USER_AGENT,
         }
         request = urllib.request.Request(url, headers=headers, method="GET")
 

--- a/python/src/asqav/compliance.py
+++ b/python/src/asqav/compliance.py
@@ -207,10 +207,15 @@ def fetch_audit_pack(
     if agent_id is not None:
         body["agent_id"] = agent_id
 
+    from ._useragent import USER_AGENT
+
     resp = _client.httpx.post(
         url,
         json=body,
-        headers={"Authorization": f"Bearer {_client._api_key}"},
+        headers={
+            "Authorization": f"Bearer {_client._api_key}",
+            "User-Agent": USER_AGENT,
+        },
         timeout=30.0,
     )
     resp.raise_for_status()

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -40,6 +40,24 @@ from datetime import datetime, timezone
 
 API_BASE = "https://api.asqav.com/api/v1"
 JWKS_URL = "https://api.asqav.com/.well-known/jwks.json"
+
+
+def _user_agent() -> str:
+    """Identify this tool; the api.asqav.com edge 403s the bare urllib default.
+
+    Self-contained (no asqav import) so the file still runs as a standalone
+    download, per the module docstring.
+    """
+    try:
+        from importlib.metadata import version
+
+        ver = version("asqav")
+    except Exception:
+        ver = "standalone"
+    return f"asqav-python/{ver} (+https://www.asqav.com)"
+
+
+USER_AGENT = _user_agent()
 SKEW_BOUND_SECONDS = 300
 FIRST_RECEIPT_SEED = "0" * 64  # mirrors core/integrity.py FIRST_RECEIPT_SEED
 REQUIRED_FIELDS = (
@@ -90,7 +108,9 @@ def envelope_minus_anchors_jcs(env: dict) -> bytes:
 
 
 def _get_json(url: str) -> dict:
-    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    req = urllib.request.Request(
+        url, headers={"Accept": "application/json", "User-Agent": USER_AGENT}
+    )
     with urllib.request.urlopen(req, timeout=30) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
@@ -227,6 +247,18 @@ def check_structure(payload: dict):
 def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
     envelope = normalise_envelope(envelope)
     payload = envelope.get("payload", envelope)
+    if not isinstance(payload, dict):
+        # Hosted /verify can return ``payload: null`` (e.g. hash-only or
+        # redacted receipts). Nothing to verify; say so instead of crashing.
+        print("Asqav receipt verification")
+        print(
+            "  [FAIL] payload      receipt payload not available from this "
+            "surface (the server returned payload: null). Verify with a saved "
+            "receipt instead: --receipt FILE from your Audit Pack or SDK "
+            "capture."
+        )
+        print("\n  => INCOMPLETE (no payload to verify; never a PASS)")
+        return 2
     sig_obj = envelope.get("signature", {})
     if isinstance(sig_obj, str):  # flat-string signature, derive the object
         sig_obj = {

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -540,7 +540,8 @@ def test_quickstart_without_api_key() -> None:
 # === doctor command ===
 
 
-def test_doctor_no_api_key() -> None:
+@patch("urllib.request.urlopen")
+def test_doctor_no_api_key(mock_urlopen: MagicMock) -> None:
     """doctor reports failure when API key is missing."""
     result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": ""})
     assert result.exit_code == 1
@@ -549,9 +550,12 @@ def test_doctor_no_api_key() -> None:
     assert "SKIP" in result.output
 
 
+@patch("urllib.request.urlopen")
 @patch("asqav.client.health_check")
 @patch("asqav.init")
-def test_doctor_all_pass(mock_init: MagicMock, mock_health: MagicMock) -> None:
+def test_doctor_all_pass(
+    mock_init: MagicMock, mock_health: MagicMock, mock_urlopen: MagicMock
+) -> None:
     """doctor passes all checks when API key is set and API is reachable."""
     mock_health.return_value = {"status": "ok"}
     result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": "sk_test"})
@@ -559,18 +563,75 @@ def test_doctor_all_pass(mock_init: MagicMock, mock_health: MagicMock) -> None:
     assert "PASS" in result.output
     assert "API key set" in result.output
     assert "API reachable" in result.output
+    assert "API edge accepts this client" in result.output
     assert "All checks passed" in result.output
 
 
+@patch("urllib.request.urlopen")
 @patch("asqav.client.health_check")
 @patch("asqav.init")
-def test_doctor_api_unreachable(mock_init: MagicMock, mock_health: MagicMock) -> None:
+def test_doctor_api_unreachable(
+    mock_init: MagicMock, mock_health: MagicMock, mock_urlopen: MagicMock
+) -> None:
     """doctor reports failure when API is unreachable."""
     mock_health.side_effect = Exception("Connection refused")
     result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": "sk_test"})
     assert result.exit_code == 1
     assert "API unreachable" in result.output
     assert "Connection refused" in result.output
+
+
+@patch("urllib.request.urlopen")
+@patch("asqav.client.health_check")
+@patch("asqav.init")
+def test_doctor_edge_blocked_403(
+    mock_init: MagicMock, mock_health: MagicMock, mock_urlopen: MagicMock
+) -> None:
+    """doctor FAILS loudly when the API edge 403-blocks this client.
+
+    Pins the stranger-funnel regression: the key-authenticated health check
+    can succeed while the edge firewall (Cloudflare error 1010) rejects the
+    client and every sign call dies. doctor must not print all-pass then.
+    """
+    import urllib.error
+
+    mock_health.return_value = {"status": "ok"}
+    mock_urlopen.side_effect = urllib.error.HTTPError(
+        "https://api.asqav.com/api/v1/health", 403, "Forbidden", None, None
+    )
+    result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": "sk_test"})
+    assert result.exit_code == 1
+    assert "BLOCKED" in result.output
+    assert "Sign calls will fail" in result.output
+    assert "All checks passed" not in result.output
+
+
+@patch("urllib.request.urlopen")
+@patch("asqav.client.health_check")
+@patch("asqav.init")
+def test_doctor_edge_unreachable(
+    mock_init: MagicMock, mock_health: MagicMock, mock_urlopen: MagicMock
+) -> None:
+    """doctor reports a clear failure when the edge probe cannot connect."""
+    import urllib.error
+
+    mock_health.return_value = {"status": "ok"}
+    mock_urlopen.side_effect = urllib.error.URLError("no route to host")
+    result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": "sk_test"})
+    assert result.exit_code == 1
+    assert "API edge unreachable" in result.output
+    assert "All checks passed" not in result.output
+
+
+@patch("urllib.request.urlopen")
+def test_doctor_edge_probe_sends_user_agent(mock_urlopen: MagicMock) -> None:
+    """The edge probe identifies itself with the SDK User-Agent."""
+    from asqav._useragent import USER_AGENT
+
+    runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": ""})
+    assert mock_urlopen.called
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_header("User-agent") == USER_AGENT
 
 
 # === replay command ===

--- a/python/tests/test_user_agent.py
+++ b/python/tests/test_user_agent.py
@@ -1,0 +1,100 @@
+"""Every outbound HTTP call carries the asqav-python User-Agent.
+
+The api.asqav.com edge 403s (Cloudflare error 1010) the bare
+``Python-urllib/x.y`` default, which made every stranger's first sign call
+fail with a bare "HTTP Error 403: Forbidden". These tests pin the header on
+each transport so the regression cannot come back silently.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import sys
+import urllib.request
+from unittest.mock import patch
+
+# Ensure src is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav._useragent import USER_AGENT
+from asqav.verifier import verify_receipt
+
+
+def test_user_agent_format() -> None:
+    assert re.fullmatch(
+        r"asqav-python/\S+ \(\+https://www\.asqav\.com\)", USER_AGENT
+    ), USER_AGENT
+
+
+class _FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+def test_urllib_request_sends_user_agent() -> None:
+    """The stdlib fallback transport (no httpx) sends the SDK User-Agent."""
+    from asqav import client
+
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["ua"] = req.get_header("User-agent")
+        return _FakeResponse(json.dumps({"ok": True}).encode())
+
+    with (
+        patch.object(client, "_api_key", "sk_test"),
+        patch.object(client, "_api_base", "https://api.example.test/api/v1/"),
+        patch.object(urllib.request, "urlopen", fake_urlopen),
+    ):
+        client._urllib_request("GET", "health")
+
+    assert captured["ua"] == USER_AGENT
+
+
+def test_httpx_client_sends_user_agent() -> None:
+    """init() builds the persistent httpx client with the SDK User-Agent."""
+    from asqav import client
+
+    if not client._HTTPX_AVAILABLE:
+        import pytest
+
+        pytest.skip("httpx not installed")
+
+    import asqav
+
+    asqav.init(api_key="sk_test_user_agent")
+    assert client._client is not None
+    assert client._client.headers["user-agent"] == USER_AGENT
+
+
+def test_verifier_get_json_sends_user_agent() -> None:
+    """The standalone verifier's network fetch sends a real User-Agent."""
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["ua"] = req.get_header("User-agent")
+        return _FakeResponse(b"{}")
+
+    with patch.object(urllib.request, "urlopen", fake_urlopen):
+        verify_receipt._get_json("https://api.example.test/api/v1/verify/sig_x")
+
+    assert captured["ua"] is not None
+    assert captured["ua"].startswith("asqav-python/")
+
+
+def test_async_client_headers_include_user_agent() -> None:
+    """The async transport builds its httpx clients with the SDK User-Agent."""
+    import inspect
+
+    from asqav import async_client
+
+    src = inspect.getsource(async_client)
+    # Every AsyncClient that talks to the API carries the header.
+    assert '"User-Agent": USER_AGENT' in src

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -112,3 +112,34 @@ def test_run_structure_axis_passes_on_code_authorship(capsys) -> None:
     for line in out.splitlines():
         if "[FAIL]" in line:
             assert "structure" not in line
+
+
+# === payload: null fail-clean (stranger-funnel B2) ===
+
+
+def test_run_payload_null_fails_clean(capsys) -> None:
+    """A hosted /verify response with ``payload: null`` must not traceback.
+
+    The published verifier crashed with a raw AttributeError here; it now
+    prints a readable message and returns the INCOMPLETE exit code (2).
+    """
+    envelope = {
+        "signature_id": "sig_abc123",
+        "payload": None,
+        "signature": "AAAA",
+        "algorithm": "ML-DSA-65",
+    }
+    code = v.run(envelope, {"keys": []}, predecessor_payload=None)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "receipt payload not available from this surface" in out
+    assert "INCOMPLETE" in out
+    assert "PASS" not in out.replace("never a PASS", "")
+
+
+def test_run_payload_null_without_signature_keys(capsys) -> None:
+    """Same guard when the response carries only nulls."""
+    code = v.run({"payload": None}, {"keys": []}, predecessor_payload=None)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "INCOMPLETE" in out

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -32,8 +32,9 @@ import {
   type LocalSigningAlgorithm,
   type SignatureResponse,
 } from "./index.js";
+import { SDK_VERSION, userAgentHeaders } from "./userAgent.js";
 
-export const CLI_VERSION = "0.5.12";
+export const CLI_VERSION = SDK_VERSION;
 
 function die(msg: string, code = 1): never {
   process.stderr.write(`${msg}\n`);
@@ -752,6 +753,7 @@ async function sessionRequest(
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
+        ...userAgentHeaders(),
       },
       body: JSON.stringify(body),
     });
@@ -918,6 +920,7 @@ async function cmdMigrateRun(args: string[]): Promise<void> {
         "X-API-Key": process.env.ASQAV_API_KEY,
         "X-Maintenance-Key": maintenanceKey,
         "Content-Type": "application/json",
+        ...userAgentHeaders(),
       },
       body: "{}",
     });

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -21,6 +21,9 @@ import { canonicalizeAction } from "./canonicalize.js";
 import { _dispatchAfter, _dispatchBefore } from "./hooks.js";
 import { canonicalJson } from "./jcs.js";
 import { type Mode, resolveMode } from "./mode.js";
+import { userAgentHeaders } from "./userAgent.js";
+
+export { SDK_VERSION, USER_AGENT, userAgentHeaders } from "./userAgent.js";
 
 /** Allowed values for `receiptType` per the IETF Compliance Receipts profile. */
 export const RECEIPT_TYPE_NAMESPACE = [
@@ -946,6 +949,7 @@ export async function request<T = unknown>(
     "X-API-Key": config.apiKey as string,
     "Content-Type": "application/json",
     Accept: "application/json",
+    ...userAgentHeaders(),
   };
 
   let lastError: Error | null = null;

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared User-Agent for every outbound HTTP call the SDK makes from Node.
+ *
+ * The api.asqav.com edge runs a Cloudflare browser-integrity check that
+ * 403s anonymous default agents, so SDK requests must identify themselves.
+ * Browsers forbid setting User-Agent on fetch (it is a forbidden header
+ * name), so the helper only adds it when running under Node.
+ */
+
+export const SDK_VERSION = "0.5.12";
+
+export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
+
+/** Headers to merge into fetch calls: `{ "User-Agent": ... }` in Node, `{}` in browsers. */
+export function userAgentHeaders(): Record<string, string> {
+  try {
+    if (typeof process !== "undefined" && process.versions?.node) {
+      return { "User-Agent": USER_AGENT };
+    }
+  } catch {
+    // Some sandboxes throw on `process` access; treat as browser.
+  }
+  return {};
+}

--- a/typescript/tests/userAgent.test.ts
+++ b/typescript/tests/userAgent.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Every outbound API call from Node carries the asqav-js User-Agent.
+ *
+ * The api.asqav.com edge runs a Cloudflare browser-integrity check that
+ * 403s anonymous default agents; the SDK must identify itself. Browsers
+ * forbid setting User-Agent on fetch, so the helper returns {} there.
+ */
+
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetForTests, Agent, init } from "../src/index.js";
+import { SDK_VERSION, USER_AGENT, userAgentHeaders } from "../src/userAgent.js";
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("user agent", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("matches the asqav-js/<version> (+url) shape", () => {
+    expect(USER_AGENT).toMatch(/^asqav-js\/\S+ \(\+https:\/\/www\.asqav\.com\)$/);
+  });
+
+  it("SDK_VERSION matches package.json version", () => {
+    const pkgPath = new URL("../package.json", `file://${__filename}`);
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
+    expect(SDK_VERSION).toBe(pkg.version);
+  });
+
+  it("userAgentHeaders sets the header under Node", () => {
+    expect(userAgentHeaders()).toEqual({ "User-Agent": USER_AGENT });
+  });
+
+  it("API requests send the User-Agent header", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockJsonResponse({
+        agent_id: "agt_1",
+        name: "test",
+        public_key: "pk",
+        key_id: "kid",
+        algorithm: "ml-dsa-65",
+        capabilities: ["read"],
+        created_at: "2026-01-01T00:00:00Z",
+      }),
+    );
+
+    await Agent.create({ name: "test" });
+
+    const headers = (fetchSpy.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBe(USER_AGENT);
+  });
+});


### PR DESCRIPTION
## Revenue blocker: edge 403 on the default agent string

Stranger-funnel finding B1 (5/5): the api.asqav.com edge runs a Cloudflare browser-integrity rule (error 1010) that rejects the Python SDK's bare urllib default agent on POST. Every stranger's first sign call returned a bare "HTTP Error 403: Forbidden". Reproduced with identical POST /api/v1/agents/create calls on the same key, IP and minute: the default agent gets 403 code 1010, a real agent string gets 201.

### What changed

**User-Agent on every request, both halves**
- New `python/src/asqav/_useragent.py` builds `asqav-python/<version> (+https://www.asqav.com)` from package metadata with an `__version__` fallback.
- Header lands on every transport: the urllib fallback and the persistent httpx client in `client.py` (plus the verify fetch, CSV export and OTel export), all four `httpx.AsyncClient` builds in `async_client.py`, the three one-off urllib requests and the shadow-ai probes in `cli.py`, the audit-pack export in `compliance.py`, and the standalone verifier fetch in `verifier/verify_receipt.py` (self-contained there so the file still runs as a lone download).
- TypeScript: new `src/userAgent.ts` sends `asqav-js/<version>` from `index.ts` `request()` and both `cli.ts` fetch sites. Browsers forbid setting User-Agent on fetch, so the helper checks for Node (`process.versions.node`) and returns an empty object in browsers, keeping bundles safe. `CLI_VERSION` now derives from the same constant.
- Live proof: GET `/api/v1/health` with the default agent gets 403, with the new header gets 200.

**Verifier fails clean on `payload: null` (finding B2)**
- The published verifier crashed with a raw `AttributeError` when hosted `/verify/{id}` returns `payload: null`. `run()` now prints "receipt payload not available from this surface" with a pointer to `--receipt FILE` and exits with the INCOMPLETE code (2). Never a traceback, never a PASS.

**`asqav doctor` stops false-passing while the sign path is blocked**
- doctor printed "All checks passed" while sign calls 403d, because the key-authenticated health check rides httpx while the failing path was the urllib default agent. New edge-reachability check probes the API base over urllib with the SDK User-Agent and fails loudly on a 403 block or connection failure.

### Tests
- Python: `tests/test_user_agent.py` (header pinned on the urllib transport, the httpx client, the verifier fetch and the async transport, plus the agent-string shape), payload-null cases in `tests/test_verify_receipt.py`, and five doctor cases in `tests/test_cli.py` including the 403-block and the probe's own header. Local run: full suite 1041 passed.
- TypeScript: `tests/userAgent.test.ts` (shape, package.json version match, Node gating, header asserted on a mocked fetch). Local run: 422 passed across 33 files, `tsc --noEmit` clean.

### Publishing
Do NOT publish to PyPI or npm from this PR. Per the version-bump policy the batch is held until substantial. This lands in the repo and ships with the next batch publish alongside the SoD-guard mirror.
