### PR TITLE
Align comments with the contributor hygiene rules

### DIFF
--- a/python/examples/smolagents_example.py
+++ b/python/examples/smolagents_example.py
@@ -25,9 +25,7 @@ except ImportError as err:
         "Install with: pip install asqav[smolagents]"
     ) from err
 
-# ---------------------------------------------------------------------------
-# Initialise asqav
-# ---------------------------------------------------------------------------
+# === Initialise asqav ===
 
 api_key = os.environ.get("ASQAV_API_KEY", "")
 if not api_key:
@@ -41,9 +39,7 @@ asqav.init(api_key=api_key)
 # Create a governance hook - one hook can wrap multiple tools.
 hook = AsqavSmolagentsHook(agent_name="smolagents-demo")
 
-# ---------------------------------------------------------------------------
-# Define tools and wrap them with asqav signing
-# ---------------------------------------------------------------------------
+# === Define tools and wrap them with asqav signing ===
 
 
 @tool
@@ -75,9 +71,7 @@ def read_file(path: str) -> str:
 signed_search = hook.wrap_tool(search_web)
 signed_read = hook.wrap_tool(read_file)
 
-# ---------------------------------------------------------------------------
-# Build and run the agent
-# ---------------------------------------------------------------------------
+# === Build and run the agent ===
 
 model = HfApiModel()  # Uses the HF Inference API; set HF_TOKEN env var.
 

--- a/python/examples/strands_integration.py
+++ b/python/examples/strands_integration.py
@@ -25,9 +25,7 @@ except ImportError as err:
         "Install with: pip install asqav[strands]"
     ) from err
 
-# ---------------------------------------------------------------------------
-# Initialise asqav
-# ---------------------------------------------------------------------------
+# === Initialise asqav ===
 
 api_key = os.environ.get("ASQAV_API_KEY", "")
 if not api_key:
@@ -38,24 +36,17 @@ if not api_key:
 
 asqav.init(api_key=api_key)
 
-# ---------------------------------------------------------------------------
-# Build the governance hook and attach it to a Strands Agent
-# ---------------------------------------------------------------------------
+# === Build the governance hook and attach it to a Strands Agent ===
 
-# AsqavStrandsHooks implements Strands' HookProvider protocol. It registers
-# BeforeModelCallEvent and AfterModelCallEvent callbacks, so every model call
-# made through this agent is auto-signed via asqav.
+# AsqavStrandsHooks implements Strands' HookProvider protocol: its BeforeModelCallEvent
+# and AfterModelCallEvent callbacks auto-sign every model call made through this agent.
 hooks = AsqavStrandsHooks(agent_name="strands-demo")
 
-# Construct a Strands Agent with the hook provider attached.
-# Strands picks up the model from the environment (e.g. AWS credentials for
-# Bedrock, or any configured provider). See:
-# https://strandsagents.com/latest/documentation/docs/user-guide/
+# Strands picks up the model from the environment (AWS credentials for Bedrock, or any
+# configured provider): https://strandsagents.com/latest/documentation/docs/user-guide/
 agent = Agent(hooks=[hooks])
 
-# ---------------------------------------------------------------------------
-# Run a query - every model call is signed automatically
-# ---------------------------------------------------------------------------
+# === Run a query - every model call is signed automatically ===
 
 print("Running Strands agent with asqav governance...")
 result = agent("What is the capital of France? Answer in one short sentence.")
@@ -63,9 +54,7 @@ result = agent("What is the capital of France? Answer in one short sentence.")
 print("\nAgent result:")
 print(result)
 
-# ---------------------------------------------------------------------------
-# Inspect the signed audit trail
-# ---------------------------------------------------------------------------
+# === Inspect the signed audit trail ===
 
 print(f"\nSigned {len(hooks._signatures)} model call(s) for this run:")
 for sig in hooks._signatures:

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -989,11 +989,8 @@ def doctor() -> None:
             + "  API reachable (no key)"
         )
 
-    # Check 2b: urllib fallback URL join hits a real prefixed endpoint.
-    # /health exists at BOTH the host root and under /api/v1, so a broken
-    # join can pass the health check while every real call 404s. This probe
-    # forces the exact stdlib fallback path (_urllib_request + _join_url)
-    # against /agents, which only exists under the API prefix.
+    # Check 2b: force the stdlib fallback path (_urllib_request + _join_url) against
+    # /agents (exists only under the API prefix); /health passes even with a broken join.
     if api_key:
         from asqav import client as _probe_mod
         from asqav.client import APIError as _APIError
@@ -1029,9 +1026,8 @@ def doctor() -> None:
             + "  URL join probe (no key)"
         )
 
-    # Check 3: API edge accepts this client (catches the Cloudflare
-    # browser-integrity 403/1010 block that fails sign calls while the
-    # key-authenticated health check above still looks fine).
+    # Check 3: API edge accepts this client (catches the Cloudflare browser-integrity
+    # 403/1010 block that fails sign calls while the key-authed health check looks fine).
     import urllib.error
     import urllib.request
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -292,9 +292,8 @@ SANDBOX_STATE_NAMESPACE: frozenset[str] = frozenset(
     {"enabled", "disabled", "unavailable"}
 )
 
-#: Durable-anchoring witnesses Asqav ships. The cloud `witness_policy`
-#: extension accepts only this set; `rekor` is explicitly rejected because
-#: it is not a shipped witness. Mirrors the live governance.json contract.
+#: Durable-anchoring witnesses Asqav ships; the cloud `witness_policy` extension accepts
+#: only this set (`rekor` rejected, not shipped). Mirrors the governance.json contract.
 WITNESS_NAMESPACE: frozenset[str] = frozenset({"rfc3161", "opentimestamps"})
 
 #: Producer-side `capture_topology` vocabulary mirrored from the cloud
@@ -979,9 +978,8 @@ _ALLOWED_CONTROL_KEYS: frozenset[str] = frozenset(
 )
 
 
-#: Wire format for ``tool_fingerprint``: 32 bare lowercase hex chars
-#: (SHA-256[:32]). The cloud validates this field with the bare form, not
-#: the self-describing ``sha256:<hex>`` form used by the other digests.
+#: Wire format for ``tool_fingerprint``: 32 bare lowercase hex chars (SHA-256[:32]); the
+#: cloud validates the bare form, not the ``sha256:<hex>`` form the other digests use.
 _TOOL_FINGERPRINT_RE = re.compile(r"^[0-9a-f]{32}$")
 
 

--- a/python/src/asqav/verifier/oracle/adapters/acta.py
+++ b/python/src/asqav/verifier/oracle/adapters/acta.py
@@ -111,7 +111,8 @@ class ActaAdapter(FormatAdapter):
         sig = doc.get("signature")
         if not isinstance(payload, dict) or not isinstance(sig, dict):
             return "FAIL", "ACTA receipt needs object payload and signature"
-        # Require only the temporal anchor + signature triple; `type`/`issuer_id` are OPTIONAL Asqav-profile fields.
+        # Require only the temporal anchor + signature triple; `type`/`issuer_id` are
+        # OPTIONAL Asqav-profile fields.
         missing = [f for f in ("issued_at",) if f not in payload]
         missing += [f"signature.{f}" for f in ("alg", "kid", "sig") if f not in sig]
         if missing:

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -20,9 +20,8 @@ from asqav.verifier.oracle.adapters.asqav_native import AsqavNativeAdapter
 from asqav.verifier.oracle.runner import main as runner_main
 from asqav.verifier.oracle.runner import run_corpus
 
-# The corpus stays at the repo root (verifier/conformance-vectors) so the TS
-# parity gate and the published governance URL keep one source of truth. Walk up
-# from this test file (tests -> python -> repo root) to reach it.
+# The corpus stays at the repo root (verifier/conformance-vectors) so the TS parity gate
+# and the published governance URL keep one source of truth; walk up from tests to it.
 _CORPUS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
 
 _ED25519_AVAILABLE = crypto.verify_ed25519(b"\x00" * 32, b"m", b"\x00" * 64)[0] != crypto.SKIPPED

--- a/typescript/examples/langchain-js.ts
+++ b/typescript/examples/langchain-js.ts
@@ -51,13 +51,8 @@ async function main(): Promise<void> {
 
   const refund = tool(
     async (args: z.infer<typeof refundSchema>) => {
-      // Sign the intent FIRST. If the side effect throws, the audit
-      // record still proves what the agent decided to do.
-      //
-      // We opt into the IETF Compliance Receipts profile here because
-      // refunds are High-Risk and we want fail-closed anchoring +
-      // raised retention. The cloud derives `previousReceiptHash`,
-      // `policy_digest`, and `issuer_id`; the SDK fills in the rest.
+      // Sign the intent FIRST: if the refund throws, the receipt still proves what the
+      // agent decided. complianceMode adds fail-closed anchoring + raised retention.
       const sig = await agent.sign({
         actionType: "stripe:refund",
         context: {

--- a/typescript/examples/vercel-ai-sdk.ts
+++ b/typescript/examples/vercel-ai-sdk.ts
@@ -52,13 +52,8 @@ async function main(): Promise<void> {
       reason: z.string().describe("Short reason for the refund"),
     }),
     execute: async ({ chargeId, amountCents, reason }) => {
-      // Sign the intent FIRST. If the side effect throws, the audit
-      // record still proves what the agent decided to do.
-      //
-      // Opt into the IETF Compliance Receipts profile so the cloud
-      // emits a §5.7-conformant chain link, content-addressed
-      // policy_digest, and applies fail-closed anchoring under the
-      // raised retention floor.
+      // Sign the intent FIRST: if the refund throws, the receipt still proves what the
+      // agent decided. complianceMode adds a conformant chain link + fail-closed anchoring.
       const sig = await agent.sign({
         actionType: "stripe:refund",
         context: { chargeId, amountCents, reason, model: "gpt-4o" },

--- a/typescript/src/canonicalize.ts
+++ b/typescript/src/canonicalize.ts
@@ -43,7 +43,7 @@ function canonicalString(value: unknown): string {
     if (!Number.isFinite(value)) {
       throw new Error("NaN / Infinity are not allowed in canonical JSON");
     }
-    // Integers serialize without trailing .0; floats use V8's shortest round-trip via Number.toString.
+    // Integers serialize without a trailing .0; floats use V8's shortest round-trip.
     return numberToCanonical(value);
   }
   if (typeof value === "string") {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1143,7 +1143,8 @@ function validateSignOptions(options: SignOptions, complianceMode: boolean): voi
       );
     }
   }
-  // Threat-framework taxonomy validators; verbatim guard tokens kept in lockstep with the cloud SignRequest validator.
+  // Threat-framework taxonomy validators; verbatim guard tokens kept in lockstep
+  // with the cloud SignRequest validator.
   const _taxonomyChecks: Array<[string, string[] | undefined]> = [
     ["mitre_techniques", options.mitreTechniques],
     ["mitre_atlas", options.mitreAtlas],

--- a/typescript/src/verifier/adapters/acta.ts
+++ b/typescript/src/verifier/adapters/acta.ts
@@ -119,7 +119,8 @@ export class ActaAdapter extends FormatAdapter {
     const p = payload as Record<string, unknown>;
     const s = sig as Record<string, unknown>;
     const missing: string[] = [];
-    // Require only the temporal anchor + signature triple; `type`/`issuer_id` are OPTIONAL Asqav-profile fields.
+    // Require only the temporal anchor + signature triple; `type`/`issuer_id` are
+    // OPTIONAL Asqav-profile fields.
     for (const f of ["issued_at"]) {
       if (!(f in p)) missing.push(f);
     }

--- a/typescript/src/verifier/canonical.ts
+++ b/typescript/src/verifier/canonical.ts
@@ -314,7 +314,8 @@ function serialize(
   if (value === true) return "true";
   if (value === false) return "false";
   if (isRawFloat(value)) return honorFloat ? floatToString(value.value) : numberToString(value.value);
-  // A >2^53 integer: emit exact source digits in every dialect, matching Python's str(int), so distinct ints stay distinct.
+  // A >2^53 integer: emit exact source digits in every dialect (Python str(int)
+  // parity) so distinct ints stay distinct.
   if (isRawBigInt(value)) return value.source;
   if (typeof value === "number") return numberToString(value);
   if (typeof value === "string") return jsonString(value);

--- a/typescript/tests/jcs.test.ts
+++ b/typescript/tests/jcs.test.ts
@@ -19,7 +19,8 @@ describe("canonicalJson() RFC 8785 golden vectors", () => {
   it("§3.2.3 sorts object keys lexicographically (UTF-16 code unit order)", () => {
     const input = { peach: "This sorting order", péché: "is wrong according to French", pêche: "but ordains", sin: "ordering by code unit" };
     const out = decode(canonicalJson(input));
-    // Keys sort by JavaScript's default UTF-16 code unit order: ascii letters precede pre-composed Latin accented letters.
+    // Keys sort by JavaScript's default UTF-16 code unit order: ascii letters
+    // precede pre-composed Latin accented letters.
     expect(out).toBe(
       "{\"peach\":\"This sorting order\",\"péché\":\"is wrong according to French\",\"pêche\":\"but ordains\",\"sin\":\"ordering by code unit\"}"
     );

--- a/typescript/tests/nsaAlignedFields.test.ts
+++ b/typescript/tests/nsaAlignedFields.test.ts
@@ -320,9 +320,8 @@ describe("Rule 10: expiry_collision_guard", () => {
     const spy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(jsonResponse(okBody()));
-    // Far-future horizon -> a large positive duration. The cloud reverted
-    // its expires_at field, so the SDK converts client-side to avoid a
-    // silent-drop footgun.
+    // Far-future horizon -> a large positive duration. The SDK converts ISO expiresAt
+    // to valid_seconds client-side so the field is never silently dropped.
     await fakeAgent().sign({
       actionType: "api.call",
       complianceMode: true,

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -79,9 +79,8 @@ describe("real Authproof receipt verifies PASS (ES256 path)", () => {
 });
 
 describe("canonical-bytes cross-check (TS signing_input sha256 == Python)", () => {
-  // Each TS signing_input sha256 is pinned to the digest the Python oracle's
-  // adapter.signing_input produces for the same receipt, so a canonicaliser drift
-  // on either side breaks this test.
+  // Each TS signing_input sha256 is pinned to the digest the Python oracle's adapter
+  // produces for the same receipt, so a canonicaliser drift on either side reddens here.
   const pinned: Record<string, { fmt: string; sha: string }> = {
     "aerf-01-genesis": {
       fmt: "aerf",


### PR DESCRIPTION
Condense multi-line comment blocks into compact WHY comments and structured homes, convert boxed example section markers to single-line markers, and shorten over-length comment lines across python/ and typescript/. No behavior changes.

comment hygiene clean