### PR TITLE
fix(preflight): close client-side preflight fail-open and SQL match gaps

### DIFF
--- a/python/src/asqav/_sql_match.py
+++ b/python/src/asqav/_sql_match.py
@@ -19,10 +19,10 @@ import re
 _WRITE_SQL_PREFIX = "data:write:sql:"
 _DELETE_SQL_PREFIX = "data:delete:sql:"
 
-# Matches DELETE, DROP, TRUNCATE, ALTER as whole words (non-letter boundary on each side).
+# Matches destructive SQL verbs as whole words (non-letter boundary on each side).
 # Underscore counts as a word separator (e.g. DELETE_FROM matches, deleted_at does not).
 _DESTRUCTIVE_VERB_RE = re.compile(
-    r"(?<![A-Za-z])(DELETE|DROP|TRUNCATE|ALTER)(?![A-Za-z])",
+    r"(?<![A-Za-z])(DELETE|DROP|TRUNCATE|ALTER|GRANT|REVOKE|REPLACE|COPY|UPSERT)(?![A-Za-z])",
     re.IGNORECASE,
 )
 
@@ -30,21 +30,29 @@ _DESTRUCTIVE_VERB_RE = re.compile(
 def action_candidates(action_type: str) -> list[str]:
     """Return match candidates for policy evaluation.
 
-    For most actions returns [action_type]. For a destructive SQL write, also
-    returns a derived `data:delete:sql:` entry so destructive policies fire.
+    Normalizes the action_type (strip + lowercase) so case variants and stray
+    whitespace cannot dodge the prefix check. For most actions returns the
+    normalized form. For a destructive SQL write, also returns a derived
+    `data:delete:sql:` entry so destructive policies fire.
     """
-    if not action_type.startswith(_WRITE_SQL_PREFIX):
-        return [action_type]
-    suffix = action_type[len(_WRITE_SQL_PREFIX) :]
+    normalized = action_type.strip().lower()
+    if not normalized.startswith(_WRITE_SQL_PREFIX):
+        return [normalized]
+    suffix = normalized[len(_WRITE_SQL_PREFIX) :]
     if _DESTRUCTIVE_VERB_RE.search(suffix):
-        return [action_type, _DELETE_SQL_PREFIX + suffix]
-    return [action_type]
+        return [normalized, _DELETE_SQL_PREFIX + suffix]
+    return [normalized]
 
 
 def matches_pattern(pattern: str, action_type: str) -> bool:
-    """Return True if any candidate for action_type matches the pattern."""
-    prefix = pattern.rstrip("*")
+    """Return True if any candidate for action_type matches the pattern.
+
+    Matching is case-insensitive end to end: both the policy pattern and the
+    action candidates are lowercased before comparison.
+    """
+    norm_pattern = pattern.strip().lower()
+    prefix = norm_pattern.rstrip("*")
     for candidate in action_candidates(action_type):
-        if pattern == "*" or candidate.startswith(prefix):
+        if norm_pattern == "*" or candidate.startswith(prefix):
             return True
     return False

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -325,14 +325,20 @@ class AsyncAgent:
         # Check organization policies.
         try:
             policies = await _async_get("/policies")
-            for p in policies if isinstance(policies, list) else []:
-                if not p.get("is_active"):
-                    continue
-                pattern = p.get("action_pattern", "")
-                if _matches_pattern(pattern, action_type):
-                    if p.get("action") in ("block", "block_and_alert"):
-                        policy_allowed = False
-                        reasons.append(f"blocked by policy: {p.get('name', 'unknown')}")
+            if not isinstance(policies, list):
+                # A non-list response is anomalous, so fail closed instead of
+                # silently clearing on an empty iteration.
+                checks_complete = False
+                reasons.append("policy check failed (unexpected response) - could not verify")
+            else:
+                for p in policies:
+                    if not p.get("is_active"):
+                        continue
+                    pattern = p.get("action_pattern", "")
+                    if _matches_pattern(pattern, action_type):
+                        if p.get("action") in ("block", "block_and_alert"):
+                            policy_allowed = False
+                            reasons.append(f"blocked by policy: {p.get('name', 'unknown')}")
         except Exception as exc:
             checks_complete = False
             reasons.append(f"policy check failed ({exc}) - could not verify")

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -2566,14 +2566,20 @@ class Agent:
         # Check organization policies.
         try:
             policies = _get("/policies")
-            for p in policies if isinstance(policies, list) else []:
-                if not p.get("is_active"):
-                    continue
-                pattern = p.get("action_pattern", "")
-                if _matches_pattern(pattern, action_type):
-                    if p.get("action") in ("block", "block_and_alert"):
-                        policy_allowed = False
-                        reasons.append(f"blocked by policy: {p.get('name', 'unknown')}")
+            if not isinstance(policies, list):
+                # A non-list response is anomalous, so fail closed instead of
+                # silently clearing on an empty iteration.
+                checks_complete = False
+                reasons.append("policy check failed (unexpected response) - could not verify")
+            else:
+                for p in policies:
+                    if not p.get("is_active"):
+                        continue
+                    pattern = p.get("action_pattern", "")
+                    if _matches_pattern(pattern, action_type):
+                        if p.get("action") in ("block", "block_and_alert"):
+                            policy_allowed = False
+                            reasons.append(f"blocked by policy: {p.get('name', 'unknown')}")
         except Exception as exc:
             checks_complete = False
             reasons.append(f"policy check failed ({exc}) - could not verify")

--- a/python/src/asqav/patterns.py
+++ b/python/src/asqav/patterns.py
@@ -19,8 +19,13 @@ PATTERNS: dict[str, str] = {
 
 
 def resolve_pattern(pattern: str) -> str:
-    """Resolve a semantic pattern name to its glob string; passthrough for unknown patterns."""
-    return PATTERNS.get(pattern, pattern)
+    """Resolve a semantic pattern name to its glob string; passthrough for unknown patterns.
+
+    Normalizes input (strip + lowercase) so case variants resolve and stray
+    whitespace cannot dodge case-insensitive policy matching downstream.
+    """
+    key = pattern.strip().lower()
+    return PATTERNS.get(key, key)
 
 
 def list_patterns() -> dict[str, str]:

--- a/python/tests/test_async_preflight_fail_closed.py
+++ b/python/tests/test_async_preflight_fail_closed.py
@@ -60,6 +60,21 @@ async def test_policy_fetch_error_does_not_clear(mock_get: AsyncMock) -> None:
 
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_non_list_policies_does_not_clear(mock_get: AsyncMock) -> None:
+    """A non-list /policies response fails closed instead of silently clearing."""
+    mock_get.side_effect = [
+        {"revoked": False, "suspended": False},  # status check
+        {"policies": []},  # anomalous non-list policies response
+    ]
+
+    result = await AGENT.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is False
+    assert any("unexpected response" in r for r in result.reasons)
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_happy_path_still_clears(mock_get: AsyncMock) -> None:
     """An active agent with no blocking policy clears, checks_complete True."""
     mock_get.side_effect = [

--- a/python/tests/test_preflight_destructive_sql_bypass.py
+++ b/python/tests/test_preflight_destructive_sql_bypass.py
@@ -192,6 +192,118 @@ def test_negative_deleted_at_is_not_destructive(mock_post, mock_get):
     assert result.policy_allowed is True
 
 
+_UPPER_WRITE_SQL_POLICY = [
+    {
+        "is_active": True,
+        "action_pattern": "DATA:WRITE:SQL:*",
+        "action": "block",
+        "name": "no-sql-writes",
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# H3: case-variant + whitespace must not bypass matching
+# ---------------------------------------------------------------------------
+
+
+def test_action_candidates_normalize_case_and_whitespace():
+    """Uppercase and whitespace variants produce the same candidates as lowercase."""
+    from asqav._sql_match import action_candidates
+
+    base = action_candidates("data:write:sql:DELETE FROM users")
+    upper = action_candidates("DATA:WRITE:SQL:DELETE FROM users")
+    spaced = action_candidates("  data:write:sql:DELETE FROM users  ")
+
+    assert upper == base
+    assert spaced == base
+    assert "data:delete:sql:delete from users" in base
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_uppercase_action_blocked_by_lowercase_delete_policy(mock_post, mock_get):
+    """A lowercase data:delete:* policy blocks an uppercase DATA:WRITE:SQL:DELETE."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight("DATA:WRITE:SQL:DELETE FROM users")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+    assert any("no-deletions" in r for r in result.reasons)
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_whitespace_action_blocked_by_delete_policy(mock_post, mock_get):
+    """Leading/trailing whitespace does not let a DELETE write dodge the policy."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight("  data:write:sql:DELETE FROM users  ")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_lowercase_pattern_blocks_uppercase_action(mock_post, mock_get):
+    """A lowercase data:write:sql:* pattern blocks an uppercase write action."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _WRITE_SQL_POLICY]
+
+    result = agent.preflight("DATA:WRITE:SQL:DELETE FROM users")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+    assert any("no-sql-writes" in r for r in result.reasons)
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_uppercase_pattern_blocks_lowercase_action(mock_post, mock_get):
+    """An uppercase DATA:WRITE:SQL:* pattern blocks a lowercase write action."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _UPPER_WRITE_SQL_POLICY]
+
+    result = agent.preflight("data:write:sql:INSERT INTO t VALUES (1)")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+
+
+# ---------------------------------------------------------------------------
+# M1: extended destructive verbs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("verb", ["GRANT", "REVOKE", "REPLACE", "COPY", "UPSERT"])
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_extended_destructive_verb_blocked_by_delete_policy(mock_post, mock_get, verb):
+    """Each extended destructive verb matches the data:delete:* augment."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+    mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
+
+    result = agent.preflight(f"data:write:sql:{verb} something")
+
+    assert result.cleared is False
+    assert result.policy_allowed is False
+    assert any("no-deletions" in r for r in result.reasons)
+
+
 # ---------------------------------------------------------------------------
 # Async Agent tests
 # ---------------------------------------------------------------------------

--- a/python/tests/test_preflight_fail_closed.py
+++ b/python/tests/test_preflight_fail_closed.py
@@ -78,6 +78,25 @@ def test_policy_fetch_error_does_not_clear(mock_post, mock_get):
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
+def test_non_list_policies_does_not_clear(mock_post, mock_get):
+    """A non-list /policies response fails closed instead of silently clearing."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+
+    mock_get.side_effect = [
+        {"revoked": False, "suspended": False},  # status check
+        {"policies": []},  # anomalous non-list policies response
+    ]
+
+    result = agent.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is False
+    assert any("unexpected response" in r for r in result.reasons)
+
+
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
 def test_happy_path_still_clears(mock_post, mock_get):
     """An active agent with no blocking policy still clears, checks_complete True."""
     mock_post.return_value = MOCK_AGENT_DATA

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -901,6 +901,7 @@ export interface PreflightResult {
   policyAllowed: boolean;
   reasons: string[];
   explanation: string;
+  checksComplete: boolean;
 }
 
 // === init ===
@@ -1854,27 +1855,31 @@ async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, un
 
 const _WRITE_SQL_PREFIX = "data:write:sql:";
 const _DELETE_SQL_PREFIX = "data:delete:sql:";
-// Matches DELETE, DROP, TRUNCATE, ALTER as whole words (non-letter boundary on each side).
-const _DESTRUCTIVE_VERB_RE = /(?<![A-Za-z])(DELETE|DROP|TRUNCATE|ALTER)(?![A-Za-z])/i;
+// Matches destructive SQL verbs as whole words (non-letter boundary on each side).
+const _DESTRUCTIVE_VERB_RE = /(?<![A-Za-z])(DELETE|DROP|TRUNCATE|ALTER|GRANT|REVOKE|REPLACE|COPY|UPSERT)(?![A-Za-z])/i;
 
 /**
  * Returns match candidates for a given action type.
- * For a destructive SQL write, also returns a `data:delete:sql:` candidate
- * so delete-namespace policies fire without removing the write-namespace match.
+ * Normalizes (trim + lowercase) so case variants and stray whitespace cannot
+ * dodge the prefix check. For a destructive SQL write, also returns a
+ * `data:delete:sql:` candidate so delete-namespace policies fire.
  */
 function _actionCandidates(actionType: string): string[] {
-  if (!actionType.startsWith(_WRITE_SQL_PREFIX)) return [actionType];
-  const suffix = actionType.slice(_WRITE_SQL_PREFIX.length);
+  const normalized = actionType.trim().toLowerCase();
+  if (!normalized.startsWith(_WRITE_SQL_PREFIX)) return [normalized];
+  const suffix = normalized.slice(_WRITE_SQL_PREFIX.length);
   if (_DESTRUCTIVE_VERB_RE.test(suffix)) {
-    return [actionType, _DELETE_SQL_PREFIX + suffix];
+    return [normalized, _DELETE_SQL_PREFIX + suffix];
   }
-  return [actionType];
+  return [normalized];
 }
 
+// Case-insensitive end to end: pattern and candidates are both lowercased.
 function _matchesPattern(pattern: string, actionType: string): boolean {
-  const prefix = pattern.replace(/\*+$/, "");
+  const normPattern = pattern.trim().toLowerCase();
+  const prefix = normPattern.replace(/\*+$/, "");
   for (const candidate of _actionCandidates(actionType)) {
-    if (pattern === "*" || candidate.startsWith(prefix)) return true;
+    if (normPattern === "*" || candidate.startsWith(prefix)) return true;
   }
   return false;
 }
@@ -2051,12 +2056,13 @@ export class Agent {
 
   /**
    * Pre-flight check combining revocation/suspension status and policy.
-   * Fail-open: if a sub-check errors, it is recorded in `reasons` but
-   * does not block. Mirrors the Python `Agent.preflight`.
+   * Fail-closed: if a sub-check cannot complete, checksComplete is false and
+   * cleared is false so a fetch error never clears. Mirrors Python preflight.
    */
   async preflight(actionType: string): Promise<PreflightResult> {
     let agentActive = true;
     let policyAllowed = true;
+    let checksComplete = true;
     const reasons: string[] = [];
 
     try {
@@ -2075,7 +2081,8 @@ export class Agent {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      reasons.push(`status check failed (${msg}) - skipped`);
+      checksComplete = false;
+      reasons.push(`status check failed (${msg}) - could not verify`);
     }
 
     try {
@@ -2085,25 +2092,34 @@ export class Agent {
         action?: string;
         name?: string;
       }>>("GET", "/policies");
-      const list = Array.isArray(policies) ? policies : [];
-      for (const p of list) {
-        if (!p.is_active) continue;
-        const pattern = p.action_pattern ?? "";
-        const matches = _matchesPattern(pattern, actionType);
-        if (matches && (p.action === "block" || p.action === "block_and_alert")) {
-          policyAllowed = false;
-          reasons.push(`blocked by policy: ${p.name ?? "unknown"}`);
+      if (!Array.isArray(policies)) {
+        // A non-list response is anomalous, so fail closed instead of
+        // silently clearing on an empty iteration.
+        checksComplete = false;
+        reasons.push("policy check failed (unexpected response) - could not verify");
+      } else {
+        for (const p of policies) {
+          if (!p.is_active) continue;
+          const pattern = p.action_pattern ?? "";
+          const matches = _matchesPattern(pattern, actionType);
+          if (matches && (p.action === "block" || p.action === "block_and_alert")) {
+            policyAllowed = false;
+            reasons.push(`blocked by policy: ${p.name ?? "unknown"}`);
+          }
         }
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      reasons.push(`policy check failed (${msg}) - skipped`);
+      checksComplete = false;
+      reasons.push(`policy check failed (${msg}) - could not verify`);
     }
 
-    const cleared = agentActive && policyAllowed;
+    const cleared = agentActive && policyAllowed && checksComplete;
     let explanation: string;
     if (cleared) {
       explanation = "Allowed: agent is active and action is permitted by policy";
+    } else if (!checksComplete) {
+      explanation = `Blocked: could not verify (${reasons.join("; ")})`;
     } else if (!agentActive && reasons.includes("agent is revoked")) {
       explanation = "Blocked: agent has been revoked";
     } else if (!agentActive && reasons.some((r) => r.startsWith("agent is suspended"))) {
@@ -2115,7 +2131,7 @@ export class Agent {
       explanation = reasons.length ? `Blocked: ${reasons.join("; ")}` : "Blocked";
     }
 
-    return { cleared, agentActive, policyAllowed, reasons, explanation };
+    return { cleared, agentActive, policyAllowed, reasons, explanation, checksComplete };
   }
 }
 

--- a/typescript/tests/destructiveSqlBypass.test.ts
+++ b/typescript/tests/destructiveSqlBypass.test.ts
@@ -141,4 +141,71 @@ describe("destructive SQL write bypass fix", () => {
     expect(r.cleared).toBe(true);
     expect(r.policyAllowed).toBe(true);
   });
+
+  // H3: case-variant and whitespace must not bypass the destructive augment.
+  it("uppercase DATA:WRITE:SQL:DELETE is blocked by a lowercase data:delete:* policy", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+    const r = await makeAgent().preflight("DATA:WRITE:SQL:DELETE FROM users");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+    expect(r.reasons.some((s) => s.includes("no-deletions"))).toBe(true);
+  });
+
+  it("leading/trailing whitespace DELETE write is blocked by data:delete:*", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+    const r = await makeAgent().preflight("  data:write:sql:DELETE FROM users  ");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+    expect(r.reasons.some((s) => s.includes("no-deletions"))).toBe(true);
+  });
+
+  it("a lowercase block pattern blocks an uppercase write action", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(writeSqlPolicies));
+
+    const r = await makeAgent().preflight("DATA:WRITE:SQL:DELETE FROM users");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+    expect(r.reasons.some((s) => s.includes("no-sql-writes"))).toBe(true);
+  });
+
+  it("an uppercase block pattern blocks a lowercase write action", async () => {
+    const upperWritePolicy = [
+      { is_active: true, action_pattern: "DATA:WRITE:SQL:*", action: "block", name: "no-sql-writes" },
+    ];
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(activeAgent))
+      .mockResolvedValueOnce(jsonResponse(upperWritePolicy));
+
+    const r = await makeAgent().preflight("data:write:sql:INSERT INTO t VALUES (1)");
+
+    expect(r.cleared).toBe(false);
+    expect(r.policyAllowed).toBe(false);
+  });
+
+  // M1: extended destructive verbs each match the delete augment.
+  it.each(["GRANT", "REVOKE", "REPLACE", "COPY", "UPSERT"])(
+    "data:delete:* policy blocks data:write:sql:%s (extended destructive verb)",
+    async (verb) => {
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(jsonResponse(activeAgent))
+        .mockResolvedValueOnce(jsonResponse(deletePolicies));
+
+      const r = await makeAgent().preflight(`data:write:sql:${verb} something`);
+
+      expect(r.cleared).toBe(false);
+      expect(r.policyAllowed).toBe(false);
+      expect(r.reasons.some((s) => s.includes("no-deletions"))).toBe(true);
+    },
+  );
 });

--- a/typescript/tests/preflight.test.ts
+++ b/typescript/tests/preflight.test.ts
@@ -74,7 +74,7 @@ describe("Agent.preflight", () => {
     expect(r.explanation).toMatch(/policy/);
   });
 
-  it("fail-open: status check error does not block on its own", async () => {
+  it("fail-closed: status check error blocks and marks checks incomplete", async () => {
     let call = 0;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       call += 1;
@@ -87,9 +87,51 @@ describe("Agent.preflight", () => {
 
     const r = await makeAgent().preflight("data:read");
 
-    expect(r.cleared).toBe(true);
+    expect(r.cleared).toBe(false);
+    expect(r.checksComplete).toBe(false);
     expect(r.reasons.some((s) => s.includes("status check failed"))).toBe(true);
+    expect(r.explanation).toMatch(/could not verify/);
     expect(call).toBeGreaterThanOrEqual(2);
+  });
+
+  it("fail-closed: policy fetch error blocks and marks checks incomplete", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      if (url.includes("/policies")) {
+        return jsonResponse({ detail: "boom" }, 500);
+      }
+      return jsonResponse({ revoked: false, suspended: false });
+    });
+
+    const r = await makeAgent().preflight("data:read");
+
+    expect(r.cleared).toBe(false);
+    expect(r.checksComplete).toBe(false);
+    expect(r.reasons.some((s) => s.includes("policy check failed"))).toBe(true);
+  });
+
+  it("fail-closed: a non-list /policies response does not silently clear", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ revoked: false, suspended: false }))
+      .mockResolvedValueOnce(jsonResponse({ policies: [] }));
+
+    const r = await makeAgent().preflight("data:read");
+
+    expect(r.cleared).toBe(false);
+    expect(r.checksComplete).toBe(false);
+    expect(r.policyAllowed).toBe(true);
+    expect(r.reasons.some((s) => s.includes("unexpected response"))).toBe(true);
+  });
+
+  it("clears when both checks complete with no block (checksComplete true)", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ revoked: false, suspended: false }))
+      .mockResolvedValueOnce(jsonResponse([]));
+
+    const r = await makeAgent().preflight("data:read");
+
+    expect(r.cleared).toBe(true);
+    expect(r.checksComplete).toBe(true);
   });
 
   it("ignores inactive policies", async () => {


### PR DESCRIPTION
## What this changes

The SDK preflight is a client-side advisory gate. The authoritative decision still happens on the cloud sign endpoint. These four fixes harden the advisory gate so a hook-style integration that gates on the preflight result cannot be fooled into clearing, and so the Python and TypeScript halves behave identically.

### 1. TypeScript preflight could clear on a fetch error

The TS `Agent.preflight` had no checks-complete term. A failed `/status` or `/policies` fetch was recorded in `reasons` but still returned `cleared: true`. Added `checksComplete` to `PreflightResult`, set it false in both catch blocks, and folded it into `cleared`. This matches the Python clients, which fail closed.

### 2. A non-list /policies response cleared silently

All three clients iterated an empty list when `/policies` returned a non-list shape (for example an envelope object), which cleared without a real check. They now fail closed on an anomalous response instead of treating it as an empty allow.

### 3. Case and whitespace could dodge SQL matching

Destructive-SQL matching was case-sensitive on the lowercase `data:write:sql:` prefix and kept surrounding whitespace as-is, so `DATA:WRITE:SQL:DELETE` or a padded variant could skip the destructive augment and a lowercase block pattern. The action type and the policy pattern are now normalized (trim plus lowercase) and matching is case-insensitive in both directions.

### 4. Destructive-verb set widened

The destructive-verb detection covered DELETE, DROP, TRUNCATE, ALTER. It now also covers GRANT, REVOKE, REPLACE, COPY, UPSERT, with word-boundary and case-insensitive matching kept in parity across both languages.

## Tests

Added per-bug tests in both suites. Each new test fails on the base commit and passes here. Python `pytest` and TypeScript `vitest` suites are fully green, plus `ruff check` and `tsc`.

## Proof of work

```
python: PYTHONPATH=src python3 -m pytest tests/ -q
  1162 passed, 1 skipped
ruff check src
  All checks passed!

typescript: npm test
  Test Files  37 passed (37)
       Tests  481 passed (481)
npm run lint (tsc --noEmit): clean
npm run build: ok

non-vacuity: reverting the source files to the base commit while keeping the
new tests fails 12 Python tests and 13 TypeScript tests, restoring the fix
turns them all green.
```
