### PR TITLE
docs(readme): clearly label compliance block in Quick start (c9)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -36,7 +36,9 @@ asqav.init(api_key="sk_...")   # later, once you have a key
 asqav.LocalQueue().sync()      # pushes the queued actions to the cloud
 ```
 
-For a high-value action, pass compliance metadata:
+### For high-value actions
+
+Pass compliance metadata for regulated or high-risk operations:
 
 ```python
 sig = agent.sign(

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -33,7 +33,9 @@ const kp = generateKeypair("ed25519");
 console.log(kp.publicKeySpkiB64);  // SPKI DER public key, base64
 ```
 
-For a high-value action, pass compliance metadata:
+### For high-value actions
+
+Pass compliance metadata for regulated or high-risk operations:
 
 ```ts
 const sig = await agent.sign({


### PR DESCRIPTION
## What

Both SDK READMEs already had their Quick start restructured (PR #317, merged) to lead with a signup preamble and a minimal `api:openai:chat` sign. This PR adds a `### For high-value actions` markdown heading above the `payment.wire_transfer` compliance block, making the advanced section clearly labelled as a distinct block below the minimal quick start.

## Changes

- `python/README.md`: replaced `For a high-value action, pass compliance metadata:` with `### For high-value actions` heading + one-line intro
- `typescript/README.md`: same symmetric change

No SDK source, version files, or any other file is touched.

## Proof of work

**VERIFY-WITH (a)** - gentle example + signup preamble at/above Quick start:
```
python/README.md:15:Get an API key at [asqav.com](https://asqav.com), then sign your first agent action:
python/README.md:23:sig = agent.sign("api:openai:chat", {"model": "gpt-4o", "tokens": 512})
typescript/README.md:15:Get an API key at [asqav.com](https://asqav.com), then sign your first agent action:
typescript/README.md:23:const sig = await agent.sign({ actionType: "api:openai:chat", context: { model: "gpt-4o", tokens: 512 } });
```

**VERIFY-WITH (b)** - heavy example at lines 45/46 (py) and 42/43 (ts), greater than gentle example at line 23:
```
python/README.md:45:    "payment.wire_transfer",
python/README.md:46:    {"amount_eur": 850000, "beneficiary_iban": "DE89370400440532013000"},
typescript/README.md:42:  actionType: "payment.wire_transfer",
typescript/README.md:43:  context: { amountEur: 850000, beneficiaryIban: "DE89370400440532013000" },
```

**VERIFY-WITH (c)** - only README files changed:
```
python/README.md
typescript/README.md
```

**Diff stat:**
```
python/README.md     | 4 +++-
typescript/README.md | 4 +++-
2 files changed, 6 insertions(+), 2 deletions(-)
```

Claude-Session: https://claude.ai/code/session_01BXVrMmGpFwevwQGHQeRRG9