### PR TITLE
docs: note rfc3161 timestamping witness requires Enterprise tier

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -216,6 +216,7 @@ See <https://www.asqav.com/docs/threat-framework-mapping>.
 - `required` must be in `[1, len(witnesses)]`.
 - `witnesses` must be a non-empty subset of the two shipped witnesses: `rfc3161` and `opentimestamps`.
 - `rekor` is rejected. It is not a shipped witness.
+- `rfc3161` confirmation is available on the Enterprise tier only. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.
 
 ```python
 sig = agent.sign(

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -218,6 +218,7 @@ See <https://www.asqav.com/docs/threat-framework-mapping>.
 - `required` must be an integer in `[1, witnesses.length]`.
 - `witnesses` must be a non-empty subset of the two shipped witnesses: `rfc3161` and `opentimestamps`.
 - `rekor` is rejected. It is not a shipped witness.
+- `rfc3161` confirmation is available on the Enterprise tier only. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.
 
 ```typescript
 const sig = await agent.sign({


### PR DESCRIPTION
## Summary

- Both SDK READMEs (python + typescript) listed `rfc3161` as a shipped witness in `witness_policy` without noting it only activates on the Enterprise tier. A Free-tier caller passing `rfc3161` in `witnesses` will not get an inclusion proof, so `witness_quorum_met` silently stays false.
- Added a one-line tier note after the `rekor` rejection bullet in each README, stating `rfc3161` confirmation requires Enterprise and that `opentimestamps` is the quorum-reaching witness on Free.

## Tier-gating source

`FEATURE_RFC3161` is in `tier_config.py`'s enterprise features set (line 103) and absent from the free features set (lines 66-80). No code is changed; this is a docs-only accuracy fix.

## Files changed

- `python/README.md` - one line added after the `rekor` rejection bullet in the witness_policy section
- `typescript/README.md` - same one line added in the equivalent section

## Test plan

- [x] `grep -n -i "rfc3161" python/README.md typescript/README.md | grep -i enterprise` returns one matching line per file
- [x] PR title, body, and commit message verified clean against the forbidden-token and forbidden-pattern lists (no `RFC [0-9]` pattern, no temporal framing tokens)
- [x] Secret scanner returned clean
- [ ] scan-pr-text and ci-ok green

## Proof of work

```
VERIFY-WITH: grep -n -i "rfc3161" python/README.md typescript/README.md | grep -i enterprise

typescript/README.md:221:- `rfc3161` confirmation is available on the Enterprise tier only. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.
python/README.md:219:- `rfc3161` confirmation is available on the Enterprise tier only. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.

Diff stat: 2 files changed, 2 insertions(+)
Tier source: tier_config.py line 103 (FEATURE_RFC3161 in enterprise set only)
Branch: company/witness-tier-note
Commit: c0d500f
```