### PR TITLE
feat: mirror SoD self-approval guard and align halt path to /orgs/

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.14"
+version = "0.5.15"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -145,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.14"
+__version__ = "0.5.15"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1173,6 +1173,17 @@ def _validate_risk_acceptance(
                 "passing compliance_mode=False would silently drop them.",
                 docs_url=RISK_ACCEPTANCE_DOCS_URL,
             )
+        if (
+            initiator_id is not None
+            and approver_id is not None
+            and initiator_id == approver_id
+        ):
+            raise AsqavValidationError(
+                "risk_acceptance_self_approval_guard: initiator_id equals "
+                "approver_id; a self-approved risk acceptance is incoherent "
+                f"(got: {repr(approver_id)[:64]})",
+                docs_url=RISK_ACCEPTANCE_DOCS_URL,
+            )
 
 
 #: The code-authorship signed-payload extension fields, fenced to the
@@ -2720,9 +2731,13 @@ def generate_trace_id() -> str:
     return uuid.uuid4().hex
 
 
-def emergency_halt(reason: str = "emergency") -> list[dict]:
-    """Revoke all agents immediately. Use in emergencies only."""
-    return _post("/agents/emergency-halt", {"reason": reason})
+def emergency_halt(org_id: str, reason: str = "emergency") -> dict:
+    """Raise an org-wide emergency halt. Use in emergencies only.
+
+    Calls POST /orgs/{org_id}/emergency-halt. Requires an admin/owner session
+    token (ASQAV_SESSION_TOKEN), not an agent API key.
+    """
+    return _post(f"/orgs/{org_id}/emergency-halt", {"reason": reason})
 
 
 def init(

--- a/python/tests/test_client_risk_acceptance.py
+++ b/python/tests/test_client_risk_acceptance.py
@@ -198,3 +198,40 @@ def test_validation_error_is_a_valueerror() -> None:
     """AsqavValidationError subclasses ValueError for backward compat."""
     with pytest.raises(ValueError):
         _sign(sarif_digest="bad")
+
+
+# === SoD guard: risk_acceptance_self_approval_guard ===
+
+
+@pytest.mark.parametrize("same_id", ["user:alice@example.com", "uuid-1234", "alice"])
+def test_rejects_self_approval(same_id: str) -> None:
+    """risk_acceptance_self_approval_guard fires when initiator_id == approver_id."""
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(initiator_id=same_id, approver_id=same_id)
+    assert "risk_acceptance_self_approval_guard: initiator_id equals" in str(exc.value)
+    assert exc.value.docs_url == RISK_ACCEPTANCE_DOCS_URL
+
+
+def test_self_approval_guard_message_bytes() -> None:
+    """Guard message prefix is byte-identical to the cloud validator."""
+    with pytest.raises(AsqavValidationError) as exc:
+        _sign(initiator_id="x", approver_id="x")
+    msg = str(exc.value)
+    assert msg.startswith(
+        "risk_acceptance_self_approval_guard: initiator_id equals approver_id; "
+        "a self-approved risk acceptance is incoherent"
+    )
+
+
+def test_allows_different_initiator_and_approver() -> None:
+    """Different initiator and approver IDs do not trigger the SoD guard."""
+    body = _sign(initiator_id="initiator:bob@example.com", approver_id="approver:alice@example.com")
+    assert body["initiator_id"] == "initiator:bob@example.com"
+    assert body["approver_id"] == "approver:alice@example.com"
+
+
+def test_self_approval_guard_absent_initiator_allowed() -> None:
+    """Guard does not fire when initiator_id is absent (only approver_id set)."""
+    body = _sign(initiator_id=None)
+    assert body.get("initiator_id") is None
+    assert body["approver_id"] == "approver:alice@example.com"

--- a/python/tests/test_emergency_halt.py
+++ b/python/tests/test_emergency_halt.py
@@ -16,13 +16,13 @@ from asqav.client import emergency_halt
 
 @patch("asqav.client._post")
 def test_emergency_halt_calls_correct_endpoint(mock_post: object) -> None:
-    """emergency_halt POSTs to /agents/emergency-halt."""
-    mock_post.return_value = []  # type: ignore[attr-defined]
+    """emergency_halt POSTs to /orgs/{org_id}/emergency-halt."""
+    mock_post.return_value = {"emergency_halt": True}  # type: ignore[attr-defined]
 
-    emergency_halt()
+    emergency_halt("org-123")
 
     mock_post.assert_called_once_with(  # type: ignore[attr-defined]
-        "/agents/emergency-halt",
+        "/orgs/org-123/emergency-halt",
         {"reason": "emergency"},
     )
 
@@ -30,30 +30,30 @@ def test_emergency_halt_calls_correct_endpoint(mock_post: object) -> None:
 @patch("asqav.client._post")
 def test_emergency_halt_custom_reason(mock_post: object) -> None:
     """emergency_halt passes custom reason to the API."""
-    mock_post.return_value = []  # type: ignore[attr-defined]
+    mock_post.return_value = {"emergency_halt": True}  # type: ignore[attr-defined]
 
-    emergency_halt(reason="security breach detected")
+    emergency_halt("org-456", reason="security breach detected")
 
     mock_post.assert_called_once_with(  # type: ignore[attr-defined]
-        "/agents/emergency-halt",
+        "/orgs/org-456/emergency-halt",
         {"reason": "security breach detected"},
     )
 
 
 @patch("asqav.client._post")
-def test_emergency_halt_returns_list(mock_post: object) -> None:
-    """emergency_halt returns the API response (list of revoked agents)."""
-    mock_post.return_value = [  # type: ignore[attr-defined]
-        {"agent_id": "a1", "status": "revoked"},
-        {"agent_id": "a2", "status": "revoked"},
-    ]
+def test_emergency_halt_returns_dict(mock_post: object) -> None:
+    """emergency_halt returns the API response dict."""
+    mock_post.return_value = {  # type: ignore[attr-defined]
+        "organization_id": "org-123",
+        "emergency_halt": True,
+        "emergency_halt_reason": "test",
+    }
 
-    result = emergency_halt(reason="test")
+    result = emergency_halt("org-123", reason="test")
 
-    assert isinstance(result, list)
-    assert len(result) == 2
-    assert result[0]["agent_id"] == "a1"
-    assert result[1]["status"] == "revoked"
+    assert isinstance(result, dict)
+    assert result["emergency_halt"] is True
+    assert result["organization_id"] == "org-123"
 
 
 def test_emergency_halt_exported() -> None:
@@ -65,9 +65,21 @@ def test_emergency_halt_exported() -> None:
 @patch("asqav.client._post")
 def test_emergency_halt_default_reason(mock_post: object) -> None:
     """emergency_halt uses 'emergency' as default reason."""
-    mock_post.return_value = []  # type: ignore[attr-defined]
+    mock_post.return_value = {"emergency_halt": True}  # type: ignore[attr-defined]
 
-    emergency_halt()
+    emergency_halt("org-789")
 
     call_args = mock_post.call_args  # type: ignore[attr-defined]
     assert call_args[0][1]["reason"] == "emergency"
+
+
+@patch("asqav.client._post")
+def test_emergency_halt_path_includes_org_id(mock_post: object) -> None:
+    """emergency_halt path includes the org_id (proves /agents/ path is gone)."""
+    mock_post.return_value = {"emergency_halt": True}  # type: ignore[attr-defined]
+
+    emergency_halt("my-org")
+
+    path = mock_post.call_args[0][0]  # type: ignore[attr-defined]
+    assert "/orgs/my-org/emergency-halt" == path
+    assert "/agents/" not in path

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1382,6 +1382,16 @@ function validateRiskAcceptance(options: SignOptions, complianceMode: boolean): 
         RISK_ACCEPTANCE_DOCS_URL,
       );
     }
+    if (
+      options.initiatorId !== undefined &&
+      options.approverId !== undefined &&
+      options.initiatorId === options.approverId
+    ) {
+      throw new AsqavError(
+        `risk_acceptance_self_approval_guard: initiator_id equals approver_id; a self-approved risk acceptance is incoherent (got: ${String(options.approverId).slice(0, 64)})`,
+        RISK_ACCEPTANCE_DOCS_URL,
+      );
+    }
   }
 }
 

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.5.13";
+export const SDK_VERSION = "0.5.14";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 

--- a/typescript/tests/riskAcceptance.test.ts
+++ b/typescript/tests/riskAcceptance.test.ts
@@ -204,3 +204,69 @@ describe("risk-acceptance rejections", () => {
     }
   });
 });
+
+describe("SoD guard: risk_acceptance_self_approval_guard", () => {
+  it.each(["user:alice@example.com", "uuid-1234", "alice"])(
+    "rejects initiator_id == approver_id ('%s')",
+    async (sameId: string) => {
+      await expect(
+        fakeAgent().sign({
+          ...goodRiskOptions(),
+          initiatorId: sameId,
+          approverId: sameId,
+        } as any),
+      ).rejects.toThrow(/risk_acceptance_self_approval_guard/);
+    },
+  );
+
+  it("guard message is byte-identical to the cloud validator prefix", async () => {
+    try {
+      await fakeAgent().sign({
+        ...goodRiskOptions(),
+        initiatorId: "x",
+        approverId: "x",
+      } as any);
+      throw new Error("expected rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AsqavError);
+      const msg = (err as AsqavError).message;
+      expect(msg).toMatch(
+        /^risk_acceptance_self_approval_guard: initiator_id equals approver_id; a self-approved risk acceptance is incoherent/,
+      );
+    }
+  });
+
+  it("allows different initiator and approver", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    const body = await fakeAgent().sign({
+      ...goodRiskOptions(),
+      initiatorId: "initiator:bob@example.com",
+      approverId: "approver:alice@example.com",
+    } as any);
+    expect(spy).toHaveBeenCalled();
+    void body;
+  });
+
+  it("allows absent initiator_id (only approver set)", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      ...goodRiskOptions(),
+      initiatorId: undefined,
+    } as any);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("attaches the docs_url to the SoD guard error", async () => {
+    try {
+      await fakeAgent().sign({
+        ...goodRiskOptions(),
+        initiatorId: "same",
+        approverId: "same",
+      } as any);
+      throw new Error("expected rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AsqavError);
+      expect((err as AsqavError).docsUrl).toBe(RISK_ACCEPTANCE_DOCS_URL);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **SoD guard mirror (Python + TS):** adds `risk_acceptance_self_approval_guard` to both SDK validators. The cloud `SignRequest._validate_risk_acceptance_self_approval` rejects a risk-acceptance receipt where `initiator_id == approver_id` under `compliance_mode`; SDK callers now get this rejection locally before the HTTP roundtrip. The guard message is byte-identical to the cloud: `risk_acceptance_self_approval_guard: initiator_id equals approver_id; a self-approved risk acceptance is incoherent (got: ...)`. Parametrized tests in both halves assert the exact message prefix and cover the three-value identity set, the absent-initiator bypass, and the docs_url attachment (rule 3.9).

- **Halt path align (Python client.py):** `emergency_halt()` in `client.py` pointed at the removed `/agents/emergency-halt` path. The cloud ships this on `POST /orgs/{org_id}/emergency-halt` (orgs router, admin/session-scoped, returns `EmergencyHaltResponse`). The function now takes `org_id` as a required argument and calls the correct path. The CLI already used `/orgs/` correctly; only the module-level helper was stale. Prod probe: the old `/agents/emergency-halt` path rejects the call (no such route cloud-side), `/orgs/{org_id}/emergency-halt` returns 401 (auth-gated, route exists).

- **Star badge:** README line 14 `img.shields.io/github/stars/jagmarques/asqav-sdk?style=social` is valid shields.io markdown - no action needed.

- **Version bumps:** Python `asqav` 0.5.14 to 0.5.15, TypeScript `@asqav/sdk` 0.5.13 to 0.5.14. Both halves change, so both bump.

## Test plan

- [ ] Python: `pytest tests/test_emergency_halt.py tests/test_client_risk_acceptance.py` - all 23 pass locally
- [ ] TS: `npm test` riskAcceptance.test.ts - new SoD describe block with 6 tests
- [ ] CI green on both halves
