### PR TITLE
fix(verifier): TS asqav-native adapter now checks key revocation (CRIT-167)

### DIFF
--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -215,7 +215,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 47
+    assert len(results) == 48
     # asqav-05 (INCOMPLETE) upgrades to PASS when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -20,6 +20,7 @@ import {
   FormatAdapter,
   type AxisCheck,
   type ChainStep,
+  type ExtraAxis,
   type KeyProvider,
   type SignatureMaterial,
 } from "../adapter.js";
@@ -29,9 +30,11 @@ import { isLowerHex } from "./acta.js";
 import {
   FIRST_RECEIPT_SEED,
   b64decode,
+  checkKeyStatus,
   checkStructure,
   normaliseEnvelope,
   resolveKey,
+  resolveRevokedAt,
 } from "../vrShim.js";
 
 /** Field set the cloud's hash-mode signer canonicalises (for the structure check). */
@@ -177,5 +180,20 @@ export class AsqavNativeAdapter extends FormatAdapter {
       return ["PASS", "hash-mode signature receipt; required flat fields present"];
     }
     return checkStructure(payloadOf(doc));
+  }
+
+  // Gate on signing key revocation status (mirrors Python extra_axes).
+  // No-op when key is absent; the signature axis already handles that.
+  extraAxes(doc: Record<string, unknown>, keyProvider: KeyProvider): ExtraAxis[] {
+    const jwks = (keyProvider ?? { keys: [] }) as Record<string, unknown>;
+    const kid = this.extractSignature(doc).kid;
+    const [pk, status] = resolveKey(jwks, kid);
+    if (pk === null) return [];
+    const issuedAt = isHashMode(doc)
+      ? String(doc.server_timestamp ?? "")
+      : String(payloadOf(doc).issued_at ?? "");
+    const revokedAt = resolveRevokedAt(jwks, kid);
+    const [res, note] = checkKeyStatus(status, issuedAt, revokedAt);
+    return [["key_status", res, note]];
   }
 }

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -104,3 +104,47 @@ export function resolveKey(
   }
   return [null, null, null];
 }
+
+/** Return the JWKS revoked_at for kid if published, else null (mirrors `resolve_revoked_at`). */
+export function resolveRevokedAt(jwks: Record<string, unknown> | null, kid: string): string | null {
+  const keys = (jwks?.keys as Array<Record<string, unknown>> | undefined) ?? [];
+  for (const k of keys) {
+    if (kid && (kid === k.issuer_id || kid === k.kid)) {
+      return typeof k.revoked_at === "string" ? k.revoked_at : null;
+    }
+  }
+  return null;
+}
+
+// Mirrors Python REVOKED_KEY_STATUSES; receipts from these keys must not PASS offline.
+const REVOKED_KEY_STATUSES = new Set(["revoked", "suspended", "compromised"]);
+
+// Gate on the key's JWKS status (mirrors `check_key_status`).
+// With revoked_at, receipts signed before revocation still PASS.
+// Without revoked_at, any revoked-status key FAILs the axis.
+export function checkKeyStatus(
+  status: string | null,
+  issuedAt: string,
+  revokedAt: string | null,
+): readonly ["PASS" | "FAIL", string] {
+  const s = (status ?? "").toLowerCase();
+  if (!REVOKED_KEY_STATUSES.has(s)) {
+    return ["PASS", `signing key status ${JSON.stringify(status)} is active`];
+  }
+  if (revokedAt) {
+    try {
+      const rev = new Date(revokedAt).getTime();
+      const iss = new Date(issuedAt).getTime();
+      if (isNaN(rev) || isNaN(iss)) {
+        return ["FAIL", `signing key status ${JSON.stringify(status)}; unparseable revoked_at/issued_at`];
+      }
+      if (rev <= iss) {
+        return ["FAIL", `signing key revoked at ${revokedAt} on/before issuance ${issuedAt}`];
+      }
+      return ["PASS", `signing key revoked at ${revokedAt}, after issuance ${issuedAt}`];
+    } catch {
+      return ["FAIL", `signing key status ${JSON.stringify(status)}; unparseable revoked_at/issued_at`];
+    }
+  }
+  return ["FAIL", `signing key status ${JSON.stringify(status)}; receipt cannot be trusted`];
+}

--- a/typescript/tests/offline-verify.test.ts
+++ b/typescript/tests/offline-verify.test.ts
@@ -107,6 +107,98 @@ describe("verifyReceiptOffline - Ed25519 path (no network)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// verifyReceiptOffline: revoked-key receipts (CRIT-167 fix)
+// ---------------------------------------------------------------------------
+
+describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
+  const REVOKED_DIR = join(VECTORS, "asqav-07-revoked-key");
+
+  it("returns FAIL for a receipt with a valid sig but revoked key status (corpus vector)", () => {
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const jwks = loadJson(REVOKED_DIR, "jwks.json");
+    const result = verifyReceiptOffline(receipt, jwks);
+    expect(result.verdict).toBe("FAIL");
+    const keyAxis = result.axes.find((a) => a.axis === "key_status");
+    expect(keyAxis, "key_status axis must be present").toBeDefined();
+    expect(keyAxis?.result).toBe("FAIL");
+  });
+
+  it("key_status axis note names the revoked status", () => {
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const jwks = loadJson(REVOKED_DIR, "jwks.json");
+    const result = verifyReceiptOffline(receipt, jwks);
+    const keyAxis = result.axes.find((a) => a.axis === "key_status");
+    expect(keyAxis?.note).toMatch(/revoked/i);
+  });
+
+  it("signature axis is PASS (sig is valid - only revocation triggers FAIL)", () => {
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const jwks = loadJson(REVOKED_DIR, "jwks.json");
+    const result = verifyReceiptOffline(receipt, jwks);
+    const sigAxis = result.axes.find((a) => a.axis === "signature");
+    expect(sigAxis?.result).toBe("PASS");
+  });
+
+  it("returns PASS for the same receipt when key status is active (anti-vacuous: revocation is what fails it)", () => {
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const revokedJwks = loadJson(REVOKED_DIR, "jwks.json");
+    // Promote the key to active so revocation is the only difference.
+    const activeJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
+    ((activeJwks.keys as Array<Record<string, unknown>>)[0]).status = "active";
+    const result = verifyReceiptOffline(receipt, activeJwks);
+    expect(result.verdict).toBe("PASS");
+  });
+
+  it("suspended key also FAILs the key_status axis (REVOKED_KEY_STATUSES parity)", () => {
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const revokedJwks = loadJson(REVOKED_DIR, "jwks.json");
+    const suspJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
+    ((suspJwks.keys as Array<Record<string, unknown>>)[0]).status = "suspended";
+    const result = verifyReceiptOffline(receipt, suspJwks);
+    expect(result.verdict).toBe("FAIL");
+    const keyAxis = result.axes.find((a) => a.axis === "key_status");
+    expect(keyAxis?.result).toBe("FAIL");
+  });
+
+  it("compromised key also FAILs the key_status axis (REVOKED_KEY_STATUSES parity)", () => {
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const revokedJwks = loadJson(REVOKED_DIR, "jwks.json");
+    const compJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
+    ((compJwks.keys as Array<Record<string, unknown>>)[0]).status = "compromised";
+    const result = verifyReceiptOffline(receipt, compJwks);
+    expect(result.verdict).toBe("FAIL");
+    const keyAxis = result.axes.find((a) => a.axis === "key_status");
+    expect(keyAxis?.result).toBe("FAIL");
+  });
+
+  it("revoked key with revoked_at AFTER issuance passes (historical verify semantics)", () => {
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const revokedJwks = loadJson(REVOKED_DIR, "jwks.json");
+    // issued_at is 2026-06-01T12:00:00+00:00; revoked_at is after that.
+    const futureJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
+    ((futureJwks.keys as Array<Record<string, unknown>>)[0]).revoked_at = "2026-12-01T00:00:00+00:00";
+    const result = verifyReceiptOffline(receipt, futureJwks);
+    expect(result.verdict).toBe("PASS");
+    const keyAxis = result.axes.find((a) => a.axis === "key_status");
+    expect(keyAxis?.result).toBe("PASS");
+    expect(keyAxis?.note).toMatch(/after issuance/i);
+  });
+
+  it("revoked key with revoked_at AT issuance fails (at-or-before rule)", () => {
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const revokedJwks = loadJson(REVOKED_DIR, "jwks.json");
+    // Same timestamp as issued_at -> rev <= iss -> FAIL
+    const atJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
+    ((atJwks.keys as Array<Record<string, unknown>>)[0]).revoked_at = "2026-06-01T12:00:00+00:00";
+    const result = verifyReceiptOffline(receipt, atJwks);
+    expect(result.verdict).toBe("FAIL");
+    const keyAxis = result.axes.find((a) => a.axis === "key_status");
+    expect(keyAxis?.result).toBe("FAIL");
+    expect(keyAxis?.note).toMatch(/on\/before issuance/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // verifyReceiptOffline: FAIL on tampered receipts (no network)
 // ---------------------------------------------------------------------------
 

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -27,7 +27,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 47 corpus vectors", () => {
+  it("matches every manifest outcome across all 48 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -43,9 +43,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(47);
+    expect(results.length).toBe(48);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(47);
+    expect(passed).toBe(48);
   });
 });
 

--- a/verifier/conformance-vectors/asqav-07-revoked-key/expected.json
+++ b/verifier/conformance-vectors/asqav-07-revoked-key/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "FAIL",
+  "reason_code": "key_revoked",
+  "notes": "Valid Ed25519 signature but signing key status is 'revoked'; key_status axis FAILs the verdict."
+}

--- a/verifier/conformance-vectors/asqav-07-revoked-key/jwks.json
+++ b/verifier/conformance-vectors/asqav-07-revoked-key/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-revoked-vec-key",
+      "issuer_id": "asqav-revoked-vec-key",
+      "alg": "Ed25519",
+      "status": "revoked",
+      "public_key": "/PBBLcxOwjAyUBqghZxoG/xgjfxcbQWS+koNDeRa4Fk="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-07-revoked-key/receipt.json
+++ b/verifier/conformance-vectors/asqav-07-revoked-key/receipt.json
@@ -1,0 +1,23 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-06-01T12:00:00+00:00",
+    "issuer_id": "asqav-revoked-vec-key",
+    "agent_id": "agt_revoked_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-revoked-vec-key",
+    "sig": "qoWTP3Y4tdtaMsrvX84P+BnsdxMszFUMfNaEgkJM/ZWtK5bgRp8Nadq/cRGeEgmrLSKz23oZtqTlKYzAFPIWCQ=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -42,6 +42,13 @@
     "notes": "Real payload-mode prod ML-DSA-65 receipt; the signing input byte-matches and ML-DSA-65 verifies with dilithium-py (proven in test_offline_verify.py's known-answer test). Absent that optional dep the corpus SKIPs the signature axis, so the verdict is INCOMPLETE, confirming the verifier never false-PASSes the post-quantum path it cannot check."
   },
   {
+    "dir": "asqav-07-revoked-key",
+    "format": "asqav-native",
+    "outcome": "FAIL",
+    "reason_code": "key_revoked",
+    "notes": "Valid Ed25519 signature from a key whose JWKS status is 'revoked'; the key_status axis FAILs the verdict even though the signature itself verifies. Parity vector: both PY and TS oracles must return FAIL."
+  },
+  {
     "dir": "aerf-01-genesis",
     "format": "aerf",
     "outcome": "PASS",


### PR DESCRIPTION
## What this fixes

The TypeScript \`AsqavNativeAdapter\` had no \`extraAxes()\` override, so it inherited the base no-op. A receipt signed by a revoked, suspended, or compromised key returned **PASS** from the TS oracle and **FAIL** from the Python oracle. That breaks the cross-language parity guarantee and lets an attacker with an exfiltrated, now-revoked key mint receipts that the npm verifier accepts.

## Changes

**\`typescript/src/verifier/vrShim.ts\`** - adds two helpers that mirror the Python \`verify_receipt.py\` functions:
- \`resolveRevokedAt(jwks, kid)\` - returns the JWKS \`revoked_at\` timestamp for a key if present
- \`checkKeyStatus(status, issuedAt, revokedAt)\` - gates on \`REVOKED_KEY_STATUSES = {revoked, suspended, compromised}\` with the at-or-before-issuance rule when \`revoked_at\` is available

**\`typescript/src/verifier/adapters/asqavNative.ts\`** - overrides \`extraAxes()\` to call those helpers and return a \`key_status\` axis, matching the Python adapter exactly.

**\`verifier/conformance-vectors/asqav-07-revoked-key/\`** - new cross-language corpus vector: valid Ed25519 signature, key \`status: "revoked"\`, expected outcome \`FAIL\`. Manifest grows from 47 to 48 vectors.

**\`typescript/tests/offline-verify.test.ts\`** - 8 new unit tests covering the full \`REVOKED_KEY_STATUSES\` set, the historical-verify rule (\`revoked_at\` after issuance -> PASS), and the at-or-before rule (\`revoked_at <= issued_at\` -> FAIL).

**\`python/tests/test_oracle.py\`** - corpus count updated from 47 to 48 to include asqav-07-revoked-key.

## Anti-vacuous proof

The primary test returned \`expected 'PASS' to be 'FAIL'\` against pre-fix code without the \`extraAxes\` override. All 467 TS tests and 66 Python oracle tests pass with the fix.

## Proof of work

```
VERIFY-WITH: cd typescript && npm test
Output:
 Test Files  36 passed (36)
      Tests  467 passed (467)
   Start at  12:42:54
   Duration  3.26s (transform 6.21s, setup 0ms, import 15.26s, tests 3.57s, environment 11ms)

Python corpus (asqav-07-revoked-key):
  verdict: FAIL
  key_status=FAIL (signing key status 'revoked'; receipt cannot be trusted)

secret scan: SCANNER: gitleaks - clean

diff stat:
 9 files changed, 205 insertions(+), 3 deletions(-)
```