### PR TITLE
Harden the extras signing path and decorator agent bootstrap

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -28,6 +28,7 @@ import logging
 import os
 import re
 import sys
+import threading
 import time
 import uuid
 from collections.abc import Callable, Generator
@@ -2944,6 +2945,7 @@ def _urllib_request(
 
 # Global agent for decorators
 _global_agent: Agent | None = None
+_global_agent_lock = threading.Lock()
 
 
 def get_agent() -> Agent:
@@ -2957,9 +2959,13 @@ def get_agent() -> Agent:
     """
     global _global_agent
     if _global_agent is None:
-        # Auto-create an agent with default name
-        name = _auto_generate_name()
-        _global_agent = Agent.create(name)
+        # Serialise auto-creation: without the lock, two threads hitting
+        # their first decorated call can race Agent.create and register
+        # duplicate agents, splitting the receipt chain across them.
+        with _global_agent_lock:
+            if _global_agent is None:
+                name = _auto_generate_name()
+                _global_agent = Agent.create(name)
     return _global_agent
 
 

--- a/python/src/asqav/extras/_base.py
+++ b/python/src/asqav/extras/_base.py
@@ -6,6 +6,7 @@ affect only the thin framework-facing layer.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import uuid
@@ -14,6 +15,8 @@ from .. import client as _client
 from ..client import Agent, AsqavError, SignatureResponse
 
 logger = logging.getLogger("asqav")
+
+__all__ = ["AsqavAdapter"]
 
 
 def _class_name_to_agent_name(cls_name: str) -> str:
@@ -44,6 +47,13 @@ class AsqavAdapter:
 
         if _client._api_key is None and api_key is None:
             raise AsqavError("Call asqav.init() first")
+
+        # The documented per-adapter override: an explicit key (re)initialises
+        # the client so Agent.create/get below actually authenticate with it.
+        # Without this, an adapter constructed with only api_key= passes the
+        # guard above yet fails on its first request.
+        if api_key is not None and api_key != _client._api_key:
+            _client.init(api_key)
 
         if agent_id is not None:
             self._agent: Agent = Agent.get(agent_id)
@@ -77,6 +87,38 @@ class AsqavAdapter:
         except AsqavError as exc:
             logger.warning("asqav signing failed (fail-open): %s", exc)
             return None
+
+    async def _sign_action_async(
+        self,
+        action_type: str,
+        context: dict | None = None,
+        **compliance_kwargs,
+    ) -> SignatureResponse | None:
+        """Async-context wrapper for ``_sign_action``.
+
+        ``Agent.sign`` is a synchronous HTTP round trip; calling it directly
+        from an async framework hook blocks the host's event loop for the
+        full request (seconds when the cloud anchors via an external TSA).
+        This runs it on a worker thread instead so concurrent requests keep
+        flowing. Async hooks must use this, never ``_sign_action`` directly.
+        """
+        if self._observe:
+            logger.info(
+                "OBSERVE: would sign %s with context %s", action_type, context
+            )
+            return None
+        return await asyncio.to_thread(
+            self._sign_action, action_type, context, **compliance_kwargs
+        )
+
+    def __repr__(self) -> str:
+        """Config-only repr: agent identity and mode, never the API key."""
+        return (
+            f"{type(self).__name__}("
+            f"agent_id={self._agent.agent_id!r}, "
+            f"agent_name={self._agent.name!r}, "
+            f"observe={self._observe!r})"
+        )
 
     def _start_session(self) -> None:
         """Start a session to group related signatures."""

--- a/python/src/asqav/extras/litellm.py
+++ b/python/src/asqav/extras/litellm.py
@@ -26,6 +26,8 @@ except ImportError as err:
 
 from ._base import AsqavAdapter
 
+__all__ = ["AsqavGuardrail"]
+
 
 class AsqavGuardrail(AsqavAdapter):
     """Guardrail that signs LiteLLM calls via Asqav governance.
@@ -51,7 +53,7 @@ class AsqavGuardrail(AsqavAdapter):
     ) -> None:
         """Sign before an LLM call is made."""
         messages = data.get("messages", [])
-        self._sign_action(
+        await self._sign_action_async(
             "llm:pre_call",
             {
                 "call_type": call_type,
@@ -79,7 +81,7 @@ class AsqavGuardrail(AsqavAdapter):
                 "completion_tokens": getattr(usage, "completion_tokens", None),
                 "total_tokens": getattr(usage, "total_tokens", None),
             }
-        self._sign_action("llm:post_call", context)
+        await self._sign_action_async("llm:post_call", context)
 
     async def async_post_call_failure_hook(
         self,
@@ -95,7 +97,7 @@ class AsqavGuardrail(AsqavAdapter):
         cloud only emits risk_class on the signed envelope under
         compliance_mode; outside it the value is dropped.
         """
-        self._sign_action(
+        await self._sign_action_async(
             "llm:error",
             {
                 "error_type": type(original_exception).__name__,
@@ -111,7 +113,7 @@ class AsqavGuardrail(AsqavAdapter):
         call_type: str,
     ) -> None:
         """Sign moderation events."""
-        self._sign_action(
+        await self._sign_action_async(
             "llm:moderation",
             {
                 "call_type": call_type,

--- a/python/src/asqav/extras/openai_agents.py
+++ b/python/src/asqav/extras/openai_agents.py
@@ -38,6 +38,8 @@ from ._base import AsqavAdapter
 
 logger = logging.getLogger("asqav")
 
+__all__ = ["AsqavGuardrail", "AsqavTracingProcessor", "GuardrailResult"]
+
 
 @dataclasses.dataclass
 class GuardrailResult:
@@ -86,14 +88,15 @@ class AsqavGuardrail(AsqavAdapter):
         try:
             agent_name = self._resolve_agent_name(agent)
             data_repr = repr(input_data)
-            if len(data_repr) > 200:
+            input_length = len(data_repr)
+            if input_length > 200:
                 data_repr = data_repr[:200]
-            self._sign_action(
+            await self._sign_action_async(
                 "agent:input",
                 {
                     "agent_name": agent_name,
                     "input_type": type(input_data).__name__,
-                    "input_length": len(data_repr),
+                    "input_length": input_length,
                     "input_preview": data_repr,
                 },
             )
@@ -113,14 +116,15 @@ class AsqavGuardrail(AsqavAdapter):
         try:
             agent_name = self._resolve_agent_name(agent)
             data_repr = repr(output_data)
-            if len(data_repr) > 200:
+            output_length = len(data_repr)
+            if output_length > 200:
                 data_repr = data_repr[:200]
-            self._sign_action(
+            await self._sign_action_async(
                 "agent:output",
                 {
                     "agent_name": agent_name,
                     "output_type": type(output_data).__name__,
-                    "output_length": len(data_repr),
+                    "output_length": output_length,
                     "output_preview": data_repr,
                 },
             )

--- a/python/src/asqav/local.py
+++ b/python/src/asqav/local.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any, Callable
 from uuid import uuid4
 
+__all__ = ["LocalQueue", "local_sign"]
+
 _DEFAULT_QUEUE_DIR = os.path.join(os.path.expanduser("~"), ".asqav", "queue")
 
 
@@ -44,8 +46,13 @@ class LocalQueue:
             "status": "pending",
         }
 
+        # Write-then-rename so a crash mid-write never leaves a truncated
+        # .json item that list_pending() would silently skip forever.
+        # The .tmp suffix keeps half-written files out of the *.json glob.
         filepath = self.queue_dir / f"{item_id}.json"
-        filepath.write_text(json.dumps(payload, indent=2))
+        tmp_path = self.queue_dir / f"{item_id}.json.tmp"
+        tmp_path.write_text(json.dumps(payload, indent=2))
+        os.replace(tmp_path, filepath)
         return item_id
 
     def list_pending(self) -> list[dict[str, Any]]:

--- a/python/tests/test_adapter_base.py
+++ b/python/tests/test_adapter_base.py
@@ -274,3 +274,78 @@ def test_sign_action_no_compliance_kwargs_unchanged(mock_agent_cls):
 
     adapter._sign_action("api:call", {"k": "v"})
     mock_agent.sign.assert_called_once_with("api:call", {"k": "v"})
+
+
+# === c3-lessons regressions: async offload, api_key override, repr ===
+
+
+@patch("asqav.extras._base.Agent")
+def test_sign_action_async_offloads_to_thread(mock_agent_cls):
+    """_sign_action_async runs the sync sign off the event loop thread."""
+    import asyncio
+    import threading
+
+    mock_agent = MagicMock()
+    sign_thread: list[str] = []
+
+    def _record_thread(*args, **kwargs):
+        sign_thread.append(threading.current_thread().name)
+        return SignatureResponse(**MOCK_SIGN_RESPONSE)
+
+    mock_agent.sign.side_effect = _record_thread
+    mock_agent_cls.create.return_value = mock_agent
+
+    with patch("asqav.client._api_key", "sk_test"):
+        adapter = _TestAdapter(agent_name="test")
+
+    async def _run():
+        loop_thread = threading.current_thread().name
+        result = await adapter._sign_action_async("llm:call", {"model": "gpt-4"})
+        return loop_thread, result
+
+    loop_thread, result = asyncio.run(_run())
+    assert result is not None
+    assert sign_thread, "Agent.sign never ran"
+    assert sign_thread[0] != loop_thread, "sync sign blocked the event loop thread"
+
+
+@patch("asqav.extras._base.Agent")
+def test_sign_action_async_observe_skips_network(mock_agent_cls):
+    """Observe mode returns None without touching Agent.sign."""
+    import asyncio
+
+    mock_agent_cls.create.return_value = MagicMock()
+    with patch("asqav.client._api_key", "sk_test"):
+        adapter = _TestAdapter(agent_name="test", observe=True)
+
+    result = asyncio.run(adapter._sign_action_async("llm:call", {}))
+    assert result is None
+    adapter._agent.sign.assert_not_called()
+
+
+@patch("asqav.extras._base._client.init")
+@patch("asqav.extras._base.Agent")
+def test_api_key_argument_initialises_client(mock_agent_cls, mock_init):
+    """An explicit api_key= actually initialises the client (was silently ignored)."""
+    mock_agent_cls.create.return_value = MagicMock()
+    with patch("asqav.client._api_key", None):
+        _TestAdapter(api_key="sk_adapter", agent_name="test")
+    mock_init.assert_called_once_with("sk_adapter")
+
+
+@patch("asqav.extras._base.Agent")
+def test_repr_reports_config_and_omits_api_key(mock_agent_cls):
+    """__repr__ surfaces agent identity and observe flag, never the key."""
+    mock_agent = MagicMock()
+    mock_agent.agent_id = "agent_123"
+    mock_agent.name = "my-agent"
+    mock_agent_cls.create.return_value = mock_agent
+
+    with patch("asqav.client._api_key", "sk_super_secret"):
+        adapter = _TestAdapter(agent_name="my-agent")
+
+    text = repr(adapter)
+    assert "agent_123" in text
+    assert "my-agent" in text
+    assert "observe=False" in text
+    assert "sk_super_secret" not in text

--- a/python/tests/test_decorators.py
+++ b/python/tests/test_decorators.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+import time
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -281,3 +282,33 @@ def test_existing_secure_still_works() -> None:
     assert hasattr(asqav, "sign")
     assert hasattr(asqav, "session")
     assert hasattr(asqav, "async_session")
+
+
+@patch("asqav.client.Agent.create")
+def test_get_agent_concurrent_first_call_creates_once(mock_create: MagicMock) -> None:
+    """Concurrent first calls to get_agent create exactly one agent (no duplicate race)."""
+    import threading
+
+    _reset_global_agent()
+    barrier = threading.Barrier(8)
+    agents: list[object] = []
+
+    def _slow_create(name: str) -> MagicMock:
+        time.sleep(0.05)  # widen the race window
+        return MagicMock(name=f"agent-{name}")
+
+    mock_create.side_effect = _slow_create
+
+    def _worker() -> None:
+        barrier.wait()
+        agents.append(asqav_client.get_agent())
+
+    threads = [threading.Thread(target=_worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert mock_create.call_count == 1
+    assert len({id(a) for a in agents}) == 1
+    _reset_global_agent()

--- a/python/tests/test_local.py
+++ b/python/tests/test_local.py
@@ -204,3 +204,16 @@ def test_cli_queue_list(tmp_path: object) -> None:
     assert result.exit_code == 0
     assert "agent_abc" in result.output
     assert "api:call" in result.output
+
+
+def test_enqueue_is_atomic_no_tmp_residue(tmp_path) -> None:
+    """enqueue writes via tmp+rename; no .tmp residue, item parses back cleanly."""
+    queue = LocalQueue(queue_dir=str(tmp_path))
+    item_id = queue.enqueue("agent_abc", "api:call", {"k": "v"})
+
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == []
+    items = queue.list_pending()
+    assert len(items) == 1
+    assert items[0]["id"] == item_id
+    assert items[0]["context"] == {"k": "v"}


### PR DESCRIPTION
Correctness fixes across the Python SDK extras and decorator path.

- The async hooks in the litellm and openai_agents extras called the synchronous sign round trip directly, blocking the host event loop for the full request. They now go through an asyncio.to_thread wrapper on the shared adapter base.
- get_agent() auto-creation is serialised with a lock so two threads hitting their first decorated call cannot register duplicate agents and split the receipt chain.
- An explicit api_key passed to an adapter constructor reinitialises the client instead of being ignored when init() ran with a different key.
- The openai_agents input and output receipts record the full repr length instead of the truncated preview length.
- LocalQueue items are written to a temp file and atomically renamed so a crash mid-write cannot leave a truncated .json item that list_pending() would skip.
- Added __all__ to the extras and local modules plus a config-only __repr__ on the adapter base that never exposes the API key.

Tests: 1064 passed locally. Ruff clean on python/src.
