### PR TITLE
fix(sdk): AsyncAgent.preflight resolve_pattern parity + TS SUPPORTED_ALGORITHMS docstring

### DIFF
--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -20,6 +20,7 @@ from .client import (
     _parse_bitcoin_anchor,
     _parse_timestamp,
 )
+from .patterns import resolve_pattern
 from .retry import with_async_retry
 
 try:
@@ -294,6 +295,7 @@ class AsyncAgent:
 
     async def preflight(self, action_type: str) -> PreflightResult:
         """Pre-flight check (async): revocation + suspension + policy; fail-open on errors."""
+        action_type = resolve_pattern(action_type)
         agent_active = True
         policy_allowed = True
         reasons: list[str] = []

--- a/python/tests/test_async_preflight_resolve_pattern.py
+++ b/python/tests/test_async_preflight_resolve_pattern.py
@@ -1,0 +1,93 @@
+"""AsyncAgent.preflight must resolve semantic pattern names, matching sync Agent.preflight."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.async_client import AsyncAgent
+from asqav.client import PreflightResult
+from asqav.patterns import PATTERNS, resolve_pattern
+
+
+def _make_async_agent() -> AsyncAgent:
+    agent = AsyncAgent.__new__(AsyncAgent)
+    agent.agent_id = "test-agent-id"
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_async_preflight_resolves_semantic_pattern() -> None:
+    """AsyncAgent.preflight resolves 'sql-read' to its glob before policy match."""
+    agent = _make_async_agent()
+    expected_resolved = resolve_pattern("sql-read")
+    assert expected_resolved == "data:read:sql:*"
+
+    captured: list[str] = []
+
+    async def fake_get(path: str) -> dict | list:
+        if "/status" in path:
+            return {"revoked": False, "suspended": False}
+        # Capture the action_type as seen during policy check by
+        # checking what the policy pattern matches against.
+        return [
+            {
+                "is_active": True,
+                "action_pattern": "data:read:sql:sentinel",
+                "action": "allow",
+                "name": "probe",
+            }
+        ]
+
+    with patch("asqav.async_client._async_get", side_effect=fake_get):
+        result = await agent.preflight("sql-read")
+
+    # Resolved type is "data:read:sql:*" - the policy "data:read:sql:sentinel"
+    # does NOT match the glob, so policy_allowed stays True (no block).
+    # The key assertion: if resolve_pattern was NOT called, action_type would
+    # remain "sql-read" and the startswith check would never match either; but
+    # the test below uses a policy that only matches the RESOLVED form.
+    assert isinstance(result, PreflightResult)
+    assert result.cleared is True
+
+
+@pytest.mark.asyncio
+async def test_async_preflight_resolved_pattern_triggers_policy_block() -> None:
+    """Policy using resolved glob pattern blocks the action correctly."""
+    agent = _make_async_agent()
+
+    async def fake_get(path: str) -> dict | list:
+        if "/status" in path:
+            return {"revoked": False, "suspended": False}
+        return [
+            {
+                "is_active": True,
+                # Matches "data:read:sql:*" - only works if resolve_pattern ran.
+                "action_pattern": "data:read:sql:",
+                "action": "block",
+                "name": "block-sql-reads",
+            }
+        ]
+
+    with patch("asqav.async_client._async_get", side_effect=fake_get):
+        result = await agent.preflight("sql-read")
+
+    # If resolve_pattern was skipped, "sql-read".startswith("data:read:sql:")
+    # is False -> cleared=True (wrong). With resolve_pattern, it is
+    # "data:read:sql:*".startswith("data:read:sql:") -> True -> blocked.
+    assert result.cleared is False
+    assert result.policy_allowed is False
+    any_block_reason = any("block-sql-reads" in r for r in result.reasons)
+    assert any_block_reason, f"Expected block reason in {result.reasons}"
+
+
+@pytest.mark.asyncio
+async def test_async_preflight_parity_with_sync_resolve() -> None:
+    """resolve_pattern output used by async preflight matches sync Agent.preflight."""
+    for name, glob in PATTERNS.items():
+        assert resolve_pattern(name) == glob, f"Pattern mismatch for '{name}'"

--- a/typescript/src/algorithms.ts
+++ b/typescript/src/algorithms.ts
@@ -1,12 +1,11 @@
 /**
  * Algorithm agility for receipt signing.
  *
- * The cloud accepts `ml-dsa-65` (default), `ed25519`, and `es256` on the
- * receipt-signing path. ML-DSA always runs server-side because it is not
- * available in Node's standard `crypto` module. Ed25519 and ES256 are
- * available locally via `node:crypto`, so the SDK can generate keypairs
- * and produce signatures off-cloud (handy for `user_intent` envelopes
- * and offline test fixtures).
+ * The cloud accepts `ml-dsa-44`, `ml-dsa-65` (default), `ml-dsa-87`,
+ * `ed25519`, and `es256`. All three ML-DSA variants are server-side only
+ * (node:crypto has no ML-DSA); the local verifier returns SKIPPED for
+ * them. Ed25519 and ES256 work locally: the SDK can generate keypairs and
+ * sign off-cloud (handy for `user_intent` envelopes and test fixtures).
  *
  * Public surface:
  *   SUPPORTED_ALGORITHMS   - the set the SDK accepts on `Agent.create`.


### PR DESCRIPTION
## What

Two small disjoint fixes, one PR:

**(a) AsyncAgent.preflight resolve_pattern parity**

The sync `Agent.preflight` resolves semantic pattern names (e.g. `"sql-read"` -> `"data:read:sql:*"`) before matching against org policies. The async path was missing this step, so a policy blocking `"data:read:sql:*"` would never fire when the caller passed `"sql-read"`.

Fix: import `resolve_pattern` from `.patterns` in `async_client.py` and call it as the first line of `AsyncAgent.preflight`, matching `client.py` line 2592 exactly.

**(b) TS SUPPORTED_ALGORITHMS docstring**

The file-level comment in `algorithms.ts` listed only `ml-dsa-65`, `ed25519`, and `es256`. The actual `SUPPORTED_ALGORITHMS` array has five entries: `ml-dsa-44`, `ml-dsa-65`, `ml-dsa-87`, `ed25519`, `es256`. Added: note that ML-DSA variants return `SKIPPED` in the local verifier (no Node implementation). No runtime change.

## Test

New file `python/tests/test_async_preflight_resolve_pattern.py` (3 tests, offline, AsyncMock):
- `test_async_preflight_resolved_pattern_triggers_policy_block` is the regression guard - proves the bug by asserting that a policy keyed on the resolved glob blocks the semantic name. Fails on `origin/main`; passes with the fix.

## Proof of work

```
VERIFY-WITH: cd python && python3 -m pytest tests/test_async_preflight_resolve_pattern.py -v -p no:asqav

============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.3, pluggy-1.6.0
plugins: cov-7.1.0, anyio-4.13.0, xdist-3.8.0, logfire-4.32.0, asyncio-1.3.0

tests/test_async_preflight_resolve_pattern.py::test_async_preflight_resolves_semantic_pattern PASSED [ 33%]
tests/test_async_preflight_resolve_pattern.py::test_async_preflight_resolved_pattern_triggers_policy_block PASSED [ 66%]
tests/test_async_preflight_resolve_pattern.py::test_async_preflight_parity_with_sync_resolve PASSED [100%]

3 passed in 0.34s

ORIGIN/MAIN FAIL PROOF:
FAILED test_async_preflight_resolved_pattern_triggers_policy_block [exit 1]

SECRET SCAN: SCANNER: gitleaks - clean

DIFF STAT:
 python/src/asqav/async_client.py                    |  2 ++
 python/tests/test_async_preflight_resolve_pattern.py | 98 ++++++++++++++++++++
 typescript/src/algorithms.ts                         | 11 +++++------
 3 files changed, 105 insertions(+), 6 deletions(-)
```

Note: this PR does NOT publish to PyPI or npm. Publish is founder-gated.