### PR TITLE
chore(release): bump both SDK halves to 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the Asqav SDK are documented here.
 Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
+## [0.6.5] - 2026-06-27
+
+### Fixed
+
+- **Preflight fails closed on a non-object `/status` response in TypeScript, matching Python.**
+  If the status endpoint returns a truthy non-object body (a string, number, or any primitive),
+  the TypeScript client now treats the check as failed and blocks the action. A well-formed
+  response is an object; anything else is anomalous and should not leave the advisory gate
+  cleared.
+
 ## [0.6.4] - 2026-06-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 - **Preflight fails closed on a non-object `/status` response in TypeScript, matching Python.**
   If the status endpoint returns a truthy non-object body (a string, number, or any primitive),
   the TypeScript client now treats the check as failed and blocks the action. A well-formed
-  response is an object; anything else is anomalous and should not leave the advisory gate
+  response is an object. Anything else is anomalous and should not leave the advisory gate
   cleared.
 
 ## [0.6.4] - 2026-06-27

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.6.4"
+version = "0.6.5"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -148,7 +148,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.6.4";
+export const SDK_VERSION = "0.6.5";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Bumps Python and TypeScript SDK halves from 0.6.4 to 0.6.5 and adds the [0.6.5] CHANGELOG entry.

**What changed**

Version 0.6.5 ships one fix: the TypeScript preflight /status check now fails closed when the status endpoint returns a truthy non-object body (a string, number, or any primitive). A well-formed response is an object; anything else is anomalous and blocks the action. This restores parity with the Python client, which already behaved this way.

Four version sites updated: `python/pyproject.toml`, `python/src/asqav/__init__.py`, `typescript/package.json`, `typescript/src/userAgent.ts`. CHANGELOG.md gets the [0.6.5] section above [0.6.4].

**Gates**

- Python: 1170 passed, 1 skipped. Ruff clean.
- TypeScript: 485 passed across 37 test files. tsc --noEmit clean.
- Version consistency tests: both green.
- Secret scan: gitleaks clean.

**Proof of work**

```
VERIFY-WITH: gh pr view <n> -- shows 5-file diff
2.14 TS tarball:
  tar -xzOf asqav-sdk-0.6.5.tgz package/dist/index.js | grep 'SDK_VERSION\|asqav-js/'
    SDK_VERSION: () => SDK_VERSION,
    var SDK_VERSION = "0.6.5";
    var USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
    SDK_VERSION,

  tar -xzOf asqav-sdk-0.6.5.tgz package/dist/index.js | grep -c 'Array.isArray(status)'
    1

2.14 Python venv:
  version OK: 0.6.5
  asqav/async_client.py   2020-02-02 00:00:00   14924
  asqav/client.py         2020-02-02 00:00:00   163936

diff stat:
  CHANGELOG.md                 | 10 ++++++++++
  python/pyproject.toml        |  2 +-
  python/src/asqav/__init__.py |  2 +-
  typescript/package.json      |  2 +-
  typescript/src/userAgent.ts  |  2 +-
  5 files changed, 14 insertions(+), 4 deletions(-)
```