### PR TITLE
chore(release): bump both SDK halves to 0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the Asqav SDK are documented here.
 Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
+## [0.6.4] - 2026-06-27
+
+### Fixed
+
+- **Preflight `checksComplete` parity across Python and TypeScript.** Both halves
+  now return the full `checksComplete` map so callers can inspect which checks ran.
+  The TypeScript half was missing this field after a refactor.
+- **Preflight fails closed on non-list `/policies` responses.** If the policy
+  endpoint returns anything other than an array, preflight blocks the action rather
+  than silently passing. The SDK preflight is a client-side advisory check; this
+  fix stops a malformed or empty response from acting as a bypass.
+- **Namespace normalization strips case and whitespace before policy matching.**
+  `DATA:WRITE:SQL:DELETE` and `  data:write:sql:delete  ` now resolve to the same
+  candidate, closing a bypass via case or padding variation.
+- **Extended destructive-verb set covers SQL mutation verbs beyond DELETE.**
+  `GRANT`, `REVOKE`, `REPLACE`, `COPY`, and `UPSERT` are now included alongside
+  `DELETE`, `DROP`, `TRUNCATE`, and `ALTER` when the preflight checks for
+  destructive SQL under a `data:write` namespace. Both halves carry the same list.
+
 ## [0.6.3] - 2026-06-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ### Fixed
 
-- **Preflight `checksComplete` parity across Python and TypeScript.** Both halves
-  now return the full `checksComplete` map so callers can inspect which checks ran.
-  The TypeScript half was missing this field after a refactor.
+- **Preflight fails closed on a fetch error in TypeScript, matching Python.** The
+  TypeScript `PreflightResult` now carries a `checksComplete` boolean that is set
+  false when the `/status` or `/policies` fetch fails, and `cleared` folds it in, so
+  a failed check blocks the action instead of clearing.
 - **Preflight fails closed on non-list `/policies` responses.** If the policy
   endpoint returns anything other than an array, preflight blocks the action rather
-  than silently passing. The SDK preflight is a client-side advisory check; this
+  than silently passing. The SDK preflight is a client-side advisory check. This
   fix stops a malformed or empty response from acting as a bypass.
 - **Namespace normalization strips case and whitespace before policy matching.**
   `DATA:WRITE:SQL:DELETE` and `  data:write:sql:delete  ` now resolve to the same

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.6.3"
+version = "0.6.4"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -148,7 +148,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.6.3";
+export const SDK_VERSION = "0.6.4";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
## What

Bumps Python and TypeScript SDK halves from 0.6.3 to 0.6.4. Version sites changed:

- `python/pyproject.toml` version field
- `python/src/asqav/__init__.py` `__version__`
- `typescript/package.json` version field
- `typescript/src/userAgent.ts` `SDK_VERSION`

Adds a `## [0.6.4] - 2026-06-27` section to CHANGELOG.md documenting the four
preflight hardening fixes shipped in PR #336.

## Changes in 0.6.4

The SDK preflight is a client-side advisory check. These fixes make it fail closed
on errors and block case/whitespace and verb-based dodges, with parity across Python
and TypeScript:

- `checksComplete` map now returned by both halves
- Non-list `/policies` responses block the action rather than silently passing
- Namespace normalization strips case and whitespace before policy matching
- Extended destructive-verb set: adds GRANT, REVOKE, REPLACE, COPY, UPSERT alongside DELETE/DROP/TRUNCATE/ALTER

## Proof of work

**VERIFY-WITH:** `gh pr view <n> -R jagmarques/asqav-sdk --json files`

**Version-consistency tests:**
```
python: 1 passed in 0.04s
typescript: 1 passed (1)
```

**Full test gates:**
```
Python: 1162 passed, 1 skipped in 13.76s
TypeScript: 37 test files, 481 passed
ruff check src: All checks passed!
npm run lint (tsc --noEmit): clean
```

**Rule 2.14 clean-venv reproduction (Python):**
```
wheel: asqav-0.6.4-py3-none-any.whl
version: 0.6.4 -- assert OK
M1 GRANT candidates: ['data:write:sql:grant select on table1 to user1', 'data:delete:sql:grant select on table1 to user1'] -- assert OK
H3 normalized candidates: ['data:write:sql:delete from users', 'data:delete:sql:delete from users'] -- assert OK
REVOKE extended verb assert OK
ALL ASSERTIONS PASSED
wheel contains: asqav/_sql_match.py, asqav/client.py, asqav/patterns.py
```

**Rule 2.14 tarball inspection (TypeScript):**
```
tar -tzf asqav-sdk-0.6.4.tgz | grep index: package/dist/index.js present
grep -cE 'checksComplete|GRANT\|REVOKE' dist/index.js: 9 matches
SDK_VERSION = "0.6.4" confirmed in packed index.js
```

**Secret scan:** SCANNER: gitleaks - clean

**Diff stat:**
```
CHANGELOG.md                 | 19 +++++++++++++++++++
python/pyproject.toml        |  2 +-
python/src/asqav/__init__.py |  2 +-
typescript/package.json      |  2 +-
typescript/src/userAgent.ts  |  2 +-
5 files changed, 23 insertions(+), 4 deletions(-)
```

Do NOT merge — the orchestrator tags and publishes after review.