### PR TITLE
chore(release): bump both SDK halves to 0.5.16

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.5.15"
+version = "0.5.16"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -145,7 +145,7 @@ from .replay import ReplayStep, ReplayTimeline, replay, replay_from_bundle
 from .retry import with_async_retry, with_retry
 from .scope import ScopeToken, create_scope_token, is_replay, verify_scope_token
 
-__version__ = "0.5.15"
+__version__ = "0.5.16"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.5.15";
+export const SDK_VERSION = "0.5.16";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Release prep for SDK 0.5.16, both halves in lockstep. This PR is the version bump plus the verified release artifacts. It does not publish anything; the orchestrator runs the npm and PyPI upload after review.

## Version: 0.5.16

The cross-format verifier reading Pipelock EvidenceReceipt v2 (#293) is an additive adapter on the neutral verifier with no breaking change to existing receipt handling, so both halves take a patch bump. `asqav` and `@asqav/sdk` both move to 0.5.16 for version parity.

## What ships

- Added: the neutral verifier reads Pipelock EvidenceReceipt v2 (`record_type: evidence_receipt_v2`), a sixth verified format. Ed25519 PureEdDSA over `JCS(receipt with the signature object zeroed)`, chain hash `sha256: + SHA-256(JCS(predecessor))`, corpus grows 44 to 46 vectors, Python and TypeScript stay byte-for-byte at parity. (#293)
- Changed: Python extras signing path and decorator agent bootstrap hardened (async hooks via `asyncio.to_thread`, locked agent auto-creation, atomic queue writes, key-free `AsqavAdapter.__repr__`). (#286)
- Docs: rfc3161 witness noted Enterprise-only (#289), README-ZH corrections (#288), dead `verifyUserIntent` dropped (#290), SECURITY.md chromadb advisory (#285).

## Note on the changelog

CHANGELOG.md was removed from the published tree and gitignored in #281, so it is not a tracked file. The release notes above are the source for the GitHub Release body on the 0.5.16 tag. The local draft was updated for that purpose but is intentionally not committed (it is gitignored).

## Proof of work

VERIFY-WITH (Python oracle, exercises the Pipelock verifier):
```
$ PYTHONPATH=src python3 -m pytest tests/test_oracle.py -q
..................................................................       [100%]
66 passed in 1.52s
```

Full Python suite (macOS, no torch needed):
```
$ PYTHONPATH=src python3 -m pytest -q
1071 passed in 11.89s
```

TypeScript suite:
```
$ npm test
 Test Files  34 passed (34)
      Tests  432 passed (432)
```

Built artifacts (not committed, dist/ is gitignored):
- python/dist/asqav-0.5.16-py3-none-any.whl
- python/dist/asqav-0.5.16.tar.gz
- typescript/asqav-sdk-0.5.16.tgz

Pipelock adapter present in each artifact:
```
wheel : asqav/verifier/oracle/adapters/pipelock.py
sdist : asqav-0.5.16/src/asqav/verifier/oracle/adapters/pipelock.py
npm   : package/dist/verifier/index.{js,mjs,d.ts}  (PipelockEvidence + evidence_receipt_v2 bundled by tsup)
```

Diff stat:
```
 python/pyproject.toml        | 2 +-
 python/src/asqav/__init__.py | 2 +-
 typescript/package.json      | 2 +-
 typescript/src/userAgent.ts  | 2 +-
 4 files changed, 4 insertions(+), 4 deletions(-)
```

Do not merge or publish until reviewed.
