### PR TITLE
docs: remove unimplemented verifyUserIntent from user-intent doc

### DIFF
--- a/docs/user-intent.md
+++ b/docs/user-intent.md
@@ -108,5 +108,4 @@ WebAuthn assertion verification is store-only today. The bytes are persisted on 
 ## Roadmap
 
 - WebAuthn assertion verification: parse `authenticatorData` plus `clientDataJSON`, then verify against the stored COSE key.
-- A `verifyUserIntent(signatureId)` helper on both SDKs that re-runs verification against the stored bytes.
 - Optional policy: require `user_intent_verified=true` for specific action_type patterns.


### PR DESCRIPTION
## Summary

- The public doc `docs/user-intent.md` had a Roadmap bullet promising a `verifyUserIntent(signatureId)` helper on both SDKs.
- That helper does not exist in any source file (`grep -rn verifyUserIntent src/` returns nothing).
- This removes the bullet so the public doc does not promise an unimplemented feature (rule 2.2).

## Change

One line deleted from the Roadmap section in `docs/user-intent.md`. No code, no other docs.

## Proof of work

```
grep -rn "verifyUserIntent" /Users/jagmarques/asqav-repos/asqav-sdk
/Users/jagmarques/asqav-repos/asqav-sdk/docs/user-intent.md:111:- A `verifyUserIntent(signatureId)` helper on both SDKs that re-runs verification against the stored bytes.
(no src/ hits)

node .../secret-scan.js --worktree .../wt-sdk-intent
SCANNER: gitleaks - clean

diff --git a/docs/user-intent.md b/docs/user-intent.md
index 57df1b8..4bc6a5e 100644
--- a/docs/user-intent.md
+++ b/docs/user-intent.md
@@ -108,5 +108,4 @@ WebAuthn assertion verification is store-only today.
 ## Roadmap
 
 - WebAuthn assertion verification: parse authenticatorData plus clientDataJSON, then verify against the stored COSE key.
-- A `verifyUserIntent(signatureId)` helper on both SDKs that re-runs verification against the stored bytes.
 - Optional policy: require user_intent_verified=true for specific action_type patterns.
```

1 file changed, 1 deletion(-)