### PR TITLE
Add opt-in schema-driven structured receipts (Python + TS)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -344,6 +344,64 @@ except APIError as exc:
 
 `ValueError` is raised before the HTTP roundtrip for the verbatim rule 8 / 9 / 10 / 11 guards listed above. Catch `ValueError` separately so guard violations surface as developer errors, not API errors.
 
+## Structured receipts (optional schema)
+
+Pass a `context_schema` to `Agent.sign()` to validate and normalise the
+`context` dict before it is signed. This keeps every receipt in your audit
+trail in a consistent, queryable shape.
+
+```python
+import asqav
+from asqav import AsqavValidationError
+
+PAYMENT_SCHEMA = {
+    "user_id":  {"type": "string", "required": True},
+    "amount":   {"type": "number", "required": True},
+    "currency": {"type": "string", "required": True},
+}
+
+asqav.init(api_key="sk_...")
+agent = asqav.Agent.create("my-agent")
+
+# Valid context: keys are sorted before signing (consistent hash order).
+sig = agent.sign(
+    "payment:initiate",
+    {"user_id": "u1", "currency": "EUR", "amount": 49.95},
+    context_schema=PAYMENT_SCHEMA,
+)
+
+# Missing required field: raises AsqavValidationError BEFORE the network call.
+try:
+    agent.sign(
+        "payment:initiate",
+        {"amount": 100},          # user_id missing, currency missing
+        context_schema=PAYMENT_SCHEMA,
+    )
+except AsqavValidationError as exc:
+    print(exc)            # context_schema_error: field 'user_id' is required but missing
+    print(exc.docs_url)   # https://asqav.com/docs/structured-receipts
+```
+
+Field descriptor keys:
+- `type` (required) - one of `"string"`, `"number"`, `"boolean"`, `"object"`, `"array"`.
+- `required` (optional, default `False`) - whether the field must be present.
+
+`"number"` rejects `bool` values; `"array"` rejects plain dicts.
+No schema means today's exact behaviour (zero behaviour change).
+
+You can also pass a callable for full JSON Schema validation (no new
+mandatory dependencies needed in the core package):
+
+```python
+def my_validator(ctx: dict) -> None:
+    import jsonschema
+    jsonschema.validate(ctx, MY_FULL_SCHEMA)
+
+agent.sign("action", context, context_schema=my_validator)
+```
+
+See `examples/schema_receipts_example.py` for a runnable demo.
+
 ## Requirements
 
 Python 3.10 or newer. Uses `httpx` for the API client. Zero native dependencies. ML-DSA cryptography runs server-side.

--- a/python/examples/schema_receipts_example.py
+++ b/python/examples/schema_receipts_example.py
@@ -1,0 +1,103 @@
+"""Structured receipts with an optional context schema.
+
+When you pass ``context_schema`` to ``Agent.sign()``, the SDK validates and
+normalises the ``context`` dict BEFORE signing, so every receipt in your
+audit trail has the same key order and the cloud can index them consistently.
+
+If the context does not match the schema, ``AsqavValidationError`` is raised
+BEFORE any network call, so no token is consumed and no partial record is
+written.
+
+Requirements:
+    pip install asqav
+
+Usage:
+    ASQAV_API_KEY=sk_... python examples/schema_receipts_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import asqav
+from asqav import AsqavValidationError
+
+# Schema: field -> {type: string|number|boolean|object|array, required?: bool}
+PAYMENT_SCHEMA = {
+    "user_id": {"type": "string", "required": True},
+    "amount": {"type": "number", "required": True},
+    "currency": {"type": "string", "required": True},
+    "metadata": {"type": "object"},  # optional
+}
+
+
+def main() -> int:
+    api_key = os.environ.get("ASQAV_API_KEY", "")
+    if not api_key:
+        print(
+            "Set ASQAV_API_KEY before running.\n"
+            "Get your key at https://asqav.com"
+        )
+        return 1
+
+    asqav.init(api_key=api_key)
+    agent = asqav.Agent.create("schema-demo")
+
+    # --- Valid context: passes validation, keys are sorted before signing ---
+    print("Signing with a valid, schema-validated context...")
+    sig = agent.sign(
+        "payment:initiate",
+        {
+            # Deliberately unsorted: SDK normalises to alphabetical key order.
+            "user_id": "user_abc123",
+            "currency": "EUR",
+            "amount": 49.95,
+            "metadata": {"source": "api"},
+        },
+        context_schema=PAYMENT_SCHEMA,
+    )
+    print(f"  signature_id : {sig.signature_id}")
+    print(f"  verify       : {sig.verification_url}")
+
+    # --- Invalid context: raises BEFORE the network call ---
+    print("\nAttempting to sign with a missing required field (user_id)...")
+    try:
+        agent.sign(
+            "payment:initiate",
+            {"amount": 100.0, "currency": "USD"},  # user_id missing
+            context_schema=PAYMENT_SCHEMA,
+        )
+    except AsqavValidationError as exc:
+        print(f"  Caught (expected): {exc}")
+        print(f"  Docs: {exc.docs_url}")
+
+    # --- Wrong type: raises BEFORE the network call ---
+    print("\nAttempting to sign with the wrong type for 'amount'...")
+    try:
+        agent.sign(
+            "payment:initiate",
+            {"user_id": "u1", "amount": "one-hundred", "currency": "USD"},
+            context_schema=PAYMENT_SCHEMA,
+        )
+    except AsqavValidationError as exc:
+        print(f"  Caught (expected): {exc}")
+
+    # --- Custom callable validator (e.g. wrap jsonschema for full JSON Schema) ---
+    print("\nSigning with a custom callable validator...")
+
+    def my_validator(ctx: dict) -> None:
+        if ctx.get("amount", 0) <= 0:
+            raise ValueError("amount must be positive")
+
+    sig2 = agent.sign(
+        "payment:initiate",
+        {"user_id": "user_xyz", "amount": 10.00, "currency": "GBP"},
+        context_schema=my_validator,
+    )
+    print(f"  signature_id : {sig2.signature_id}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -28,6 +28,7 @@ Get your API key at asqav.com
 """
 
 from ._jcs import canonical_json
+from ._schema import normalize_context, validate_context_schema
 from .async_client import AsyncAgent
 from .canonicalize import canonicalize, canonicalize_tool_args, hash_action
 from .client import (
@@ -323,6 +324,9 @@ __all__ = [
     # Offline / air-gapped verification helpers
     "fetch_jwks",
     "verify_receipt_offline",
+    # Structured receipts (criterion 328)
+    "validate_context_schema",
+    "normalize_context",
 ]
 
 

--- a/python/src/asqav/_schema.py
+++ b/python/src/asqav/_schema.py
@@ -1,0 +1,129 @@
+"""Lightweight, dependency-free context-schema validator (criterion 328).
+
+Schema spec: a dict mapping field names to a field descriptor.
+
+Field descriptor keys:
+    type     - one of "string" | "number" | "boolean" | "object" | "array"
+    required - bool, defaults to False
+
+Example::
+
+    schema = {
+        "user_id": {"type": "string", "required": True},
+        "score":   {"type": "number"},
+        "tags":    {"type": "array"},
+    }
+
+Pass to ``Agent.sign(..., context_schema=schema)``. The SDK validates the
+context dict against the schema and raises ``AsqavValidationError`` on
+mismatch before any network call. On success the context is returned with
+keys in stable sorted order so audit trails are consistent and queryable.
+
+You may instead pass a callable as ``context_schema``:
+
+    def my_validator(ctx: dict) -> None:
+        import jsonschema
+        jsonschema.validate(ctx, MY_FULL_JSON_SCHEMA)
+
+    agent.sign("action", ctx, context_schema=my_validator)
+
+A callable receives the (possibly None-coerced-to-{}) context dict and must
+raise on invalid input. The built-in path needs no new runtime dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Docs URL stamped on AsqavValidationError instances from this module.
+_SCHEMA_DOCS_URL = "https://asqav.com/docs/structured-receipts"
+
+# Maps schema "type" strings to the Python runtime type(s) they check against.
+_TYPE_MAP: dict[str, type | tuple[type, ...]] = {
+    "string": str,
+    "number": (int, float),
+    "boolean": bool,
+    "object": dict,
+    "array": list,
+}
+
+_VALID_TYPE_NAMES = frozenset(_TYPE_MAP)
+
+
+def validate_context_schema(
+    context: dict[str, Any] | None,
+    schema: dict[str, Any],
+) -> None:
+    """Validate *context* against the built-in *schema* descriptor.
+
+    Raises ``AsqavValidationError`` on the first offending field so the
+    developer sees one clear message rather than a list dump.
+
+    Args:
+        context: The context dict passed to ``Agent.sign()``. ``None`` is
+            treated as an empty dict (no user keys supplied).
+        schema:  A ``{field_name: {"type": ..., "required": ...}}`` mapping.
+
+    Raises:
+        AsqavValidationError: When a required field is absent or a value
+            does not match its declared type.
+        ValueError: When the schema itself uses an unknown type name; this
+            is a programmer error, not a runtime data error.
+    """
+    # Lazy import to avoid circular dependency with client.py.
+    from .client import AsqavValidationError
+
+    ctx = context or {}
+
+    for field, descriptor in schema.items():
+        required = descriptor.get("required", False)
+        type_name = descriptor.get("type")
+
+        if type_name is not None and type_name not in _VALID_TYPE_NAMES:
+            raise ValueError(
+                f"context_schema_error: unknown type '{type_name}' for field '{field}'; "
+                f"must be one of {sorted(_VALID_TYPE_NAMES)}"
+            )
+
+        if field not in ctx:
+            if required:
+                raise AsqavValidationError(
+                    f"context_schema_error: field '{field}' is required but missing",
+                    docs_url=_SCHEMA_DOCS_URL,
+                )
+            continue
+
+        if type_name is None:
+            continue
+
+        value = ctx[field]
+        expected = _TYPE_MAP[type_name]
+
+        # bool is a subclass of int; reject it from "number" explicitly so
+        # {"active": True} does not silently pass a "number" field.
+        if type_name == "number" and isinstance(value, bool):
+            raise AsqavValidationError(
+                f"context_schema_error: field '{field}' expected type number, got bool",
+                docs_url=_SCHEMA_DOCS_URL,
+            )
+
+        if not isinstance(value, expected):
+            actual = type(value).__name__
+            raise AsqavValidationError(
+                f"context_schema_error: field '{field}' expected type {type_name}, got {actual}",
+                docs_url=_SCHEMA_DOCS_URL,
+            )
+
+
+def normalize_context(context: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return *context* with keys in stable sorted order.
+
+    Stable key order means two sign() calls with identical data but
+    different insertion orders produce the same signed bytes, making
+    receipts consistent and queryable.
+
+    Returns ``None`` unchanged; an empty dict becomes ``{}``.
+    """
+    if context is None:
+        return None
+    return dict(sorted(context.items()))

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1607,6 +1607,7 @@ class Agent:
         tool_name: str | None = None,
         model_name: str | None = None,
         *,
+        context_schema: "dict[str, Any] | Callable[[dict[str, Any]], None] | None" = None,
         co_signers: list[str] | None = None,
         mandate_id: str | None = None,
         user_intent: dict[str, Any] | None = None,
@@ -1675,6 +1676,30 @@ class Agent:
                 Accepts semantic pattern names like "sql-read" which
                 auto-expand to their glob equivalents.
             context: Additional context for the action.
+            context_schema: Optional schema for the ``context`` dict.
+                When supplied, the context is validated and then key-sorted
+                before signing so audit trails are consistent and queryable.
+                Two forms are accepted:
+
+                Built-in descriptor (dependency-free)::
+
+                    {"user_id": {"type": "string", "required": True},
+                     "score":   {"type": "number"}}
+
+                Field types: string | number | boolean | object | array.
+                ``required`` defaults to False. Raises
+                ``AsqavValidationError`` on mismatch BEFORE the network call.
+
+                Custom callable (bring-your-own validator)::
+
+                    def my_validator(ctx: dict) -> None:
+                        import jsonschema
+                        jsonschema.validate(ctx, MY_FULL_SCHEMA)
+
+                    agent.sign("action", ctx, context_schema=my_validator)
+
+                A callable receives the (merged, hook-dispatched) context
+                and must raise on invalid input. Omit for today's behavior.
             system_prompt_hash: Optional hash of the system prompt for
                 reproducibility tracking.
             model_params: Optional dict of model parameters (temperature,
@@ -1823,6 +1848,18 @@ class Agent:
             context = _hooks_mod._dispatch_before(action_type, dict(context) if context else {})
         except Exception:
             logger.warning("asqav before-hook dispatch failed (fail-open)", exc_info=True)
+
+        # Opt-in schema validation + normalization (criterion 328).
+        # Runs after hook dispatch so the validated form is what gets signed.
+        if context_schema is not None:
+            from ._schema import normalize_context, validate_context_schema
+
+            if callable(context_schema) and not isinstance(context_schema, dict):
+                # User-supplied validator function (e.g. wrapping jsonschema).
+                context_schema(dict(context) if context else {})
+            else:
+                validate_context_schema(context, context_schema)
+            context = normalize_context(context)
 
         # Surface bad arguments client-side; the cloud re-validates.
         if receipt_type is not None and receipt_type not in RECEIPT_TYPE_NAMESPACE:

--- a/python/tests/test_client_schema_receipts.py
+++ b/python/tests/test_client_schema_receipts.py
@@ -1,0 +1,420 @@
+"""Tests for opt-in schema-driven structured receipts (criterion 328).
+
+Three core contract proofs (non-vacuous):
+
+(a) Valid context passes validation and sign() is called with the
+    normalized (key-sorted) context.
+(b) Invalid context (missing required field / wrong type) raises
+    AsqavValidationError and sign is NOT called (network never reached).
+(c) No schema supplied => unchanged behavior (sign called as before).
+
+Non-vacuity probe: case (b) tests include an inline check that the test
+would FAIL if validation were skipped (the error must come from the SDK,
+not from a missing stub call).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav
+from asqav._schema import normalize_context, validate_context_schema
+from asqav.client import Agent, AsqavValidationError
+
+# === Shared helpers ===
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_schema_test",
+        name="schema-test-agent",
+        public_key="pk_xxx",
+        key_id="key_schema",
+        algorithm="ML-DSA-65",
+        capabilities=["api:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "signature": "sig_b64",
+        "signature_id": "sig_schema",
+        "action_id": "act_schema",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_schema",
+        "algorithm": "ML-DSA-65",
+        "chain_hash": "deadbeef",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+_BASIC_SCHEMA: dict[str, Any] = {
+    "user_id": {"type": "string", "required": True},
+    "score": {"type": "number"},
+    "active": {"type": "boolean"},
+    "tags": {"type": "array"},
+    "meta": {"type": "object"},
+}
+
+
+# === (a) Valid context passes and sign is called with the normalized context ===
+
+
+def test_valid_context_passes_schema_and_sign_is_called() -> None:
+    """A context that matches the schema reaches the network call."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"user_id": "u1", "score": 42.5, "active": True},
+            context_schema=_BASIC_SCHEMA,
+            compliance_mode=False,
+        )
+
+    assert captured, "sign() was never called"
+    # The raw body must exist (context lives here or nested under 'payload').
+    assert captured["body"] is not None
+
+
+def test_valid_context_is_key_sorted_before_signing() -> None:
+    """After schema validation the context keys are sorted."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
+        captured["body"] = body
+        return _ok_response()
+
+    # Deliberately supply keys in reverse alphabetical order.
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"user_id": "u1", "score": 7, "active": False},
+            context_schema=_BASIC_SCHEMA,
+            compliance_mode=False,
+        )
+
+    # The body context (or payload context) should have keys in sorted order.
+    # We verify via the context embedded in the body dict.
+    body = captured["body"]
+    ctx = body.get("context") or (body.get("payload") or {}).get("context")
+    if ctx is not None and isinstance(ctx, dict):
+        keys = list(ctx.keys())
+        # Strip SDK-injected underscore keys before sorting check.
+        public_keys = [k for k in keys if not k.startswith("_")]
+        assert public_keys == sorted(public_keys), (
+            f"Expected sorted context keys, got {public_keys}"
+        )
+
+
+def test_all_schema_types_pass_correct_values() -> None:
+    """Each supported type passes with a matching Python value."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {
+                "user_id": "alice",
+                "score": 3.14,
+                "active": True,
+                "tags": ["a", "b"],
+                "meta": {"k": "v"},
+            },
+            context_schema=_BASIC_SCHEMA,
+            compliance_mode=False,
+        )
+
+    assert captured, "sign() was not called"
+
+
+def test_optional_field_absent_passes() -> None:
+    """An optional field (required=False) may be absent with no error."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            # Only required user_id; score, active, tags, meta are optional.
+            {"user_id": "u2"},
+            context_schema=_BASIC_SCHEMA,
+            compliance_mode=False,
+        )
+
+    assert captured
+
+
+# === (b) Invalid context raises AsqavValidationError and sign is NOT called ===
+
+
+def test_missing_required_field_raises_before_network() -> None:
+    """Missing required field raises AsqavValidationError; HTTP is never called.
+
+    Non-vacuity: if we strip the raise from validate_context_schema the
+    mock_post assertion on `call_count == 0` catches the regression.
+    """
+    with patch("asqav.client._post") as mock_post:
+        with pytest.raises(AsqavValidationError, match="user_id"):
+            _agent().sign(
+                "api:call",
+                {"score": 5},  # user_id missing
+                context_schema=_BASIC_SCHEMA,
+                compliance_mode=False,
+            )
+        mock_post.assert_not_called()
+
+
+def test_wrong_type_raises_before_network() -> None:
+    """Wrong-type field raises AsqavValidationError; HTTP is never called."""
+    with patch("asqav.client._post") as mock_post:
+        with pytest.raises(AsqavValidationError, match="score"):
+            _agent().sign(
+                "api:call",
+                {"user_id": "u1", "score": "not-a-number"},
+                context_schema=_BASIC_SCHEMA,
+                compliance_mode=False,
+            )
+        mock_post.assert_not_called()
+
+
+def test_bool_rejected_for_number_type() -> None:
+    """bool is a subclass of int; it must be rejected for type=number."""
+    with patch("asqav.client._post") as mock_post:
+        with pytest.raises(AsqavValidationError, match="score"):
+            _agent().sign(
+                "api:call",
+                {"user_id": "u1", "score": True},
+                context_schema=_BASIC_SCHEMA,
+                compliance_mode=False,
+            )
+        mock_post.assert_not_called()
+
+
+def test_wrong_type_object_raises_before_network() -> None:
+    """A string where object is expected raises the validation error."""
+    with patch("asqav.client._post") as mock_post:
+        with pytest.raises(AsqavValidationError, match="meta"):
+            _agent().sign(
+                "api:call",
+                {"user_id": "u1", "meta": "not-a-dict"},
+                context_schema=_BASIC_SCHEMA,
+                compliance_mode=False,
+            )
+        mock_post.assert_not_called()
+
+
+def test_wrong_type_array_raises_before_network() -> None:
+    """A dict where array is expected raises the validation error."""
+    with patch("asqav.client._post") as mock_post:
+        with pytest.raises(AsqavValidationError, match="tags"):
+            _agent().sign(
+                "api:call",
+                {"user_id": "u1", "tags": {"wrong": "type"}},
+                context_schema=_BASIC_SCHEMA,
+                compliance_mode=False,
+            )
+        mock_post.assert_not_called()
+
+
+def test_validation_error_carries_docs_url() -> None:
+    """AsqavValidationError.docs_url points to structured-receipts docs."""
+    with patch("asqav.client._post"):
+        with pytest.raises(AsqavValidationError) as exc_info:
+            _agent().sign(
+                "api:call",
+                {"score": 5},  # user_id missing
+                context_schema=_BASIC_SCHEMA,
+                compliance_mode=False,
+            )
+    assert exc_info.value.docs_url == "https://asqav.com/docs/structured-receipts"
+
+
+# === (c) No schema supplied => unchanged behavior ===
+
+
+def test_no_schema_sign_called_as_before() -> None:
+    """When context_schema is omitted, sign() behavior is unchanged."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"any_key": "any_value"},
+            compliance_mode=False,
+        )
+
+    assert captured, "sign() must be called when no schema is provided"
+
+
+def test_no_schema_none_context_unchanged() -> None:
+    """None context + no schema is unchanged (no normalization applied)."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            None,
+            compliance_mode=False,
+        )
+
+    assert captured
+
+
+# === Custom callable validator ===
+
+
+def test_custom_callable_validator_passes() -> None:
+    """A callable context_schema that returns None passes through."""
+    captured: dict[str, Any] = {}
+    calls: list[Any] = []
+
+    def my_validator(ctx: dict[str, Any]) -> None:
+        calls.append(ctx)
+
+    def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign(
+            "api:call",
+            {"x": 1},
+            context_schema=my_validator,
+            compliance_mode=False,
+        )
+
+    assert calls, "validator was not called"
+    assert captured, "sign() was not called"
+
+
+def test_custom_callable_validator_raises_propagates() -> None:
+    """A callable that raises propagates; sign() must not be called."""
+
+    def strict_validator(ctx: dict[str, Any]) -> None:
+        raise ValueError("custom_schema_error: x must be positive")
+
+    with patch("asqav.client._post") as mock_post:
+        with pytest.raises(ValueError, match="x must be positive"):
+            _agent().sign(
+                "api:call",
+                {"x": -1},
+                context_schema=strict_validator,
+                compliance_mode=False,
+            )
+        mock_post.assert_not_called()
+
+
+# === Unit tests for _schema helpers ===
+
+
+class TestValidateContextSchema:
+    def test_missing_required_field(self) -> None:
+        with pytest.raises(AsqavValidationError, match="context_schema_error.*user_id.*required"):
+            validate_context_schema({}, {"user_id": {"type": "string", "required": True}})
+
+    def test_optional_field_absent_is_ok(self) -> None:
+        # Should not raise.
+        validate_context_schema({}, {"score": {"type": "number", "required": False}})
+
+    def test_correct_string_passes(self) -> None:
+        validate_context_schema({"name": "alice"}, {"name": {"type": "string"}})
+
+    def test_correct_number_int_passes(self) -> None:
+        validate_context_schema({"n": 7}, {"n": {"type": "number"}})
+
+    def test_correct_number_float_passes(self) -> None:
+        validate_context_schema({"n": 3.14}, {"n": {"type": "number"}})
+
+    def test_bool_rejected_for_number(self) -> None:
+        with pytest.raises(AsqavValidationError, match="got bool"):
+            validate_context_schema({"n": True}, {"n": {"type": "number"}})
+
+    def test_wrong_type_string_for_number(self) -> None:
+        with pytest.raises(AsqavValidationError, match="expected type number, got str"):
+            validate_context_schema({"n": "oops"}, {"n": {"type": "number"}})
+
+    def test_boolean_field(self) -> None:
+        validate_context_schema({"ok": True}, {"ok": {"type": "boolean"}})
+
+    def test_object_field(self) -> None:
+        validate_context_schema({"m": {"a": 1}}, {"m": {"type": "object"}})
+
+    def test_array_field(self) -> None:
+        validate_context_schema({"arr": [1, 2]}, {"arr": {"type": "array"}})
+
+    def test_unknown_type_name_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="unknown type"):
+            validate_context_schema({"x": 1}, {"x": {"type": "bigdecimal"}})
+
+    def test_none_context_treated_as_empty(self) -> None:
+        # Optional field -> no error on None context.
+        validate_context_schema(None, {"x": {"type": "string"}})
+
+    def test_none_context_required_field_raises(self) -> None:
+        with pytest.raises(AsqavValidationError, match="x.*required"):
+            validate_context_schema(None, {"x": {"type": "string", "required": True}})
+
+
+class TestNormalizeContext:
+    def test_sorts_keys(self) -> None:
+        ctx = {"z": 1, "a": 2, "m": 3}
+        result = normalize_context(ctx)
+        assert result is not None
+        assert list(result.keys()) == ["a", "m", "z"]
+
+    def test_none_returns_none(self) -> None:
+        assert normalize_context(None) is None
+
+    def test_empty_dict_returns_empty(self) -> None:
+        assert normalize_context({}) == {}
+
+    def test_already_sorted_unchanged(self) -> None:
+        ctx = {"a": 1, "b": 2}
+        result = normalize_context(ctx)
+        assert result == {"a": 1, "b": 2}
+
+    def test_returns_new_dict(self) -> None:
+        ctx = {"x": 1}
+        result = normalize_context(ctx)
+        assert result is not ctx
+
+
+# === Top-level re-export ===
+
+
+def test_schema_helpers_exported_at_top_level() -> None:
+    """validate_context_schema and normalize_context are public symbols."""
+    assert hasattr(asqav, "validate_context_schema")
+    assert hasattr(asqav, "normalize_context")
+    assert asqav.validate_context_schema is validate_context_schema
+    assert asqav.normalize_context is normalize_context

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -345,6 +345,72 @@ const result = verify(receipt, ADAPTERS, keyProvider);
 
 It verifies the issuer signature over the canonical bytes, the hash-chain link, and structural presence across the asqav-native, AERF, ACTA, agent-receipts, and Authproof formats. It never attests the behaviour of the recorded action, and no account is required. Ed25519 and ES256 verify in-process via `node:crypto`. ML-DSA-65 downgrades to `INCOMPLETE` rather than ever returning a false `PASS`. This is the TypeScript port of the Python `asqav.verifier.oracle`, held to verdict parity by a shared conformance corpus.
 
+## Structured receipts (optional schema)
+
+Pass a `contextSchema` to `agent.sign()` to validate and normalise the
+`context` object before it is signed. This keeps every receipt in your audit
+trail in a consistent, queryable shape.
+
+```typescript
+import { Agent, ValidationError, type ContextSchema, init } from "@asqav/sdk";
+
+const PAYMENT_SCHEMA: ContextSchema = {
+  userId:   { type: "string",  required: true },
+  amount:   { type: "number",  required: true },
+  currency: { type: "string",  required: true },
+};
+
+init({ apiKey: "sk_..." });
+const agent = await Agent.create({ name: "my-agent" });
+
+// Valid context: keys are sorted before signing (consistent hash order).
+const sig = await agent.sign({
+  actionType: "payment:initiate",
+  context: { userId: "u1", currency: "EUR", amount: 49.95 },
+  contextSchema: PAYMENT_SCHEMA,
+});
+
+// Missing required field: throws ValidationError BEFORE the network call.
+try {
+  await agent.sign({
+    actionType: "payment:initiate",
+    context: { amount: 100 },       // userId missing, currency missing
+    contextSchema: PAYMENT_SCHEMA,
+  });
+} catch (err) {
+  if (err instanceof ValidationError) {
+    console.error(err.message);   // context_schema_error: field 'userId' is required but missing
+    console.error(err.docsUrl);   // https://asqav.com/docs/structured-receipts
+  }
+}
+```
+
+Field descriptor keys:
+- `type` (required) - one of `"string"`, `"number"`, `"boolean"`, `"object"`, `"array"`.
+- `required` (optional, default `false`) - whether the field must be present.
+
+`"number"` rejects `boolean` values; `"array"` rejects plain objects.
+No schema means today's exact behaviour (zero behaviour change).
+
+You can also pass a callable for full JSON Schema (no new mandatory
+dependencies in the core package):
+
+```typescript
+import Ajv from "ajv";
+const ajv = new Ajv();
+const validate = ajv.compile(MY_FULL_SCHEMA);
+
+await agent.sign({
+  actionType: "action",
+  context: { ... },
+  contextSchema: (ctx) => {
+    if (!validate(ctx)) throw new Error(ajv.errorsText(validate.errors));
+  },
+});
+```
+
+See `examples/schema-receipts.ts` for a runnable demo.
+
 ## Requirements
 
 Node 20 or newer. Uses the built-in `fetch`. Zero native dependencies. ML-DSA cryptography runs server-side.

--- a/typescript/examples/schema-receipts.ts
+++ b/typescript/examples/schema-receipts.ts
@@ -1,0 +1,93 @@
+/** Runnable example: opt-in context schema validation in agent.sign().
+ * ASQAV_API_KEY=sk_... npx ts-node examples/schema-receipts.ts */
+
+import {
+  Agent,
+  ValidationError,
+  type ContextSchema,
+  init,
+} from "@asqav/sdk";
+
+// Schema: field -> {type: string|number|boolean|object|array, required?: bool}
+const PAYMENT_SCHEMA: ContextSchema = {
+  userId:   { type: "string",  required: true },
+  amount:   { type: "number",  required: true },
+  currency: { type: "string",  required: true },
+  metadata: { type: "object" },                // optional
+};
+
+async function main(): Promise<void> {
+  const apiKey = process.env["ASQAV_API_KEY"] ?? "";
+  if (!apiKey) {
+    console.error(
+      "Set ASQAV_API_KEY before running.\nGet your key at https://asqav.com"
+    );
+    process.exit(1);
+  }
+
+  init({ apiKey });
+  const agent = await Agent.create({ name: "schema-demo" });
+
+  // --- Valid context: passes validation, keys are sorted before signing ---
+  console.log("Signing with a valid, schema-validated context...");
+  const sig = await agent.sign({
+    actionType: "payment:initiate",
+    // Deliberately unsorted: SDK normalises to alphabetical key order.
+    context: {
+      userId:   "user_abc123",
+      currency: "EUR",
+      amount:   49.95,
+      metadata: { source: "api" },
+    },
+    contextSchema: PAYMENT_SCHEMA,
+  });
+  console.log(`  signatureId : ${sig.signatureId}`);
+  console.log(`  verify      : ${sig.verificationUrl}`);
+
+  // --- Invalid context: throws BEFORE the network call ---
+  console.log("\nAttempting to sign with a missing required field (userId)...");
+  try {
+    await agent.sign({
+      actionType: "payment:initiate",
+      context: { amount: 100.0, currency: "USD" }, // userId missing
+      contextSchema: PAYMENT_SCHEMA,
+    });
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      console.log(`  Caught (expected): ${err.message}`);
+      console.log(`  Docs: ${err.docsUrl}`);
+    }
+  }
+
+  // --- Wrong type: throws BEFORE the network call ---
+  console.log("\nAttempting to sign with the wrong type for 'amount'...");
+  try {
+    await agent.sign({
+      actionType: "payment:initiate",
+      context: { userId: "u1", amount: "one-hundred", currency: "USD" },
+      contextSchema: PAYMENT_SCHEMA,
+    });
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      console.log(`  Caught (expected): ${err.message}`);
+    }
+  }
+
+  // --- Custom callable validator (e.g. wrap Ajv for full JSON Schema) ---
+  console.log("\nSigning with a custom callable validator...");
+  const sig2 = await agent.sign({
+    actionType: "payment:initiate",
+    context: { userId: "user_xyz", amount: 10.0, currency: "GBP" },
+    contextSchema: (ctx) => {
+      if (typeof ctx["amount"] === "number" && ctx["amount"] <= 0) {
+        throw new Error("amount must be positive");
+      }
+    },
+  });
+  console.log(`  signatureId : ${sig2.signatureId}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.6.2",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.6.2",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "@noble/post-quantum": "^0.6.1"

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -21,6 +21,14 @@ import { canonicalizeAction } from "./canonicalize.js";
 import { _dispatchAfter, _dispatchBefore } from "./hooks.js";
 import { canonicalJson } from "./jcs.js";
 import { type Mode, resolveMode } from "./mode.js";
+import {
+  type ContextSchema,
+  type ContextSchemaField,
+  type ContextSchemaFieldType,
+  ValidationError,
+  normalizeContext,
+  validateContextSchema,
+} from "./schema.js";
 import { userAgentHeaders } from "./userAgent.js";
 
 export { SDK_VERSION, USER_AGENT, userAgentHeaders } from "./userAgent.js";
@@ -199,6 +207,15 @@ export {
 } from "./algorithms.js";
 export { resolveMode, isAsqavCloudHost, type Mode } from "./mode.js";
 export { BudgetTracker, type BudgetCheckResult, type BudgetTrackerOptions } from "./budget.js";
+// Structured receipts (criterion 328): opt-in schema validation helpers.
+export {
+  ValidationError,
+  validateContextSchema,
+  normalizeContext,
+  type ContextSchema,
+  type ContextSchemaField,
+  type ContextSchemaFieldType,
+} from "./schema.js";
 
 // Compliance Receipts wire-shape projection helpers.
 export {
@@ -612,6 +629,11 @@ export interface SignOptions {
    * `modelId` / `modelVersion` requires `attestationSource` so the
    * machine-authorship claim is never read as Asqav-verified. */
   authoredBy?: AuthoredBy;
+
+  /** Optional schema for context (criterion 328). Built-in descriptor map or
+   * custom validator function. Validates + normalises context before signing;
+   * throws ValidationError on mismatch. Omit for today's exact behavior. */
+  contextSchema?: ContextSchema | ((ctx: Record<string, unknown>) => void);
 }
 
 /** Producer-asserted point-in-time snapshot of third-party risk signals.
@@ -1944,8 +1966,21 @@ export class Agent {
 
   async sign(options: SignOptions): Promise<SignatureResponse> {
     const initialContext = surfaceKwargsIntoContext(options);
-    const finalContext = _dispatchBefore(options.actionType, initialContext);
+    const afterHookContext = _dispatchBefore(options.actionType, initialContext);
     const complianceMode = options.complianceMode !== false;
+
+    // Opt-in schema validation + normalization (criterion 328).
+    // Runs after hook dispatch so the validated form is what gets signed.
+    let finalContext = afterHookContext;
+    if (options.contextSchema !== undefined) {
+      const schema = options.contextSchema;
+      if (typeof schema === "function") {
+        schema(finalContext ?? {});
+      } else {
+        validateContextSchema(finalContext, schema);
+      }
+      finalContext = normalizeContext(finalContext) ?? finalContext;
+    }
 
     validateSignOptions(options, complianceMode);
 

--- a/typescript/src/schema.ts
+++ b/typescript/src/schema.ts
@@ -1,0 +1,132 @@
+/** Opt-in context-schema validator for agent.sign() (criterion 328). */
+
+/** Valid type names for built-in field descriptors. */
+export type ContextSchemaFieldType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "object"
+  | "array";
+
+/** Per-field descriptor in a ContextSchema. */
+export interface ContextSchemaField {
+  /** Expected JavaScript type of the value. */
+  type: ContextSchemaFieldType;
+  /** When true the field must be present. Defaults to false. */
+  required?: boolean;
+}
+
+/** Built-in schema: a record of field names to ContextSchemaField descriptors. */
+export type ContextSchema = Record<string, ContextSchemaField>;
+
+/** Docs URL stamped on ValidationError instances. */
+const SCHEMA_DOCS_URL = "https://asqav.com/docs/structured-receipts";
+
+/** Validate context against the schema; throws ValidationError on first bad field.
+ * null/undefined context treated as empty ({}). */
+export function validateContextSchema(
+  context: Record<string, unknown> | null | undefined,
+  schema: ContextSchema,
+): void {
+  const ctx = context ?? {};
+
+  for (const [field, descriptor] of Object.entries(schema)) {
+    const { type: typeName, required = false } = descriptor;
+
+    const validTypes: readonly string[] = [
+      "string",
+      "number",
+      "boolean",
+      "object",
+      "array",
+    ];
+    if (!validTypes.includes(typeName)) {
+      throw new Error(
+        `context_schema_error: unknown type '${typeName}' for field '${field}'; ` +
+          `must be one of ${validTypes.join(", ")}`,
+      );
+    }
+
+    if (!(field in ctx)) {
+      if (required) {
+        throw new ValidationError(
+          `context_schema_error: field '${field}' is required but missing`,
+          SCHEMA_DOCS_URL,
+        );
+      }
+      continue;
+    }
+
+    const value = ctx[field];
+
+    if (typeName === "number") {
+      // bool is rejected: typeof true === "boolean", not "number", but guard explicitly.
+      if (typeof value === "boolean") {
+        throw new ValidationError(
+          `context_schema_error: field '${field}' expected type number, got boolean`,
+          SCHEMA_DOCS_URL,
+        );
+      }
+      if (typeof value !== "number") {
+        throw new ValidationError(
+          `context_schema_error: field '${field}' expected type number, got ${typeof value}`,
+          SCHEMA_DOCS_URL,
+        );
+      }
+      continue;
+    }
+
+    if (typeName === "array") {
+      if (!Array.isArray(value)) {
+        throw new ValidationError(
+          `context_schema_error: field '${field}' expected type array, got ${typeof value}`,
+          SCHEMA_DOCS_URL,
+        );
+      }
+      continue;
+    }
+
+    if (typeName === "object") {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        const got = Array.isArray(value) ? "array" : value === null ? "null" : typeof value;
+        throw new ValidationError(
+          `context_schema_error: field '${field}' expected type object, got ${got}`,
+          SCHEMA_DOCS_URL,
+        );
+      }
+      continue;
+    }
+
+    // "string" | "boolean"
+    if (typeof value !== typeName) {
+      throw new ValidationError(
+        `context_schema_error: field '${field}' expected type ${typeName}, got ${typeof value}`,
+        SCHEMA_DOCS_URL,
+      );
+    }
+  }
+}
+
+/** Return a new object with keys sorted. Stable order makes sign() deterministic. */
+export function normalizeContext(
+  context: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | undefined {
+  if (context == null) return undefined;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(context).sort()) {
+    sorted[key] = context[key];
+  }
+  return sorted;
+}
+
+/** Thrown when context fails the caller-supplied schema. */
+export class ValidationError extends Error {
+  /** Docs page for the structured-receipts feature. */
+  docsUrl: string;
+
+  constructor(message: string, docsUrl = SCHEMA_DOCS_URL) {
+    super(message);
+    this.name = "ValidationError";
+    this.docsUrl = docsUrl;
+  }
+}

--- a/typescript/tests/schemaReceipts.test.ts
+++ b/typescript/tests/schemaReceipts.test.ts
@@ -1,0 +1,439 @@
+/** Tests for opt-in schema-driven structured receipts (criterion 328).
+ * (a) valid context -> fetch called with sorted context;
+ * (b) invalid context -> ValidationError raised, fetch NOT called;
+ * (c) no schema -> unchanged behavior (fetch called as before). */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  ValidationError,
+  _resetForTests,
+  init,
+  normalizeContext,
+  validateContextSchema,
+} from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_schema_test",
+    name: "schema-test",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-06-29T00:00:00Z",
+  });
+}
+
+function okBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    signature: "sig_b64",
+    signature_id: "sig_schema",
+    action_id: "act_schema",
+    timestamp: "2026-06-29T00:00:00Z",
+    verification_url: "https://asqav.com/verify/sig_schema",
+    algorithm: "ML-DSA-65",
+    ...extra,
+  };
+}
+
+const BASIC_SCHEMA = {
+  userId: { type: "string" as const, required: true },
+  score: { type: "number" as const },
+  active: { type: "boolean" as const },
+  tags: { type: "array" as const },
+  meta: { type: "object" as const },
+};
+
+describe("agent.sign contextSchema", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // === (a) Valid context passes ===
+
+  it("(a) valid context passes schema and fetch is called", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(okBody()));
+
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "api:call",
+      context: { userId: "u1", score: 42 },
+      contextSchema: BASIC_SCHEMA,
+      complianceMode: false,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("(a) context is key-sorted before sign is called", async () => {
+    let capturedBody: Record<string, unknown> = {};
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      capturedBody = JSON.parse((init?.body as string) ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      return jsonResponse(okBody());
+    });
+
+    const agent = fakeAgent();
+    // Supply keys in deliberate reverse alphabetical order.
+    await agent.sign({
+      actionType: "api:call",
+      context: { userId: "u1", score: 3, active: true },
+      contextSchema: BASIC_SCHEMA,
+      complianceMode: false,
+    });
+
+    const ctx = capturedBody["context"] as Record<string, unknown> | undefined;
+    if (ctx !== undefined) {
+      const publicKeys = Object.keys(ctx).filter((k) => !k.startsWith("_"));
+      expect(publicKeys).toEqual([...publicKeys].sort());
+    }
+    // Even if context is hashed (hash mode), the fetch was reached.
+    expect(vi.mocked(fetch).mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("(a) all supported field types pass with correct values", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(okBody()));
+
+    const agent = fakeAgent();
+    await agent.sign({
+      actionType: "api:call",
+      context: {
+        userId: "alice",
+        score: 3.14,
+        active: true,
+        tags: ["a", "b"],
+        meta: { k: "v" },
+      },
+      contextSchema: BASIC_SCHEMA,
+      complianceMode: false,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("(a) optional field absent passes with no error", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(okBody()));
+
+    await fakeAgent().sign({
+      actionType: "api:call",
+      context: { userId: "u2" }, // only required userId; optional fields absent
+      contextSchema: BASIC_SCHEMA,
+      complianceMode: false,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  // === (b) Invalid context raises before fetch ===
+
+  it("(b) missing required field throws ValidationError and fetch not called", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({
+        actionType: "api:call",
+        context: { score: 5 }, // userId missing
+        contextSchema: BASIC_SCHEMA,
+        complianceMode: false,
+      }),
+    ).rejects.toThrowError(ValidationError);
+
+    // Non-vacuity: if validation were removed, this assertion would fail
+    // because fetch would be called.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("(b) wrong type (string for number) throws ValidationError before fetch", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { userId: "u1", score: "not-a-number" },
+        contextSchema: BASIC_SCHEMA,
+        complianceMode: false,
+      }),
+    ).rejects.toThrowError(ValidationError);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("(b) boolean rejected for number type field", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { userId: "u1", score: true },
+        contextSchema: BASIC_SCHEMA,
+        complianceMode: false,
+      }),
+    ).rejects.toThrowError(/expected type number, got boolean/);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("(b) ValidationError message names the offending field", async () => {
+    vi.spyOn(globalThis, "fetch");
+
+    let error: unknown;
+    try {
+      await fakeAgent().sign({
+        actionType: "api:call",
+        context: { score: 5 },
+        contextSchema: BASIC_SCHEMA,
+        complianceMode: false,
+      });
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(ValidationError);
+    expect((error as ValidationError).message).toContain("userId");
+    expect((error as ValidationError).docsUrl).toContain("structured-receipts");
+  });
+
+  it("(b) wrong type for object field throws before fetch", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { userId: "u1", meta: "string-not-object" },
+        contextSchema: BASIC_SCHEMA,
+        complianceMode: false,
+      }),
+    ).rejects.toThrowError(ValidationError);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("(b) wrong type for array field throws before fetch", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { userId: "u1", tags: { not: "array" } },
+        contextSchema: BASIC_SCHEMA,
+        complianceMode: false,
+      }),
+    ).rejects.toThrowError(ValidationError);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  // === (c) No schema => unchanged behavior ===
+
+  it("(c) no schema supplied: sign called as before", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(okBody()));
+
+    await fakeAgent().sign({
+      actionType: "api:call",
+      context: { any_key: "any_value" },
+      complianceMode: false,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("(c) undefined context + no schema: sign called as before", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(okBody()));
+
+    await fakeAgent().sign({
+      actionType: "api:call",
+      complianceMode: false,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  // === Custom callable validator ===
+
+  it("custom callable validator receives the context and passes through", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(okBody()));
+
+    const receivedCtx: Record<string, unknown>[] = [];
+
+    await fakeAgent().sign({
+      actionType: "api:call",
+      context: { x: 1 },
+      contextSchema: (ctx) => {
+        receivedCtx.push({ ...ctx });
+      },
+      complianceMode: false,
+    });
+
+    expect(receivedCtx.length).toBeGreaterThan(0);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("custom callable validator that throws prevents fetch", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      fakeAgent().sign({
+        actionType: "api:call",
+        context: { x: -1 },
+        contextSchema: (_ctx) => {
+          throw new Error("custom_schema_error: x must be positive");
+        },
+        complianceMode: false,
+      }),
+    ).rejects.toThrowError("x must be positive");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+// === Unit tests for schema helpers ===
+
+describe("validateContextSchema", () => {
+  it("throws on missing required field", () => {
+    expect(() =>
+      validateContextSchema(
+        {},
+        { userId: { type: "string", required: true } },
+      ),
+    ).toThrowError(/userId.*required/);
+  });
+
+  it("optional absent field passes", () => {
+    expect(() =>
+      validateContextSchema({}, { score: { type: "number" } }),
+    ).not.toThrow();
+  });
+
+  it("correct string passes", () => {
+    expect(() =>
+      validateContextSchema({ name: "alice" }, { name: { type: "string" } }),
+    ).not.toThrow();
+  });
+
+  it("correct number (integer) passes", () => {
+    expect(() =>
+      validateContextSchema({ n: 7 }, { n: { type: "number" } }),
+    ).not.toThrow();
+  });
+
+  it("correct number (float) passes", () => {
+    expect(() =>
+      validateContextSchema({ n: 3.14 }, { n: { type: "number" } }),
+    ).not.toThrow();
+  });
+
+  it("boolean rejected for number field", () => {
+    expect(() =>
+      validateContextSchema({ n: true }, { n: { type: "number" } }),
+    ).toThrowError(/expected type number, got boolean/);
+  });
+
+  it("wrong type string-for-number raises", () => {
+    expect(() =>
+      validateContextSchema({ n: "oops" }, { n: { type: "number" } }),
+    ).toThrowError(/expected type number/);
+  });
+
+  it("boolean field passes true", () => {
+    expect(() =>
+      validateContextSchema({ ok: true }, { ok: { type: "boolean" } }),
+    ).not.toThrow();
+  });
+
+  it("object field passes plain object", () => {
+    expect(() =>
+      validateContextSchema({ m: { a: 1 } }, { m: { type: "object" } }),
+    ).not.toThrow();
+  });
+
+  it("object field rejects array", () => {
+    expect(() =>
+      validateContextSchema({ m: [1, 2] }, { m: { type: "object" } }),
+    ).toThrowError(/expected type object/);
+  });
+
+  it("array field passes", () => {
+    expect(() =>
+      validateContextSchema({ arr: [1, 2] }, { arr: { type: "array" } }),
+    ).not.toThrow();
+  });
+
+  it("array field rejects plain object", () => {
+    expect(() =>
+      validateContextSchema({ arr: {} }, { arr: { type: "array" } }),
+    ).toThrowError(/expected type array/);
+  });
+
+  it("unknown type name throws Error", () => {
+    expect(() =>
+      validateContextSchema({ x: 1 }, { x: { type: "bigdecimal" as never } }),
+    ).toThrowError(/unknown type/);
+  });
+
+  it("null context treated as empty (optional field passes)", () => {
+    expect(() =>
+      validateContextSchema(null, { x: { type: "string" } }),
+    ).not.toThrow();
+  });
+
+  it("null context with required field throws", () => {
+    expect(() =>
+      validateContextSchema(null, {
+        x: { type: "string", required: true },
+      }),
+    ).toThrowError(/x.*required/);
+  });
+});
+
+describe("normalizeContext", () => {
+  it("sorts keys alphabetically", () => {
+    const result = normalizeContext({ z: 1, a: 2, m: 3 });
+    expect(Object.keys(result!)).toEqual(["a", "m", "z"]);
+  });
+
+  it("returns undefined for null input", () => {
+    expect(normalizeContext(null)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(normalizeContext(undefined)).toBeUndefined();
+  });
+
+  it("returns empty object for empty input", () => {
+    expect(normalizeContext({})).toEqual({});
+  });
+
+  it("preserves values", () => {
+    const result = normalizeContext({ b: 2, a: 1 });
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+});


### PR DESCRIPTION
## What
Opt-in **schema-driven structured receipts**. A new optional `context_schema` (Python) / `contextSchema` (TS) on the sign path validates and normalizes the captured `context` before signing, so audit trails are structured and queryable.

- Additive / non-breaking: no schema → today's exact behavior.
- Lightweight built-in validator (required fields + basic JSON types), **no new runtime dependency**.
- Invalid context raises a clear error naming the offending field; valid context is normalized (stable key order) before signing.
- Python + TS parity; tests (valid/invalid/no-schema), docs, runnable examples.

## Verification
- Python: `ruff` clean; schema tests 33 passed (PYTHONPATH=src).
- TS: `tsc --noEmit` clean; schema tests 34 passed.
- secret-scan clean; comment-verbosity --strict clean (6 files).

Not published (release is a founder call).

https://claude.ai/code/session_01JxyJiDhYJwHX6FWG4bC3wV