### PR TITLE
docs(zh): fix RFC 3161 tier claim and risk_class vocabulary in README-ZH

### DIFF
--- a/python/README-ZH.md
+++ b/python/README-ZH.md
@@ -93,12 +93,12 @@ Asqav 的合规凭证基于 IETF Internet-Draft [`draft-marques-asqav-compliance
 
 ## Compliance Receipts：IETF profile
 
-Compliance Receipts 是 SDK 的默认模式。每次 `agent.sign(...)` 都会生成一份符合 [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) 的凭证：ML-DSA-65 签名、RFC 3161 + OpenTimestamps 锚点、保留的 `policy_digest`、哈希链 `previousReceiptHash`。如需旧版结构，传入 `compliance_mode=False`。
+Compliance Receipts 是 SDK 的默认模式。每次 `agent.sign(...)` 都会生成一份符合 [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) 的凭证：ML-DSA-65 签名、OpenTimestamps 锚点、保留的 `policy_digest`、哈希链 `previousReceiptHash`。Enterprise 层级另加 RFC 3161 时间戳。如需旧版结构，传入 `compliance_mode=False`。
 
 调用方最常用的四个信封扩展字段：
 
 - `receipt_type` - `protectmcp:decision`、`protectmcp:restraint` 或 `protectmcp:lifecycle`。
-- `risk_class` - 受控词汇：`unacceptable | high | limited | minimal | gpai | low | medium | unknown`。
+- `risk_class` - 受控词汇：`low | medium | high | unknown`。
 - `iteration_id` - 逻辑任务 id，与 session 区分。
 - `sandbox_state` - 高风险门控用的 `enabled | disabled | unavailable`。
 - `incident_class` - DORA / NYDFS / CIRCIA token，也可为数组。


### PR DESCRIPTION
## Summary

Two accuracy errors in `python/README-ZH.md`, same class as PR #890 in the main repo:

- RFC 3161 was listed alongside OpenTimestamps as part of the default Compliance Receipt. RFC 3161 is Enterprise-only (FEATURE_RFC3161 in `tier_config.py`). Free tier gets OpenTimestamps only. Fixed to match the English `python/README.md`.
- `risk_class` vocabulary listed `unacceptable | limited | minimal | gpai` as valid standard tokens. The wire validator in `core/conformance.py` only accepts `low | medium | high | unknown`. Those four non-existent tokens would be rejected server-side. Fixed to match the English README and the conformance pattern.

## Test plan

- [ ] Docs-only change: no code paths affected
- [ ] English `python/README.md` (line 83, 88) is the canonical reference - this ZH file now matches it
- [ ] Verify source: `grep -n "FEATURE_RFC3161" asqav/src/asqav_cloud/api/tier_config.py` confirms RFC3161 Enterprise-only (line 47, 103)
- [ ] Verify source: `grep -n "_RISK_CLASS_PATTERN" asqav/src/asqav_cloud/core/conformance.py` shows pattern `^(?:low|medium|high|unknown|...)$` (line 65-66)

## Proof of work

VERIFY-WITH greps:
```
$ grep -n "FEATURE_RFC3161" asqav-repos/asqav/src/asqav_cloud/api/tier_config.py
47:FEATURE_RFC3161 = "rfc3161"
103:            FEATURE_RFC3161,
# line 103 is inside the "enterprise" TierLimits block; free tier (line 55) does not include it

$ grep -n "_RISK_CLASS_PATTERN\|low.*medium.*high.*unknown" asqav-repos/asqav/src/asqav_cloud/core/conformance.py
65:_RISK_CLASS_PATTERN = re.compile(
66:    r"^(?:low|medium|high|unknown|[a-z0-9][a-z0-9_-]*(?::[a-z0-9][a-z0-9_-]*){2,})$"
86:    return _RISK_CLASS_PATTERN.match(value) is not None
```

Diff stat: 1 file changed, 2 insertions(+), 2 deletions(-)