### PR TITLE
fix: preserve the API base path in every stdlib URL join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Asqav (the SDK) will be documented here.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/).
 
+## [Python 0.5.14] - 2026-06-10
+
+Applies to the Python (`asqav`) package only. The TypeScript (`@asqav/sdk`) URL builder already preserves the base path, so the npm half stays at 0.5.13.
+
+### Fixed
+- A plain `pip install asqav` (no `httpx` extra) can reach the API again. The stdlib urllib fallback built request URLs with `urljoin(base, "/agents/create")`, and a leading-slash path makes `urljoin` reset to the host root, stripping the `/api/v1` prefix from the default base. Every call on that path 404ed, so the quickstart died on `Agent.create`. All non-httpx call sites (client requests, CSV export, public verify, CLI compliance download, session-token and maintenance helpers) now build URLs through one join helper that preserves the base path.
+- `fetch_audit_pack` no longer doubles the API prefix. It appended `/api/v1/audit-pack/export` to a base that already ends in `/api/v1`, producing a 404 for every audit-pack export.
+- `asqav doctor` now probes a real prefixed endpoint (`/agents`) through the exact stdlib fallback path. `/health` exists at the host root too, so the old check passed while every real call 404ed; a broken URL join now fails doctor loudly.
+
 ## [0.5.13] - 2026-06-10
 
 Applies to both the Python (`asqav`) and TypeScript (`@asqav/sdk`) packages.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.13"
+version = "0.5.14"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -145,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.13"
+__version__ = "0.5.14"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -989,6 +989,46 @@ def doctor() -> None:
             + "  API reachable (no key)"
         )
 
+    # Check 2b: urllib fallback URL join hits a real prefixed endpoint.
+    # /health exists at BOTH the host root and under /api/v1, so a broken
+    # join can pass the health check while every real call 404s. This probe
+    # forces the exact stdlib fallback path (_urllib_request + _join_url)
+    # against /agents, which only exists under the API prefix.
+    if api_key:
+        from asqav import client as _probe_mod
+        from asqav.client import APIError as _APIError
+
+        try:
+            _probe_mod._urllib_request("GET", "/agents")
+            typer.echo(
+                typer.style("PASS", fg=typer.colors.GREEN, bold=True)
+                + "  URL join preserves API base path (stdlib fallback)"
+            )
+        except _APIError as exc:
+            if exc.status_code == 404:
+                typer.echo(
+                    typer.style("FAIL", fg=typer.colors.RED, bold=True)
+                    + "  URL join drops the API base path. Real calls will "
+                    "404. Upgrade the asqav package."
+                )
+            else:
+                typer.echo(
+                    typer.style("FAIL", fg=typer.colors.RED, bold=True)
+                    + f"  stdlib fallback probe failed: {exc}"
+                )
+            all_ok = False
+        except Exception as exc:
+            typer.echo(
+                typer.style("FAIL", fg=typer.colors.RED, bold=True)
+                + f"  stdlib fallback probe failed: {exc}"
+            )
+            all_ok = False
+    else:
+        typer.echo(
+            typer.style("SKIP", fg=typer.colors.YELLOW, bold=True)
+            + "  URL join probe (no key)"
+        )
+
     # Check 3: API edge accepts this client (catches the Cloudflare
     # browser-integrity 403/1010 block that fails sign calls while the
     # key-authenticated health check above still looks fine).
@@ -997,7 +1037,7 @@ def doctor() -> None:
 
     from asqav import client as _client_mod
 
-    edge_url = _client_mod._api_base.rstrip("/") + "/health"
+    edge_url = _client_mod._join_url(_client_mod._api_base, "/health")
     edge_req = urllib.request.Request(
         edge_url, headers={"User-Agent": USER_AGENT}, method="GET"
     )
@@ -1510,8 +1550,10 @@ def _session_request(
         )
         raise typer.Exit(code=1)
 
+    from asqav.client import _join_url
+
     base = os.environ.get("ASQAV_API_URL", "https://api.asqav.com/api/v1")
-    url = base.rstrip("/") + path
+    url = _join_url(base, path)
     body = json_mod.dumps(data).encode("utf-8") if data is not None else b"{}"
     req = urllib.request.Request(
         url,
@@ -1896,8 +1938,10 @@ def migrate_run(
         raise typer.Exit(code=1)
     _init(api_key=api_key)
 
+    from asqav.client import _join_url
+
     base = os.environ.get("ASQAV_API_URL", "https://api.asqav.com/api/v1")
-    url = f"{base}/maintenance/run-migration-{migration}"
+    url = _join_url(base, f"/maintenance/run-migration-{migration}")
 
     import urllib.error
     import urllib.request
@@ -2108,14 +2152,13 @@ def compliance_download(
     """
     import urllib.error
     import urllib.request
-    from urllib.parse import urljoin
 
     _init_sdk()
     from asqav import client as _client_mod
 
-    url = urljoin(
-        _client_mod._api_base.rstrip("/") + "/",
-        f"compliance-reports/{report_id}/download",
+    url = _client_mod._join_url(
+        _client_mod._api_base,
+        f"/compliance-reports/{report_id}/download",
     )
     req = urllib.request.Request(
         url,

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -34,7 +34,6 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar
-from urllib.parse import urljoin
 
 if TYPE_CHECKING:
     from .phases import PhaseChain
@@ -107,6 +106,17 @@ except ImportError:
 # API configuration
 _api_key: str | None = None
 _api_base: str = os.environ.get("ASQAV_API_URL", "https://api.asqav.com/api/v1")
+
+
+def _join_url(base: str, path: str) -> str:
+    """Join ``base`` and ``path`` preserving the base path component.
+
+    ``urllib.parse.urljoin`` resets a leading-slash path to the host root,
+    which strips the ``/api/v1`` prefix from the default base. Every
+    non-httpx call site must build URLs through this helper so the urllib
+    fallback hits the same path httpx (which merges base_url correctly) does.
+    """
+    return base.rstrip("/") + "/" + path.lstrip("/")
 _client: Any = None
 # Hybrid GDPR mode: resolved at init() time, overridable per-call. See _mode.py.
 _mode: str = "full-payload"
@@ -2893,7 +2903,7 @@ def _urllib_request(
     import urllib.error
     import urllib.request
 
-    url = urljoin(_api_base, path)
+    url = _join_url(_api_base, path)
     headers = {
         "X-API-Key": _api_key,
         "Content-Type": "application/json",
@@ -3162,7 +3172,7 @@ def verify_signature(signature_id: str) -> VerificationResponse:
         if result.verified:
             print(f"Signature valid for agent {result.agent_name}")
     """
-    url = f"{_api_base}/verify/{signature_id}"
+    url = _join_url(_api_base, f"/verify/{signature_id}")
 
     # Use httpx if available (better SSL handling)
     if _HTTPX_AVAILABLE:
@@ -4288,7 +4298,7 @@ def export_audit_csv(
         import urllib.error
         import urllib.request
 
-        url = urljoin(_api_base, path)
+        url = _join_url(_api_base, path)
         headers = {
             "Authorization": f"Bearer {_api_key}",
             "User-Agent": USER_AGENT,

--- a/python/src/asqav/compliance.py
+++ b/python/src/asqav/compliance.py
@@ -202,7 +202,7 @@ def fetch_audit_pack(
     if _client.httpx is None:
         raise RuntimeError("httpx is required; install with `pip install asqav[http]`.")
 
-    url = _client._api_base.rstrip("/") + "/api/v1/audit-pack/export"
+    url = _client._join_url(_client._api_base, "/audit-pack/export")
     body = {"start": start, "end": end, "only_compliance": only_compliance}
     if agent_id is not None:
         body["agent_id"] = agent_id

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -550,28 +550,64 @@ def test_doctor_no_api_key(mock_urlopen: MagicMock) -> None:
     assert "SKIP" in result.output
 
 
+@patch("asqav.client._urllib_request")
 @patch("urllib.request.urlopen")
 @patch("asqav.client.health_check")
 @patch("asqav.init")
 def test_doctor_all_pass(
-    mock_init: MagicMock, mock_health: MagicMock, mock_urlopen: MagicMock
+    mock_init: MagicMock,
+    mock_health: MagicMock,
+    mock_urlopen: MagicMock,
+    mock_urllib_req: MagicMock,
 ) -> None:
     """doctor passes all checks when API key is set and API is reachable."""
     mock_health.return_value = {"status": "ok"}
+    mock_urllib_req.return_value = []
     result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": "sk_test"})
     assert result.exit_code == 0
     assert "PASS" in result.output
     assert "API key set" in result.output
     assert "API reachable" in result.output
+    assert "URL join preserves API base path" in result.output
     assert "API edge accepts this client" in result.output
     assert "All checks passed" in result.output
+    mock_urllib_req.assert_called_once_with("GET", "/agents")
 
 
+@patch("asqav.client._urllib_request")
+@patch("urllib.request.urlopen")
+@patch("asqav.client.health_check")
+@patch("asqav.init")
+def test_doctor_url_join_broken_fails(
+    mock_init: MagicMock,
+    mock_health: MagicMock,
+    mock_urlopen: MagicMock,
+    mock_urllib_req: MagicMock,
+) -> None:
+    """doctor FAILS when the stdlib fallback join 404s a real endpoint.
+
+    Pins the stranger-funnel regression where /health passed (it exists at
+    the host root too) while every prefixed call died on 404.
+    """
+    from asqav.client import APIError
+
+    mock_health.return_value = {"status": "ok"}
+    mock_urllib_req.side_effect = APIError("HTTP Error 404: Not Found", 404)
+    result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": "sk_test"})
+    assert result.exit_code == 1
+    assert "URL join drops the API base path" in result.output
+    assert "All checks passed" not in result.output
+
+
+@patch("asqav.client._urllib_request", return_value=[])
 @patch("urllib.request.urlopen")
 @patch("asqav.client.health_check")
 @patch("asqav.init")
 def test_doctor_api_unreachable(
-    mock_init: MagicMock, mock_health: MagicMock, mock_urlopen: MagicMock
+    mock_init: MagicMock,
+    mock_health: MagicMock,
+    mock_urlopen: MagicMock,
+    mock_urllib_req: MagicMock,
 ) -> None:
     """doctor reports failure when API is unreachable."""
     mock_health.side_effect = Exception("Connection refused")
@@ -581,11 +617,15 @@ def test_doctor_api_unreachable(
     assert "Connection refused" in result.output
 
 
+@patch("asqav.client._urllib_request", return_value=[])
 @patch("urllib.request.urlopen")
 @patch("asqav.client.health_check")
 @patch("asqav.init")
 def test_doctor_edge_blocked_403(
-    mock_init: MagicMock, mock_health: MagicMock, mock_urlopen: MagicMock
+    mock_init: MagicMock,
+    mock_health: MagicMock,
+    mock_urlopen: MagicMock,
+    mock_urllib_req: MagicMock,
 ) -> None:
     """doctor FAILS loudly when the API edge 403-blocks this client.
 
@@ -606,11 +646,15 @@ def test_doctor_edge_blocked_403(
     assert "All checks passed" not in result.output
 
 
+@patch("asqav.client._urllib_request", return_value=[])
 @patch("urllib.request.urlopen")
 @patch("asqav.client.health_check")
 @patch("asqav.init")
 def test_doctor_edge_unreachable(
-    mock_init: MagicMock, mock_health: MagicMock, mock_urlopen: MagicMock
+    mock_init: MagicMock,
+    mock_health: MagicMock,
+    mock_urlopen: MagicMock,
+    mock_urllib_req: MagicMock,
 ) -> None:
     """doctor reports a clear failure when the edge probe cannot connect."""
     import urllib.error

--- a/python/tests/test_url_join.py
+++ b/python/tests/test_url_join.py
@@ -1,0 +1,146 @@
+"""URL-join regression tests for the stdlib (no-httpx) fallback.
+
+A plain `pip install asqav` ships without httpx, so the SDK falls back to
+urllib. That path used urljoin(base, "/agents/create"), and urljoin RESETS
+a leading-slash path to the host root: the /api/v1 prefix was stripped and
+the first quickstart call 404ed. These tests pin _join_url and pin that the
+urllib fallback requests the exact URL the httpx client would.
+"""
+
+import urllib.request
+from unittest.mock import MagicMock
+
+import pytest
+
+from asqav import client as client_mod
+from asqav.client import _join_url
+
+BASE_WITH_PATH = "https://api.asqav.com/api/v1"
+BASE_NO_PATH = "https://api.asqav.com"
+
+
+# === _join_url helper ===
+
+
+def test_join_preserves_base_path() -> None:
+    assert (
+        _join_url(BASE_WITH_PATH, "/agents/create")
+        == "https://api.asqav.com/api/v1/agents/create"
+    )
+
+
+def test_join_base_without_path() -> None:
+    assert (
+        _join_url(BASE_NO_PATH, "/agents/create")
+        == "https://api.asqav.com/agents/create"
+    )
+
+
+def test_join_trailing_slash_base() -> None:
+    assert (
+        _join_url(BASE_WITH_PATH + "/", "/agents/create")
+        == "https://api.asqav.com/api/v1/agents/create"
+    )
+
+
+def test_join_path_without_leading_slash() -> None:
+    assert (
+        _join_url(BASE_WITH_PATH, "agents/create")
+        == "https://api.asqav.com/api/v1/agents/create"
+    )
+
+
+def test_join_keeps_query_string() -> None:
+    assert (
+        _join_url(BASE_WITH_PATH, "/export/csv?agent_id=agt_1")
+        == "https://api.asqav.com/api/v1/export/csv?agent_id=agt_1"
+    )
+
+
+# === urllib fallback parity with httpx ===
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes = b"{}") -> None:
+        self._body = body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._body
+
+
+@pytest.mark.parametrize("base", [BASE_WITH_PATH, BASE_NO_PATH])
+def test_urllib_fallback_requests_same_url_as_httpx(
+    monkeypatch: pytest.MonkeyPatch, base: str
+) -> None:
+    """The stdlib fallback must hit the exact URL the httpx client would."""
+    httpx = pytest.importorskip("httpx")
+    expected = str(
+        httpx.Client(base_url=base).build_request("POST", "/agents/create").url
+    )
+
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(request: urllib.request.Request, timeout: float = 0) -> _FakeResponse:
+        captured["url"] = request.full_url
+        return _FakeResponse()
+
+    monkeypatch.setattr(client_mod, "_api_key", "sk_test")
+    monkeypatch.setattr(client_mod, "_api_base", base)
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client_mod._urllib_request("POST", "/agents/create", {"name": "qa"})
+
+    assert captured["url"] == expected
+    if base == BASE_WITH_PATH:
+        assert captured["url"] == "https://api.asqav.com/api/v1/agents/create"
+
+
+def test_urllib_fallback_never_strips_api_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct pin of the funnel bug: prefix survives for the quickstart call."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(request: urllib.request.Request, timeout: float = 0) -> _FakeResponse:
+        captured["url"] = request.full_url
+        return _FakeResponse()
+
+    monkeypatch.setattr(client_mod, "_api_key", "sk_test")
+    monkeypatch.setattr(client_mod, "_api_base", BASE_WITH_PATH)
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    client_mod._urllib_request("POST", "/agents/create", {"name": "qa"})
+
+    assert captured["url"].startswith("https://api.asqav.com/api/v1/")
+
+
+# === audit pack export URL (was doubled to /api/v1/api/v1/...) ===
+
+
+def test_fetch_audit_pack_url_has_single_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from asqav import compliance
+
+    fake_httpx = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {"receipts": []}
+    fake_httpx.post.return_value = resp
+
+    monkeypatch.setattr(client_mod, "_api_key", "sk_test")
+    monkeypatch.setattr(client_mod, "_api_base", BASE_WITH_PATH)
+    monkeypatch.setattr(client_mod, "httpx", fake_httpx)
+
+    compliance.fetch_audit_pack(
+        start="2026-04-01T00:00:00Z", end="2026-05-01T00:00:00Z"
+    )
+
+    url = fake_httpx.post.call_args.args[0]
+    assert url == "https://api.asqav.com/api/v1/audit-pack/export"
+    assert "/api/v1/api/v1/" not in url


### PR DESCRIPTION
## Description

A plain `pip install asqav` ships without httpx, so the SDK uses its stdlib urllib fallback. That path built request URLs with `urljoin(base, "/agents/create")`, and a leading-slash path makes `urljoin` reset to the host root, stripping the `/api/v1` prefix from the default base. The first quickstart call POSTs `https://api.asqav.com/agents/create`, gets a 404, and raises `APIError`. Every plain-install user dies on call one. The join has been wrong for these endpoints in every release of the stdlib path, the bare-urllib edge 403 masked it until the `User-Agent` fix let those requests through to the API.

Changes:
- One `_join_url` helper (`base.rstrip('/') + '/' + path.lstrip('/')`) builds every non-httpx URL: `_urllib_request`, `export_audit_csv`, `verify_signature`, CLI compliance download, CLI session-token helper, CLI maintenance command, and the doctor edge probe.
- `fetch_audit_pack` appended `/api/v1/audit-pack/export` to a base that already ends in `/api/v1`, so every audit-pack export 404ed on a doubled prefix. Fixed to use the helper.
- `asqav doctor` gains a check that calls the exact stdlib fallback (`_urllib_request("GET", "/agents")`). `/health` exists at the host root too, which is why doctor passed while every real call 404ed. A broken join now fails doctor loudly.
- Python half bumps to 0.5.14. The TypeScript URL builder (`baseUrl.replace(/\/+$/, "") + path`) already preserves the base path, so the npm half stays at 0.5.13.

Tests: `_join_url` pinned for bases with and without a path component, trailing slashes, and bare endpoint names. A parity test asserts the urllib fallback requests the exact URL `httpx.Client(base_url=...)` would build. The audit-pack URL is pinned to a single prefix. Doctor gains a red-path test where the join probe 404s. Local run: 1049 passed, 2 skipped.

## Type of change

- [x] Bug fix
- [x] Tests

## Testing

- [x] Tests pass locally (`pytest`)
- [x] New tests added for new functionality
- [x] Existing tests still pass

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] No new warnings
- [x] Documentation updated if needed
