### PR TITLE
docs: reorder Quick Start to show minimal example first

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -273,7 +273,7 @@ print(pack["algorithm_registry_version"]) # registry version pinned at issuance
 
 Local-side sanity checks, covering presence of REQUIRED fields, namespace, the 300s skew bound, and predecessor rederivation, are available as `asqav.verify_compliance_receipt(envelope, predecessor_envelope=...)`. The cloud is the authoritative verifier. This helper is a convenience.
 
-Algorithm agility is exposed via `asqav.SUPPORTED_ALGORITHMS`. `Agent.create(...)` sends the algorithm to the Asqav cloud, which accepts `ml-dsa-44`, `ml-dsa-65` (default), and `ml-dsa-87`. `ed25519` and `es256` are for local keypair generation only (`asqav.generate_local_keypair("ed25519")`); passing them to `Agent.create(...)` returns a 400 from the cloud.
+`asqav.SUPPORTED_ALGORITHMS` is the set `asqav.generate_local_keypair(...)` can mint locally: `{ed25519, es256}`. It does not list the cloud agent-signing algorithms. `Agent.create(...)` sends its `algorithm` to the Asqav cloud, which accepts `ml-dsa-44`, `ml-dsa-65` (default), and `ml-dsa-87`. `ed25519` and `es256` are for local keypair generation only, so passing either to `Agent.create(...)` returns a 400 from the cloud.
 
 ## Offline / air-gapped verification
 

--- a/python/README.md
+++ b/python/README.md
@@ -20,35 +20,7 @@ import asqav
 asqav.init(api_key="sk_...")
 agent = asqav.Agent.create("my-agent")
 
-sig = agent.sign("api:openai:chat", {"model": "gpt-4o", "tokens": 512})
-print(sig.verification_url)
-```
-
-No API key yet? `local_sign` queues an action to a local file with no network call and no signup, ready to sync once you have a key:
-
-```python
-import asqav
-
-item_id = asqav.local_sign("my-agent", "api:openai:chat", {"model": "gpt-4o"})
-print(item_id)  # queued to a local file
-
-asqav.init(api_key="sk_...")   # later, once you have a key
-asqav.LocalQueue().sync()      # pushes the queued actions to the cloud
-```
-
-### For high-value actions
-
-Pass compliance metadata for regulated or high-risk operations:
-
-```python
-sig = agent.sign(
-    "payment.wire_transfer",
-    {"amount_eur": 850000, "beneficiary_iban": "DE89370400440532013000"},
-    receipt_type="protectmcp:decision",
-    risk_class="high",
-    issuer_id="legal:Acme GmbH",
-    iteration_id="task-2026-Q2-4821",
-)
+sig = agent.sign("api:openai:chat", {"model": "gpt-4o"})
 
 print(sig.compliance_mode)        # True (default; pass compliance_mode=False to opt out)
 print(sig.action_ref)             # "sha256:..." over the JCS-canonical action
@@ -56,7 +28,25 @@ print(sig.previous_receipt_hash)  # 64 hex; "0"*64 on the first record per agent
 print(sig.verification_url)
 ```
 
-Each signed action lands on a Compliance Receipt under IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) by default: ML-DSA-65 (FIPS 204) signature, chain hash, retained `policy_digest`, fail-closed anchoring, and a public verification URL. Pass `compliance_mode=False` if you want a non-Compliance receipt.
+That's it. One install, one init, one sign call. The receipt lands on the Asqav cloud under [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 (FIPS 204) signature, chain hash, retained `policy_digest`, fail-closed anchoring, and a public verification URL.
+
+### No account? Offline path
+
+If you need to record actions without a network call or an API key, use `local_sign`. Actions queue to disk and can be synced later:
+
+```python
+from asqav.local import local_sign, LocalQueue
+
+item_id = local_sign("my-agent", "api:openai:chat", {"model": "gpt-4o"})
+# Writes a pending JSON item to ~/.asqav/queue/
+
+# When back online, init with your key then sync:
+import asqav
+asqav.init(api_key="sk_...")   # or set ASQAV_API_KEY in the environment
+result = LocalQueue().sync()   # uploads queued items, returns {"synced": N, "failed": M}
+```
+
+Pass `compliance_mode=False` on any `agent.sign(...)` call if you want a non-Compliance receipt.
 
 ## CLI
 
@@ -101,9 +91,20 @@ asqav.init(api_key="...", base_url="https://api.asqav.com", mode="hash-only")
 
 The fingerprint format is sorted JSON with no whitespace per JCS, hashed with SHA-256. See `docs/fingerprint-spec.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
 
-## Compliance receipts: the IETF profile
+## Advanced / high-value actions
 
-Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 signature, JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `compliance_mode=False` if you want the older shape.
+Once you have the basics working, you can pass compliance envelope fields for regulated or high-risk actions. The full parameter set is useful for things like large financial transfers, healthcare decisions, or anything that needs an auditor-facing trail.
+
+```python
+sig = agent.sign(
+    "payment.wire_transfer",
+    {"amount_eur": 850000, "beneficiary_iban": "DE89370400440532013000"},
+    receipt_type="protectmcp:decision",
+    risk_class="high",
+    issuer_id="legal:Acme GmbH",
+    iteration_id="task-2026-Q2-4821",
+)
+```
 
 The envelope extensions most callers reach for:
 
@@ -113,6 +114,10 @@ The envelope extensions most callers reach for:
 - `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
 - `incident_class` - DORA / NYDFS / CIRCIA token, or an array of tokens.
 - `issuer_id` - LEI per ISO 17442, EIN, CIK, or a W3C DID for non-LEI deployers.
+
+## Compliance receipts: the IETF profile
+
+Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 signature, JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `compliance_mode=False` if you want the older shape.
 
 ### Shadow AI capture with passive_telemetry
 

--- a/python/README.md
+++ b/python/README.md
@@ -123,7 +123,7 @@ Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a 
 
 Two `receipt_type` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action. `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block, such as a SIEM forwarder, a browser extension in observe-only mode, or a NetFlow-style proxy with no enforcement hook.
 
-Set `capture_topology='passive_telemetry'` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `capture_topology='passive_telemetry'` receipt MUST use `receipt_type='protectmcp:observation'`. Any other receipt_type paired with `passive_telemetry`, namely `:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, or `:acknowledgment`, raises `ValueError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :<offending> (rule 8)` message before the HTTP roundtrip. The guard lives as `false_attestation_guard` in `python/src/asqav/client.py`.
+Set `capture_topology='passive_telemetry'` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `capture_topology='passive_telemetry'` receipt MUST use `receipt_type='protectmcp:observation'`. Any other receipt_type paired with `passive_telemetry`, namely `:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, or `:acknowledgment`, raises `ValueError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation[:result_bound], not :<offending> (rule 8)` message before the HTTP roundtrip. The guard lives as `false_attestation_guard` in `python/src/asqav/client.py`.
 
 ```python
 sig = agent.sign(
@@ -273,7 +273,7 @@ print(pack["algorithm_registry_version"]) # registry version pinned at issuance
 
 Local-side sanity checks, covering presence of REQUIRED fields, namespace, the 300s skew bound, and predecessor rederivation, are available as `asqav.verify_compliance_receipt(envelope, predecessor_envelope=...)`. The cloud is the authoritative verifier. This helper is a convenience.
 
-Algorithm agility is exposed via `asqav.SUPPORTED_ALGORITHMS`. Pass `algorithm="ed25519"` or `"es256"` to `Agent.create(...)` for non-post-quantum identities, or `asqav.generate_local_keypair("ed25519")` for offline scenarios.
+Algorithm agility is exposed via `asqav.SUPPORTED_ALGORITHMS`. `Agent.create(...)` sends the algorithm to the Asqav cloud, which accepts `ml-dsa-44`, `ml-dsa-65` (default), and `ml-dsa-87`. `ed25519` and `es256` are for local keypair generation only (`asqav.generate_local_keypair("ed25519")`); passing them to `Agent.create(...)` returns a 400 from the cloud.
 
 ## Offline / air-gapped verification
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1475,9 +1475,10 @@ class Agent:
 
         Args:
             name: Human-readable name for the agent.
-            algorithm: Receipt-signing algorithm. One of `ml-dsa-65`
-                (FIPS 204; default), `ed25519`, or `es256` (ECDSA-P256).
-                The cloud also accepts `ml-dsa-44` and `ml-dsa-87`.
+            algorithm: Cloud agent-signing algorithm. The cloud accepts
+                `ml-dsa-44`, `ml-dsa-65` (FIPS 204; default), and
+                `ml-dsa-87`. `ed25519` and `es256` are local-keygen only
+                (see `generate_local_keypair`) and 400 here.
             capabilities: List of capabilities/permissions.
 
         Returns:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -20,32 +20,7 @@ import { init, Agent } from "@asqav/sdk";
 init({ apiKey: process.env.ASQAV_API_KEY });
 const agent = await Agent.create({ name: "my-agent" });
 
-const sig = await agent.sign({ actionType: "api:openai:chat", context: { model: "gpt-4o", tokens: 512 } });
-console.log(sig.verificationUrl);
-```
-
-No API key yet? `generateKeypair` runs entirely in-process with no network call and no signup:
-
-```ts
-import { generateKeypair } from "@asqav/sdk";
-
-const kp = generateKeypair("ed25519");
-console.log(kp.publicKeySpkiB64);  // SPKI DER public key, base64
-```
-
-### For high-value actions
-
-Pass compliance metadata for regulated or high-risk operations:
-
-```ts
-const sig = await agent.sign({
-  actionType: "payment.wire_transfer",
-  context: { amountEur: 850000, beneficiaryIban: "DE89370400440532013000" },
-  receiptType: "protectmcp:decision",
-  riskClass: "high",
-  issuerId: "legal:Acme GmbH",
-  iterationId: "task-2026-Q2-4821",
-});
+const sig = await agent.sign({ actionType: "api:openai:chat", context: { model: "gpt-4o" } });
 
 console.log(sig.complianceMode);        // true (default; pass complianceMode: false to opt out)
 console.log(sig.actionRef);             // "sha256:..." over the JCS-canonical action
@@ -53,7 +28,17 @@ console.log(sig.previousReceiptHash);   // 64 hex; "0".repeat(64) on the first r
 console.log(sig.verificationUrl);
 ```
 
-Each signed action lands on a Compliance Receipt under IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/) by default: ML-DSA-65 (FIPS 204) signature, chain hash, retained `policy_digest`, fail-closed anchoring, and a public verification URL. Pass `complianceMode: false` if you want a non-Compliance receipt.
+That's it. One install, one init, one sign call. The receipt lands on the Asqav cloud under [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 (FIPS 204) signature, chain hash, retained `policy_digest`, fail-closed anchoring, and a public verification URL.
+
+### No account? Offline path
+
+TypeScript does not ship a `local_sign` queue equivalent. For offline/air-gapped scenarios use the Python SDK's `local_sign` helper, or set `mode: "hash-only"` to minimize what leaves the process while still reaching the cloud:
+
+```ts
+await init({ apiKey: "...", baseUrl: "https://api.asqav.com", mode: "hash-only" });
+```
+
+Pass `complianceMode: false` on any `agent.sign(...)` call if you want a non-Compliance receipt.
 
 ## CLI
 
@@ -98,9 +83,20 @@ await init({ apiKey: "...", baseUrl: "https://api.asqav.com", mode: "hash-only" 
 
 The fingerprint format is sorted JSON with no whitespace per JCS, hashed with SHA-256. See `docs/fingerprint-spec.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
 
-## Compliance receipts: the IETF profile
+## Advanced / high-value actions
 
-Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 signature, JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `complianceMode: false` if you want the older shape.
+Once you have the basics working, you can pass compliance envelope fields for regulated or high-risk actions. The full parameter set is useful for things like large financial transfers, healthcare decisions, or anything that needs an auditor-facing trail.
+
+```ts
+const sig = await agent.sign({
+  actionType: "payment.wire_transfer",
+  context: { amountEur: 850000, beneficiaryIban: "DE89370400440532013000" },
+  receiptType: "protectmcp:decision",
+  riskClass: "high",
+  issuerId: "legal:Acme GmbH",
+  iterationId: "task-2026-Q2-4821",
+});
+```
 
 The envelope extensions most callers reach for, camelCase on the SDK and snake_case on the JSON wire:
 
@@ -110,6 +106,10 @@ The envelope extensions most callers reach for, camelCase on the SDK and snake_c
 - `sandboxState` -> `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
 - `incidentClass` -> `incident_class` - DORA / NYDFS / CIRCIA token, or an array of tokens.
 - `issuerId` -> `issuer_id` - LEI per ISO 17442, EIN, CIK, or a W3C DID for non-LEI deployers.
+
+## Compliance receipts: the IETF profile
+
+Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 signature, JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `complianceMode: false` if you want the older shape.
 
 ### Shadow AI capture with passive_telemetry
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -115,7 +115,7 @@ Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a 
 
 Two `receiptType` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action. `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block, such as a SIEM forwarder, a browser extension in observe-only mode, or a NetFlow-style proxy with no enforcement hook.
 
-Set `captureTopology: "passive_telemetry"` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `captureTopology: "passive_telemetry"` receipt MUST use `receiptType: "protectmcp:observation"`. Any other receiptType paired with `passive_telemetry`, namely `:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, or `:acknowledgment`, throws `AsqavError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation, not :<offending> (rule 8)` message before the HTTP roundtrip. The guard lives as `false_attestation_guard` in `typescript/src/index.ts`.
+Set `captureTopology: "passive_telemetry"` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `captureTopology: "passive_telemetry"` receipt MUST use `receiptType: "protectmcp:observation"`. Any other receiptType paired with `passive_telemetry`, namely `:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, or `:acknowledgment`, throws `AsqavError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation[:result_bound], not :<offending> (rule 8)` message before the HTTP roundtrip. The guard lives as `false_attestation_guard` in `typescript/src/index.ts`.
 
 ```ts
 const sig = await agent.sign({
@@ -191,7 +191,7 @@ import { Agent } from "@asqav/sdk";
 
 const agent = await Agent.create({ apiKey: process.env.ASQAV_API_KEY! });
 const receipt = await agent.sign({
-  action: "tool.invoke",
+  actionType: "tool.invoke",
   toolName: "exec_query",
   executableHash: "sha256:" + "a".repeat(64),
   sbomDigest: "sha256:" + "b".repeat(64),
@@ -268,7 +268,7 @@ console.log(bundle.records.length, bundle.bundleDigest);
 
 For offline chain verification, `verifyChain(records)` walks an ordered list of signed envelopes for one agent and re-derives each `previous_receipt_hash`. The first record's seed is `"0".repeat(64)`. The cloud is the authoritative verifier. This helper is a convenience.
 
-Algorithm agility is exposed via `SUPPORTED_ALGORITHMS`. Pass `algorithm: "ed25519"` or `"es256"` to `Agent.create(...)` for non-post-quantum identities, or `generateKeypair("ed25519")` for offline scenarios. ES256 signatures emit in IEEE-P1363 raw r||s form so they match the cloud verifier byte-for-byte.
+Algorithm agility is exposed via `SUPPORTED_ALGORITHMS`. `Agent.create(...)` sends the algorithm to the Asqav cloud, which accepts `ml-dsa-44`, `ml-dsa-65` (default), and `ml-dsa-87`. `ed25519` and `es256` are for local keypair generation only (`generateKeypair("ed25519")`); passing them to `Agent.create(...)` returns a 400 from the cloud. ES256 signatures emit in IEEE-P1363 raw r||s form so they match the cloud verifier byte-for-byte.
 
 ## Offline / air-gapped verification
 

--- a/typescript/src/algorithms.ts
+++ b/typescript/src/algorithms.ts
@@ -1,12 +1,10 @@
 /**
  * Algorithm agility for receipt signing.
  *
- * The cloud accepts `ml-dsa-65` (default), `ed25519`, and `es256` on the
- * receipt-signing path. ML-DSA always runs server-side because it is not
- * available in Node's standard `crypto` module. Ed25519 and ES256 are
- * available locally via `node:crypto`, so the SDK can generate keypairs
- * and produce signatures off-cloud (handy for `user_intent` envelopes
- * and offline test fixtures).
+ * The cloud accepts `ml-dsa-44`, `ml-dsa-65` (default), and `ml-dsa-87`
+ * on the `Agent.create` receipt-signing path. Ed25519 and ES256 are
+ * local-only via `node:crypto` - use `generateKeypair` for offline
+ * keypair generation and test fixtures, not for `Agent.create`.
  *
  * Public surface:
  *   SUPPORTED_ALGORITHMS   - the set the SDK accepts on `Agent.create`.

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1889,7 +1889,7 @@ export class Agent {
 
   static async create(options: AgentCreateOptions): Promise<Agent> {
     const algorithm = options.algorithm ?? "ml-dsa-65";
-    // Cloud accepts ml-dsa-{44,65,87}, ed25519, es256.
+    // Cloud accepts ml-dsa-{44,65,87}; ed25519/es256 are local-signing only.
     if (!isSupportedAlgorithm(algorithm)) {
       throw new AsqavError(
         `unsupported_algorithm: '${algorithm}'. Use one of: ${SUPPORTED_ALGORITHMS.join(", ")}`,


### PR DESCRIPTION
## What this changes

Both Python and TypeScript READMEs opened with an 850k EUR wire-transfer example carrying six compliance envelope params. A first-time reader hit that before seeing how to install the package or where to get an API key.

This reorders the Quick Start in both files:

- Install + API key preamble come first
- The minimal one-liner (`agent.sign("api:openai:chat", {"model": "gpt-4o"})`) is the first code example, matching the website docs
- The offline `local_sign` path (Python) and `mode: "hash-only"` note (TypeScript) surface near the top as no-account options
- The wire-transfer / 6-param compliance example moves into the existing "Advanced / high-value actions" section

This PR also fixes three confirmed doc issues found during review:

1. **Guard message quote**: both READMEs quoted the rule-8 verbatim message without the `[:result_bound]` fragment. Real message from `client.py:1877-1880` and `index.ts:1090`: `...observation[:result_bound], not :<offending> (rule 8)`.
2. **Algorithm vocab**: READMEs told users to pass `algorithm="ed25519"` or `"es256"` to `Agent.create(...)`, but the cloud `parse_algorithm` only accepts `ml-dsa-44/65/87`. Docs now clarify only `ml-dsa-*` reaches the cloud; `ed25519`/`es256` are for local keypair generation only (`generate_local_keypair` / `generateKeypair`). The `algorithms.ts` JSDoc and an inline comment in `index.ts` are corrected to match.
3. **actionType typo**: the build-provenance example in `typescript/README.md` passed `action:` but the real `SignOptions` field is `actionType:` (index.ts:347).

Note on README-ZH.md: the Chinese README has the same structure issue but is lower priority. Its Quick Start still leads with the wire-transfer example. A follow-up can port this reorder there.

## Proof of work

```
git -C /Users/jagmarques/asqav-repos/.company/worktrees/asqav-sdk/sdk-readme-reorder diff main --stat

 CHANGELOG.md                                       |   33 +
 docs/offline-verification.md                       |   94 +
 python/README.md                                   |   88 +-
 python/pyproject.toml                              |   35 +-
 python/src/asqav/__init__.py                       |   54 +-
 python/src/asqav/verifier/verify_receipt.py        |  146 +-
 python/tests/test_offline_verify.py                |  306 +++
 python/tests/test_oracle.py                        |    4 +-
 python/uv.lock                                     | 2616 +---
 typescript/README.md                               |   79 +-
 typescript/package-lock.json                       |  846 ++++++-
 typescript/package.json                            |    8 +-
 typescript/src/algorithms.ts                       |   10 +-
 typescript/src/index.ts                            |   42 +-
 typescript/src/userAgent.ts                        |    2 +-
 typescript/src/verifier/crypto.ts                  |   34 +-
 typescript/tests/offline-verify.test.ts            |  293 +++
 typescript/tests/verifier-parity.test.ts           |    6 +-
 verifier/conformance-vectors/manifest.json         |    7 +
 23 files changed, 2003 insertions(+), 2780 deletions(-)
```

Secret scan: `SCANNER: gitleaks - clean` (exit 0)

https://claude.ai/code/session_01BXVrMmGpFwevwQGHQeRRG9