### PR TITLE
chore(sdk): drop asqav-mcp config gen, add hook discoverability, bump 0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ Both SDKs cover the same core surface: agent identity, signed actions, batched s
 
 The Python SDK additionally ships:
 
-- The `asqav` CLI: `quickstart`, `demo`, `verify`, `doctor`, `agents`, `sync`, plus `replay`, `preflight`, `approve`, `budget` with `check` and `record`, and `compliance` with `frameworks` and `export`. See [asqav.com/docs/cli](https://asqav.com/docs/cli).
+- The `asqav` CLI: `quickstart`, `demo`, `verify`, `doctor`, `agents`, `sync`, `hook`, plus `replay`, `preflight`, `approve`, `budget` with `check` and `record`, and `compliance` with `frameworks` and `export`. See [asqav.com/docs/cli](https://asqav.com/docs/cli).
+- The `asqav hook` CLI signs Claude Code harness hook events for audit and gating. See [`hooks/README.md`](hooks/README.md).
 - A pytest plugin, enabled with `pytest --asqav`, that signs every test result and emits a Merkle-rooted compliance bundle on session finish. See [asqav.com/docs/pytest-plugin](https://asqav.com/docs/pytest-plugin).
 - Native callbacks for LangChain, CrewAI, LiteLLM, Haystack, OpenAI Agents SDK, LlamaIndex, smolagents, DSPy, PydanticAI, Letta, Strands, and Instructor through the Hooks API.
 - Cookbooks for Streamlit dashboards and Dify workflows under `python/examples/`.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.6.0"
+version = "0.6.1"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -148,7 +148,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -911,19 +911,12 @@ def quickstart() -> None:
             )
         )
 
-    typer.echo("\n--- MCP config (.mcp.json) ---\n")
+    typer.echo("\n--- Claude Code hook ---\n")
     typer.echo(
-        '{\n'
-        '  "mcpServers": {\n'
-        '    "asqav": {\n'
-        '      "command": "uvx",\n'
-        '      "args": ["asqav-mcp"],\n'
-        '      "env": {\n'
-        '        "ASQAV_API_KEY": "<your-key>"\n'
-        '      }\n'
-        '    }\n'
-        '  }\n'
-        '}'
+        "Sign harness hook events with the asqav hook CLI:\n"
+        "  asqav hook posttool   # audit tool calls\n"
+        "  asqav hook pretool    # gate tool calls\n"
+        "See the hooks guide for wiring instructions."
     )
 
     typer.echo("\n--- Default policy example ---\n")

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -523,8 +523,7 @@ def test_quickstart_with_api_key() -> None:
     result = runner.invoke(app, ["quickstart"], env={"ASQAV_API_KEY": "sk_test"})
     assert result.exit_code == 0
     assert "API key detected" in result.output
-    assert "mcpServers" in result.output
-    assert "asqav-mcp" in result.output
+    assert "asqav hook" in result.output
     assert "Policy" in result.output
     assert "Next steps" in result.output
 
@@ -534,7 +533,7 @@ def test_quickstart_without_api_key() -> None:
     result = runner.invoke(app, ["quickstart"], env={"ASQAV_API_KEY": ""})
     assert result.exit_code == 0
     assert "ASQAV_API_KEY not set" in result.output
-    assert "mcpServers" in result.output
+    assert "asqav hook" in result.output
 
 
 # === doctor command ===

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.5.16",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.5.16",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@noble/post-quantum": "^0.6.1"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.6.0";
+export const SDK_VERSION = "0.6.1";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Pre-publish cleanup for the 0.6.1 release.

1. Remove the asqav-mcp config scaffold from the quickstart command. The quickstart points users at the asqav hook CLI instead of emitting an .mcp.json / uvx asqav-mcp snippet. The asqav-mcp PyPI package is being retired in favor of asqav hook. No asqav-mcp references remain in python/src or python/tests.
2. Add asqav hook to the README CLI list and link hooks/README.md so the surface is discoverable.
3. Bump 0.6.0 to 0.6.1 at the Python and TypeScript parity sites (plus the package-lock root) for the pending publish.

Proof: grep asqav-mcp python/src python/tests is empty; 385 cli/version/hook tests pass; the two quickstart tests fail against the pre-change tree and pass on this branch.