### PR TITLE
docs(changelog): record 0.6.1 and 0.6.2, add Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to the Asqav SDK are documented here.
 Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
+## [Unreleased]
+
+### Fixed
+
+- **The neutral verifier fails clean on malformed input (Python and TypeScript).**
+  A non-object receipt, a non-string `alg`, and a timezone-mismatched `revoked_at`
+  or `issued_at` return a verdict instead of raising. No forged, tampered,
+  downgraded, or cross-format receipt verifies as valid.
+- **The TypeScript verifier checks signing-key revocation, for parity with
+  Python.** A receipt signed by a revoked key fails in both verifiers.
+- **Preflight blocks destructive SQL routed under a `data:write` namespace.**
+
+### Documentation
+
+- Correct the SDK license to MIT in the Python and TypeScript READMEs.
+
+## [0.6.2] - 2026-06-23
+
+### Added
+
+- **litellm cloud-signing callback and `verify-litellm-log` CLI.** An opt-in
+  `AsqavLogger` signs each litellm record server-side, and the CLI verifies a
+  litellm log offline.
+
+## [0.6.1] - 2026-06-23
+
+### Added
+
+- **`asqav hook` CLI subcommand for Claude Code harness hooks**, with a hooks
+  guide covering fail-open and fail-closed modes.
+
+### Fixed
+
+- **`AsyncAgent.preflight` fails closed on a fetch error** and resolves semantic
+  policy pattern aliases.
+- **The verifier gates on signing-key status in `run_structured`**, so a receipt
+  signed by a revoked key fails offline.
+- **Offline verification rejects a revoked signing key.**
+
+### Removed
+
+- **Dropped the `asqav-mcp` config generation** from the SDK.
+
 ## [0.6.0] - 2026-06-20
 
 ### Added


### PR DESCRIPTION
The changelog stopped at 0.6.0 while 0.6.1 and 0.6.2 both shipped to PyPI and npm on 2026-06-23. This adds their entries and an Unreleased section, traced from the version-bump commits:

- **0.6.1** (#328): `asqav hook` CLI subcommand + hooks guide, fail-closed `AsyncAgent.preflight` on fetch error and semantic alias resolution, verifier key-status revocation gate in `run_structured`, dropped `asqav-mcp` config generation.
- **0.6.2** (#329): litellm cloud-signing callback + `verify-litellm-log` CLI.
- **Unreleased** (post-0.6.2 on main): verifier fail-clean fix (#332), TS verifier revocation parity (#331), `data:write` SQL preflight block (#330), license correction (#333).

Doc-only. No version bump (0.6.3 stays unreleased until the next publish).

Found by a staleness audit of the repos.