### PR TITLE
Drop unused Awaitable import from FastAPI middleware example

### DIFF
--- a/python/examples/fastapi_middleware.py
+++ b/python/examples/fastapi_middleware.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from typing import Any
 
 import asqav


### PR DESCRIPTION
Deep sweep finding (vulture, cold-verified): python/examples/fastapi_middleware.py imports Awaitable from collections.abc and never references it again. Callable from the same import line stays in use.

Change: import line now reads from collections.abc import Callable.

Verification: ast.parse passes on the edited file. Example-only change, no library code touched.

Sweep notes for the maintainer, no change shipped here: osv-scanner reports advisories against dev pins in python/uv.lock - pyjwt 2.12.1 (PYSEC-2026-175, PYSEC-2026-177, PYSEC-2026-178, PYSEC-2026-179), chromadb 1.1.1 (GHSA-f4j7-r4q5-qw2c), diskcache 5.6.3 (GHSA-w8v5-vhqr-4h9v), dspy 2.6.13 (GHSA-vvw2-h478-xwr3), smolagents 1.24.0 (GHSA-54fq-v6x8-244g, GHSA-jxgv-6j54-wwc7). None are runtime dependencies of the published package, so a lock refresh is left as a separate maintainer decision.