### PR TITLE
docs(readme): lead quickstart with a minimal sign + no-key path

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -32,7 +32,8 @@ import asqav
 item_id = asqav.local_sign("my-agent", "api:openai:chat", {"model": "gpt-4o"})
 print(item_id)  # queued to a local file
 
-asqav.LocalQueue().sync(api_key="sk_...")  # later, with a key
+asqav.init(api_key="sk_...")   # later, once you have a key
+asqav.LocalQueue().sync()      # pushes the queued actions to the cloud
 ```
 
 For a high-value action, pass compliance metadata:

--- a/python/README.md
+++ b/python/README.md
@@ -12,12 +12,32 @@ pip install asqav
 
 ## Quick start
 
+Get an API key at [asqav.com](https://asqav.com), then sign your first agent action:
+
 ```python
 import asqav
 
 asqav.init(api_key="sk_...")
 agent = asqav.Agent.create("my-agent")
 
+sig = agent.sign("api:openai:chat", {"model": "gpt-4o", "tokens": 512})
+print(sig.verification_url)
+```
+
+No API key yet? `local_sign` queues an action to a local file with no network call and no signup, ready to sync once you have a key:
+
+```python
+import asqav
+
+item_id = asqav.local_sign("my-agent", "api:openai:chat", {"model": "gpt-4o"})
+print(item_id)  # queued to a local file
+
+asqav.LocalQueue().sync(api_key="sk_...")  # later, with a key
+```
+
+For a high-value action, pass compliance metadata:
+
+```python
 sig = agent.sign(
     "payment.wire_transfer",
     {"amount_eur": 850000, "beneficiary_iban": "DE89370400440532013000"},

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -12,12 +12,30 @@ npm install @asqav/sdk
 
 ## Quick start
 
+Get an API key at [asqav.com](https://asqav.com), then sign your first agent action:
+
 ```ts
 import { init, Agent } from "@asqav/sdk";
 
 init({ apiKey: process.env.ASQAV_API_KEY });
 const agent = await Agent.create({ name: "my-agent" });
 
+const sig = await agent.sign({ actionType: "api:openai:chat", context: { model: "gpt-4o", tokens: 512 } });
+console.log(sig.verificationUrl);
+```
+
+No API key yet? `generateKeypair` runs entirely in-process with no network call and no signup:
+
+```ts
+import { generateKeypair } from "@asqav/sdk";
+
+const kp = generateKeypair("ed25519");
+console.log(kp.publicKeySpkiB64);  // SPKI DER public key, base64
+```
+
+For a high-value action, pass compliance metadata:
+
+```ts
 const sig = await agent.sign({
   actionType: "payment.wire_transfer",
   context: { amountEur: 850000, beneficiaryIban: "DE89370400440532013000" },


### PR DESCRIPTION
## What
Both the Python and TypeScript READMEs opened the Quick start with the 850,000 EUR wire-transfer example and six envelope params before the reader had signed anything, with no signup preamble and the no-network path buried far down (activation friction: a copy-paste-first dev hits an auth error before any first value).

Restructured both Quick starts to:
1. a one-line `get a key at asqav.com` preamble + the simplest possible sign (`api:openai:chat`),
2. the no-key, no-network path next (`local_sign` / `generateKeypair`),
3. the compliance-metadata example moved below.

## Verification
Every snippet checked against the published API surface: `asqav.init(api_key=)`, `Agent.create(name)`, `agent.sign(action_type, context)`, `local_sign(agent_id, action_type, context)`, `LocalQueue().sync(api_key=)`, `sig.verification_url`; TS `init({apiKey})`, `Agent.create({name})`, `generateKeypair("ed25519").publicKeySpkiB64`, `sig.verificationUrl`. The original compliance example is unchanged (already published API).

## Scope
Docs-only. No API, wire, or version change; the PyPI/npm READMEs refresh on the next release, the GitHub READMEs on merge.