### PR TITLE
fix(sdk): fail-closed AsyncAgent.preflight on status/policy fetch errors

### DIFF
--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -293,9 +293,17 @@ class AsyncAgent:
         )
 
     async def preflight(self, action_type: str) -> PreflightResult:
-        """Pre-flight check (async): revocation + suspension + policy; fail-open on errors."""
+        """Pre-flight check (async): revocation + suspension + policy status.
+
+        Fail-closed on error: if a status or policy fetch errors out, the
+        check could not complete, so cleared is False and checks_complete is
+        False. A transient outage never silently clears a revoked or blocked
+        agent. Inspect checks_complete to tell a real verdict from an
+        unfinished one. Mirrors the sync Agent.preflight semantics.
+        """
         agent_active = True
         policy_allowed = True
+        checks_complete = True
         reasons: list[str] = []
 
         # Check agent status (revoked / suspended).
@@ -308,7 +316,8 @@ class AsyncAgent:
                 agent_active = False
                 reasons.append("agent is suspended")
         except Exception as exc:
-            reasons.append(f"status check failed ({exc}) - skipped")
+            checks_complete = False
+            reasons.append(f"status check failed ({exc}) - could not verify")
 
         # Check organization policies.
         try:
@@ -322,14 +331,38 @@ class AsyncAgent:
                         policy_allowed = False
                         reasons.append(f"blocked by policy: {p.get('name', 'unknown')}")
         except Exception as exc:
-            reasons.append(f"policy check failed ({exc}) - skipped")
+            checks_complete = False
+            reasons.append(f"policy check failed ({exc}) - could not verify")
 
-        cleared = agent_active and policy_allowed
+        # A failed fetch leaves the verdict unknown, so do not clear on it.
+        cleared = agent_active and policy_allowed and checks_complete
+
+        # Build human-readable explanation from check results.
+        if cleared:
+            explanation = "Allowed: agent is active and action is permitted by policy"
+        elif not checks_complete:
+            explanation = "Blocked: could not verify (" + "; ".join(reasons) + ")"
+        elif not agent_active and "agent is revoked" in reasons:
+            explanation = "Blocked: agent has been revoked"
+        elif not agent_active and "agent is suspended" in reasons:
+            suspend_reason = ""
+            for r in reasons:
+                if r.startswith("agent is suspended"):
+                    suspend_reason = r
+                    break
+            explanation = f"Blocked: agent is suspended ({suspend_reason})"
+        elif not policy_allowed:
+            explanation = "Blocked: action not permitted by current policy rules"
+        else:
+            explanation = "Blocked: " + "; ".join(reasons) if reasons else "Blocked"
+
         return PreflightResult(
             cleared=cleared,
             agent_active=agent_active,
             policy_allowed=policy_allowed,
             reasons=reasons,
+            explanation=explanation,
+            checks_complete=checks_complete,
         )
 
     async def verify(self, signature_id: str) -> VerificationResponse:

--- a/python/tests/test_async_preflight_fail_closed.py
+++ b/python/tests/test_async_preflight_fail_closed.py
@@ -1,0 +1,87 @@
+"""AsyncAgent.preflight does not silently clear when a check cannot complete.
+
+Mirrors the sync test_preflight_fail_closed guarantees for the async client. A
+transient status/policy fetch error must not leave the agent cleared. The result
+reports checks_complete=False and cleared=False so a network blip never reads as
+a pass for a revoked or policy-blocked agent.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.async_client import AsyncAgent
+
+AGENT = AsyncAgent(
+    agent_id="agent_test123",
+    name="test-agent",
+    public_key="pk_test123",
+    key_id="key_test123",
+    algorithm="ml-dsa-65",
+    capabilities=[],
+    created_at=1700000000.0,
+)
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_status_fetch_error_does_not_clear(mock_get: AsyncMock) -> None:
+    """A status fetch error blocks rather than silently clearing the agent."""
+    mock_get.side_effect = [
+        ConnectionError("network down"),  # status check
+        [],  # policies check
+    ]
+
+    result = await AGENT.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is False
+    assert "could not verify" in result.explanation.lower()
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_policy_fetch_error_does_not_clear(mock_get: AsyncMock) -> None:
+    """A policy fetch error blocks rather than silently clearing the agent."""
+    mock_get.side_effect = [
+        {"revoked": False, "suspended": False},  # status check
+        ConnectionError("network down"),  # policies check
+    ]
+
+    result = await AGENT.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is False
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_happy_path_still_clears(mock_get: AsyncMock) -> None:
+    """An active agent with no blocking policy clears, checks_complete True."""
+    mock_get.side_effect = [
+        {"revoked": False, "suspended": False},  # status check
+        [],  # policies check
+    ]
+
+    result = await AGENT.preflight("llm:call")
+    assert result.cleared is True
+    assert result.checks_complete is True
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_revoked_agent_is_a_real_verdict(mock_get: AsyncMock) -> None:
+    """A revoked agent blocks with checks_complete True, distinct from an error."""
+    mock_get.side_effect = [
+        {"revoked": True, "suspended": False},  # status check
+        [],  # policies check
+    ]
+
+    result = await AGENT.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is True
+    assert "revoked" in result.explanation.lower()


### PR DESCRIPTION
## What

`AsyncAgent.preflight` now fails closed on a transient status or policy fetch error, matching the sync `Agent.preflight` shipped in #321.

The async sibling was left out of #321. On a fetch exception it computed `cleared = agent_active and policy_allowed` and left `checks_complete` at its default `True`, while its docstring promised fail-open. A caller following the documented pattern (`if r.checks_complete and r.cleared: proceed`) would proceed on a revoked or policy-blocked agent during any API blip. `AsyncAgent` is public (exported in `__all__`), so this was a reachable fail-open security gap.

## Change

- On a status or policy fetch error, set `checks_complete=False` and `cleared=False` so an unfinished check never reads as a pass.
- Keep the happy path and the real revoked/blocked path identical to the sync version, including the explanation builder and reason strings.
- Update the async docstring to state the fail-closed contract.
- Add `test_async_preflight_fail_closed.py` covering status-error, policy-error, happy-path, and revoked-verdict cases.

## Scope check

Grep across the SDK found exactly two `PreflightResult(...)` construction sites: the sync one (already fail-closed via #321) and this async one. The remaining `fail-open` mentions are all in the signing and observability adapters (`hooks.py`, `extras/*`), which are intentionally non-blocking and are not authorization gates. The verifier oracle and offline-verify paths already downgrade unchecked axes to INCOMPLETE rather than PASS, and `async_client.py` has no offline-verify sibling. No other fail-open authorization surface found.

## Proof of work

VERIFY-WITH: the async test failing against main, then passing on the branch.

Against the main `async_client.py` (the fail-open code):

```
3 failed, 1 passed in 0.21s
FAILED tests/test_async_preflight_fail_closed.py::test_status_fetch_error_does_not_clear
FAILED tests/test_async_preflight_fail_closed.py::test_policy_fetch_error_does_not_clear
FAILED tests/test_async_preflight_fail_closed.py::test_revoked_agent_is_a_real_verdict
```

The failing assertion shows the gap: `PreflightResult(cleared=True, ..., checks_complete=True)` on a forced `ConnectionError`.

On this branch:

```
4 passed in 0.08s
```

Related suites stay green (sync preflight + async retry):

```
19 passed in 0.27s
```

Diff stat:

```
 python/src/asqav/async_client.py                 | 41 +++++++++--
 python/tests/test_async_preflight_fail_closed.py | 87 ++++++++++++++++++++++++
 2 files changed, 124 insertions(+), 4 deletions(-)
```

https://claude.ai/code/session_01BXVrMmGpFwevwQGHQeRRG9
