### PR TITLE
fix(sdk): fail-closed preflight and offline key-revocation gate

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -746,6 +746,11 @@ class PreflightResult:
     If cleared is True the agent is allowed to proceed with the action.
     When cleared is False, reasons lists the blocking factors.
     The explanation field provides a human-readable summary of the result.
+
+    checks_complete is False when a status or policy fetch errored, so the
+    check could not run to a verdict. In that case cleared is also False, so
+    a transient error never reads as a pass. The caller decides whether to
+    proceed on an incomplete check.
     """
 
     cleared: bool
@@ -753,6 +758,7 @@ class PreflightResult:
     policy_allowed: bool
     reasons: list[str]
     explanation: str = ""
+    checks_complete: bool = True
 
 
 @dataclass
@@ -2578,8 +2584,11 @@ class Agent:
 
         Use before executing sensitive actions to catch issues early.
 
-        Fail-open: if any individual check errors out, the agent is not
-        blocked. A warning is added to reasons instead.
+        Fail-closed on error: if a status or policy fetch errors out, the
+        check could not complete, so cleared is False and checks_complete is
+        False. A transient outage never silently clears a revoked or blocked
+        agent. Inspect checks_complete to tell a real verdict from an
+        unfinished one.
 
         Args:
             action_type: The action to check (e.g., "data:read", "api:call").
@@ -2592,6 +2601,7 @@ class Agent:
         action_type = resolve_pattern(action_type)
         agent_active = True
         policy_allowed = True
+        checks_complete = True
         reasons: list[str] = []
 
         # Check agent status (revoked / suspended).
@@ -2604,7 +2614,8 @@ class Agent:
                 agent_active = False
                 reasons.append("agent is suspended")
         except Exception as exc:
-            reasons.append(f"status check failed ({exc}) - skipped")
+            checks_complete = False
+            reasons.append(f"status check failed ({exc}) - could not verify")
 
         # Check organization policies.
         try:
@@ -2618,13 +2629,17 @@ class Agent:
                         policy_allowed = False
                         reasons.append(f"blocked by policy: {p.get('name', 'unknown')}")
         except Exception as exc:
-            reasons.append(f"policy check failed ({exc}) - skipped")
+            checks_complete = False
+            reasons.append(f"policy check failed ({exc}) - could not verify")
 
-        cleared = agent_active and policy_allowed
+        # A failed fetch leaves the verdict unknown, so do not clear on it.
+        cleared = agent_active and policy_allowed and checks_complete
 
         # Build human-readable explanation from check results.
         if cleared:
             explanation = "Allowed: agent is active and action is permitted by policy"
+        elif not checks_complete:
+            explanation = "Blocked: could not verify (" + "; ".join(reasons) + ")"
         elif not agent_active and "agent is revoked" in reasons:
             explanation = "Blocked: agent has been revoked"
         elif not agent_active and "agent is suspended" in reasons:
@@ -2645,6 +2660,7 @@ class Agent:
             policy_allowed=policy_allowed,
             reasons=reasons,
             explanation=explanation,
+            checks_complete=checks_complete,
         )
 
     def get_certificate(self) -> CertificateResponse:

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -160,3 +160,23 @@ class AsqavNativeAdapter(FormatAdapter):
                 return "FAIL", f"hash-mode receipt missing fields: {','.join(missing)}"
             return "PASS", "hash-mode signature receipt; required flat fields present"
         return _vr.check_structure(_payload(doc))
+
+    def extra_axes(self, doc: dict, key_provider: Any) -> list[tuple[str, str, str]]:
+        """Gate the verdict on the signing key's revocation status.
+
+        A receipt signed by a revoked key must not PASS offline, matching the
+        hosted /verify. No key resolved means the signature axis already FAILs,
+        so this axis only weighs in once a key is found.
+        """
+        jwks = key_provider or {"keys": []}
+        kid = self.extract_signature(doc).kid
+        pk, status, _alg = _vr.resolve_key(jwks, kid)
+        if pk is None:
+            return []
+        if _is_hash_mode(doc):
+            issued_at = doc.get("server_timestamp", "")
+        else:
+            issued_at = _payload(doc).get("issued_at", "")
+        revoked_at = _vr.resolve_revoked_at(jwks, kid)
+        res, note = _vr.check_key_status(status, issued_at, revoked_at)
+        return [("key_status", res, note)]

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -197,6 +197,48 @@ def resolve_key(jwks: dict, kid: str):
     return None, None, None
 
 
+def resolve_revoked_at(jwks: dict, kid: str):
+    """Return the JWKS revoked_at for kid if published, else None.
+
+    Optional field: the public JWKS publishes status today but not the
+    timestamp, so the key-status axis falls back to a bare status gate.
+    """
+    for k in jwks.get("keys", []):
+        if kid and kid in (k.get("issuer_id"), k.get("kid")):
+            return k.get("revoked_at")
+    return None
+
+
+#: Key statuses that revoke trust in the signing key for attestation.
+REVOKED_KEY_STATUSES = {"revoked", "suspended", "compromised"}
+
+
+def check_key_status(status, issued_at: str, revoked_at=None):
+    """Gate the verdict on the signing key's published status.
+
+    The public JWKS marks a key revoked once its agent is revoked. A receipt
+    signed by such a key must not PASS offline, mirroring the hosted /verify.
+
+    When the JWKS carries a precise revoked_at, prefer the at-or-before-issuance
+    check so a receipt signed BEFORE revocation still PASSes (historical verify).
+    The JWKS today publishes status only, so without revoked_at any revoked key
+    fails the axis.
+    """
+    s = (status or "").lower()
+    if s not in REVOKED_KEY_STATUSES:
+        return "PASS", f"signing key status {status!r} is active"
+    if revoked_at:
+        try:
+            rev = datetime.fromisoformat(str(revoked_at).replace("Z", "+00:00"))
+            iss = datetime.fromisoformat(str(issued_at).replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            return "FAIL", f"signing key status {status!r}; unparseable revoked_at/issued_at"
+        if rev <= iss:
+            return "FAIL", f"signing key revoked at {revoked_at} on/before issuance {issued_at}"
+        return "PASS", f"signing key revoked at {revoked_at}, after issuance {issued_at}"
+    return "FAIL", f"signing key status {status!r}; receipt cannot be trusted"
+
+
 def verify_signature(pk: bytes, msg: bytes, sig: bytes, alg: str):
     """ML-DSA-65 verify. Returns (result, note); result in PASS/FAIL/SKIPPED."""
     if (alg or "").upper() != "ML-DSA-65":
@@ -302,6 +344,10 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
         results.append(("signature", "SKIPPED", "no issuer key to verify against"))
     else:
         results.append(("issuer_key", "PASS", f"resolved kid {kid} (status={status})"))
+        revoked_at = resolve_revoked_at(jwks, kid)
+        results.append(
+            ("key_status", *check_key_status(status, payload.get("issued_at", ""), revoked_at))
+        )
         sig = _b64decode(sig_obj.get("sig", ""))
         results.append(("signature", *verify_signature(pk, msg, sig, alg or jwks_alg)))
 

--- a/python/tests/test_preflight_fail_closed.py
+++ b/python/tests/test_preflight_fail_closed.py
@@ -1,0 +1,112 @@
+"""Preflight does not silently clear when a check cannot complete.
+
+A transient status/policy fetch error must not leave the agent cleared. The
+result reports checks_complete=False and cleared=False so a network blip never
+reads as a pass for a revoked or policy-blocked agent.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import Agent, PreflightResult
+
+MOCK_AGENT_DATA = {
+    "agent_id": "agent_test123",
+    "name": "test-agent",
+    "public_key": "pk_test123",
+    "key_id": "key_test123",
+    "algorithm": "ml-dsa-65",
+    "capabilities": [],
+    "created_at": 1700000000.0,
+}
+
+
+def test_checks_complete_defaults_true():
+    """checks_complete defaults to True so existing constructions stay valid."""
+    result = PreflightResult(
+        cleared=True,
+        agent_active=True,
+        policy_allowed=True,
+        reasons=[],
+    )
+    assert result.checks_complete is True
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_status_fetch_error_does_not_clear(mock_post, mock_get):
+    """A status fetch error blocks rather than silently clearing the agent."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+
+    # Status fetch raises (transient), policies return empty.
+    mock_get.side_effect = [
+        ConnectionError("network down"),  # status check
+        [],  # policies check
+    ]
+
+    result = agent.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is False
+    assert "could not verify" in result.explanation.lower()
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_policy_fetch_error_does_not_clear(mock_post, mock_get):
+    """A policy fetch error blocks rather than silently clearing the agent."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+
+    mock_get.side_effect = [
+        {"revoked": False, "suspended": False},  # status check
+        ConnectionError("network down"),  # policies check
+    ]
+
+    result = agent.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is False
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_happy_path_still_clears(mock_post, mock_get):
+    """An active agent with no blocking policy still clears, checks_complete True."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+
+    mock_get.side_effect = [
+        {"revoked": False, "suspended": False},  # status check
+        [],  # policies check
+    ]
+
+    result = agent.preflight("llm:call")
+    assert result.cleared is True
+    assert result.checks_complete is True
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_revoked_agent_is_a_real_verdict(mock_post, mock_get):
+    """A revoked agent blocks with checks_complete True, distinct from an error."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+
+    mock_get.side_effect = [
+        {"revoked": True, "suspended": False},  # status check
+        [],  # policies check
+    ]
+
+    result = agent.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is True
+    assert "revoked" in result.explanation.lower()

--- a/python/tests/test_verify_receipt_revoked_key.py
+++ b/python/tests/test_verify_receipt_revoked_key.py
@@ -1,0 +1,122 @@
+"""Offline verifier gates the verdict on the signing key's revocation status.
+
+A receipt signed by a key the JWKS marks revoked must not PASS offline, matching
+the hosted /verify. The public JWKS publishes status today (no revoked_at), so a
+revoked key fails the key_status axis and the verdict is FAIL, not PASS.
+"""
+
+from __future__ import annotations
+
+from asqav.verifier import verify_receipt as v
+from asqav.verifier.oracle.adapters.asqav_native import AsqavNativeAdapter
+
+
+def _payload() -> dict:
+    return {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-06-01T19:26:44.289388Z",
+        "issuer_id": "agent-revoked-001",
+        "action_ref": "sha256:" + "8" * 64,
+        "payload_digest": {"hash": "8" * 64, "size": 512},
+        "policy_digest": "sha256:" + "3" * 64,
+        "previousReceiptHash": "0" * 64,
+        "decision": "allow",
+    }
+
+
+def _jwks(status: str, revoked_at=None) -> dict:
+    key = {
+        "kid": "agent-revoked-001",
+        "issuer_id": "agent-revoked-001",
+        "alg": "ML-DSA-65",
+        "public_key": "QUFBQQ==",  # base64 placeholder, never reached for revoked key gate
+        "status": status,
+    }
+    if revoked_at is not None:
+        key["revoked_at"] = revoked_at
+    return {"keys": [key]}
+
+
+# --- unit: the key-status axis ---
+
+
+def test_check_key_status_active_passes():
+    res, _ = v.check_key_status("active", "2026-06-01T00:00:00Z")
+    assert res == "PASS"
+
+
+def test_check_key_status_revoked_fails_without_revoked_at():
+    res, note = v.check_key_status("revoked", "2026-06-01T00:00:00Z")
+    assert res == "FAIL"
+    assert "revoked" in note.lower()
+
+
+def test_check_key_status_revoked_before_issuance_fails():
+    res, _ = v.check_key_status(
+        "revoked", "2026-06-01T00:00:00Z", revoked_at="2026-05-01T00:00:00Z"
+    )
+    assert res == "FAIL"
+
+
+def test_check_key_status_revoked_after_issuance_passes():
+    """A receipt signed before the key was revoked still verifies (historical)."""
+    res, _ = v.check_key_status(
+        "revoked", "2026-05-01T00:00:00Z", revoked_at="2026-06-01T00:00:00Z"
+    )
+    assert res == "PASS"
+
+
+# --- standalone verify_receipt.run ---
+
+
+def test_run_revoked_key_does_not_pass(capsys):
+    """A revoked-key receipt yields a FAIL verdict, never PASS, from run()."""
+    envelope = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    code = v.run(envelope, _jwks("revoked"), None)
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+    assert "key_status" in out
+    assert code == 1  # FAIL dominates; never 0 (PASS)
+
+
+def test_run_active_key_has_key_status_pass(capsys):
+    """An active key contributes a key_status PASS line."""
+    envelope = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    v.run(envelope, _jwks("active"), None)
+    out = capsys.readouterr().out
+    assert "key_status" in out
+    assert "active" in out
+
+
+# --- oracle adapter path ---
+
+
+def test_oracle_revoked_key_axis_fails():
+    """The asqav-native adapter surfaces a failing key_status axis for a revoked key."""
+    doc = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    ad = AsqavNativeAdapter()
+    axes = ad.extra_axes(doc, _jwks("revoked"))
+    assert ("key_status", "FAIL", axes[0][2]) == axes[0]
+
+
+def test_oracle_active_key_axis_passes():
+    doc = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    ad = AsqavNativeAdapter()
+    axes = ad.extra_axes(doc, _jwks("active"))
+    assert axes[0][1] == "PASS"


### PR DESCRIPTION
Two correctness fixes in the Python SDK. Python files only, no README or TypeScript touched.

## FIX 1: preflight fails closed on a fetch error

`Agent.preflight()` started `agent_active` and `policy_allowed` at True and left them there when the status or policy fetch raised. So `cleared` came back True on any fetch error and a revoked or policy-blocked agent was cleared by a network blip.

Now a fetch error sets a new `checks_complete=False` and forces `cleared=False`. The caller can tell an unfinished check from a real verdict instead of reading a skipped check as a pass. A definitive negative (revoked, suspended, blocked) keeps `checks_complete=True` with `cleared=False`. The happy path is unchanged. `checks_complete` defaults to True on the dataclass so existing `PreflightResult(...)` constructions stay valid.

## FIX 2: offline verifier gates on key revocation

The standalone `verify_receipt.run` and the asqav-native oracle adapter resolved the signing key's `status` from the JWKS but never gated on it, so a receipt signed by a revoked key PASSed offline while the hosted /verify caught it. Added a `key_status` axis that FAILs when the JWKS marks the key revoked.

The public JWKS publishes `status` but no `revoked_at` today (confirmed live: 101 keys, 7 revoked, fields are kid/agent_id/issuer_id/alg/public_key/status). So the gate is on status. When a `revoked_at` is present the axis uses the at-or-before-issuance check, so a receipt signed before revocation still verifies (historical-verify intent preserved).

## FIX 3 (kid_mismatch): not applicable to the SDK

The kid_mismatch advisory (`expect_ack_from` returning verified=True on mismatch) lives only in the cloud `verify.py`. Grep of the SDK offline verifier finds no `expect_ack_from` / `kid_mismatch` / `counterparty_binding`, so there is nothing to fix here. Flagged for a separate cloud PR.

## Proof of work

VERIFY-WITH, new tests against the unfixed main tree (copied in, run, removed):

```
=== running new tests against MAIN (unfixed) ===
22efbbf4cc32aa7eed68467db3996d9d953eb776
13 failed in 5.05s
```

Same tests on this branch:

```
$ python3 -m pytest tests/test_preflight_fail_closed.py tests/test_verify_receipt_revoked_key.py -q -p no:asqav
.............                                                            [100%]
13 passed in 1.42s
```

Related suites on this branch, no regression:

```
$ python3 -m pytest tests/test_explanations.py tests/test_verify_receipt.py tests/test_oracle.py tests/test_guardrail_provider.py tests/test_phases.py tests/test_conformance_vectors.py tests/test_preflight_fail_closed.py tests/test_verify_receipt_revoked_key.py -q -p no:asqav
122 passed in 8.60s
```

ruff:

```
$ python3 -m ruff check src/asqav/client.py src/asqav/verifier/verify_receipt.py src/asqav/verifier/oracle/adapters/asqav_native.py tests/test_preflight_fail_closed.py tests/test_verify_receipt_revoked_key.py
All checks passed!
```

diff stat:

```
 python/src/asqav/client.py                         |  26 ++++-
 .../asqav/verifier/oracle/adapters/asqav_native.py |  20 ++++
 python/src/asqav/verifier/verify_receipt.py        |  46 ++++++++
 python/tests/test_preflight_fail_closed.py         | 112 +++++++++++++++++++
 python/tests/test_verify_receipt_revoked_key.py    | 122 +++++++++++++++++++++
 5 files changed, 321 insertions(+), 5 deletions(-)
```

CI: will populate on this PR.

https://claude.ai/code/session_01BXVrMmGpFwevwQGHQeRRG9