### PR TITLE
fix(verifier): add key_status gate to run_structured

### DIFF
--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -384,7 +384,8 @@ def run_structured(
     """Verify a receipt offline and return a structured result dict.
 
     Same logic as ``run()`` but returns a dict instead of printing and exiting.
-    Used by ``verify_receipt_offline()`` in the public SDK API.
+    Callable directly from the verifier module; the public SDK uses the oracle
+    adapter path for multi-format support.
 
     Returns:
         dict with keys:
@@ -457,6 +458,11 @@ def run_structured(
                 "note": f"resolved kid {kid} (status={status})",
             }
         )
+        revoked_at = resolve_revoked_at(jwks, kid)
+        ks_r, ks_n = check_key_status(
+            status, payload.get("issued_at", ""), revoked_at
+        )
+        axes.append({"name": "key_status", "result": ks_r, "note": ks_n})
         sig_bytes = _b64decode(sig_obj.get("sig", ""))
         sig_r, sig_n = verify_signature(pk, msg, sig_bytes, alg or jwks_alg)
         axes.append({"name": "signature", "result": sig_r, "note": sig_n})

--- a/python/tests/test_verify_receipt_revoked_key.py
+++ b/python/tests/test_verify_receipt_revoked_key.py
@@ -96,6 +96,51 @@ def test_run_active_key_has_key_status_pass(capsys):
     assert "active" in out
 
 
+# --- run_structured path ---
+
+
+def test_run_structured_revoked_key_has_key_status_fail_axis():
+    """run_structured must include a key_status FAIL axis for a revoked key."""
+    envelope = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    result = v.run_structured(envelope, _jwks("revoked"), None)
+    names = [a["name"] for a in result["axes"]]
+    assert "key_status" in names, f"key_status axis missing; got axes: {names}"
+    ks = next(a for a in result["axes"] if a["name"] == "key_status")
+    assert ks["result"] == "FAIL", f"expected FAIL, got {ks['result']!r}"
+
+
+def test_run_structured_active_key_has_key_status_pass_axis():
+    """run_structured includes a key_status PASS axis for an active key."""
+    envelope = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    result = v.run_structured(envelope, _jwks("active"), None)
+    names = [a["name"] for a in result["axes"]]
+    assert "key_status" in names, f"key_status axis missing; got axes: {names}"
+    ks = next(a for a in result["axes"] if a["name"] == "key_status")
+    assert ks["result"] == "PASS", f"expected PASS, got {ks['result']!r}"
+
+
+def test_run_structured_revoked_at_after_issuance_passes_key_status():
+    """Key revoked after issuance: key_status PASS (historical verify ok)."""
+    envelope = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    result = v.run_structured(
+        envelope, _jwks("revoked", revoked_at="2026-07-01T00:00:00Z"), None
+    )
+    ks = next(a for a in result["axes"] if a["name"] == "key_status")
+    assert ks["result"] == "PASS"
+
+
 # --- oracle adapter path ---
 
 


### PR DESCRIPTION
## What this changes

PR #321 added a key_status revocation axis to the offline verifier run() path and the oracle adapter. The sibling run_structured() function lacked the same gate, so it returned PASS for a receipt signed by a revoked key. This adds the gate to run_structured() so a revoked-key receipt yields FAIL, consistent with run() and the oracle path.

## Changes
- run_structured(): apply resolve_revoked_at + check_key_status (identical to run()), so a revoked key FAILs, an active key PASSes, and a key revoked after issuance keeps historical PASS.
- Corrected the run_structured docstring (it claimed to back verify_receipt_offline, which routes through the oracle adapter).
- Tests: three cases for the run_structured path (revoked key, active key, revoked-after-issuance). They fail against the base commit and pass with this change.

No public SDK entry point routed through run_structured, so this closes a latent consistency gap between the two offline paths.