### PR TITLE
chore(release): bump both SDK halves to 0.5.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to Asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [0.5.13] - 2026-06-10
+
+Applies to both the Python (`asqav`) and TypeScript (`@asqav/sdk`) packages.
 
 ### Fixed
 - Every HTTP request from both SDK halves now sends a real `User-Agent` (`asqav-python/<version> (+https://www.asqav.com)` and `asqav-js/<version>`). The api.asqav.com edge rejects anonymous default agents with a 403 (Cloudflare error 1010), which made a fresh install's first sign call fail with a bare "HTTP Error 403: Forbidden". Covers the Python urllib and httpx transports (client, async client, CLI, compliance export, standalone verifier) and the TypeScript fetch transport; in browsers, where fetch forbids setting `User-Agent`, the header is skipped so bundles keep working.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.12"
+version = "0.5.13"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -145,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.12"
+__version__ = "0.5.13"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.11",
+  "version": "0.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.5.11",
+      "version": "0.5.13",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.5.12";
+export const SDK_VERSION = "0.5.13";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Patch release for the User-Agent header, the verifier payload-null fail-clean path, and the doctor edge-reachability check. Bumps python/pyproject.toml, asqav.__version__, typescript/package.json + lockfile, the SDK_VERSION constant, and dates the CHANGELOG entry. Version-only diff.