### PR TITLE
Bump TypeScript SDK to 0.5.15 and raise the Node engines floor to 20

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "license": "MIT",
       "bin": {
         "asqav": "dist/cli.js"
@@ -18,7 +18,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@langchain/core": "*",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",
@@ -79,7 +79,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "peerDependencies": {
     "@langchain/core": "*",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.5.14";
+export const SDK_VERSION = "0.5.15";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Bumps @asqav/sdk to 0.5.15 so the ESM bundle crash fix from #283 (Dynamic require of crypto in generateNonce) ships to npm.

The fix relies on globalThis.crypto, which Node added as a stable global in 19. Node 18 would crash on both module formats with this build, so the engines floor moves to Node 20, matching the CI matrix. Node 18 is past end of life.

The Python half is untouched.