### PR TITLE
docs: correct SDK license to MIT in Python and TS READMEs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -375,4 +375,4 @@ See <https://asqav.com/docs> for the live feature set.
 
 ## License
 
-Apache-2.0. Get an API key at [asqav.com](https://asqav.com).
+MIT. Get an API key at [asqav.com](https://asqav.com).

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -376,4 +376,4 @@ See <https://asqav.com/docs> for the live feature set.
 
 ## License
 
-Apache-2.0. Get an API key at [asqav.com](https://asqav.com).
+MIT. Get an API key at [asqav.com](https://asqav.com).


### PR DESCRIPTION
The README license sections in `python/README.md` and `typescript/README.md` stated Apache-2.0, but every authoritative source declares MIT: the `LICENSE` file, `python/pyproject.toml` (`license = "MIT"` + the MIT trove classifier), `typescript/package.json` (`"license": "MIT"`), the npm registry metadata, and the root `README.md` (MIT badge + license section). This aligns the two README lines with the actual license.

Found by a staleness audit of the repos. Doc-only, no code change.