### PR TITLE
feat(litellm): cloud-signing CustomLogger + verify-litellm-log (0.6.2)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.6.1"
+version = "0.6.2"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -148,7 +148,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -184,6 +184,83 @@ def verify(
             print(f"Missing fields: {', '.join(detail.missing_fields)}")
 
 
+@app.command("verify-litellm-log")
+def verify_litellm_log(
+    path: str = typer.Argument(
+        help="Path to the JSONL index written by AsqavSigningLogger."
+    ),
+    output: str = typer.Option(
+        "text", "--output", "-o", help="Output format: text or json."
+    ),
+) -> None:
+    """Verify every receipt in a litellm signing-log index, rolling up N/N.
+
+    Reads the JSONL index that ``AsqavSigningLogger`` appends one line per
+    LLM call (each carrying a ``signature_id``) and verifies each receipt
+    via the public ``/verify`` route, reusing the same path as ``asqav
+    verify``. Prints ``verified N/N`` and exits non-zero if any receipt
+    fails or any line is unverifiable, so it works as a gate.
+    """
+    import json as json_mod
+
+    from asqav import APIError, verify_signature
+
+    try:
+        with open(path) as fh:
+            lines = [ln for ln in fh.read().splitlines() if ln.strip()]
+    except OSError as exc:
+        print(f"Error reading log: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    total = 0
+    verified = 0
+    failures: list[dict[str, Any]] = []
+    for lineno, raw in enumerate(lines, start=1):
+        try:
+            record = json_mod.loads(raw)
+        except json_mod.JSONDecodeError as exc:
+            total += 1
+            failures.append({"line": lineno, "reason": f"bad json: {exc}"})
+            continue
+
+        sig_id = record.get("signature_id")
+        if not sig_id:
+            # Lines without a signature_id are unsigned (no key at call time).
+            continue
+
+        total += 1
+        try:
+            result = verify_signature(sig_id)
+        except APIError as exc:
+            failures.append(
+                {"line": lineno, "signature_id": sig_id, "reason": str(exc)}
+            )
+            continue
+        if result.verified:
+            verified += 1
+        else:
+            failures.append(
+                {"line": lineno, "signature_id": sig_id, "reason": "not verified"}
+            )
+
+    if output == "json":
+        print(
+            json_mod.dumps(
+                {"verified": verified, "total": total, "failures": failures},
+                indent=2,
+                default=str,
+            )
+        )
+    else:
+        print(f"verified {verified}/{total}")
+        for f in failures:
+            sid = f.get("signature_id", "?")
+            print(f"  FAIL line {f['line']} {sid}: {f['reason']}")
+
+    if verified != total or failures:
+        raise typer.Exit(code=1)
+
+
 def _load_json_arg(source: str, label: str) -> dict | None:
     """Load a JSON arg from a file path, stdin (`-`), or return None when empty.
 

--- a/python/src/asqav/extras/litellm.py
+++ b/python/src/asqav/extras/litellm.py
@@ -50,6 +50,7 @@ try:
 except ImportError:
     CustomLogger = object  # type: ignore[assignment,misc]
 
+from .. import client as _client
 from ._base import AsqavAdapter
 
 logger = logging.getLogger("asqav")
@@ -252,8 +253,17 @@ class AsqavSigningLogger(CustomLogger):
     never raise into the LLM call (fail-soft, reusing the base adapter's
     fail-open signing path).
 
+    Caveats:
+        Streamed calls expose no aggregated response object to the logger,
+        so ``response_content_digest`` is None for them (the request side
+        still signs).
+        The JSONL append lock is per-instance. Two loggers pointed at the
+        same ASQAV_LOG_PATH from different processes can still interleave
+        writes, so give separate processes separate index paths.
+
     Env:
-        ASQAV_API_KEY: required. When unset the logger warns once and no-ops.
+        ASQAV_API_KEY: must be set (or pass api_key= / call asqav.init()).
+            With no key resolvable the logger warns once and no-ops.
         ASQAV_LOG_PATH: JSONL index path. Defaults to
             ~/.litellm_asqav_audit.jsonl.
         ASQAV_REDACT_CONTENT: "false" stores raw prompt/response in the
@@ -299,9 +309,12 @@ class AsqavSigningLogger(CustomLogger):
         self._lock = threading.Lock()
         self._warned = False
 
-        # Env-gated: with no key the logger announces no-op (not enforcement)
-        # once and signs nothing, rather than half-initialising a client.
-        resolved_key = api_key or os.environ.get("ASQAV_API_KEY")
+        # Key resolution mirrors AsqavAdapter (_base.py): explicit api_key,
+        # then ASQAV_API_KEY env, then the key asqav.init() set on the client.
+        # The init() fallback keeps the documented quickstart actually signing.
+        resolved_key = (
+            api_key or os.environ.get("ASQAV_API_KEY") or _client._api_key
+        )
         self._adapter: AsqavAdapter | None = None
         if not resolved_key:
             self._warn_no_key()

--- a/python/src/asqav/extras/litellm.py
+++ b/python/src/asqav/extras/litellm.py
@@ -2,18 +2,35 @@
 
 Install: pip install asqav[litellm]
 
-Usage::
+Two adapters live here:
+
+``AsqavGuardrail``
+    Proxy-guardrail seam (pre/post-call hooks). Signs request lifecycle
+    events when wired as a LiteLLM guardrail.
+
+``AsqavSigningLogger``
+    CustomLogger logging seam. Signs each successful LLM call via the
+    Asqav cloud (ML-DSA receipt) and writes a local JSONL index line so
+    the cloud signature and the local record are stitched together.
+
+Usage (signing logger)::
 
     import asqav
-    from asqav.extras.litellm import AsqavGuardrail
+    from asqav.extras.litellm import AsqavSigningLogger
     import litellm
 
     asqav.init("sk_live_...")
-    litellm.callbacks = [AsqavGuardrail(agent_name="my-litellm-proxy")]
+    litellm.callbacks = [AsqavSigningLogger()]
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
 from typing import Any
 
 try:
@@ -24,9 +41,26 @@ except ImportError as err:
         "Install with: pip install asqav[litellm]"
     ) from err
 
+try:
+    # Optional at import time: the CustomLogger base may not be present in
+    # every litellm build. AsqavSigningLogger is duck-typed by litellm's
+    # callback dispatch, so falling back to object keeps the module importable
+    # (and AsqavGuardrail usable) when the base is unavailable.
+    from litellm.integrations.custom_logger import CustomLogger
+except ImportError:
+    CustomLogger = object  # type: ignore[assignment,misc]
+
 from ._base import AsqavAdapter
 
-__all__ = ["AsqavGuardrail"]
+logger = logging.getLogger("asqav")
+
+__all__ = ["AsqavGuardrail", "AsqavSigningLogger"]
+
+# Default index path, overridable via ASQAV_LOG_PATH. Aligns with the merged
+# litellm AsqavLogger default so local and cloud records share a home.
+_DEFAULT_LOG_PATH = os.path.join(
+    os.path.expanduser("~"), ".litellm_asqav_audit.jsonl"
+)
 
 
 class AsqavGuardrail(AsqavAdapter):
@@ -118,4 +152,248 @@ class AsqavGuardrail(AsqavAdapter):
             {
                 "call_type": call_type,
             },
+        )
+
+
+def _content_digest(value: Any) -> str | None:
+    """SHA-256 hex digest of a content value, or None when empty.
+
+    Canonical JSON (sorted keys, tight separators) so the digest is
+    reproducible from the same value across runs and platforms.
+    """
+    if value is None:
+        return None
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _redact_content_default() -> bool:
+    """Read the ASQAV_REDACT_CONTENT env default (digest-only unless 'false')."""
+    return os.environ.get("ASQAV_REDACT_CONTENT", "true").lower() != "false"
+
+
+def _extract_call_fields(
+    kwargs: dict[str, Any],
+    response_obj: Any,
+    start_time: Any,
+    end_time: Any,
+    redact: bool,
+) -> dict[str, Any]:
+    """Pull model, provider, usage, and content digests out of a call.
+
+    Raw prompt/response stay out of the signed context unless ``redact``
+    is False. Aligns field names with the merged litellm AsqavLogger.
+    """
+    model = kwargs.get("model", "")
+    messages = kwargs.get("messages")
+
+    provider: str | None = None
+    prompt_tokens = completion_tokens = total_tokens = None
+    finish_reason: str | None = None
+    response_content: Any = None
+    try:
+        provider = (kwargs.get("litellm_params") or {}).get("custom_llm_provider")
+    except Exception:
+        provider = None
+    try:
+        usage = getattr(response_obj, "usage", None)
+        if usage:
+            prompt_tokens = getattr(usage, "prompt_tokens", None)
+            completion_tokens = getattr(usage, "completion_tokens", None)
+            total_tokens = getattr(usage, "total_tokens", None)
+        choices = getattr(response_obj, "choices", None)
+        if choices:
+            finish_reason = getattr(choices[0], "finish_reason", None)
+            response_content = getattr(
+                getattr(choices[0], "message", None), "content", None
+            )
+    except Exception:
+        pass
+
+    latency_ms: int | None = None
+    try:
+        if start_time is not None and end_time is not None:
+            latency_ms = int((end_time - start_time).total_seconds() * 1000)
+    except Exception:
+        latency_ms = None
+
+    fields: dict[str, Any] = {
+        "model": model,
+        "provider": provider,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "finish_reason": finish_reason,
+        "latency_ms": latency_ms,
+        "messages_digest": _content_digest(messages),
+        "response_content_digest": _content_digest(response_content),
+    }
+    if not redact:
+        fields["messages"] = messages
+        fields["response_content"] = response_content
+    return fields
+
+
+class AsqavSigningLogger(CustomLogger):
+    """LiteLLM CustomLogger that cloud-signs each call (ML-DSA receipt).
+
+    On every successful LLM call this signs the call's mapped fields and
+    content digests via the Asqav cloud, producing a third-party-verifiable
+    ML-DSA receipt. It also appends one local JSONL index line carrying the
+    ``signature_id`` + ``verification_url`` (plus the call's digests) so the
+    local record and the cloud signature are stitched and verifiable later
+    with ``asqav verify-litellm-log``.
+
+    A receipt proves the agent key signed the exact recorded fields and
+    digests at sign time, third-party verifiable. It does not reconstruct
+    redacted prompt/response content.
+
+    Honesty: this is signing, not enforcement. Signing or network errors
+    never raise into the LLM call (fail-soft, reusing the base adapter's
+    fail-open signing path).
+
+    Env:
+        ASQAV_API_KEY: required. When unset the logger warns once and no-ops.
+        ASQAV_LOG_PATH: JSONL index path. Defaults to
+            ~/.litellm_asqav_audit.jsonl.
+        ASQAV_REDACT_CONTENT: "false" stores raw prompt/response in the
+            index. Defaults to digest-only.
+
+    Usage::
+
+        pip install "asqav[litellm]"
+
+        import asqav, litellm
+        from asqav.extras.litellm import AsqavSigningLogger
+
+        asqav.init("sk_live_...")
+        litellm.callbacks = [AsqavSigningLogger()]
+
+    Args:
+        api_key: Optional API key override (else ASQAV_API_KEY / asqav.init).
+        agent_name: Name for a new agent (calls Agent.create).
+        agent_id: ID of an existing agent (calls Agent.get).
+        log_path: JSONL index path override (else ASQAV_LOG_PATH).
+        redact_content: Override the ASQAV_REDACT_CONTENT default.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        agent_name: str | None = None,
+        agent_id: str | None = None,
+        log_path: str | None = None,
+        redact_content: bool | None = None,
+    ) -> None:
+        super().__init__()
+
+        self._log_path = log_path or os.environ.get(
+            "ASQAV_LOG_PATH", _DEFAULT_LOG_PATH
+        )
+        self._redact = (
+            redact_content
+            if redact_content is not None
+            else _redact_content_default()
+        )
+        self._lock = threading.Lock()
+        self._warned = False
+
+        # Env-gated: with no key the logger announces no-op (not enforcement)
+        # once and signs nothing, rather than half-initialising a client.
+        resolved_key = api_key or os.environ.get("ASQAV_API_KEY")
+        self._adapter: AsqavAdapter | None = None
+        if not resolved_key:
+            self._warn_no_key()
+            return
+        try:
+            self._adapter = AsqavAdapter(
+                api_key=resolved_key,
+                agent_name=agent_name,
+                agent_id=agent_id,
+            )
+        except Exception as exc:
+            # Setup failure must never break the host. No-op + warn.
+            logger.warning(
+                "AsqavSigningLogger setup failed, signing disabled (fail-soft): %s",
+                exc,
+            )
+            self._adapter = None
+
+    def _warn_no_key(self) -> None:
+        """Warn once that signing is off so the logger never looks like enforcement."""
+        if not self._warned:
+            logger.warning(
+                "AsqavSigningLogger: ASQAV_API_KEY not set. No receipts are "
+                "signed and no enforcement happens. Set ASQAV_API_KEY (or pass "
+                "api_key=) to enable cloud-signed receipts."
+            )
+            self._warned = True
+
+    def _action_type(self, model: str) -> str:
+        """Map a call to an action_type like ``llm:gpt-4``."""
+        return f"llm:{model}" if model else "llm:call"
+
+    def _sign_and_index(
+        self,
+        kwargs: dict[str, Any],
+        response_obj: Any,
+        start_time: Any,
+        end_time: Any,
+    ) -> None:
+        """Sign the call via the cloud then append the local index line.
+
+        Fully fail-soft: any error is swallowed so the LLM call completes.
+        """
+        if self._adapter is None:
+            self._warn_no_key()
+            return
+        try:
+            fields = _extract_call_fields(
+                kwargs, response_obj, start_time, end_time, self._redact
+            )
+            sig = self._adapter._sign_action(
+                self._action_type(fields.get("model", "")), fields
+            )
+            self._append_index(fields, sig)
+        except Exception as exc:
+            # Last-resort guard: nothing from signing or indexing escapes.
+            logger.warning(
+                "AsqavSigningLogger sign/index failed (fail-soft): %s", exc
+            )
+
+    def _append_index(self, fields: dict[str, Any], sig: Any) -> None:
+        """Append one JSONL index line stitching local digests to the cloud receipt."""
+        record = {
+            "ts": time.time(),
+            "model": fields.get("model"),
+            "provider": fields.get("provider"),
+            "prompt_tokens": fields.get("prompt_tokens"),
+            "completion_tokens": fields.get("completion_tokens"),
+            "total_tokens": fields.get("total_tokens"),
+            "messages_digest": fields.get("messages_digest"),
+            "response_content_digest": fields.get("response_content_digest"),
+            "signature_id": getattr(sig, "signature_id", None),
+            "verification_url": getattr(sig, "verification_url", None),
+        }
+        with self._lock:
+            with open(self._log_path, "a", encoding="utf-8") as fh:
+                fh.write(
+                    json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+                )
+
+    # -- LiteLLM CustomLogger interface --
+
+    def log_success_event(self, kwargs, response_obj, start_time, end_time):
+        """Sync success hook: sign + index the completed call."""
+        self._sign_and_index(kwargs, response_obj, start_time, end_time)
+
+    async def async_log_success_event(
+        self, kwargs, response_obj, start_time, end_time
+    ):
+        """Async success hook: sign off the event loop so calls keep flowing."""
+        import asyncio
+
+        await asyncio.to_thread(
+            self._sign_and_index, kwargs, response_obj, start_time, end_time
         )

--- a/python/tests/test_litellm_signing.py
+++ b/python/tests/test_litellm_signing.py
@@ -1,0 +1,199 @@
+"""Tests for the litellm cloud-signing CustomLogger + verify-litellm-log CLI.
+
+No network: litellm is mocked via ModuleType (including the CustomLogger
+base class the logger subclasses), and Agent/sign are patched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import AsqavError, SignatureResponse  # noqa: E402
+
+# === Mock litellm + its CustomLogger base before importing the integration ===
+
+_mock_litellm = ModuleType("litellm")
+_mock_integrations = ModuleType("litellm.integrations")
+_mock_custom_logger = ModuleType("litellm.integrations.custom_logger")
+
+
+class _StubCustomLogger:
+    """Stand-in for litellm.integrations.custom_logger.CustomLogger."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+_mock_custom_logger.CustomLogger = _StubCustomLogger
+_mock_integrations.custom_logger = _mock_custom_logger
+_mock_litellm.integrations = _mock_integrations
+
+sys.modules.setdefault("litellm", _mock_litellm)
+sys.modules.setdefault("litellm.integrations", _mock_integrations)
+sys.modules.setdefault(
+    "litellm.integrations.custom_logger", _mock_custom_logger
+)
+
+from asqav.extras.litellm import AsqavSigningLogger, _content_digest  # noqa: E402
+
+MOCK_SIGN_RESPONSE: dict = {
+    "signature": "sig_abc123",
+    "signature_id": "sid_abc123",
+    "action_id": "act_abc123",
+    "timestamp": 1700000001.0,
+    "verification_url": "https://api.asqav.com/verify/sid_abc123",
+}
+
+
+def _make_logger(tmp_path, **kwargs) -> AsqavSigningLogger:
+    """Build a logger with a mocked Agent and a temp index path."""
+    log_path = str(tmp_path / "index.jsonl")
+    with patch("asqav.client._api_key", "sk_test"), patch(
+        "asqav.extras._base.Agent"
+    ) as mock_agent_cls:
+        mock_agent_cls.create.return_value = MagicMock()
+        return AsqavSigningLogger(
+            api_key="sk_test", agent_name="test-litellm", log_path=log_path, **kwargs
+        )
+
+
+def _response_obj(content: str = "hi there") -> MagicMock:
+    resp = MagicMock()
+    resp.usage.prompt_tokens = 10
+    resp.usage.completion_tokens = 20
+    resp.usage.total_tokens = 30
+    choice = MagicMock()
+    choice.finish_reason = "stop"
+    choice.message.content = content
+    resp.choices = [choice]
+    return resp
+
+
+# === Signing on success ===
+
+
+class TestSignOnSuccess:
+    def test_success_signs_mapped_action_with_digest_context(self, tmp_path):
+        logger = _make_logger(tmp_path)
+        mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
+        logger._adapter._sign_action = MagicMock(return_value=mock_sig)
+
+        kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "secret prompt"}],
+            "litellm_params": {"custom_llm_provider": "openai"},
+        }
+        logger.log_success_event(kwargs, _response_obj(), 0, 1)
+
+        logger._adapter._sign_action.assert_called_once()
+        action_type, context = logger._adapter._sign_action.call_args[0]
+        assert action_type == "llm:gpt-4"
+        assert context["model"] == "gpt-4"
+        assert context["provider"] == "openai"
+        assert context["total_tokens"] == 30
+        # Content redacted by default: digests present, raw content absent.
+        assert context["messages_digest"] == _content_digest(kwargs["messages"])
+        assert context["response_content_digest"] == _content_digest("hi there")
+        assert "messages" not in context
+        assert "response_content" not in context
+
+    def test_success_writes_index_line_with_signature_id(self, tmp_path):
+        logger = _make_logger(tmp_path)
+        mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
+        logger._adapter._sign_action = MagicMock(return_value=mock_sig)
+
+        logger.log_success_event(
+            {"model": "gpt-4", "messages": [{"role": "user", "content": "x"}]},
+            _response_obj(),
+            0,
+            1,
+        )
+
+        with open(logger._log_path) as fh:
+            lines = [ln for ln in fh.read().splitlines() if ln.strip()]
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["signature_id"] == "sid_abc123"
+        assert rec["verification_url"].endswith("sid_abc123")
+        assert rec["model"] == "gpt-4"
+        assert rec["messages_digest"]
+
+    def test_redact_false_keeps_raw_content_in_context(self, tmp_path):
+        logger = _make_logger(tmp_path, redact_content=False)
+        mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
+        logger._adapter._sign_action = MagicMock(return_value=mock_sig)
+
+        msgs = [{"role": "user", "content": "raw prompt"}]
+        logger.log_success_event(
+            {"model": "gpt-4", "messages": msgs}, _response_obj("raw reply"), 0, 1
+        )
+        _, context = logger._adapter._sign_action.call_args[0]
+        assert context["messages"] == msgs
+        assert context["response_content"] == "raw reply"
+
+    def test_async_success_signs(self, tmp_path):
+        logger = _make_logger(tmp_path)
+        mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
+        logger._adapter._sign_action = MagicMock(return_value=mock_sig)
+
+        asyncio.run(
+            logger.async_log_success_event(
+                {"model": "gpt-4", "messages": []}, _response_obj(), 0, 1
+            )
+        )
+        logger._adapter._sign_action.assert_called_once()
+
+
+# === Fail-soft ===
+
+
+class TestFailSoft:
+    def test_sign_error_does_not_propagate(self, tmp_path):
+        logger = _make_logger(tmp_path)
+        logger._adapter._agent.sign.side_effect = AsqavError("network down")
+
+        # Real _sign_action fail-open returns None; the call must still complete
+        # and no exception escapes the logger.
+        logger.log_success_event(
+            {"model": "gpt-4", "messages": []}, _response_obj(), 0, 1
+        )
+
+    def test_index_write_error_does_not_propagate(self, tmp_path):
+        logger = _make_logger(tmp_path)
+        mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
+        logger._adapter._sign_action = MagicMock(return_value=mock_sig)
+        logger._log_path = "/nonexistent-dir/cannot/write/index.jsonl"
+
+        # Write failure is swallowed (fail-soft), no raise into the call.
+        logger.log_success_event(
+            {"model": "gpt-4", "messages": []}, _response_obj(), 0, 1
+        )
+
+
+# === Missing key -> warn + no-op ===
+
+
+class TestMissingKey:
+    def test_no_key_warns_and_noops(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.delenv("ASQAV_API_KEY", raising=False)
+        log_path = str(tmp_path / "index.jsonl")
+        with patch("asqav.client._api_key", None):
+            logger = AsqavSigningLogger(log_path=log_path)
+        assert logger._adapter is None
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="asqav"):
+            # No crash, no index line written.
+            logger.log_success_event(
+                {"model": "gpt-4", "messages": []}, _response_obj(), 0, 1
+            )
+        assert not os.path.exists(log_path)
+        assert any("ASQAV_API_KEY not set" in r.message for r in caplog.records)

--- a/python/tests/test_litellm_signing.py
+++ b/python/tests/test_litellm_signing.py
@@ -177,6 +177,37 @@ class TestFailSoft:
         )
 
 
+# === init() key resolution (documented quickstart) ===
+
+
+class TestInitKeyResolution:
+    def test_init_key_resolves_adapter_and_signs(self, tmp_path, monkeypatch):
+        """The documented quickstart: key only via asqav.init(), no env var.
+
+        Pins that AsqavSigningLogger() honors the client key set by
+        asqav.init() rather than no-opping. Fails against code that resolves
+        the key from api_key/ASQAV_API_KEY only.
+        """
+        monkeypatch.delenv("ASQAV_API_KEY", raising=False)
+        log_path = str(tmp_path / "index.jsonl")
+
+        # Key set ONLY on the client (as asqav.init does), no api_key=, no env.
+        with patch("asqav.client._api_key", "sk_test_init"), patch(
+            "asqav.extras._base.Agent"
+        ) as mock_agent_cls:
+            mock_agent_cls.create.return_value = MagicMock()
+            logger = AsqavSigningLogger(agent_name="test-init", log_path=log_path)
+
+        assert logger._adapter is not None
+
+        mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
+        logger._adapter._sign_action = MagicMock(return_value=mock_sig)
+        logger.log_success_event(
+            {"model": "gpt-4", "messages": []}, _response_obj(), 0, 1
+        )
+        logger._adapter._sign_action.assert_called_once()
+
+
 # === Missing key -> warn + no-op ===
 
 

--- a/python/tests/test_verify_litellm_log_cli.py
+++ b/python/tests/test_verify_litellm_log_cli.py
@@ -1,0 +1,76 @@
+"""Tests for the `asqav verify-litellm-log` CLI command.
+
+No network: verify_signature is patched. A tampered (unverifiable) line
+must drive a non-zero exit so the rollup is non-vacuous.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from typer.testing import CliRunner  # noqa: E402
+
+from asqav.cli import app  # noqa: E402
+
+runner = CliRunner()
+
+
+def _write_log(tmp_path, sig_ids):
+    path = tmp_path / "index.jsonl"
+    with open(path, "w") as fh:
+        for sid in sig_ids:
+            fh.write(
+                json.dumps(
+                    {
+                        "ts": 1700000000.0,
+                        "model": "gpt-4",
+                        "signature_id": sid,
+                        "verification_url": f"https://api.asqav.com/verify/{sid}",
+                        "messages_digest": "abc",
+                    }
+                )
+                + "\n"
+            )
+    return str(path)
+
+
+def _verify_result(verified: bool) -> MagicMock:
+    r = MagicMock()
+    r.verified = verified
+    return r
+
+
+class TestVerifyLitellmLog:
+    def test_all_verified_rolls_up_and_exits_zero(self, tmp_path):
+        path = _write_log(tmp_path, ["sid_1", "sid_2", "sid_3"])
+
+        with patch("asqav.verify_signature", return_value=_verify_result(True)):
+            result = runner.invoke(app, ["verify-litellm-log", path])
+
+        assert result.exit_code == 0, result.output
+        assert "verified 3/3" in result.output
+
+    def test_tampered_line_fails_non_vacuous(self, tmp_path):
+        path = _write_log(tmp_path, ["sid_ok", "sid_tampered"])
+
+        def fake_verify(sig_id):
+            return _verify_result(sig_id != "sid_tampered")
+
+        with patch("asqav.verify_signature", side_effect=fake_verify):
+            result = runner.invoke(app, ["verify-litellm-log", path])
+
+        # One receipt fails verification -> non-zero exit, rollup shows 1/2.
+        assert result.exit_code == 1, result.output
+        assert "verified 1/2" in result.output
+        assert "sid_tampered" in result.output
+
+    def test_missing_file_exits_nonzero(self, tmp_path):
+        result = runner.invoke(
+            app, ["verify-litellm-log", str(tmp_path / "nope.jsonl")]
+        )
+        assert result.exit_code == 1

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@noble/post-quantum": "^0.6.1"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.6.1";
+export const SDK_VERSION = "0.6.2";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
## What

litellm users today get the local hash-chain JSONL callback, which is tamper-evident but not signed. This adds a signing seam so they also get real Asqav cloud-signed (ML-DSA) receipts that any third party can verify.

- **`AsqavSigningLogger`** (new litellm `CustomLogger` in `asqav/extras/litellm.py`): on each successful LLM call it signs via `_base` (cloud ML-DSA receipt), mapping the call to `action_type` `llm:{model}` with context carrying model, provider, token usage, and content digests. Raw prompt/response are redacted to digests by default (`ASQAV_REDACT_CONTENT=false` keeps them), matching the local callback's default.
  - Env-gated on `ASQAV_API_KEY`: when unset it logs one clear warning and no-ops, so it never silently looks like enforcement.
  - Fail-soft always: a signing or network error never raises into the LLM call (reuses the base adapter's fail-open path). Async-safe via `asyncio.to_thread`.
  - Appends one local JSONL index line per call (`signature_id` + `verification_url` + digests) so local and cloud are stitched. Path defaults to `~/.litellm_asqav_audit.jsonl`, overridable with `ASQAV_LOG_PATH`.
  - Usage: `pip install "asqav[litellm]"` then `litellm.callbacks=[AsqavSigningLogger()]`.
- **`asqav verify-litellm-log <path.jsonl>`** (new CLI command): reads the JSONL index and verifies each receipt via the public verify route, printing `verified N/N` and exiting non-zero if any fail.
- Version bumped `0.6.1` -> `0.6.2` across python + ts parity sites.

The `CustomLogger` base imports lazily (falls back to `object`), so importing asqav never hard-requires litellm.

## Honesty

A receipt proves the agent key ML-DSA-signed the exact recorded fields and digests at sign time, third-party verifiable. It does not prove the inference happened and does not reconstruct redacted content.

This does not publish; the PyPI/npm publish is a separate later step.

## Proof of work

VERIFY-WITH: `cd python && python -m pytest tests -k "litellm or verify_litellm or signing" -q -p no:asqav`

```
..s.....................                                                 [100%]
23 passed, 1 skipped, 1108 deselected in 19.65s
```

New tests in isolation (includes the non-vacuous tamper test, exit 1 + `verified 1/2`):

```
tests/test_verify_litellm_log_cli.py ... test_tampered_line_fails_non_vacuous PASSED
tests/test_litellm_signing.py ... TestFailSoft / TestMissingKey ... PASSED
10 passed in 1.78s
```

`ruff check` on changed files: All checks passed!
secret-scan (gitleaks): clean, exit 0.

Diff stat:

```
 python/pyproject.toml                       |   2 +-
 python/src/asqav/__init__.py                |   2 +-
 python/src/asqav/cli.py                     |  77 ++++++++
 python/src/asqav/extras/litellm.py          | 286 +++++++++++++++++++++++++++-
 python/tests/test_litellm_signing.py        | 199 +++++++++++++++++++
 python/tests/test_verify_litellm_log_cli.py |  76 ++++++++
 typescript/package-lock.json                |   4 +-
 typescript/package.json                     |   2 +-
 typescript/src/userAgent.ts                 |   2 +-
 9 files changed, 640 insertions(+), 10 deletions(-)
```

https://claude.ai/code/session_01BXVrMmGpFwevwQGHQeRRG9