### PR TITLE
fix(verifier): fail clean on malformed receipt input

### DIFF
--- a/python/src/asqav/verifier/oracle/crypto.py
+++ b/python/src/asqav/verifier/oracle/crypto.py
@@ -97,9 +97,9 @@ _DISPATCH = {
 }
 
 
-def verify_signature(alg: str, pk: bytes, msg: bytes, sig: bytes) -> tuple[str, str]:
+def verify_signature(alg: object, pk: bytes, msg: bytes, sig: bytes) -> tuple[str, str]:
     """Dispatch to the algorithm's verifier; SKIP an unsupported alg."""
-    fn = _DISPATCH.get((alg or "").upper())
+    fn = _DISPATCH.get((alg if isinstance(alg, str) else "").upper())
     if fn is None:
         return SKIPPED, f"unsupported alg {alg!r} (oracle checks {sorted(_DISPATCH)})"
     return fn(pk, msg, sig)

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -265,6 +265,8 @@ def check_skew(issued_at: str):
         ts = datetime.fromisoformat(issued_at.replace("Z", "+00:00"))
     except (ValueError, AttributeError):
         return "FAIL", f"unparseable issued_at {issued_at!r}"
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
     skew = (ts - datetime.now(timezone.utc)).total_seconds()
     if skew > SKEW_BOUND_SECONDS:
         return (

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -233,15 +233,19 @@ def check_key_status(status, issued_at: str, revoked_at=None):
             iss = datetime.fromisoformat(str(issued_at).replace("Z", "+00:00"))
         except (ValueError, AttributeError):
             return "FAIL", f"signing key status {status!r}; unparseable revoked_at/issued_at"
+        if rev.tzinfo is None:
+            rev = rev.replace(tzinfo=timezone.utc)
+        if iss.tzinfo is None:
+            iss = iss.replace(tzinfo=timezone.utc)
         if rev <= iss:
             return "FAIL", f"signing key revoked at {revoked_at} on/before issuance {issued_at}"
         return "PASS", f"signing key revoked at {revoked_at}, after issuance {issued_at}"
     return "FAIL", f"signing key status {status!r}; receipt cannot be trusted"
 
 
-def verify_signature(pk: bytes, msg: bytes, sig: bytes, alg: str):
+def verify_signature(pk: bytes, msg: bytes, sig: bytes, alg: object):
     """ML-DSA-65 verify. Returns (result, note); result in PASS/FAIL/SKIPPED."""
-    if (alg or "").upper() != "ML-DSA-65":
+    if (alg if isinstance(alg, str) else "").upper() != "ML-DSA-65":
         return "SKIPPED", f"unsupported alg {alg!r} (this tool checks ML-DSA-65)"
     try:
         from dilithium_py.ml_dsa import ML_DSA_65

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -868,3 +868,18 @@ def test_pipelock_chain_genesis_sentinel_accepted() -> None:
     doc3 = json.loads(json.dumps(doc))
     doc3["chain_prev_hash"] = "sha256:" + "a" * 64
     assert ad.chain_step(doc3).is_genesis is False
+
+
+def test_oracle_verify_signature_nonstring_alg_skips_clean() -> None:
+    """A non-string alg from a malformed receipt SKIPs, never crashes on .upper()."""
+    z = b""
+    for bad_alg in (123, None, ["x"], {}):
+        result, _ = crypto.verify_signature(bad_alg, z, z, z)
+        assert result == crypto.SKIPPED
+
+
+def test_oracle_verify_nonobject_doc_fails_clean() -> None:
+    """A non-dict top-level receipt returns a FAIL verdict, never raises in detect()."""
+    for bad_doc in (None, "a string", 123, [1, 2]):
+        res = verify(bad_doc, ADAPTERS)
+        assert res.verdict == "FAIL"

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -143,3 +143,20 @@ def test_run_payload_null_without_signature_keys(capsys) -> None:
     out = capsys.readouterr().out
     assert code == 2
     assert "INCOMPLETE" in out
+
+
+def test_verify_signature_nonstring_alg_skips_clean() -> None:
+    """A non-string alg SKIPs cleanly instead of crashing on (alg or '').upper()."""
+    z = b""
+    for bad_alg in (123, None, ["x"], {}):
+        result, _ = v.verify_signature(z, z, z, bad_alg)
+        assert result == "SKIPPED"
+
+
+def test_check_key_status_tz_mismatch_fails_clean() -> None:
+    """Revoked-before-issuance with a tz-aware revoked_at and tz-naive issued_at FAILs
+    the axis, never raises a naive-vs-aware TypeError."""
+    result, _ = v.check_key_status(
+        "revoked", "2026-06-01T00:00:00", "2026-05-04T12:00:00+00:00"
+    )
+    assert result == "FAIL"

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -160,3 +160,10 @@ def test_check_key_status_tz_mismatch_fails_clean() -> None:
         "revoked", "2026-06-01T00:00:00", "2026-05-04T12:00:00+00:00"
     )
     assert result == "FAIL"
+
+
+def test_check_skew_tz_naive_issued_at_no_crash() -> None:
+    """A tz-naive issued_at must produce a verdict, never a naive-vs-aware TypeError
+    in the wall-clock subtraction."""
+    result, _ = v.check_skew("2026-05-04T00:00:00")
+    assert result in ("PASS", "FAIL")

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -41,6 +41,7 @@ export function detect(
   doc: Record<string, unknown>,
   adapters: FormatAdapter[],
 ): FormatAdapter | null {
+  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) return null;
   return adapters.find((a) => a.detect(doc)) ?? null;
 }
 

--- a/typescript/src/verifier/crypto.ts
+++ b/typescript/src/verifier/crypto.ts
@@ -130,7 +130,7 @@ export function verifySignature(
   msg: Uint8Array,
   sig: Uint8Array,
 ): VerifyOutcome {
-  const fn = DISPATCH[(alg || "").toUpperCase()];
+  const fn = DISPATCH[(typeof alg === "string" ? alg : "").toUpperCase()];
   if (fn === undefined) {
     const known = Object.keys(DISPATCH).sort().join(", ");
     return { result: SKIPPED, note: `unsupported alg '${alg}' (oracle checks ${known})` };

--- a/typescript/tests/verifier-fail-clean.test.ts
+++ b/typescript/tests/verifier-fail-clean.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Fail-clean robustness (rule 3.12): the neutral verifier returns a verdict, never
+ * throws, on malformed input (non-object receipt, non-string alg). Parity with Python.
+ */
+import { describe, expect, it } from "vitest";
+
+import { ADAPTERS } from "../src/verifier/index.js";
+import { verify as oracleVerify } from "../src/verifier/core.js";
+import { verifySignature } from "../src/verifier/crypto.js";
+
+describe("verifier fail-clean on malformed input", () => {
+  it("returns FAIL (no throw) on a non-object top-level receipt", () => {
+    for (const doc of [null, "a string", 123, [1, 2]] as unknown[]) {
+      const r = oracleVerify(doc as Record<string, unknown>, ADAPTERS);
+      expect(r.verdict).toBe("FAIL");
+    }
+  });
+
+  it("SKIPs (no throw) when alg is not a string", () => {
+    const z = new Uint8Array(0);
+    for (const alg of [123, null, ["x"], {}] as unknown[]) {
+      const r = verifySignature(alg as string, z, z, z);
+      expect(r.result).toBe("SKIPPED");
+    }
+  });
+});


### PR DESCRIPTION
## What

The neutral verifier raised raw exceptions on four malformed-input paths instead of returning a verdict, which breaks the fail-clean contract (rule 3.12) a stranger relies on when verifying an untrusted receipt. Found by a proactive adversarial sweep of the verifier, with the fourth path caught by the adversarial review of the first commit.

- **TS `detect()`** threw a `TypeError` on a non-object top-level receipt (`null`, string, number), because the adapters assume an object. It returns `null` so `verify()` reports a clean `structure=FAIL`, matching the guard Python already had.
- **Both verifiers** crashed on a non-string `alg` field (`.upper()` / `.toUpperCase()` on attacker-controlled JSON, e.g. `"alg": 123`). A non-string `alg` resolves to an unsupported alg and SKIPs, never a crash.
- **Python `check_key_status`** raised a naive-vs-aware `TypeError` when a JWKS `revoked_at` was timezone-aware and the receipt `issued_at` was naive. Both datetimes normalize to UTC before comparison (TS already handled this).
- **Python `check_skew`** had the same naive-vs-aware `TypeError` on `issued_at` in the wall-clock subtraction, outside the parse guard, so a tz-naive `issued_at` crashed the public `run()` entry. `ts` normalizes to UTC before the subtraction, matching `check_key_status`.

## Not changed

No false-attestation path. Every forged signature, payload tamper, alg downgrade, and cross-format input still FAILs. This is fail-clean hardening only (never crash on malformed input), separate from fail-closed (never PASS a forgery), which already held. The verifier was swept for every tz-sensitive datetime site and the two found (`check_key_status`, `check_skew`) are both fixed.

## Tests

New adversarial tests in `python/tests/test_oracle.py`, `python/tests/test_verify_receipt.py`, and `typescript/tests/verifier-fail-clean.test.ts` feed each path malformed input and assert a clean FAIL/SKIPPED with no exception. Confirmed non-vacuous: reverting each guard reproduces the original crash and reddens the test. Full suites green locally (Python verifier suites 80, TS 469).

## THREAT_MODEL
- attack surface: attacker-controlled receipt fields (non-object document, non-string `alg`, timezone-mismatched `revoked_at` / `issued_at`) reaching the public verifier
- existing guard: signature and structure axes already FAIL forgeries and tampers; the gap was a crash instead of a clean FAIL on malformed shapes
- new test: the four fail-clean test cases assert FAIL/SKIPPED and no raise on each path
- trust boundary changed: no. No input that FAILed before now PASSes; this only converts crashes into clean verdicts