### PR TITLE
chore(release): bump both SDK halves to 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Asqav SDK are documented here.
 Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
-## [Unreleased]
+## [0.6.3] - 2026-06-27
 
 ### Fixed
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.6.2"
+version = "0.6.3"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -148,7 +148,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.6.2";
+export const SDK_VERSION = "0.6.3";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Release 0.6.3 (founder-directed publish). Bumps Python (`pyproject` + `__version__`) and TypeScript (`package.json` + `SDK_VERSION`) to 0.6.3 and retitles the changelog `[Unreleased]` to `[0.6.3]`.

Contents since 0.6.2:
- Verifier fail-clean on malformed input, Python and TS (#332)
- TypeScript verifier checks key revocation for parity with Python (#331)
- Preflight blocks destructive SQL under a `data:write` namespace (#330)
- License corrected to MIT in both READMEs (#333)

Publish path on merge: push `py-v0.6.3` (PyPI via OIDC trusted publishing) and `ts-v0.6.3` (npm via repo secret), after a clean-venv install reproduction per rule 2.14.