### PR TITLE
fix(preflight): augment-match catches destructive SQL verbs in write namespace (#318)

### DIFF
--- a/python/src/asqav/_sql_match.py
+++ b/python/src/asqav/_sql_match.py
@@ -35,7 +35,7 @@ def action_candidates(action_type: str) -> list[str]:
     """
     if not action_type.startswith(_WRITE_SQL_PREFIX):
         return [action_type]
-    suffix = action_type[len(_WRITE_SQL_PREFIX):]
+    suffix = action_type[len(_WRITE_SQL_PREFIX) :]
     if _DESTRUCTIVE_VERB_RE.search(suffix):
         return [action_type, _DELETE_SQL_PREFIX + suffix]
     return [action_type]

--- a/python/src/asqav/_sql_match.py
+++ b/python/src/asqav/_sql_match.py
@@ -1,0 +1,50 @@
+"""Helper for augment-match on destructive SQL action types.
+
+A write action like `data:write:sql:DELETE FROM users` must match BOTH
+`data:write:sql:*` (write policies) AND `data:delete:*` (destructive policies).
+
+This is done by returning the full set of action_type candidates for matching:
+- Normal: [action_type]
+- Destructive write: [action_type, derived] where derived replaces the
+  `data:write:sql:` prefix with `data:delete:sql:`.
+
+Only `data:write:sql:` namespaced actions are inspected; reads and non-sql
+namespaces are never augmented, so a SELECT mentioning "delete" is unaffected.
+"""
+
+from __future__ import annotations
+
+import re
+
+_WRITE_SQL_PREFIX = "data:write:sql:"
+_DELETE_SQL_PREFIX = "data:delete:sql:"
+
+# Matches DELETE, DROP, TRUNCATE, ALTER as whole words (non-letter boundary on each side).
+# Underscore counts as a word separator (e.g. DELETE_FROM matches, deleted_at does not).
+_DESTRUCTIVE_VERB_RE = re.compile(
+    r"(?<![A-Za-z])(DELETE|DROP|TRUNCATE|ALTER)(?![A-Za-z])",
+    re.IGNORECASE,
+)
+
+
+def action_candidates(action_type: str) -> list[str]:
+    """Return match candidates for policy evaluation.
+
+    For most actions returns [action_type]. For a destructive SQL write, also
+    returns a derived `data:delete:sql:` entry so destructive policies fire.
+    """
+    if not action_type.startswith(_WRITE_SQL_PREFIX):
+        return [action_type]
+    suffix = action_type[len(_WRITE_SQL_PREFIX):]
+    if _DESTRUCTIVE_VERB_RE.search(suffix):
+        return [action_type, _DELETE_SQL_PREFIX + suffix]
+    return [action_type]
+
+
+def matches_pattern(pattern: str, action_type: str) -> bool:
+    """Return True if any candidate for action_type matches the pattern."""
+    prefix = pattern.rstrip("*")
+    for candidate in action_candidates(action_type):
+        if pattern == "*" or candidate.startswith(prefix):
+            return True
+    return False

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from ._sql_match import matches_pattern as _matches_pattern
 from ._useragent import USER_AGENT
 from .client import (
     APIError,
@@ -21,7 +22,6 @@ from .client import (
     _parse_timestamp,
 )
 from .patterns import resolve_pattern
-from ._sql_match import matches_pattern as _matches_pattern
 from .retry import with_async_retry
 
 try:

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -21,6 +21,7 @@ from .client import (
     _parse_timestamp,
 )
 from .patterns import resolve_pattern
+from ._sql_match import matches_pattern as _matches_pattern
 from .retry import with_async_retry
 
 try:
@@ -328,7 +329,7 @@ class AsyncAgent:
                 if not p.get("is_active"):
                     continue
                 pattern = p.get("action_pattern", "")
-                if pattern == "*" or action_type.startswith(pattern.rstrip("*")):
+                if _matches_pattern(pattern, action_type):
                     if p.get("action") in ("block", "block_and_alert"):
                         policy_allowed = False
                         reasons.append(f"blocked by policy: {p.get('name', 'unknown')}")

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -40,9 +40,9 @@ if TYPE_CHECKING:
     from .phases import PhaseChain
     from .scope import ScopeToken
 
+from ._sql_match import matches_pattern as _matches_pattern
 from ._useragent import USER_AGENT
 from .patterns import resolve_pattern
-from ._sql_match import matches_pattern as _matches_pattern
 from .retry import with_retry
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -119,6 +119,8 @@ def _join_url(base: str, path: str) -> str:
     fallback hits the same path httpx (which merges base_url correctly) does.
     """
     return base.rstrip("/") + "/" + path.lstrip("/")
+
+
 _client: Any = None
 # Hybrid GDPR mode: resolved at init() time, overridable per-call. See _mode.py.
 _mode: str = "full-payload"
@@ -280,9 +282,7 @@ DORA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
 )
 
 #: HIPAA Security Rule incident_class vocabulary (45 CFR 164.304).
-HIPAA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset(
-    {"hipaa_security_incident"}
-)
+HIPAA_INCIDENT_CLASS_NAMESPACE: frozenset[str] = frozenset({"hipaa_security_incident"})
 
 #: Union of every canonical incident_class token the SDK accepts.
 INCIDENT_CLASS_NAMESPACE: frozenset[str] = (
@@ -290,9 +290,7 @@ INCIDENT_CLASS_NAMESPACE: frozenset[str] = (
 )
 
 #: Sandbox-state enum: {enabled, disabled, unavailable}.
-SANDBOX_STATE_NAMESPACE: frozenset[str] = frozenset(
-    {"enabled", "disabled", "unavailable"}
-)
+SANDBOX_STATE_NAMESPACE: frozenset[str] = frozenset({"enabled", "disabled", "unavailable"})
 
 #: Durable-anchoring witnesses Asqav ships; the cloud `witness_policy` extension accepts
 #: only this set (`rekor` rejected, not shipped). Mirrors the governance.json contract.
@@ -350,6 +348,7 @@ def _map_policy_decision_to_decision(policy_decision: str | None) -> str:
     misconfigured caller never publishes an out-of-vocabulary token.
     """
     return DECISION_MAP.get((policy_decision or "").lower(), "deny")
+
 
 #: REQUIRED fields on a Compliance Receipt envelope (wire form); top-level
 #: discriminator is ``type``. Used by `verify_compliance_receipt`.
@@ -952,9 +951,7 @@ def flush_spans() -> None:
         pass  # Don't fail on export errors
 
 
-def _compute_action_ref(
-    action_type: str, context: dict[str, Any] | None
-) -> str:
+def _compute_action_ref(action_type: str, context: dict[str, Any] | None) -> str:
     """Client-side ``sha256:<hex>`` of the canonical Action object.
 
     The Action shape mirrors `core/canonical.py:hash_action` on the cloud
@@ -1062,9 +1059,7 @@ def _validate_risk_snapshot(rs: Any) -> None:
             docs_url=RISK_ACCEPTANCE_DOCS_URL,
         )
     source = rs.get("snapshot_source")
-    numeric_present = any(
-        rs.get(k) is not None for k in _RISK_SNAPSHOT_NUMERIC_KEYS
-    )
+    numeric_present = any(rs.get(k) is not None for k in _RISK_SNAPSHOT_NUMERIC_KEYS)
     if numeric_present and (not isinstance(source, str) or not source):
         raise AsqavValidationError(
             "risk_snapshot_numeric_requires_snapshot_source: a populated "
@@ -1181,11 +1176,7 @@ def _validate_risk_acceptance(
                 "passing compliance_mode=False would silently drop them.",
                 docs_url=RISK_ACCEPTANCE_DOCS_URL,
             )
-        if (
-            initiator_id is not None
-            and approver_id is not None
-            and initiator_id == approver_id
-        ):
+        if initiator_id is not None and approver_id is not None and initiator_id == approver_id:
             raise AsqavValidationError(
                 "risk_acceptance_self_approval_guard: initiator_id equals "
                 "approver_id; a self-approved risk acceptance is incoherent "
@@ -1235,10 +1226,7 @@ def _validate_code_authorship(
             f"'sha256:<64 lowercase hex>' (got: {repr(change_digest)[:64]}).",
             docs_url=CODE_AUTHORSHIP_DOCS_URL,
         )
-    if (
-        change_class is not None
-        and change_class not in _CODE_AUTHORSHIP_CHANGE_CLASS_NAMESPACE
-    ):
+    if change_class is not None and change_class not in _CODE_AUTHORSHIP_CHANGE_CLASS_NAMESPACE:
         raise AsqavValidationError(
             "code_authorship_change_class_invalid: change_class must be one of "
             "read|write|delete|execute|deploy "
@@ -1318,9 +1306,7 @@ def _validate_authored_by(ab: Any) -> None:
         )
 
 
-def _compute_tool_fingerprint(
-    tool_name: str, tool_schema: dict[str, Any] | None
-) -> str:
+def _compute_tool_fingerprint(tool_name: str, tool_schema: dict[str, Any] | None) -> str:
     """Compute a deterministic 32-bare-hex fingerprint over `{tool_name, schema}`.
 
     NSA CSI U/OO/6030316-26 binds receipts to the exact tool surface the
@@ -1397,9 +1383,7 @@ def _build_sign_body(
         canonical_bytes = canonicalize_action(action_type, context)
         payload_size = len(canonical_bytes)
         if _org_salt is not None:
-            digest_hex = hmac.new(
-                _org_salt, canonical_bytes, hashlib.sha256
-            ).hexdigest()
+            digest_hex = hmac.new(_org_salt, canonical_bytes, hashlib.sha256).hexdigest()
         else:
             digest_hex = hashlib.sha256(canonical_bytes).hexdigest()
         digest = f"sha256:{digest_hex}"
@@ -1835,47 +1819,37 @@ class Agent:
         # Dispatch before-hooks (fail-open).
         try:
             from . import hooks as _hooks_mod
-            context = _hooks_mod._dispatch_before(
-                action_type, dict(context) if context else {}
-            )
+
+            context = _hooks_mod._dispatch_before(action_type, dict(context) if context else {})
         except Exception:
             logger.warning("asqav before-hook dispatch failed (fail-open)", exc_info=True)
 
         # Surface bad arguments client-side; the cloud re-validates.
         if receipt_type is not None and receipt_type not in RECEIPT_TYPE_NAMESPACE:
             raise ValueError(
-                "invalid_receipt_type: must be one of "
-                f"{sorted(RECEIPT_TYPE_NAMESPACE)}"
+                f"invalid_receipt_type: must be one of {sorted(RECEIPT_TYPE_NAMESPACE)}"
             )
         if policy_decision in {"deny", "rate_limit"} and not reason:
             raise ValueError(
-                "missing_reason: policy_decision=deny|rate_limit "
-                "requires a `reason` code."
+                "missing_reason: policy_decision=deny|rate_limit requires a `reason` code."
             )
         # Fail fast on sandbox_state vocabulary before the HTTP roundtrip.
-        if (
-            sandbox_state is not None
-            and sandbox_state not in SANDBOX_STATE_NAMESPACE
-        ):
+        if sandbox_state is not None and sandbox_state not in SANDBOX_STATE_NAMESPACE:
             raise ValueError(
-                "invalid_sandbox_state: must be one of "
-                f"{sorted(SANDBOX_STATE_NAMESPACE)}."
+                f"invalid_sandbox_state: must be one of {sorted(SANDBOX_STATE_NAMESPACE)}."
             )
         # Fail fast on capture_topology vocabulary before the HTTP roundtrip.
-        if (
-            capture_topology is not None
-            and capture_topology not in CAPTURE_TOPOLOGY_NAMESPACE
-        ):
+        if capture_topology is not None and capture_topology not in CAPTURE_TOPOLOGY_NAMESPACE:
             raise ValueError(
-                "invalid_capture_topology: must be one of "
-                f"{sorted(CAPTURE_TOPOLOGY_NAMESPACE)}."
+                f"invalid_capture_topology: must be one of {sorted(CAPTURE_TOPOLOGY_NAMESPACE)}."
             )
         # Rule 8 (lockstep with cloud SignRequest validator): passive_telemetry
         # pairs only with protectmcp:observation or protectmcp:observation:result_bound.
         if (
             capture_topology == "passive_telemetry"
             and receipt_type is not None
-            and receipt_type not in {
+            and receipt_type
+            not in {
                 "protectmcp:observation",
                 "protectmcp:observation:result_bound",
             }
@@ -1890,11 +1864,7 @@ class Agent:
         # Fail fast on incident_class vocabulary before the HTTP roundtrip.
         # The field accepts a JSON string or a JSON array of such strings.
         if incident_class is not None:
-            _tokens = (
-                incident_class
-                if isinstance(incident_class, list)
-                else [incident_class]
-            )
+            _tokens = incident_class if isinstance(incident_class, list) else [incident_class]
             for _t in _tokens:
                 if _t not in INCIDENT_CLASS_NAMESPACE:
                     raise ValueError(
@@ -1913,10 +1883,7 @@ class Agent:
                 "receipt_type=protectmcp:lifecycle:configuration_change "
                 "requires config_manifest_digest (sha256:<64 hex>)."
             )
-        if (
-            receipt_type == "protectmcp:observation:result_bound"
-            and result_digest is None
-        ):
+        if receipt_type == "protectmcp:observation:result_bound" and result_digest is None:
             raise ValueError(
                 "result_bound_missing_result_digest: "
                 "receipt_type=protectmcp:observation:result_bound requires "
@@ -1967,9 +1934,7 @@ class Agent:
             from math import ceil
 
             if isinstance(expires_at, (int, float)):
-                expires_at_dt = datetime.fromtimestamp(
-                    float(expires_at), tz=timezone.utc
-                )
+                expires_at_dt = datetime.fromtimestamp(float(expires_at), tz=timezone.utc)
             else:
                 _s = expires_at
                 if _s.endswith("Z"):
@@ -1978,9 +1943,7 @@ class Agent:
                 if expires_at_dt.tzinfo is None:
                     expires_at_dt = expires_at_dt.replace(tzinfo=timezone.utc)
             now = datetime.now(timezone.utc)
-            valid_seconds = max(
-                1, ceil((expires_at_dt - now).total_seconds())
-            )
+            valid_seconds = max(1, ceil((expires_at_dt - now).total_seconds()))
 
         # Rule 11 lockstep: per-field tokens mirror cloud <field>_not_sha256_wire_form.
         for _name, _value in (
@@ -1991,15 +1954,11 @@ class Agent:
         ):
             if _value is not None and not _SHA256_HEX_RE.match(_value):
                 raise ValueError(
-                    f"{_name}_not_sha256_wire_form: must look like "
-                    "'sha256:<64 lowercase hex>'."
+                    f"{_name}_not_sha256_wire_form: must look like 'sha256:<64 lowercase hex>'."
                 )
-        if tool_fingerprint is not None and not _TOOL_FINGERPRINT_RE.match(
-            tool_fingerprint
-        ):
+        if tool_fingerprint is not None and not _TOOL_FINGERPRINT_RE.match(tool_fingerprint):
             raise ValueError(
-                "tool_fingerprint_not_32_hex_chars: must be 32 lowercase "
-                "hex chars (SHA-256[:32])."
+                "tool_fingerprint_not_32_hex_chars: must be 32 lowercase hex chars (SHA-256[:32])."
             )
         for _name, _value in (
             ("slsa_provenance_pointer", slsa_provenance_pointer),
@@ -2008,9 +1967,7 @@ class Agent:
             if _value is not None and not (
                 _value.startswith("https://") or _value.startswith("http://")
             ):
-                raise ValueError(
-                    f"pointer_url_guard: {_name} must be an http(s) URL"
-                )
+                raise ValueError(f"pointer_url_guard: {_name} must be an http(s) URL")
 
         # Threat-framework taxonomy validators lockstep with cloud SignRequest.
         for _name, _value in (
@@ -2037,6 +1994,7 @@ class Agent:
         if rfc3161_timestamp is not None:
             import base64 as _b64
             import binascii as _binascii
+
             if not isinstance(rfc3161_timestamp, str) or not rfc3161_timestamp:
                 raise ValueError(
                     "rfc3161_timestamp_not_base64: must be a non-empty "
@@ -2046,16 +2004,14 @@ class Agent:
                 _b64.b64decode(rfc3161_timestamp, validate=True)
             except (_binascii.Error, ValueError) as _exc:
                 raise ValueError(
-                    "rfc3161_timestamp_not_base64: must be valid base64 "
-                    f"(decode failed: {_exc})."
+                    f"rfc3161_timestamp_not_base64: must be valid base64 (decode failed: {_exc})."
                 ) from _exc
 
         # witness_policy: {required, witnesses: subset of rfc3161/opentimestamps}.
         if witness_policy is not None:
             if not isinstance(witness_policy, dict):
                 raise ValueError(
-                    "witness_policy_invalid: must be a dict "
-                    '{"required": int, "witnesses": [...]}.'
+                    'witness_policy_invalid: must be a dict {"required": int, "witnesses": [...]}.'
                 )
             _witnesses = witness_policy.get("witnesses")
             _required = witness_policy.get("required")
@@ -2074,8 +2030,7 @@ class Agent:
                     )
             if len(set(_witnesses)) != len(_witnesses):
                 raise ValueError(
-                    "witness_policy_duplicate_witness: witnesses must not "
-                    "contain duplicates."
+                    "witness_policy_duplicate_witness: witnesses must not contain duplicates."
                 )
             if not isinstance(_required, int) or isinstance(_required, bool):
                 raise ValueError(
@@ -2094,11 +2049,7 @@ class Agent:
 
         # Derive tool_fingerprint client-side when the caller supplied
         # tool_name + tool_schema but no explicit fingerprint.
-        if (
-            tool_fingerprint is None
-            and tool_name is not None
-            and tool_schema is not None
-        ):
+        if tool_fingerprint is None and tool_name is not None and tool_schema is not None:
             tool_fingerprint = _compute_tool_fingerprint(tool_name, tool_schema)
 
         # Auto-generate 24-hex nonce when caller omits; cloud rejects duplicates in-window.
@@ -2108,9 +2059,7 @@ class Agent:
         compliance_fields: dict[str, Any] = {}
         if compliance_mode:
             compliance_fields["compliance_mode"] = True
-            compliance_fields["receipt_type"] = (
-                receipt_type or "protectmcp:decision"
-            )
+            compliance_fields["receipt_type"] = receipt_type or "protectmcp:decision"
             compliance_fields["policy_decision"] = policy_decision
             compliance_fields["action_ref"] = action_ref
             for k, v in (
@@ -2218,17 +2167,14 @@ class Agent:
             incident_class=data.get("incident_class"),
             reason=data.get("reason"),
             previous_receipt_hash=(
-                data.get("previousReceiptHash")
-                or data.get("previous_receipt_hash")
+                data.get("previousReceiptHash") or data.get("previous_receipt_hash")
             ),
             # Spec-shape `decision`; fall back to local translation for
             # older clouds that only emit `policy_decision`.
             decision=(
                 data.get("decision")
                 or (
-                    _map_policy_decision_to_decision(
-                        data.get("policy_decision")
-                    )
+                    _map_policy_decision_to_decision(data.get("policy_decision"))
                     if data.get("compliance_mode")
                     else None
                 )
@@ -2240,6 +2186,7 @@ class Agent:
         # Dispatch after-hooks (fail-open).
         try:
             from . import hooks as _hooks_mod
+
             _hooks_mod._dispatch_after(action_type, response)
         except Exception:
             logger.warning("asqav after-hook dispatch failed (fail-open)", exc_info=True)
@@ -2289,9 +2236,7 @@ class Agent:
             decision=(
                 data.get("decision")
                 or (
-                    _map_policy_decision_to_decision(
-                        data.get("policy_decision")
-                    )
+                    _map_policy_decision_to_decision(data.get("policy_decision"))
                     if data.get("compliance_mode")
                     else None
                 )
@@ -2365,9 +2310,7 @@ class Agent:
                         decision=(
                             sig.get("decision")
                             or (
-                                _map_policy_decision_to_decision(
-                                    sig.get("policy_decision")
-                                )
+                                _map_policy_decision_to_decision(sig.get("policy_decision"))
                                 if sig.get("compliance_mode")
                                 else None
                             )
@@ -2401,6 +2344,7 @@ class Agent:
             output_hash = _hash_value(output)
         except Exception:
             import warnings
+
             warnings.warn("asqav: failed to hash output, signing without output_hash")
             output_hash = ""
 
@@ -3335,9 +3279,7 @@ def verify_compliance_receipt(
     errors: list[str] = []
 
     # 1. REQUIRED fields present.
-    missing = [
-        f for f in _COMPLIANCE_REQUIRED_FIELDS if f not in envelope
-    ]
+    missing = [f for f in _COMPLIANCE_REQUIRED_FIELDS if f not in envelope]
     fields_present = not missing
     if missing:
         errors.append(f"missing_fields:{','.join(missing)}")
@@ -3386,9 +3328,7 @@ def verify_compliance_receipt(
             _chain_input: dict[str, Any] = _inner
         else:
             _chain_input = predecessor_envelope
-        actual_prev = hashlib.sha256(
-            canonical_json(_chain_input)
-        ).hexdigest()
+        actual_prev = hashlib.sha256(canonical_json(_chain_input)).hexdigest()
         if actual_prev != expected_prev:
             chain_link_rederives = False
             errors.append("chain_link_mismatch")
@@ -3758,6 +3698,7 @@ def _parse_signing_session(data: dict[str, Any]) -> SigningSessionResponse:
 
 # --- Signing Groups ---
 
+
 def create_signing_group(
     agent_id: str,
     min_approvals: int,
@@ -3776,11 +3717,14 @@ def create_signing_group(
     Example:
         config = asqav.create_signing_group("agt_xxx", min_approvals=2, total_shares=3)
     """
-    data = _post("/signing-groups/configs", {
-        "agent_id": agent_id,
-        "min_approvals": min_approvals,
-        "total_shares": total_shares,
-    })
+    data = _post(
+        "/signing-groups/configs",
+        {
+            "agent_id": agent_id,
+            "min_approvals": min_approvals,
+            "total_shares": total_shares,
+        },
+    )
     return _parse_signing_group(data)
 
 
@@ -3836,6 +3780,7 @@ def _parse_signing_group(data: dict[str, Any]) -> SigningGroupResponse:
 
 # --- Signing Entities ---
 
+
 def add_entity(
     config_id: str,
     entity_class: str,
@@ -3857,10 +3802,13 @@ def add_entity(
     Example:
         entity = asqav.add_entity("cfg_xxx", entity_class="B", label="operator-1")
     """
-    data = _post(f"/signing-groups/configs/{config_id}/entities", {
-        "entity_class": entity_class,
-        "label": label,
-    })
+    data = _post(
+        f"/signing-groups/configs/{config_id}/entities",
+        {
+            "entity_class": entity_class,
+            "label": label,
+        },
+    )
     return SigningEntityResponse(
         id=data["id"],
         config_id=data["config_id"],
@@ -3907,6 +3855,7 @@ def remove_entity(entity_id: str) -> dict[str, Any]:
 
 
 # --- Group Keypairs ---
+
 
 def generate_keypair(config_id: str) -> GroupKeypairResponse:
     """Generate a multi-party ML-DSA keypair with Shamir secret sharing.
@@ -3961,9 +3910,12 @@ def group_sign(
         result = asqav.group_sign("kp_xxx", message_hex="deadbeef")
         assert result.verified  # Standard ML-DSA verifier works
     """
-    data = _post(f"/signing-groups/keypairs/{keypair_id}/sign", {
-        "message_hex": message_hex,
-    })
+    data = _post(
+        f"/signing-groups/keypairs/{keypair_id}/sign",
+        {
+            "message_hex": message_hex,
+        },
+    )
     return GroupSignResponse(
         signature_hex=data["signature_hex"],
         message_hex=data["message_hex"],
@@ -4010,10 +3962,13 @@ def recover_share(
     Returns:
         ShareRecoveryResponse with recovery details.
     """
-    data = _post(f"/signing-groups/keypairs/{keypair_id}/recover", {
-        "entity_id": entity_id,
-        "contributing_entity_ids": contributing_entity_ids,
-    })
+    data = _post(
+        f"/signing-groups/keypairs/{keypair_id}/recover",
+        {
+            "entity_id": entity_id,
+            "contributing_entity_ids": contributing_entity_ids,
+        },
+    )
     return ShareRecoveryResponse(
         keypair_id=data["keypair_id"],
         recovered_entity_id=data["recovered_entity_id"],
@@ -4035,6 +3990,7 @@ def _parse_group_keypair(data: dict[str, Any]) -> GroupKeypairResponse:
 
 
 # --- Risk Rules ---
+
 
 def create_risk_rule(
     name: str,
@@ -4156,6 +4112,7 @@ def _parse_risk_rule(data: dict[str, Any]) -> RiskRuleResponse:
 
 # --- Delegations ---
 
+
 def create_delegation(
     config_id: str,
     delegator_entity_id: str,
@@ -4184,12 +4141,15 @@ def create_delegation(
             expires_in=3600,  # 1 hour
         )
     """
-    data = _post("/signing-groups/delegations", {
-        "config_id": config_id,
-        "delegator_entity_id": delegator_entity_id,
-        "delegate_entity_id": delegate_entity_id,
-        "expires_in": expires_in,
-    })
+    data = _post(
+        "/signing-groups/delegations",
+        {
+            "config_id": config_id,
+            "delegator_entity_id": delegator_entity_id,
+            "delegate_entity_id": delegate_entity_id,
+            "expires_in": expires_in,
+        },
+    )
     return _parse_delegation(data)
 
 
@@ -4242,6 +4202,7 @@ def _parse_delegation(data: dict[str, Any]) -> DelegationResponse:
 
 
 # --- List Signing Sessions ---
+
 
 def list_sessions(
     status: str | None = None,
@@ -4355,6 +4316,7 @@ def export_audit_csv(
 
 
 # --- Trust Signal Export ---
+
 
 def generate_attestation(
     agent_id: str,

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 from ._useragent import USER_AGENT
 from .patterns import resolve_pattern
+from ._sql_match import matches_pattern as _matches_pattern
 from .retry import with_retry
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -2625,7 +2626,7 @@ class Agent:
                 if not p.get("is_active"):
                     continue
                 pattern = p.get("action_pattern", "")
-                if pattern == "*" or action_type.startswith(pattern.rstrip("*")):
+                if _matches_pattern(pattern, action_type):
                     if p.get("action") in ("block", "block_and_alert"):
                         policy_allowed = False
                         reasons.append(f"blocked by policy: {p.get('name', 'unknown')}")

--- a/python/tests/test_preflight_destructive_sql_bypass.py
+++ b/python/tests/test_preflight_destructive_sql_bypass.py
@@ -1,0 +1,259 @@
+"""Destructive SQL bypass fix: augment-match policy coverage.
+
+A data:write:sql: action containing a destructive verb (DELETE, DROP, TRUNCATE,
+ALTER) must also match a data:delete:* block policy. The original write match
+must still fire too (regression guard). Reads and non-destructive writes must
+not be affected.
+
+These tests fail against pre-fix code (bare startswith matcher) and pass after.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import Agent
+from asqav.async_client import AsyncAgent
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+MOCK_AGENT_DATA = {
+    "agent_id": "agent_test123",
+    "name": "test-agent",
+    "public_key": "pk_test123",
+    "key_id": "key_test123",
+    "algorithm": "ml-dsa-65",
+    "capabilities": [],
+    "created_at": 1700000000.0,
+}
+
+ASYNC_AGENT = AsyncAgent(
+    agent_id="agent_test123",
+    name="test-agent",
+    public_key="pk_test123",
+    key_id="key_test123",
+    algorithm="ml-dsa-65",
+    capabilities=[],
+    created_at=1700000000.0,
+)
+
+_DELETE_POLICY = [
+    {
+        "is_active": True,
+        "action_pattern": "data:delete:*",
+        "action": "block",
+        "name": "no-deletions",
+    }
+]
+
+_WRITE_SQL_POLICY = [
+    {
+        "is_active": True,
+        "action_pattern": "data:write:sql:*",
+        "action": "block",
+        "name": "no-sql-writes",
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# Sync Agent tests
+# ---------------------------------------------------------------------------
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_delete_policy_blocks_write_sql_delete_from(mock_post, mock_get):
+    """data:delete:* policy blocks data:write:sql:DELETE FROM users."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight("data:write:sql:DELETE FROM users")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+    assert any("no-deletions" in r for r in result.reasons)
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_delete_policy_blocks_write_sql_delete_from_underscore(mock_post, mock_get):
+    """data:delete:* policy blocks data:write:sql:DELETE_FROM_users (underscore form)."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight("data:write:sql:DELETE_FROM_users")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+    assert any("no-deletions" in r for r in result.reasons)
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_delete_policy_blocks_write_sql_drop(mock_post, mock_get):
+    """data:delete:* policy blocks data:write:sql:DROP TABLE t."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight("data:write:sql:DROP TABLE t")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_delete_policy_blocks_write_sql_truncate(mock_post, mock_get):
+    """data:delete:* policy blocks data:write:sql:TRUNCATE TABLE t."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight("data:write:sql:TRUNCATE TABLE t")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_regression_write_policy_still_blocks_destructive_write(mock_post, mock_get):
+    """Regression guard: data:write:sql:* policy still blocks a DELETE write action."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _WRITE_SQL_POLICY]
+
+    result = agent.preflight("data:write:sql:DELETE FROM users")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+    assert any("no-sql-writes" in r for r in result.reasons)
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_negative_delete_policy_does_not_block_benign_write(mock_post, mock_get):
+    """data:delete:* policy must not block data:write:sql:INSERT INTO t."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight("data:write:sql:INSERT INTO t VALUES (1)")
+
+    assert result.cleared is True
+    assert result.policy_allowed is True
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_negative_delete_policy_does_not_block_read_mentioning_delete(mock_post, mock_get):
+    """data:delete:* policy must not block data:read:sql:SELECT delete_flag FROM t."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight("data:read:sql:SELECT delete_flag FROM t")
+
+    assert result.cleared is True
+    assert result.policy_allowed is True
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_negative_deleted_at_is_not_destructive(mock_post, mock_get):
+    """deleted_at in a write action does not trigger the destructive verb detection."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight("data:write:sql:UPDATE t SET deleted_at=NOW()")
+
+    assert result.cleared is True
+    assert result.policy_allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Async Agent tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_async_delete_policy_blocks_write_sql_delete(mock_get):
+    """Async: data:delete:* policy blocks data:write:sql:DELETE FROM users."""
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = await ASYNC_AGENT.preflight("data:write:sql:DELETE FROM users")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+    assert any("no-deletions" in r for r in result.reasons)
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_async_delete_policy_blocks_write_sql_drop(mock_get):
+    """Async: data:delete:* policy blocks data:write:sql:DROP TABLE t."""
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = await ASYNC_AGENT.preflight("data:write:sql:DROP TABLE t")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_async_regression_write_policy_still_fires(mock_get):
+    """Async regression guard: data:write:sql:* still blocks a destructive write."""
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _WRITE_SQL_POLICY]
+
+    result = await ASYNC_AGENT.preflight("data:write:sql:DELETE FROM users")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+    assert any("no-sql-writes" in r for r in result.reasons)
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_async_negative_delete_policy_does_not_block_insert(mock_get):
+    """Async: data:delete:* policy must not block a benign INSERT."""
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = await ASYNC_AGENT.preflight("data:write:sql:INSERT INTO t VALUES (1)")
+
+    assert result.cleared is True
+    assert result.policy_allowed is True
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_async_negative_delete_policy_does_not_block_read(mock_get):
+    """Async: data:delete:* does not block data:read:sql:SELECT delete_flag FROM t."""
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = await ASYNC_AGENT.preflight("data:read:sql:SELECT delete_flag FROM t")
+
+    assert result.cleared is True
+    assert result.policy_allowed is True

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1850,6 +1850,35 @@ async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, un
   return fullBody;
 }
 
+// === Destructive SQL augment-match helper ===
+
+const _WRITE_SQL_PREFIX = "data:write:sql:";
+const _DELETE_SQL_PREFIX = "data:delete:sql:";
+// Matches DELETE, DROP, TRUNCATE, ALTER as whole words (non-letter boundary on each side).
+const _DESTRUCTIVE_VERB_RE = /(?<![A-Za-z])(DELETE|DROP|TRUNCATE|ALTER)(?![A-Za-z])/i;
+
+/**
+ * Returns match candidates for a given action type.
+ * For a destructive SQL write, also returns a `data:delete:sql:` candidate
+ * so delete-namespace policies fire without removing the write-namespace match.
+ */
+function _actionCandidates(actionType: string): string[] {
+  if (!actionType.startsWith(_WRITE_SQL_PREFIX)) return [actionType];
+  const suffix = actionType.slice(_WRITE_SQL_PREFIX.length);
+  if (_DESTRUCTIVE_VERB_RE.test(suffix)) {
+    return [actionType, _DELETE_SQL_PREFIX + suffix];
+  }
+  return [actionType];
+}
+
+function _matchesPattern(pattern: string, actionType: string): boolean {
+  const prefix = pattern.replace(/\*+$/, "");
+  for (const candidate of _actionCandidates(actionType)) {
+    if (pattern === "*" || candidate.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
 // === Agent ===
 
 interface AgentData {
@@ -2060,7 +2089,7 @@ export class Agent {
       for (const p of list) {
         if (!p.is_active) continue;
         const pattern = p.action_pattern ?? "";
-        const matches = pattern === "*" || actionType.startsWith(pattern.replace(/\*+$/, ""));
+        const matches = _matchesPattern(pattern, actionType);
         if (matches && (p.action === "block" || p.action === "block_and_alert")) {
           policyAllowed = false;
           reasons.push(`blocked by policy: ${p.name ?? "unknown"}`);

--- a/typescript/tests/destructiveSqlBypass.test.ts
+++ b/typescript/tests/destructiveSqlBypass.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Destructive SQL bypass fix: augment-match policy coverage.
+ *
+ * A data:write:sql: action with a destructive verb (DELETE, DROP, TRUNCATE,
+ * ALTER) must also match a data:delete:* block policy. The write-namespace
+ * match must be preserved (regression guard). Reads and benign writes are not
+ * affected.
+ *
+ * Each test here fails against pre-fix code and passes after the fix.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Agent, _resetForTests, init } from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_1",
+    name: "test",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-01-01T00:00:00Z",
+  });
+}
+
+const activeAgent = { revoked: false, suspended: false };
+
+const deletePolicies = [
+  { is_active: true, action_pattern: "data:delete:*", action: "block", name: "no-deletions" },
+];
+
+const writeSqlPolicies = [
+  { is_active: true, action_pattern: "data:write:sql:*", action: "block", name: "no-sql-writes" },
+];
+
+describe("destructive SQL write bypass fix", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("data:delete:* policy blocks data:write:sql:DELETE FROM users", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+    const r = await makeAgent().preflight("data:write:sql:DELETE FROM users");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+    expect(r.reasons.some((s) => s.includes("no-deletions"))).toBe(true);
+  });
+
+  it("data:delete:* policy blocks data:write:sql:DELETE_FROM_users (underscore form)", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+    const r = await makeAgent().preflight("data:write:sql:DELETE_FROM_users");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+    expect(r.reasons.some((s) => s.includes("no-deletions"))).toBe(true);
+  });
+
+  it("data:delete:* policy blocks data:write:sql:DROP TABLE t", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+    const r = await makeAgent().preflight("data:write:sql:DROP TABLE t");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+  });
+
+  it("data:delete:* policy blocks data:write:sql:TRUNCATE TABLE t", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+    const r = await makeAgent().preflight("data:write:sql:TRUNCATE TABLE t");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+  });
+
+  it("regression guard: data:write:sql:* still blocks a destructive write action", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(writeSqlPolicies));
+
+    const r = await makeAgent().preflight("data:write:sql:DELETE FROM users");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+    expect(r.reasons.some((s) => s.includes("no-sql-writes"))).toBe(true);
+  });
+
+  it("negative: data:delete:* does not block a benign INSERT write", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+    const r = await makeAgent().preflight("data:write:sql:INSERT INTO t VALUES (1)");
+
+    expect(r.cleared).toBe(true);
+    expect(r.policyAllowed).toBe(true);
+  });
+
+  it("negative: data:delete:* does not block a read mentioning delete", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+    const r = await makeAgent().preflight("data:read:sql:SELECT delete_flag FROM t");
+
+    expect(r.cleared).toBe(true);
+    expect(r.policyAllowed).toBe(true);
+  });
+
+  it("negative: deleted_at in a write suffix does not trigger destructive detection", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+    const r = await makeAgent().preflight("data:write:sql:UPDATE t SET deleted_at=NOW()");
+
+    expect(r.cleared).toBe(true);
+    expect(r.policyAllowed).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #318.

A `data:write:sql:DELETE FROM users` action was not matched by a `data:delete:*` block policy because the local matcher did only a prefix check. An agent routing a destructive SQL command through the write namespace could bypass a no-deletions policy.

## What changed

- Added `python/src/asqav/_sql_match.py` with `action_candidates(action_type)` and `matches_pattern(pattern, action_type)`. For a `data:write:sql:` action whose suffix contains a destructive verb (DELETE, DROP, TRUNCATE, ALTER, word-bounded), it returns both the original action type and a derived `data:delete:sql:` variant so both write and delete policies match. All other actions are unchanged.
- Imported and used in `client.py` (sync) and `async_client.py` (async).
- Mirrored as `_actionCandidates` / `_matchesPattern` in `typescript/src/index.ts`.

The original write-namespace match is preserved (regression guard passes).

## Proof of work

Pre-fix (stashed src changes):
```
python -m pytest tests/test_preflight_destructive_sql_bypass.py -q
6 failed, 7 passed in 0.15s
```

Post-fix Python:
```
python -m pytest tests/test_preflight_destructive_sql_bypass.py -q
13 passed in 0.07s

python -m pytest tests/test_preflight_fail_closed.py tests/test_async_preflight_fail_closed.py tests/test_async_preflight_resolve_pattern.py tests/test_patterns.py -q
30 passed in 0.21s
```

Post-fix TypeScript:
```
npx vitest run
Test Files  36 passed (36)
Tests  459 passed (459)
```

Diff stat: 6 files changed, 487 insertions(+), 3 deletions(-)