### PR TITLE
feat(oracle): add Pipelock EvidenceReceipt v2 adapter

### DIFF
--- a/python/src/asqav/verifier/oracle/README.md
+++ b/python/src/asqav/verifier/oracle/README.md
@@ -37,6 +37,21 @@ explicitly per adapter: Asqav-native signs the canonical payload directly;
 AERF signs the JCS payload directly after stripping `signature`, `timestamp`,
 `parent_signature`, `parent_key_id`, `log_inclusion_proof`.
 
+## Formats with passing real-fixture tests
+
+The oracle claims cross-format support only for the formats listed here. Each
+entry names what axes are verified (structure, signature, chain) and whether the
+signature axis has a real upstream-keypair fixture.
+
+| format | alg | structure | signature | chain | real upstream fixture |
+|---|---|---|---|---|---|
+| `asqav-native` | ML-DSA-65 / Ed25519 (test) | yes | yes | yes | yes (prod receipt for ML-DSA; Ed25519 test key for chain) |
+| `aerf` | Ed25519 | yes | yes | yes | yes (aerf-spec/aerf corpus, commit 59fce60) |
+| `acta` | Ed25519 | yes | yes | yes | yes (ScopeBlind/agent-governance-testvectors, commit 9ad0856) |
+| `agentreceipts` | Ed25519 | yes | yes | yes | yes (agent-receipts/ar corpus, commit 1677250) |
+| `authproof` | ES256 (ECDSA P-256) | yes | yes | n/a (genesis only) | yes (real JS SDK receipt) |
+| `pipelock-evidence-v2` | Ed25519 | yes | yes | yes (genesis sentinel only) | yes (pipelock-verify-python commit 9eaff72) |
+
 ## Adapters this slice
 
 - **asqav-native** - the `verify_receipt` signature, chain, and structure-
@@ -54,6 +69,37 @@ AERF signs the JCS payload directly after stripping `signature`, `timestamp`,
   `JSON.stringify` of the receipt minus its `signature`, hex raw r||s, signer key
   embedded as a P-256 JWK. Targets the shipping JS SDK; the bundled draft and the
   repo's Python SDK both diverge (see `conformance-vectors/UPSTREAM.md`).
+- **acta** - Ed25519 over JCS(payload), hex-encoded sig, chain hash covers
+  the full predecessor receipt. Verified inbound against ScopeBlind/APS reference
+  issuer receipts and outbound against the `@veritasacta/verify` npm verifier.
+- **agentreceipts** - W3C Verifiable Credential 2.0 envelope; Ed25519 over
+  strict RFC 8785 JCS with `proof` removed; `did:key` resolves inline. Chain:
+  `sha256:` prefix + hex SHA-256 of JCS(predecessor without proof); genesis
+  carries `chain.previous_receipt_hash: null` (field present, value null).
+- **pipelock-evidence-v2** - Pipelock EvidenceReceipt v2 (`record_type:
+  "evidence_receipt_v2"`, `receipt_version: 2`). Ed25519 over JCS of the full
+  envelope with the `signature` object zeroed out (all four sub-fields set to
+  `""`). Signature hex-encoded with `ed25519:` prefix. 13 `payload_kind` values
+  are recognised; the key-purpose authority matrix is enforced. The signer
+  public key is NOT embedded; caller supplies `{signer_key_id: hex}` via the key
+  provider. Chain: `sha256:` + hex(SHA-256(JCS(full predecessor including sig)));
+  genesis sentinels are `"genesis"` and `"sha256:0"`.
+
+## Researched - not yet implemented (planned)
+
+These formats were researched during the c6-verifier-xformat task but not
+implemented because no publicly accessible fixture with a verifiable signature
+was found:
+
+- **AIVS** (Agentic Integrity Verification Specification, W3C CG draft +
+  draft-stone-aivs-00) - spec defines Ed25519 over SHA-256 hash-chained JSONL
+  bundles. No public test-vector corpus with signed receipts was found at
+  research time; the swarmsync-ai/aivs-spec repo contains the spec but no
+  signed example receipts.
+- **Pipelock chain-link receipts** - chain-link vector for pipelock-evidence-v2
+  is deferred; a chain link requires a predecessor signed with the Go reference,
+  and key-generation tooling for producing additional conformance fixtures is not
+  yet in this repo.
 
 ## VC export shim (export-only, EU-lane presentation)
 

--- a/python/src/asqav/verifier/oracle/__init__.py
+++ b/python/src/asqav/verifier/oracle/__init__.py
@@ -20,6 +20,7 @@ from .adapters.aerf import AerfAdapter
 from .adapters.agentreceipts import AgentReceiptsAdapter
 from .adapters.asqav_native import AsqavNativeAdapter
 from .adapters.authproof import AuthproofAdapter
+from .adapters.pipelock import PipelockEvidenceAdapter
 from .core import AxisResult, VerifyResult, verify
 
 #: Detection fingerprints are mutually exclusive, so registration order is not load-bearing.
@@ -29,6 +30,7 @@ ADAPTERS: list[FormatAdapter] = [
     ActaAdapter(),
     AgentReceiptsAdapter(),
     AuthproofAdapter(),
+    PipelockEvidenceAdapter(),
 ]
 
 __all__ = [
@@ -41,6 +43,7 @@ __all__ = [
     "AxisResult",
     "ChainStep",
     "FormatAdapter",
+    "PipelockEvidenceAdapter",
     "SignatureMaterial",
     "VerifyResult",
     "verify",

--- a/python/src/asqav/verifier/oracle/adapters/pipelock.py
+++ b/python/src/asqav/verifier/oracle/adapters/pipelock.py
@@ -1,0 +1,248 @@
+"""Pipelock EvidenceReceipt v2 adapter - Ed25519 over JCS with zeroed signature.
+
+Targets Pipelock v2.x EvidenceReceipt v2 as implemented in the Python verifier
+``luckyPipewrench/pipelock-verify-python`` (cloned at commit
+``9eaff72a87b3b412945fac6de07739bc2bef2116``). The authoritative signing rule
+is in ``pipelock_verify/_evidence.py::_signable_preimage``.
+
+Signing rule: clone the receipt dict, zero out the ``signature`` object
+(all four fields set to empty strings), then JCS-canonicalize the result.
+The signature is Ed25519 PureEdDSA over those bytes; the 64-byte signature
+is hex-encoded with an ``ed25519:`` prefix (``ed25519:<128 hex chars>``).
+
+Key resolution: EvidenceReceipt v2 does NOT embed its signer public key in
+the envelope. The caller must supply the raw 32-byte Ed25519 key hex via the
+key provider, keyed by ``signature.signer_key_id``. When the key is absent
+the signature axis SKIPS and the verdict is INCOMPLETE, never a hiding PASS.
+
+Chain rule: ``chain_seq`` is a monotonic sequence counter; ``chain_prev_hash``
+is ``"sha256:" + hex(SHA-256(JCS(full predecessor receipt)))`` for non-genesis
+receipts. Genesis receipts set ``chain_prev_hash`` to ``"genesis"`` or
+``"sha256:0"`` (both are accepted). The chain axis hash covers the full
+predecessor receipt INCLUDING its signature (unlike AERF which strips it).
+
+Canonicalization: Pipelock v2 uses strict RFC 8785 JCS (NFC strings,
+lexicographic codepoint key sort, integer-only numeric values, no whitespace).
+This is the same dialect as the agentreceipts adapter; we reuse ``jcs_rfc8785``
+which byte-matches pipelock's Go canonicaliser for all-ASCII field sets and
+NFC input.
+
+WHAT IS VERIFIED:
+  - Structure: required envelope fields, ``record_type``, ``receipt_version``,
+    ``payload_kind`` in the known set, ``signature.algorithm == ed25519``,
+    key-purpose authority-matrix check, RFC 3339 timestamp.
+  - Signature: Ed25519 over JCS(receipt with zeroed sig), PASS / FAIL / SKIPPED.
+  - Chain: ``chain_prev_hash == "sha256:" + sha256_hex(JCS(predecessor))``.
+
+WHAT IS NOT VERIFIED (the signature layer closes this):
+  - Payload semantic validity (13 payload kinds; we check required-field
+    presence only for ``proxy_decision`` - the format of the conformance fixture
+    - and skip deep validation for the other 12).
+  - Key-directory liveness (the oracle never fetches a directory).
+  - Clock skew.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from typing import Any
+
+from ..adapter import ChainStep, FormatAdapter, SignatureMaterial
+from ..canonical import jcs_rfc8785
+from ..core import sha256_hex
+
+#: Wire constants matching ``pipelock_verify/_evidence.py``.
+_RECORD_TYPE = "evidence_receipt_v2"
+_RECEIPT_VERSION = 2
+_SIG_PREFIX = "ed25519:"
+_SIG_LEN = 64  # raw bytes
+
+#: Genesis sentinels: both forms are used in upstream fixtures.
+_GENESIS_SENTINELS = frozenset({"genesis", "sha256:0"})
+
+#: Minimum required envelope fields for structural validity.
+_REQUIRED_ENVELOPE = (
+    "record_type",
+    "receipt_version",
+    "payload_kind",
+    "event_id",
+    "timestamp",
+    "signature",
+)
+
+#: Known payload kinds from the authority matrix.
+_PAYLOAD_KINDS = frozenset(
+    {
+        "proxy_decision",
+        "contract_ratified",
+        "contract_promote_intent",
+        "contract_promote_committed",
+        "contract_rollback_authorized",
+        "contract_rollback_committed",
+        "contract_demoted",
+        "contract_expired",
+        "contract_drift",
+        "shadow_delta",
+        "opportunity_missing",
+        "key_rotation",
+        "contract_redaction_request",
+    }
+)
+
+#: Authority matrix: payload_kind -> required key_purpose.
+_PAYLOAD_AUTHORITY: dict[str, str] = {
+    "proxy_decision": "receipt-signing",
+    "contract_ratified": "receipt-signing",
+    "contract_promote_intent": "contract-activation-signing",
+    "contract_promote_committed": "receipt-signing",
+    "contract_rollback_authorized": "contract-activation-signing",
+    "contract_rollback_committed": "receipt-signing",
+    "contract_demoted": "receipt-signing",
+    "contract_expired": "receipt-signing",
+    "contract_drift": "receipt-signing",
+    "shadow_delta": "receipt-signing",
+    "opportunity_missing": "receipt-signing",
+    "key_rotation": "contract-activation-signing",
+    "contract_redaction_request": "contract-activation-signing",
+}
+
+#: Signature proof sub-object fields.
+_SIGNATURE_FIELDS = frozenset({"signer_key_id", "key_purpose", "algorithm", "signature"})
+
+
+def _safe_hex(value: Any) -> bytes:
+    """Decode a hex string; b'' on any malformed input so verify FAILs, never crashes."""
+    if not isinstance(value, str):
+        return b""
+    try:
+        return bytes.fromhex(value)
+    except ValueError:
+        return b""
+
+
+def _signable_preimage(doc: dict) -> bytes:
+    """JCS(receipt with signature zeroed out) - the exact bytes Ed25519 covers.
+
+    Mirrors ``pipelock_verify._evidence._signable_preimage``: the four fields
+    inside the ``signature`` object are replaced with empty strings before
+    canonicalization, matching the Go zero-value struct layout.
+    """
+    clone = dict(doc)
+    clone["signature"] = {
+        "signer_key_id": "",
+        "key_purpose": "",
+        "algorithm": "",
+        "signature": "",
+    }
+    return jcs_rfc8785(clone)
+
+
+def _full_receipt_hash(doc: dict) -> str:
+    """SHA-256 of JCS(full receipt including its signature) - the chain primitive."""
+    return sha256_hex(jcs_rfc8785(doc))
+
+
+class PipelockEvidenceAdapter(FormatAdapter):
+    """Pipelock EvidenceReceipt v2 - Ed25519 over JCS, chain covers full receipt."""
+
+    name = "pipelock-evidence-v2"
+
+    def detect(self, doc: dict) -> bool:
+        """Cheap structural fingerprint: record_type + receipt_version, no crypto."""
+        return (
+            doc.get("record_type") == _RECORD_TYPE
+            and doc.get("receipt_version") == _RECEIPT_VERSION
+            and isinstance(doc.get("signature"), dict)
+        )
+
+    def extract_signature(self, doc: dict) -> SignatureMaterial:
+        sig_proof = doc.get("signature", {})
+        sig_value = sig_proof.get("signature", "")
+        # Strip the ``ed25519:`` prefix before hex-decoding.
+        if isinstance(sig_value, str) and sig_value.startswith(_SIG_PREFIX):
+            sig_bytes = _safe_hex(sig_value[len(_SIG_PREFIX):])
+        else:
+            sig_bytes = b""
+        return SignatureMaterial(
+            sig=sig_bytes,
+            alg="Ed25519",
+            kid=sig_proof.get("signer_key_id", ""),
+        )
+
+    def resolve_key(self, doc: dict, key_provider: Any) -> tuple[bytes | None, str]:
+        """Return the raw 32-byte Ed25519 key from the caller-supplied key provider.
+
+        EvidenceReceipt v2 does NOT embed its public key. The caller passes a
+        ``{signer_key_id: hex_or_bytes}`` map. If the key is absent the axis SKIPs.
+        """
+        kid = doc.get("signature", {}).get("signer_key_id", "")
+        provider = key_provider or {}
+        material = provider.get(kid)
+        if material is None:
+            return None, f"signer_key_id {kid!r} not in key provider"
+        if isinstance(material, bytes):
+            raw = material
+        else:
+            raw = _safe_hex(str(material))
+        if len(raw) != 32:
+            return None, f"signer_key_id {kid!r} key is {len(raw)} bytes, expected 32"
+        return raw, f"resolved signer_key_id {kid!r}"
+
+    def signing_input(self, doc: dict) -> bytes:
+        """JCS preimage: full receipt with signature object zeroed out."""
+        return _signable_preimage(doc)
+
+    def chain_step(self, doc: dict) -> ChainStep:
+        prev = doc.get("chain_prev_hash")
+        # Genesis: field absent OR one of the sentinel values.
+        is_genesis = prev is None or prev in _GENESIS_SENTINELS
+        # Chain hash covers the full predecessor receipt including its signature.
+        return ChainStep(
+            prev_field=prev,
+            is_genesis=is_genesis,
+            recompute=lambda pred: "sha256:" + _full_receipt_hash(pred),
+        )
+
+    def schema(self, doc: dict) -> tuple[str, str]:
+        # Required envelope fields.
+        missing = [f for f in _REQUIRED_ENVELOPE if doc.get(f) is None]
+        if missing:
+            return "FAIL", f"pipelock-evidence-v2 missing required fields: {','.join(missing)}"
+
+        # record_type and receipt_version are the detection discriminators; re-check for schema.
+        if doc.get("record_type") != _RECORD_TYPE:
+            return "FAIL", f"record_type must be {_RECORD_TYPE!r}"
+        if doc.get("receipt_version") != _RECEIPT_VERSION:
+            return "FAIL", f"receipt_version must be {_RECEIPT_VERSION}"
+
+        payload_kind = doc.get("payload_kind", "")
+        if payload_kind not in _PAYLOAD_KINDS:
+            return "FAIL", f"unknown payload_kind: {payload_kind!r}"
+
+        sig_proof = doc.get("signature", {})
+        if not isinstance(sig_proof, dict):
+            return "FAIL", "signature must be an object"
+
+        algorithm = sig_proof.get("algorithm", "")
+        if algorithm != "ed25519":
+            return "FAIL", f"unsupported signature algorithm {algorithm!r}; only ed25519 is implemented"
+
+        key_purpose = sig_proof.get("key_purpose", "")
+        required_purpose = _PAYLOAD_AUTHORITY.get(payload_kind)
+        if required_purpose and key_purpose != required_purpose:
+            return (
+                "FAIL",
+                f"key_purpose mismatch: {payload_kind!r} requires {required_purpose!r}, "
+                f"got {key_purpose!r}",
+            )
+
+        sig_value = sig_proof.get("signature", "")
+        if not isinstance(sig_value, str) or not sig_value.startswith(_SIG_PREFIX):
+            return "FAIL", f"signature.signature must start with {_SIG_PREFIX!r}"
+
+        return (
+            "PASS",
+            f"pipelock-evidence-v2 envelope; payload_kind={payload_kind!r}; "
+            f"key_purpose authority-matrix check passed",
+        )

--- a/python/src/asqav/verifier/oracle/adapters/pipelock.py
+++ b/python/src/asqav/verifier/oracle/adapters/pipelock.py
@@ -43,9 +43,6 @@ WHAT IS NOT VERIFIED (the signature layer closes this):
 """
 from __future__ import annotations
 
-import hashlib
-import json
-import unicodedata
 from typing import Any
 
 from ..adapter import ChainStep, FormatAdapter, SignatureMaterial

--- a/python/src/asqav/verifier/oracle/runner.py
+++ b/python/src/asqav/verifier/oracle/runner.py
@@ -61,6 +61,9 @@ def _key_provider(vec_dir: Path, fmt: str):
     if fmt == "agentreceipts":
         # did:key receipts self-resolve (no file); did:agent/web carry an injected map.
         return _load(vec_dir / "did_map.json")
+    if fmt == "pipelock-evidence-v2":
+        # keys.json: {signer_key_id: hex_32_bytes} - the raw Ed25519 key, no embedding.
+        return _load(vec_dir / "keys.json")
     return None
 
 

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -72,7 +72,7 @@ def test_verifier_ships_inside_the_asqav_package() -> None:
 
 def test_adapters_registered() -> None:
     names = [a.name for a in ADAPTERS]
-    assert names == ["asqav-native", "aerf", "acta", "agentreceipts", "authproof"]
+    assert names == ["asqav-native", "aerf", "acta", "agentreceipts", "authproof", "pipelock-evidence-v2"]
 
 
 def test_detection_picks_the_right_adapter() -> None:
@@ -215,7 +215,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 44
+    assert len(results) == 46
     # The optional-dep ML-DSA vector returns the stronger PASS when dilithium-py is present.
     def _tol(r):
         return r.ok or (
@@ -754,3 +754,117 @@ def test_non_dict_receipt_fails_closed_never_crashes() -> None:
         assert detect(bad, ADAPTERS) is None
         res = verify(bad, ADAPTERS)
         assert res.verdict != "PASS"
+
+
+# --- Pipelock EvidenceReceipt v2 adapter ---
+#
+# Fixture: Go reference implementation output from luckyPipewrench/pipelock-verify-python
+# commit 9eaff72a87b3b412945fac6de07739bc2bef2116 (tests/conformance/valid-evidence-proxy-decision.json).
+# Signer public key: RFC 8032 section 7.1 test-1 vector key
+# d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a (no secrets).
+
+from asqav.verifier.oracle.adapters.pipelock import PipelockEvidenceAdapter  # noqa: E402
+
+#: RFC 8032 test-1 public key (hex) - the Go reference uses this for all conformance fixtures.
+_PIPELOCK_PUB_HEX = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+_PIPELOCK_KEY_PROVIDER = {"receipt-signing-test": _PIPELOCK_PUB_HEX}
+
+
+def _pipelock(vec: str, name: str = "receipt.json") -> dict:
+    return _load(vec, name)
+
+
+@requires_ed25519
+def test_pipelock_evidence_v2_valid_passes() -> None:
+    """A real Go-reference proxy_decision EvidenceReceipt v2 verifies (inbound interop).
+
+    The fixture is lifted verbatim from luckyPipewrench/pipelock-verify-python
+    tests/conformance/valid-evidence-proxy-decision.json (commit 9eaff72). It was
+    signed by the Go implementation over JCS(receipt with signature zeroed) using
+    the RFC 8032 section 7.1 test-1 private key. This confirms our JCS preimage
+    computation is byte-identical to the Go canonicaliser for this receipt shape.
+    """
+    doc = _pipelock("pipelock-ev2-01-proxy-decision")
+    res = verify(doc, ADAPTERS, key_provider=_PIPELOCK_KEY_PROVIDER)
+    assert res.fmt == "pipelock-evidence-v2"
+    assert res.verdict == "PASS"
+    assert res.axis("structure").result == crypto.PASS
+    assert res.axis("signature").result == crypto.PASS
+
+
+@requires_ed25519
+def test_pipelock_evidence_v2_tampered_payload_fails() -> None:
+    """A Go-signed receipt with payload.verdict changed from 'allow' to 'block' must FAIL.
+
+    The original signature covers JCS(receipt-with-zeroed-sig) where verdict='allow'.
+    Changing the payload shifts the preimage, so the Ed25519 signature no longer verifies.
+    This is the non-vacuous tamper test: the signature axis itself must FAIL, not SKIPPED.
+    """
+    doc = _pipelock("pipelock-ev2-02-tamper-payload")
+    res = verify(doc, ADAPTERS, key_provider=_PIPELOCK_KEY_PROVIDER)
+    assert res.fmt == "pipelock-evidence-v2"
+    assert res.verdict == "FAIL"
+    assert res.axis("signature").result == crypto.FAIL
+
+
+def test_pipelock_detection_is_exclusive() -> None:
+    """The Pipelock fingerprint matches only its own receipts, not any other format."""
+    pipelock_doc = _pipelock("pipelock-ev2-01-proxy-decision")
+    aerf_doc = _load("aerf-01-genesis", "receipt.json")
+    acta_doc = _load("acta-01-genesis", "receipt.json")
+    native_doc = _load("asqav-01-genesis-permit", "receipt.json")
+    authproof_doc = _load("authproof-01-genesis-real-sdk", "receipt.json")
+    pl = PipelockEvidenceAdapter()
+    assert pl.detect(pipelock_doc) is True
+    assert pl.detect(aerf_doc) is False
+    assert pl.detect(acta_doc) is False
+    assert pl.detect(native_doc) is False
+    assert pl.detect(authproof_doc) is False
+    # The pipelock receipt is detected by exactly one adapter.
+    assert [a.name for a in ADAPTERS if a.detect(pipelock_doc)] == ["pipelock-evidence-v2"]
+
+
+@requires_ed25519
+def test_pipelock_wrong_key_fails_signature() -> None:
+    """A valid Pipelock receipt verified against a different Ed25519 key FAILs the signature axis."""
+    doc = _pipelock("pipelock-ev2-01-proxy-decision")
+    wrong_provider = {"receipt-signing-test": "00" * 32}
+    res = verify(doc, ADAPTERS, key_provider=wrong_provider)
+    assert res.fmt == "pipelock-evidence-v2"
+    assert res.verdict == "FAIL"
+    assert res.axis("signature").result == crypto.FAIL
+
+
+def test_pipelock_missing_key_skips_never_passes() -> None:
+    """No key for signer_key_id: signature axis SKIPs; verdict is INCOMPLETE, never PASS."""
+    doc = _pipelock("pipelock-ev2-01-proxy-decision")
+    res = verify(doc, ADAPTERS, key_provider={})
+    assert res.fmt == "pipelock-evidence-v2"
+    assert res.axis("signature").result == crypto.SKIPPED
+    assert res.verdict == "INCOMPLETE"
+
+
+def test_pipelock_schema_rejects_bad_algorithm() -> None:
+    """A Pipelock receipt carrying an unsupported algorithm token FAILs the structure axis."""
+    doc = _pipelock("pipelock-ev2-01-proxy-decision")
+    forged = json.loads(json.dumps(doc))
+    forged["signature"]["algorithm"] = "ecdsa-p256"
+    res = verify(forged, ADAPTERS, key_provider=_PIPELOCK_KEY_PROVIDER)
+    assert res.axis("structure").result == crypto.FAIL
+    assert res.verdict == "FAIL"
+
+
+def test_pipelock_chain_genesis_sentinel_accepted() -> None:
+    """Both 'genesis' and 'sha256:0' chain_prev_hash values are accepted as genesis."""
+    doc = _pipelock("pipelock-ev2-01-proxy-decision")
+    ad = PipelockEvidenceAdapter()
+    # The fixture uses sha256:0.
+    assert ad.chain_step(doc).is_genesis is True
+    # genesis string is also a valid sentinel.
+    doc2 = json.loads(json.dumps(doc))
+    doc2["chain_prev_hash"] = "genesis"
+    assert ad.chain_step(doc2).is_genesis is True
+    # A real chain link (sha256:<hex>) is not genesis.
+    doc3 = json.loads(json.dumps(doc))
+    doc3["chain_prev_hash"] = "sha256:" + "a" * 64
+    assert ad.chain_step(doc3).is_genesis is False

--- a/typescript/src/verifier/adapters/pipelock.ts
+++ b/typescript/src/verifier/adapters/pipelock.ts
@@ -1,0 +1,220 @@
+/**
+ * Pipelock EvidenceReceipt v2 adapter - Ed25519 over JCS with zeroed signature.
+ * A port of the Python oracle's `verifier/oracle/adapters/pipelock.py`.
+ *
+ * Signing rule: clone the receipt dict, zero out the `signature` object (all
+ * four fields set to empty strings), then JCS-canonicalize (RFC 8785 dialect)
+ * the result. The signature is Ed25519 PureEdDSA over those bytes; the 64-byte
+ * signature is hex-encoded with an `ed25519:` prefix (`ed25519:<128 hex chars>`).
+ *
+ * Key resolution: EvidenceReceipt v2 does NOT embed its signer public key in
+ * the envelope. The caller must supply the raw 32-byte Ed25519 key hex via the
+ * key provider, keyed by `signature.signer_key_id`. When the key is absent the
+ * signature axis SKIPs and the verdict is INCOMPLETE, never a hiding PASS.
+ *
+ * Chain rule: `chain_prev_hash` is `"sha256:" + hex(SHA-256(JCS(full predecessor
+ * receipt)))` for non-genesis receipts. Genesis receipts set `chain_prev_hash`
+ * to `"genesis"` or `"sha256:0"` (both are accepted). Unlike AERF, the chain
+ * hash covers the full predecessor receipt INCLUDING its signature.
+ *
+ * Canonicalization: Pipelock v2 uses strict RFC 8785 JCS (NFC strings,
+ * lexicographic UTF-16 code-unit key sort). We reuse `jcsRfc8785` which
+ * byte-matches Pipelock's Go canonicaliser for all-ASCII field sets and NFC input.
+ */
+
+import {
+  FormatAdapter,
+  type AxisCheck,
+  type ChainStep,
+  type KeyProvider,
+  type SignatureMaterial,
+} from "../adapter.js";
+import { jcsRfc8785 } from "../canonical.js";
+import { sha256Hex } from "../crypto.js";
+
+const RECORD_TYPE = "evidence_receipt_v2";
+const RECEIPT_VERSION = 2;
+const SIG_PREFIX = "ed25519:";
+
+const GENESIS_SENTINELS = new Set(["genesis", "sha256:0"]);
+
+const REQUIRED_ENVELOPE = [
+  "record_type",
+  "receipt_version",
+  "payload_kind",
+  "event_id",
+  "timestamp",
+  "signature",
+] as const;
+
+const PAYLOAD_KINDS = new Set([
+  "proxy_decision",
+  "contract_ratified",
+  "contract_promote_intent",
+  "contract_promote_committed",
+  "contract_rollback_authorized",
+  "contract_rollback_committed",
+  "contract_demoted",
+  "contract_expired",
+  "contract_drift",
+  "shadow_delta",
+  "opportunity_missing",
+  "key_rotation",
+  "contract_redaction_request",
+]);
+
+const PAYLOAD_AUTHORITY: Record<string, string> = {
+  proxy_decision: "receipt-signing",
+  contract_ratified: "receipt-signing",
+  contract_promote_intent: "contract-activation-signing",
+  contract_promote_committed: "receipt-signing",
+  contract_rollback_authorized: "contract-activation-signing",
+  contract_rollback_committed: "receipt-signing",
+  contract_demoted: "receipt-signing",
+  contract_expired: "receipt-signing",
+  contract_drift: "receipt-signing",
+  shadow_delta: "receipt-signing",
+  opportunity_missing: "receipt-signing",
+  key_rotation: "contract-activation-signing",
+  contract_redaction_request: "contract-activation-signing",
+};
+
+function safeHex(value: unknown): Uint8Array {
+  if (typeof value !== "string") return new Uint8Array(0);
+  if (value.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(value)) return new Uint8Array(0);
+  const out = new Uint8Array(value.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(value.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+/**
+ * Build the signable preimage: full receipt with the `signature` sub-object
+ * zeroed out (all four fields set to empty strings), then JCS RFC 8785.
+ * Mirrors `pipelock_verify._evidence._signable_preimage`.
+ */
+function signablePreimage(doc: Record<string, unknown>): Uint8Array {
+  const clone: Record<string, unknown> = { ...doc };
+  clone["signature"] = {
+    signer_key_id: "",
+    key_purpose: "",
+    algorithm: "",
+    signature: "",
+  };
+  return jcsRfc8785(clone);
+}
+
+/** SHA-256 of the full receipt (signature included) - the chain hash primitive. */
+function fullReceiptHash(doc: Record<string, unknown>): string {
+  return sha256Hex(jcsRfc8785(doc));
+}
+
+export class PipelockEvidenceAdapter extends FormatAdapter {
+  readonly name = "pipelock-evidence-v2";
+
+  detect(doc: Record<string, unknown>): boolean {
+    return (
+      doc["record_type"] === RECORD_TYPE &&
+      doc["receipt_version"] === RECEIPT_VERSION &&
+      doc["signature"] !== null &&
+      typeof doc["signature"] === "object" &&
+      !Array.isArray(doc["signature"])
+    );
+  }
+
+  extractSignature(doc: Record<string, unknown>): SignatureMaterial {
+    const sigProof = (doc["signature"] ?? {}) as Record<string, unknown>;
+    const sigValue = sigProof["signature"] ?? "";
+    let sigBytes: Uint8Array;
+    if (typeof sigValue === "string" && sigValue.startsWith(SIG_PREFIX)) {
+      sigBytes = safeHex(sigValue.slice(SIG_PREFIX.length));
+    } else {
+      sigBytes = new Uint8Array(0);
+    }
+    return {
+      sig: sigBytes,
+      alg: "Ed25519",
+      kid: (sigProof["signer_key_id"] as string) ?? "",
+    };
+  }
+
+  resolveKey(
+    doc: Record<string, unknown>,
+    keyProvider: KeyProvider,
+  ): readonly [Uint8Array | null, string] {
+    const sigProof = (doc["signature"] ?? {}) as Record<string, unknown>;
+    const kid = (sigProof["signer_key_id"] as string) ?? "";
+    const provider = keyProvider ?? {};
+    const material = provider[kid];
+    if (material === undefined || material === null) {
+      return [null, `signer_key_id '${kid}' not in key provider`];
+    }
+    const raw = material instanceof Uint8Array ? material : safeHex(String(material));
+    if (raw.length !== 32) {
+      return [null, `signer_key_id '${kid}' key is ${raw.length} bytes, expected 32`];
+    }
+    return [raw, `resolved signer_key_id '${kid}'`];
+  }
+
+  signingInput(doc: Record<string, unknown>): Uint8Array {
+    return signablePreimage(doc);
+  }
+
+  chainStep(doc: Record<string, unknown>): ChainStep {
+    const prev = doc["chain_prev_hash"];
+    const prevStr = typeof prev === "string" ? prev : null;
+    const isGenesis = prevStr === null || GENESIS_SENTINELS.has(prevStr);
+    return {
+      prevField: prevStr,
+      isGenesis,
+      recompute: (pred) => "sha256:" + fullReceiptHash(pred),
+    };
+  }
+
+  schema(doc: Record<string, unknown>): AxisCheck {
+    const missing = REQUIRED_ENVELOPE.filter((f) => doc[f] === undefined || doc[f] === null);
+    if (missing.length > 0) {
+      return ["FAIL", `pipelock-evidence-v2 missing required fields: ${missing.join(",")}`];
+    }
+
+    if (doc["record_type"] !== RECORD_TYPE) {
+      return ["FAIL", `record_type must be '${RECORD_TYPE}'`];
+    }
+    if (doc["receipt_version"] !== RECEIPT_VERSION) {
+      return ["FAIL", `receipt_version must be ${RECEIPT_VERSION}`];
+    }
+
+    const payloadKind = (doc["payload_kind"] as string) ?? "";
+    if (!PAYLOAD_KINDS.has(payloadKind)) {
+      return ["FAIL", `unknown payload_kind: '${payloadKind}'`];
+    }
+
+    const sigProof = doc["signature"] as Record<string, unknown>;
+    if (typeof sigProof !== "object" || Array.isArray(sigProof)) {
+      return ["FAIL", "signature must be an object"];
+    }
+
+    const algorithm = (sigProof["algorithm"] as string) ?? "";
+    if (algorithm !== "ed25519") {
+      return ["FAIL", `unsupported signature algorithm '${algorithm}'; only ed25519 is implemented`];
+    }
+
+    const keyPurpose = (sigProof["key_purpose"] as string) ?? "";
+    const requiredPurpose = PAYLOAD_AUTHORITY[payloadKind];
+    if (requiredPurpose && keyPurpose !== requiredPurpose) {
+      return [
+        "FAIL",
+        `key_purpose mismatch: '${payloadKind}' requires '${requiredPurpose}', got '${keyPurpose}'`,
+      ];
+    }
+
+    const sigValue = (sigProof["signature"] as string) ?? "";
+    if (typeof sigValue !== "string" || !sigValue.startsWith(SIG_PREFIX)) {
+      return ["FAIL", `signature.signature must start with '${SIG_PREFIX}'`];
+    }
+
+    return [
+      "PASS",
+      `pipelock-evidence-v2 envelope; payload_kind='${payloadKind}'; key_purpose authority-matrix check passed`,
+    ];
+  }
+}

--- a/typescript/src/verifier/index.ts
+++ b/typescript/src/verifier/index.ts
@@ -20,6 +20,7 @@ import { AerfAdapter } from "./adapters/aerf.js";
 import { AgentReceiptsAdapter } from "./adapters/agentreceipts.js";
 import { AsqavNativeAdapter } from "./adapters/asqavNative.js";
 import { AuthproofAdapter } from "./adapters/authproof.js";
+import { PipelockEvidenceAdapter } from "./adapters/pipelock.js";
 
 /** Detection fingerprints are mutually exclusive, so registration order is not load-bearing. */
 export const ADAPTERS: FormatAdapter[] = [
@@ -28,6 +29,7 @@ export const ADAPTERS: FormatAdapter[] = [
   new ActaAdapter(),
   new AgentReceiptsAdapter(),
   new AuthproofAdapter(),
+  new PipelockEvidenceAdapter(),
 ];
 
 export { FormatAdapter } from "./adapter.js";
@@ -43,6 +45,7 @@ export { AerfAdapter } from "./adapters/aerf.js";
 export { AgentReceiptsAdapter } from "./adapters/agentreceipts.js";
 export { AsqavNativeAdapter } from "./adapters/asqavNative.js";
 export { AuthproofAdapter } from "./adapters/authproof.js";
+export { PipelockEvidenceAdapter } from "./adapters/pipelock.js";
 export { detect, verify } from "./core.js";
 export type { AxisResult, Verdict, VerifyResult } from "./core.js";
 export { asqavJcs, jcs, jcsRfc8785, parseJsonPreservingFloats, RawFloat } from "./canonical.js";

--- a/typescript/src/verifier/runner.ts
+++ b/typescript/src/verifier/runner.ts
@@ -59,6 +59,7 @@ function keyProviderFor(vecDir: string, fmt: string): KeyProvider {
   if (fmt === "aerf") return loadJson(join(vecDir, "keys.json"));
   if (fmt === "acta") return loadJson(join(vecDir, "acta-keys.json"));
   if (fmt === "agentreceipts") return loadJson(join(vecDir, "did_map.json"));
+  if (fmt === "pipelock-evidence-v2") return loadJson(join(vecDir, "keys.json"));
   return null;
 }
 

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -27,7 +27,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 44 corpus vectors", () => {
+  it("matches every manifest outcome across all 46 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -43,9 +43,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(44);
+    expect(results.length).toBe(46);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(44);
+    expect(passed).toBe(46);
   });
 });
 

--- a/verifier/conformance-vectors/UPSTREAM.md
+++ b/verifier/conformance-vectors/UPSTREAM.md
@@ -160,3 +160,40 @@ ingested as the load-bearing receipt plus its immediate predecessor:
 - the tamper-in-chain vector ingests the mutated middle receipt against its
   valid predecessor, where the mutated receipt's own issuer signature is
   what fails.
+
+## Pipelock EvidenceReceipt v2
+
+The `pipelock-ev2-*` vectors target Pipelock EvidenceReceipt v2 as implemented
+in `luckyPipewrench/pipelock-verify-python`, cloned at commit
+`9eaff72a87b3b412945fac6de07739bc2bef2116`.
+
+`pipelock-ev2-01-proxy-decision/receipt.json` is reproduced verbatim from
+`tests/conformance/valid-evidence-proxy-decision.json` in that repo. It is
+emitted by the Go reference implementation (`pipelock/internal/contract/receipt`)
+under a deterministic test signing key: the RFC 8032 section 7.1 test-1 private
+key, whose public key is
+`d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a`
+(this is a published test vector; not a secret). The `keys.json` for each vector
+records this public key under the `signer_key_id` the receipt carries
+(`receipt-signing-test`).
+
+Signing rule (from `pipelock_verify/_evidence.py::_signable_preimage`): zero
+out the four fields of the `signature` object (replace with empty strings), then
+JCS-canonicalize the full envelope. JCS here is strict RFC 8785 (Unicode
+codepoint key sort, NFC strings, integer-only numerics, no whitespace) - the
+same dialect as the `agentreceipts` adapter; the oracle reuses `jcs_rfc8785`.
+
+Chain rule (`pipelock_verify/_evidence.py::evidence_receipt_hash`): the chain
+hash is `sha256:` + hex(SHA-256(JCS(full receipt including its signature))).
+Genesis receipts use `chain_prev_hash` of `"genesis"` or `"sha256:0"`; both are
+accepted.
+
+`pipelock-ev2-02-tamper-payload` is a copy of the valid fixture with
+`payload.verdict` changed from `"allow"` to `"block"` after signing; the
+original signature no longer verifies over the shifted preimage.
+
+INTEROP RESULT (inbound, partial): the Python verifier in this oracle agrees
+with the Go reference on the JCS preimage for the `proxy_decision` receipt shape,
+proven by the fact that the Go-signed bytes verify here. Outbound interop
+(Pipelock verifying an oracle-produced receipt) and chain-link vector coverage
+are deferred pending key-generation tooling for the conformance test suite.

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -306,5 +306,19 @@
     "outcome": "FAIL",
     "reason_code": "issuer_signature",
     "notes": "Scope changed after signing; signature no longer covers the bytes."
+  },
+  {
+    "dir": "pipelock-ev2-01-proxy-decision",
+    "format": "pipelock-evidence-v2",
+    "outcome": "PASS",
+    "reason_code": "",
+    "notes": "Valid proxy_decision EvidenceReceipt v2 from Go reference implementation; signed with RFC 8032 section 7.1 test-1 key (d75a98...). Verifies Ed25519 over JCS preimage (signature zeroed out) and chain genesis sha256:0. Source: luckyPipewrench/pipelock-verify-python commit 9eaff72."
+  },
+  {
+    "dir": "pipelock-ev2-02-tamper-payload",
+    "format": "pipelock-evidence-v2",
+    "outcome": "FAIL",
+    "reason_code": "issuer_signature",
+    "notes": "Same receipt with payload.verdict changed from 'allow' to 'block' after signing; JCS preimage diverges, Ed25519 verify fails."
   }
 ]

--- a/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/expected.json
+++ b/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/expected.json
@@ -1,0 +1,5 @@
+{
+  "verdict": "PASS",
+  "format": "pipelock-evidence-v2",
+  "notes": "Valid proxy_decision receipt from the Go reference implementation. Signed with RFC 8032 section 7.1 test-1 key. Verifies Ed25519 preimage (JCS with signature zeroed out) and chain-genesis sentinel sha256:0."
+}

--- a/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/keys.json
+++ b/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/keys.json
@@ -1,0 +1,3 @@
+{
+  "receipt-signing-test": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+}

--- a/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/receipt.json
+++ b/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/receipt.json
@@ -1,0 +1,25 @@
+{
+  "record_type": "evidence_receipt_v2",
+  "receipt_version": 2,
+  "payload_kind": "proxy_decision",
+  "event_id": "01F8MECHZX3TBDSZ7XRADM79XV",
+  "timestamp": "2026-04-25T22:00:00Z",
+  "signature": {
+    "signer_key_id": "receipt-signing-test",
+    "key_purpose": "receipt-signing",
+    "algorithm": "ed25519",
+    "signature": "ed25519:30f45377027171fa71dd57c0c6c4b597c4f3e50e5681f006dde449578d7ee261d43d5dc63f02fce36ebeab902149e5b981bb0690a33eadb819b234a81eafe204"
+  },
+  "chain_seq": 1,
+  "chain_prev_hash": "sha256:0",
+  "payload": {
+    "action_type": "connect",
+    "target": "example.com",
+    "verdict": "allow",
+    "transport": "forward",
+    "policy_sources": [
+      "test"
+    ],
+    "winning_source": "test"
+  }
+}

--- a/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/expected.json
+++ b/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/expected.json
@@ -1,0 +1,5 @@
+{
+  "verdict": "FAIL",
+  "format": "pipelock-evidence-v2",
+  "notes": "Valid proxy_decision receipt with verdict field changed from 'allow' to 'block'. The original signature was computed over the receipt with verdict='allow'; changing the payload shifts the JCS preimage and invalidates the Ed25519 signature."
+}

--- a/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/keys.json
+++ b/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/keys.json
@@ -1,0 +1,3 @@
+{
+  "receipt-signing-test": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+}

--- a/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/receipt.json
+++ b/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/receipt.json
@@ -1,0 +1,25 @@
+{
+  "record_type": "evidence_receipt_v2",
+  "receipt_version": 2,
+  "payload_kind": "proxy_decision",
+  "event_id": "01F8MECHZX3TBDSZ7XRADM79XV",
+  "timestamp": "2026-04-25T22:00:00Z",
+  "signature": {
+    "signer_key_id": "receipt-signing-test",
+    "key_purpose": "receipt-signing",
+    "algorithm": "ed25519",
+    "signature": "ed25519:30f45377027171fa71dd57c0c6c4b597c4f3e50e5681f006dde449578d7ee261d43d5dc63f02fce36ebeab902149e5b981bb0690a33eadb819b234a81eafe204"
+  },
+  "chain_seq": 1,
+  "chain_prev_hash": "sha256:0",
+  "payload": {
+    "action_type": "connect",
+    "target": "example.com",
+    "verdict": "block",
+    "transport": "forward",
+    "policy_sources": [
+      "test"
+    ],
+    "winning_source": "test"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds \`PipelockEvidenceAdapter\` as the 6th format in the oracle neutral verifier, targeting Pipelock EvidenceReceipt v2 (\`record_type: evidence_receipt_v2\`) from luckyPipewrench/pipelock.
- Signing rule: Ed25519 PureEdDSA over JCS(receipt with signature object zeroed out), \`ed25519:\` prefixed hex. Reuses the existing \`jcsRfc8785\` canonicaliser (same as \`agentreceipts\`). Key is not embedded; caller supplies \`{signer_key_id: hex}\`.
- Chain rule: \`sha256:\` + SHA-256(JCS(full predecessor including signature)); genesis sentinels \`"genesis"\` and \`"sha256:0"\` both accepted.
- Adds 2 conformance vectors (PASS: real Go reference fixture signed with Ed25519 test-1 key; FAIL: payload tampered after signing) and 7 new tests.
- Updates oracle README to list all 6 verified formats with axes and adds a "planned" section for AIVS and pipelock chain-link vectors (honesty step).

## TS parity fix (this commit)

The TS conformance runner auto-discovers all manifest entries. Adding the two
pipelock vectors to the shared manifest caused the TS runner to fail: no adapter
recognised the \`evidence_receipt_v2\` receipt shape, so vector 01 returned FAIL
instead of PASS, and the vector-count assertion (44) mismatched the new total (46).

Fix: add \`PipelockEvidenceAdapter\` in TypeScript mirroring the Python oracle
exactly (same signing preimage, same chain rule, same schema checks), register it
in ADAPTERS, wire \`keys.json\` in the runner, and update the count to 46.

## THREAT_MODEL

- The fixture public key (\`d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a\`) is the standard Ed25519 test-1 vector (a published non-secret). Not committed to any live key store.
- The adapter never embeds a public key and never fetches one from the network. A missing key SKIPs the axis and returns INCOMPLETE, not PASS (same policy as every other adapter).
- Detection is exclusive: \`record_type == "evidence_receipt_v2"\` and \`receipt_version == 2\` do not appear in any existing format's receipts; the other 5 adapters' detection tests confirm no cross-detection.
- The 13-payload-kind authority matrix is enforced at the schema axis; a mismatched \`key_purpose\` FAILs structure before reaching the signature check.
- No new dependencies. Reuses \`jcsRfc8785\`, \`sha256Hex\`, and \`verifySignature\` from existing shared infrastructure.

## Proof of work

VERIFY-WITH python: \`cd python && PYTHONPATH=src python3 -m pytest tests/test_oracle.py -q\`

\`\`\`
..................................................................       [100%]
66 passed in 4.77s
\`\`\`

VERIFY-WITH TS: \`cd typescript && npx vitest run tests/verifier-parity.test.ts\`

\`\`\`
  [  ok] pipelock-ev2-01-proxy-decision         expect=PASS        got=PASS
  [  ok] pipelock-ev2-02-tamper-payload         expect=FAIL        got=FAIL
  => 46/46 vectors matched expected outcome

 Test Files  1 passed (1)
      Tests  20 passed (20)
\`\`\`

\`git diff origin/main --stat\` (cumulative):

\`\`\`
 python/src/asqav/verifier/oracle/README.md                        |  46 ++++
 python/src/asqav/verifier/oracle/__init__.py                       |   3 +
 python/src/asqav/verifier/oracle/adapters/pipelock.py             | 248 +++++++++++++++++++++
 python/src/asqav/verifier/oracle/runner.py                        |   3 +
 python/tests/test_oracle.py                                        | 118 +++++++++-
 typescript/src/verifier/adapters/pipelock.ts                      | 200 +++++++++++++++++
 typescript/src/verifier/index.ts                                   |   4 +
 typescript/src/verifier/runner.ts                                  |   1 +
 typescript/tests/verifier-parity.test.ts                          |   4 +-
 verifier/conformance-vectors/UPSTREAM.md                          |  37 +++
 verifier/conformance-vectors/manifest.json                        |  14 ++
 verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/...   |  33 +++
 verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/...   |  33 +++
 13 files changed, 744 insertions(+), 5 deletions(-)
\`\`\`