### PR TITLE
fix(preflight): close TS /status fail-open on non-object response

### DIFF
--- a/python/tests/test_async_preflight_fail_closed.py
+++ b/python/tests/test_async_preflight_fail_closed.py
@@ -74,6 +74,22 @@ async def test_non_list_policies_does_not_clear(mock_get: AsyncMock) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("status_body", [["x"], "revoked", 5, []])
+@patch("asqav.async_client._async_get", new_callable=AsyncMock)
+async def test_non_dict_status_does_not_clear(mock_get: AsyncMock, status_body) -> None:
+    """A non-dict /status body fails closed (parity pin for the TS fix)."""
+    mock_get.side_effect = [
+        status_body,  # anomalous non-dict status response
+        [],  # policies check
+    ]
+
+    result = await AGENT.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is False
+    assert "could not verify" in result.explanation.lower()
+
+
+@pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_happy_path_still_clears(mock_get: AsyncMock) -> None:
     """An active agent with no blocking policy clears, checks_complete True."""

--- a/python/tests/test_preflight_fail_closed.py
+++ b/python/tests/test_preflight_fail_closed.py
@@ -11,6 +11,8 @@ import os
 import sys
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from asqav.client import Agent, PreflightResult
@@ -92,6 +94,26 @@ def test_non_list_policies_does_not_clear(mock_post, mock_get):
     assert result.cleared is False
     assert result.checks_complete is False
     assert any("unexpected response" in r for r in result.reasons)
+
+
+@pytest.mark.parametrize("status_body", [["x"], "revoked", 5, []])
+@patch("asqav.client._get")
+@patch("asqav.client._post")
+@patch("asqav.client._api_key", "sk_test")
+def test_non_dict_status_does_not_clear(mock_post, mock_get, status_body):
+    """A non-dict /status body fails closed (parity pin for the TS fix)."""
+    mock_post.return_value = MOCK_AGENT_DATA
+    agent = Agent.create("test-agent")
+
+    mock_get.side_effect = [
+        status_body,  # anomalous non-dict status response
+        [],  # policies check
+    ]
+
+    result = agent.preflight("llm:call")
+    assert result.cleared is False
+    assert result.checks_complete is False
+    assert "could not verify" in result.explanation.lower()
 
 
 @patch("asqav.client._get")

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -2070,14 +2070,21 @@ export class Agent {
         "GET",
         `/agents/${this.agentId}/status`,
       );
-      if (status.revoked) {
-        agentActive = false;
-        reasons.push("agent is revoked");
-      }
-      if (status.suspended) {
-        agentActive = false;
-        const suffix = status.suspended_reason ? ` (${status.suspended_reason})` : "";
-        reasons.push(`agent is suspended${suffix}`);
+      if (typeof status !== "object" || status === null || Array.isArray(status)) {
+        // A non-object response is anomalous, so fail closed instead of
+        // reading revoked/suspended as undefined and clearing the agent.
+        checksComplete = false;
+        reasons.push("status check failed (unexpected response) - could not verify");
+      } else {
+        if (status.revoked) {
+          agentActive = false;
+          reasons.push("agent is revoked");
+        }
+        if (status.suspended) {
+          agentActive = false;
+          const suffix = status.suspended_reason ? ` (${status.suspended_reason})` : "";
+          reasons.push(`agent is suspended${suffix}`);
+        }
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/typescript/tests/preflight.test.ts
+++ b/typescript/tests/preflight.test.ts
@@ -123,6 +123,25 @@ describe("Agent.preflight", () => {
     expect(r.reasons.some((s) => s.includes("unexpected response"))).toBe(true);
   });
 
+  it.each([
+    ["a list", ["x"]],
+    ["a string", "revoked"],
+    ["a number", 5],
+    ["an empty list", []],
+  ])("fail-closed: a non-object /status response (%s) does not silently clear", async (_label, body) => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(body))
+      .mockResolvedValueOnce(jsonResponse([]));
+
+    const r = await makeAgent().preflight("data:read");
+
+    expect(r.cleared).toBe(false);
+    expect(r.checksComplete).toBe(false);
+    expect(r.agentActive).toBe(true);
+    expect(r.reasons.some((s) => s.includes("unexpected response"))).toBe(true);
+    expect(r.explanation).toMatch(/could not verify/);
+  });
+
   it("clears when both checks complete with no block (checksComplete true)", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(jsonResponse({ revoked: false, suspended: false }))


### PR DESCRIPTION
## What

The TypeScript `Agent.preflight` `/status` try-block read `status.revoked` and `status.suspended` straight off the response with no shape check. When `GET /agents/{id}/status` returns a truthy non-object 200 body (an array, string, or number), JS reads those properties as `undefined` without throwing, so the `catch` never runs. `agentActive` and `checksComplete` both stay `true` and the agent clears off a malformed body.

This is the same fail-open class the cycle fixed for `/policies`. The `/policies` block right below already guards with `!Array.isArray(...)`. This change mirrors that style on `/status`.

## Fix

Before reading `.revoked` / `.suspended`, guard the shape: if the body is not a plain object (null, array, or non-object), set `checksComplete = false`, push a clear reason, and skip the active/suspended reads. The normal object path is unchanged.

Both Python clients (`client.py` sync, `async_client.py` async) already fail closed here because `status_data.get(...)` raises `AttributeError` on a non-dict and lands in the `except`. This restores TS-to-Python parity.

## Tests

- TS: four new cases for `/status` bodies `['x']`, `'revoked'`, `5`, and `[]`. Each asserts `cleared=false` and `checksComplete=false`. All four fail against the pre-fix code and pass with the guard (proof in the block below).
- Python: parity-pin tests for the sync and async clients on the same non-dict bodies. These pass on main since the Python side already fails closed. They pin the behavior the TS fix matches.

## Proof of work

Non-vacuous proof (TS), revert `index.ts` to main and re-run:

```
× fail-closed: a non-object /status response (a list) does not silently clear
× fail-closed: a non-object /status response (a string) does not silently clear
× fail-closed: a non-object /status response (a number) does not silently clear
× fail-closed: a non-object /status response (an empty list) does not silently clear
 Test Files  1 failed (1)
      Tests  4 failed | 8 passed (12)
```

With the fix on the branch:

```
$ npm test
 Test Files  37 passed (37)
      Tests  485 passed (485)

$ npm run lint   # tsc --noEmit -> clean
$ npm run build  # clean

$ PYTHONPATH=src python3 -m pytest tests/ -q
1170 passed, 1 skipped in 14.01s

$ python3 -m ruff check src
All checks passed!
```

Diffstat:

```
 python/tests/test_async_preflight_fail_closed.py | 16 ++++++++++++++++
 python/tests/test_preflight_fail_closed.py       | 22 ++++++++++++++++++++++
 typescript/src/index.ts                          | 23 +++++++++++++++--------
 typescript/tests/preflight.test.ts               | 19 +++++++++++++++++++
 4 files changed, 72 insertions(+), 8 deletions(-)
```

No version, CHANGELOG, or publish changes.

https://claude.ai/code/session_01JxyJiDhYJwHX6FWG4bC3wV
