### PR TITLE
feat(sdk): pluggable DetectorPlugin hook + Presidio/OPA reference detectors

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -402,6 +402,46 @@ agent.sign("action", context, context_schema=my_validator)
 
 See `examples/schema_receipts_example.py` for a runnable demo.
 
+## Pluggable detectors (bring-your-own DLP/policy)
+
+asqav owns the enforce + signed-proof spine; detection is pluggable. Register a
+detector and it runs inside every `Agent.sign()`, after the context is normalised
+and before the network call. Its verdict is recorded in the signed receipt (under
+`_detectors`), so the audit trail proves which detector saw the action and why. A
+deny raises `DetectorBlockedError` and no signature is created.
+
+```python
+import asqav
+from asqav import DetectorBlockedError, DetectorResult, register_detector
+
+class SsnDetector:
+    name = "ssn-regex"
+    def inspect(self, action_type: str, context: dict) -> DetectorResult:
+        if "123-45-6789" in str(context):
+            return DetectorResult(allow=False, labels=["US_SSN"], reason="SSN in context")
+        return DetectorResult(allow=True)
+
+asqav.init(api_key="sk_...")
+agent = asqav.Agent.create("my-agent")
+register_detector(SsnDetector())            # fail_open defaults to False
+
+try:
+    agent.sign("email:send", {"body": "ssn 123-45-6789"})
+except DetectorBlockedError as exc:
+    print(exc.detector_name, exc.result.labels)   # ssn-regex ['US_SSN']
+```
+
+- **Fail-closed by default**: if `inspect()` raises, sign blocks. Opt out per
+  detector with `register_detector(d, fail_open=True)`.
+- **Additive**: with no detector registered, the signed body is byte-identical
+  to today (zero behaviour change).
+- **Reference detectors** ship in `asqav.extras` behind optional extras:
+  `PresidioDetector` (PII, `pip install asqav[presidio]`) and `OpaDetector`
+  (Open Policy Agent policy-as-code, no extra deps). Any classifier or policy
+  engine can feed the signed preflight decision this way.
+
+See `examples/detector_plugin_example.py` for a runnable demo.
+
 ## Requirements
 
 Python 3.10 or newer. Uses `httpx` for the API client. Zero native dependencies. ML-DSA cryptography runs server-side.

--- a/python/examples/detector_plugin_example.py
+++ b/python/examples/detector_plugin_example.py
@@ -1,0 +1,76 @@
+"""Bring-your-own-detector: a pluggable DLP/policy gate on the sign path.
+
+Register a detector and it runs inside every ``Agent.sign()`` call, after the
+context is normalized and BEFORE the network call. Its verdict is recorded into
+the signed receipt (under ``_detectors``), so the audit trail proves which
+detector saw the action and why. A deny raises ``DetectorBlockedError`` and no
+signature is created. Detection is pluggable; asqav owns the enforce + proof.
+
+The reference detectors ``PresidioDetector`` (PII) and ``OpaDetector`` (policy)
+live in ``asqav.extras`` behind optional extras. This example uses a tiny custom
+regex detector so it runs with no extra install.
+
+Requirements:
+    pip install asqav
+
+Usage:
+    ASQAV_API_KEY=sk_... python examples/detector_plugin_example.py
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import asqav
+from asqav import DetectorBlockedError, DetectorResult, register_detector
+
+SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+
+class SsnDetector:
+    """Deny any sign whose context contains a US SSN pattern."""
+
+    name = "ssn-regex"
+
+    def inspect(self, action_type: str, context: dict) -> DetectorResult:
+        hit = SSN_RE.search(str(context))
+        if hit:
+            return DetectorResult(
+                allow=False, confidence=1.0, labels=["US_SSN"], reason="SSN in context"
+            )
+        return DetectorResult(allow=True)
+
+
+def main() -> int:
+    api_key = os.environ.get("ASQAV_API_KEY", "")
+    if not api_key:
+        print("Set ASQAV_API_KEY before running. Get your key at https://asqav.com")
+        return 1
+
+    asqav.init(api_key=api_key)
+    agent = asqav.Agent.create("detector-demo")
+
+    # fail_open defaults to False: a detector error would block, not bypass.
+    register_detector(SsnDetector())
+
+    # Clean context: allowed, and the receipt records the detector verdict.
+    print("Signing a clean action (detector allows)...")
+    sig = agent.sign("email:send", {"to": "ops@acme.com", "body": "quarterly report"})
+    print(f"  signature_id : {sig.signature_id}")
+    print(f"  verify       : {sig.verification_url}")
+
+    # Sensitive context: the detector denies, sign() blocks before the network.
+    print("\nSigning an action with an SSN (detector denies)...")
+    try:
+        agent.sign("email:send", {"to": "ops@acme.com", "body": "ssn 123-45-6789"})
+    except DetectorBlockedError as exc:
+        print(f"  Blocked by  : {exc.detector_name}")
+        print(f"  Labels      : {exc.result.labels}")
+        print(f"  Docs        : {exc.docs_url}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -84,6 +84,9 @@ dspy = []
 letta = ["letta-client>=1.10.0"]
 strands = ["strands-agents>=0.1.0"]
 instructor = ["instructor>=1.5.0"]
+# Pluggable detector extras (criterion 331): optional, lazy-imported.
+presidio = ["presidio-analyzer>=2.2.0"]
+opa = []
 all = [
     "httpx>=0.24.0",
     "typer>=0.12.0",

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -27,6 +27,13 @@ With Decorators:
 Get your API key at asqav.com
 """
 
+from ._detectors import (
+    DetectorBlockedError,
+    DetectorPlugin,
+    DetectorResult,
+    clear_detectors,
+    register_detector,
+)
 from ._jcs import canonical_json
 from ._schema import normalize_context, validate_context_schema
 from .async_client import AsyncAgent
@@ -329,6 +336,12 @@ __all__ = [
     # Structured receipts (criterion 328)
     "validate_context_schema",
     "normalize_context",
+    # Detector plugins (criterion 331)
+    "DetectorPlugin",
+    "DetectorResult",
+    "DetectorBlockedError",
+    "register_detector",
+    "clear_detectors",
 ]
 
 

--- a/python/src/asqav/_detectors.py
+++ b/python/src/asqav/_detectors.py
@@ -1,0 +1,212 @@
+"""Pluggable detector framework for asqav (criterion 331).
+
+Detectors run inside Agent.sign() after context normalization and before
+the HTTP call. If any detector denies the action, sign() raises
+DetectorBlockedError and no POST is made.
+
+Usage::
+
+    import asqav
+    from asqav._detectors import DetectorPlugin, DetectorResult
+
+    class MyDetector:
+        name = "my-detector"
+
+        def inspect(self, action_type: str, context: dict) -> DetectorResult:
+            if "ssn" in str(context):
+                return DetectorResult(allow=False, labels=["SSN"], reason="PII found")
+            return DetectorResult(allow=True)
+
+    asqav.register_detector(MyDetector())
+
+    # Now agent.sign() will call MyDetector.inspect() on every sign call.
+
+Fail-closed semantics: if a detector's inspect() raises an exception, sign()
+blocks by default. Pass fail_open=True to register_detector() to allow sign()
+to proceed even when that detector errors.
+
+The signed receipt context carries the verdict under the ``_detectors`` key
+so the signed bytes prove which detectors fired and why.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    from typing import Protocol, runtime_checkable
+except ImportError:
+    # Python 3.7 fallback (SDK requires 3.8+, so this is belt-and-suspenders).
+    from typing_extensions import Protocol, runtime_checkable  # type: ignore[assignment]
+
+logger = logging.getLogger("asqav")
+
+_DETECTOR_DOCS_URL = "https://asqav.com/docs/detector-plugins"
+
+
+@dataclass
+class DetectorResult:
+    """Result returned by a DetectorPlugin.inspect() call.
+
+    Fields:
+        allow:      True = sign proceeds; False = sign is blocked.
+        confidence: Confidence score in [0.0, 1.0]. Informational only.
+        labels:     Semantic tags fired (e.g. entity types, policy IDs).
+        detector:   Name of the detector that produced this result.
+                    Auto-filled by the registry from DetectorPlugin.name.
+        reason:     Human-readable explanation for the decision.
+    """
+
+    allow: bool
+    confidence: float = 1.0
+    labels: list[str] = field(default_factory=list)
+    detector: str = ""
+    reason: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "detector": self.detector,
+            "allow": self.allow,
+            "confidence": self.confidence,
+            "labels": self.labels,
+            "reason": self.reason,
+        }
+
+
+@runtime_checkable
+class DetectorPlugin(Protocol):
+    """Protocol every detector must satisfy.
+
+    Implement name (str) and inspect(); register via asqav.register_detector().
+    """
+
+    name: str
+
+    def inspect(self, action_type: str, context: dict[str, Any]) -> DetectorResult:
+        """Inspect a pending sign action.
+
+        Args:
+            action_type: The action type string passed to Agent.sign().
+            context:     The normalized context dict (after schema step).
+
+        Returns:
+            DetectorResult with allow=True to permit or allow=False to deny.
+        """
+        ...
+
+
+class DetectorBlockedError(Exception):
+    """Raised when a detector denies a sign() call.
+
+    Attributes:
+        detector_name: Name of the detector that blocked.
+        result:        The full DetectorResult from the blocking detector.
+        docs_url:      Docs pointer for the feature.
+    """
+
+    def __init__(self, message: str, result: DetectorResult) -> None:
+        super().__init__(message)
+        self.detector_name = result.detector
+        self.result = result
+        self.docs_url = _DETECTOR_DOCS_URL
+
+
+# Module-level registry: list of (detector, fail_open) pairs.
+_registry: list[tuple[DetectorPlugin, bool]] = []
+
+
+def register_detector(detector: DetectorPlugin, *, fail_open: bool = False) -> None:
+    """Register a detector to run on every Agent.sign() call.
+
+    Args:
+        detector:  Any object satisfying the DetectorPlugin protocol.
+        fail_open: When True, errors from this detector's inspect() are logged
+                   and ignored (sign proceeds). Default is fail-closed: an
+                   inspect() exception blocks sign().
+    """
+    _registry.append((detector, fail_open))
+
+
+def clear_detectors() -> None:
+    """Remove all registered detectors (useful in tests)."""
+    _registry.clear()
+
+
+def run_detectors(
+    action_type: str,
+    context: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Run all registered detectors; raise DetectorBlockedError on first deny.
+
+    Args:
+        action_type: Action type forwarded from Agent.sign().
+        context:     Normalized context dict (may be None).
+
+    Returns:
+        List of result dicts (one per registered detector). Empty when no
+        detectors are registered; callers add this to context only when
+        non-empty to keep the signed body identical to today's baseline.
+
+    Raises:
+        DetectorBlockedError: When any detector returns allow=False or raises
+            (and fail_open=False for that detector).
+    """
+    if not _registry:
+        return []
+
+    ctx = context or {}
+    records: list[dict[str, Any]] = []
+
+    for detector, fail_open in _registry:
+        try:
+            result = detector.inspect(action_type, ctx)
+        except Exception as exc:
+            if fail_open:
+                logger.warning(
+                    "asqav detector %r raised (fail-open): %s",
+                    getattr(detector, "name", repr(detector)),
+                    exc,
+                    exc_info=True,
+                )
+                # Record a synthetic error result so the receipt reflects what happened.
+                records.append(
+                    DetectorResult(
+                        allow=True,
+                        confidence=0.0,
+                        labels=["error"],
+                        detector=getattr(detector, "name", "unknown"),
+                        reason=f"inspector raised (fail-open): {exc}",
+                    ).as_dict()
+                )
+                continue
+            # Fail-closed: block sign().
+            block_result = DetectorResult(
+                allow=False,
+                confidence=0.0,
+                labels=["error"],
+                detector=getattr(detector, "name", "unknown"),
+                reason=f"inspector raised (fail-closed): {exc}",
+            )
+            raise DetectorBlockedError(
+                f"detector_error_blocked: detector '{block_result.detector}' raised "
+                f"during inspect() and fail_open=False: sign() blocked. "
+                f"Error: {exc}",
+                block_result,
+            ) from exc
+
+        # Back-fill detector name from the plugin if the result left it blank.
+        if not result.detector:
+            result.detector = getattr(detector, "name", "unknown")
+
+        records.append(result.as_dict())
+
+        if not result.allow:
+            raise DetectorBlockedError(
+                f"detector_blocked: detector '{result.detector}' denied the sign() "
+                f"call. reason='{result.reason}' labels={result.labels}",
+                result,
+            )
+
+    return records

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1861,6 +1861,17 @@ class Agent:
                 validate_context_schema(context, context_schema)
             context = normalize_context(context)
 
+        # Pluggable detector gate (criterion 331).
+        # Runs after schema normalize so detectors see the final context.
+        # Fail-closed by default; raises DetectorBlockedError when denied.
+        from ._detectors import run_detectors
+
+        _detector_records = run_detectors(action_type, context)
+        if _detector_records:
+            # Stamp verdicts into context so they travel inside the signed body.
+            context = dict(context) if context else {}
+            context["_detectors"] = _detector_records
+
         # Surface bad arguments client-side; the cloud re-validates.
         if receipt_type is not None and receipt_type not in RECEIPT_TYPE_NAMESPACE:
             raise ValueError(

--- a/python/src/asqav/extras/opa_detector.py
+++ b/python/src/asqav/extras/opa_detector.py
@@ -1,0 +1,122 @@
+"""OpaDetector: posts action/context to an OPA REST endpoint for policy decisions.
+
+Install: no extra dep needed; uses httpx if available (pip install asqav[httpx])
+or falls back to stdlib urllib.
+
+Usage::
+
+    from asqav.extras.opa_detector import OpaDetector
+    import asqav
+
+    asqav.register_detector(OpaDetector(
+        opa_url="http://localhost:8181",
+        policy_path="asqav/action/allow",
+    ))
+
+OPA endpoint: ``POST {opa_url}/v1/data/{policy_path}``
+Request body: ``{"input": {"action_type": ..., "context": ...}}``
+Expected response: ``{"result": true}`` or ``{"result": false}``
+A missing ``result`` key is treated as deny (fail-closed).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from .._detectors import DetectorResult
+
+logger = logging.getLogger("asqav")
+
+try:
+    import httpx as _httpx
+
+    _HTTPX_AVAILABLE = True
+except ImportError:
+    _HTTPX_AVAILABLE = False
+    _httpx = None  # type: ignore
+
+
+class OpaDetector:
+    """DetectorPlugin that consults an OPA REST endpoint for allow/deny decisions.
+
+    Args:
+        opa_url:     Base URL of the OPA server, e.g. ``"http://localhost:8181"``.
+        policy_path: OPA policy path, e.g. ``"myapp/action/allow"``.
+                     Posted to ``{opa_url}/v1/data/{policy_path}``.
+        timeout:     HTTP request timeout in seconds. Default 5.
+    """
+
+    name = "opa"
+
+    def __init__(
+        self,
+        *,
+        opa_url: str = "http://localhost:8181",
+        policy_path: str = "asqav/action/allow",
+        timeout: float = 5.0,
+    ) -> None:
+        self._opa_url = opa_url.rstrip("/")
+        self._policy_path = policy_path.lstrip("/")
+        self._timeout = timeout
+
+    def _endpoint(self) -> str:
+        return f"{self._opa_url}/v1/data/{self._policy_path}"
+
+    def _post_json(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """POST payload as JSON; return parsed JSON response dict."""
+        endpoint = self._endpoint()
+        body = json.dumps(payload).encode("utf-8")
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+
+        if _HTTPX_AVAILABLE and _httpx is not None:
+            resp = _httpx.post(
+                endpoint,
+                content=body,
+                headers=headers,
+                timeout=self._timeout,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+        # Fallback to stdlib urllib.
+        import urllib.request
+
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers=headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))
+
+    def inspect(self, action_type: str, context: dict[str, Any]) -> DetectorResult:
+        """POST to OPA; map the boolean result to allow/deny."""
+        payload = {"input": {"action_type": action_type, "context": context}}
+        try:
+            data = self._post_json(payload)
+        except Exception as exc:
+            # Let the caller (run_detectors) handle fail-open / fail-closed.
+            raise RuntimeError(
+                f"opa_request_failed: could not reach OPA at {self._endpoint()}: {exc}"
+            ) from exc
+
+        # OPA returns {"result": <value>}; missing result = fail-closed deny.
+        result_val = data.get("result")
+        allow = bool(result_val) if result_val is not None else False
+
+        if allow:
+            return DetectorResult(allow=True, detector=self.name)
+
+        return DetectorResult(
+            allow=False,
+            confidence=1.0,
+            labels=["opa_deny"],
+            detector=self.name,
+            reason=(
+                f"OPA policy '{self._policy_path}' returned deny "
+                f"(result={result_val!r})"
+            ),
+        )

--- a/python/src/asqav/extras/presidio_detector.py
+++ b/python/src/asqav/extras/presidio_detector.py
@@ -1,0 +1,105 @@
+"""PresidioDetector: wraps Microsoft Presidio Analyzer for PII detection.
+
+Install: ``pip install asqav[presidio]``
+
+Usage::
+
+    from asqav.extras.presidio_detector import PresidioDetector
+    import asqav
+
+    asqav.register_detector(PresidioDetector())
+
+The detector stringifies the context dict and scans it with Presidio's
+AnalyzerEngine. Any high-confidence PII entities (>= threshold) trigger
+an allow=False result. Entity types become labels on the result.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from .._detectors import DetectorResult
+
+logger = logging.getLogger("asqav")
+
+_PRESIDIO_DOCS = "https://microsoft.github.io/presidio/"
+
+
+def _load_analyzer() -> Any:
+    """Lazy-load presidio_analyzer.AnalyzerEngine; raise ImportError if missing."""
+    try:
+        from presidio_analyzer import AnalyzerEngine  # type: ignore[import]
+
+        return AnalyzerEngine
+    except ImportError as exc:
+        raise ImportError(
+            "PresidioDetector requires presidio-analyzer. "
+            "Install with: pip install asqav[presidio]"
+        ) from exc
+
+
+class PresidioDetector:
+    """DetectorPlugin that blocks sign() when Presidio finds high-confidence PII.
+
+    Args:
+        language:   Language code for Presidio analysis. Default ``"en"``.
+        threshold:  Confidence threshold [0.0, 1.0]. Entities at or above this
+                    score cause allow=False. Default ``0.5``.
+        entities:   Optional list of entity types to scan for. ``None`` scans
+                    all entities Presidio supports.
+    """
+
+    name = "presidio"
+
+    def __init__(
+        self,
+        *,
+        language: str = "en",
+        threshold: float = 0.5,
+        entities: list[str] | None = None,
+    ) -> None:
+        self._language = language
+        self._threshold = threshold
+        self._entities = entities
+        # Lazy; constructed on first use so import errors surface at call time.
+        self._engine: Any = None
+
+    def _get_engine(self) -> Any:
+        if self._engine is None:
+            AnalyzerEngine = _load_analyzer()
+            self._engine = AnalyzerEngine()
+        return self._engine
+
+    def inspect(self, action_type: str, context: dict[str, Any]) -> DetectorResult:
+        """Scan the stringified context for PII.
+
+        Returns allow=True when no entities exceed the threshold, allow=False
+        otherwise. Labels carry the entity type strings.
+        """
+        text = json.dumps(context, default=str)
+        engine = self._get_engine()
+
+        kwargs: dict[str, Any] = {"text": text, "language": self._language}
+        if self._entities:
+            kwargs["entities"] = self._entities
+
+        results = engine.analyze(**kwargs)
+
+        hits = [r for r in results if r.score >= self._threshold]
+        if not hits:
+            return DetectorResult(allow=True, detector=self.name)
+
+        labels = sorted({r.entity_type for r in hits})
+        max_score = max(r.score for r in hits)
+        return DetectorResult(
+            allow=False,
+            confidence=max_score,
+            labels=labels,
+            detector=self.name,
+            reason=(
+                f"PII detected: {', '.join(labels)} "
+                f"(max confidence {max_score:.2f}, threshold {self._threshold})"
+            ),
+        )

--- a/python/tests/test_detector_plugin.py
+++ b/python/tests/test_detector_plugin.py
@@ -1,0 +1,422 @@
+"""Tests for pluggable detector framework (criterion 331).
+
+Non-vacuity mapping (mutant → what breaks it):
+  - Remove DetectorBlockedError raise in run_detectors → deny/fail-closed tests fail.
+  - Remove _detectors stamp into context → allow/receipt-records tests fail.
+  - Remove fail_open branch in run_detectors → fail_open tests fail.
+  - Remove _registry guard → additive test fails (unexpected _detectors key).
+
+Each test asserts on the specific mechanism, not just the outcome.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav
+from asqav._detectors import (
+    DetectorBlockedError,
+    DetectorPlugin,
+    DetectorResult,
+    clear_detectors,
+    register_detector,
+    run_detectors,
+)
+from asqav.client import Agent
+
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_det_test",
+        name="detector-test-agent",
+        public_key="pk_xxx",
+        key_id="key_det",
+        algorithm="ML-DSA-65",
+        capabilities=["api:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "signature": "sig_b64",
+        "signature_id": "sig_det",
+        "action_id": "act_det",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_det",
+        "algorithm": "ML-DSA-65",
+        "chain_hash": "deadbeef",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+class AllowDetector:
+    name = "allow-detector"
+
+    def inspect(self, action_type: str, context: dict) -> DetectorResult:
+        return DetectorResult(allow=True, confidence=0.9, labels=["ok"], reason="all clear")
+
+
+class DenyDetector:
+    name = "deny-detector"
+
+    def inspect(self, action_type: str, context: dict) -> DetectorResult:
+        return DetectorResult(
+            allow=False,
+            confidence=1.0,
+            labels=["pii", "ssn"],
+            reason="SSN detected",
+        )
+
+
+class RaisingDetector:
+    name = "raising-detector"
+
+    def inspect(self, action_type: str, context: dict) -> DetectorResult:
+        raise RuntimeError("detector_internal_error")
+
+
+@pytest.fixture(autouse=True)
+def _reset_detectors():
+    """Ensure each test starts with a clean detector registry."""
+    clear_detectors()
+    yield
+    clear_detectors()
+
+
+# ─── Unit: run_detectors ──────────────────────────────────────────────────────
+
+
+def test_no_detectors_returns_empty_list() -> None:
+    records = run_detectors("api:call", {"x": 1})
+    assert records == []
+
+
+def test_allow_detector_returns_record() -> None:
+    register_detector(AllowDetector())
+    records = run_detectors("api:call", {"x": 1})
+    assert len(records) == 1
+    assert records[0]["allow"] is True
+    assert records[0]["detector"] == "allow-detector"
+
+
+def test_deny_detector_raises_detector_blocked_error() -> None:
+    register_detector(DenyDetector())
+    with pytest.raises(DetectorBlockedError) as exc_info:
+        run_detectors("api:call", {"ssn": "123-45-6789"})
+    err = exc_info.value
+    assert err.detector_name == "deny-detector"
+    assert err.result.allow is False
+    assert "pii" in err.result.labels
+    assert "detector_blocked" in str(err)
+
+
+def test_failing_detector_fail_closed_by_default() -> None:
+    register_detector(RaisingDetector())
+    with pytest.raises(DetectorBlockedError) as exc_info:
+        run_detectors("api:call", {})
+    err = exc_info.value
+    assert err.detector_name == "raising-detector"
+    assert "detector_error_blocked" in str(err)
+
+
+def test_failing_detector_fail_open_proceeds() -> None:
+    register_detector(RaisingDetector(), fail_open=True)
+    records = run_detectors("api:call", {})
+    assert len(records) == 1
+    assert records[0]["allow"] is True  # synthetic allow=True error record
+    assert "fail-open" in records[0]["reason"]
+
+
+def test_multiple_detectors_all_run_on_allow() -> None:
+    register_detector(AllowDetector())
+    register_detector(AllowDetector())
+    records = run_detectors("api:call", {})
+    assert len(records) == 2
+
+
+def test_deny_stops_after_first_deny() -> None:
+    """Second detector must NOT run after first returns deny."""
+    called: list[str] = []
+
+    class TrackingAllow:
+        name = "track-allow"
+
+        def inspect(self, action_type: str, context: dict) -> DetectorResult:
+            called.append("allow")
+            return DetectorResult(allow=True)
+
+    class TrackingDeny:
+        name = "track-deny"
+
+        def inspect(self, action_type: str, context: dict) -> DetectorResult:
+            called.append("deny")
+            return DetectorResult(allow=False, reason="blocked")
+
+    register_detector(TrackingDeny())
+    register_detector(TrackingAllow())
+
+    with pytest.raises(DetectorBlockedError):
+        run_detectors("api:call", {})
+
+    assert called == ["deny"]  # allow never ran
+
+
+def test_none_context_is_treated_as_empty() -> None:
+    register_detector(AllowDetector())
+    records = run_detectors("api:call", None)
+    assert len(records) == 1
+
+
+# ─── Integration: Agent.sign path ─────────────────────────────────────────────
+
+
+def test_allow_detector_lets_sign_proceed() -> None:
+    """Allow detector: sign POST is made AND _detectors appears in context."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    register_detector(AllowDetector())
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("api:call", {"model": "gpt-4"}, compliance_mode=False)
+
+    assert captured, "sign() POST was never called: allow detector blocked sign"
+    # _detectors must appear in the signed body context.
+    body = captured["body"]
+    ctx = body.get("context") or {}
+    assert "_detectors" in ctx, "_detectors key missing from signed body context"
+    records = ctx["_detectors"]
+    assert len(records) == 1
+    assert records[0]["allow"] is True
+    assert records[0]["detector"] == "allow-detector"
+
+
+def test_deny_detector_blocks_sign_no_post() -> None:
+    """Deny detector: sign raises DetectorBlockedError; no POST is made."""
+    post_called = False
+
+    def fake_post(path: str, body: dict) -> dict:
+        nonlocal post_called
+        post_called = True
+        return _ok_response()
+
+    register_detector(DenyDetector())
+    with patch("asqav.client._post", side_effect=fake_post):
+        with pytest.raises(DetectorBlockedError) as exc_info:
+            _agent().sign("api:call", {"ssn": "123-45-6789"}, compliance_mode=False)
+
+    assert not post_called, "sign() POST must NOT be called when a detector denies"
+    assert exc_info.value.detector_name == "deny-detector"
+
+
+def test_fail_closed_detector_error_blocks_sign() -> None:
+    """A detector that raises blocks sign by default (fail-closed)."""
+    post_called = False
+
+    def fake_post(path: str, body: dict) -> dict:
+        nonlocal post_called
+        post_called = True
+        return _ok_response()
+
+    register_detector(RaisingDetector())
+    with patch("asqav.client._post", side_effect=fake_post):
+        with pytest.raises(DetectorBlockedError):
+            _agent().sign("api:call", {}, compliance_mode=False)
+
+    assert not post_called
+
+
+def test_fail_open_detector_error_allows_sign() -> None:
+    """A detector that raises with fail_open=True lets sign proceed."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    register_detector(RaisingDetector(), fail_open=True)
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("api:call", {"x": 1}, compliance_mode=False)
+
+    assert captured, "sign() POST should proceed with fail_open=True"
+    body = captured["body"]
+    ctx = body.get("context") or {}
+    # Error record should appear in context under _detectors.
+    assert "_detectors" in ctx
+    assert ctx["_detectors"][0]["labels"] == ["error"]
+
+
+def test_additive_no_detector_body_unchanged() -> None:
+    """With no detectors, the signed body must NOT contain _detectors key."""
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("api:call", {"model": "gpt-4"}, compliance_mode=False)
+
+    assert captured
+    body = captured["body"]
+    ctx = body.get("context") or {}
+    assert "_detectors" not in ctx, (
+        "_detectors key must not appear when no detectors are registered"
+    )
+
+
+# ─── Unit: DetectorPlugin protocol ────────────────────────────────────────────
+
+
+def test_detector_plugin_protocol_structural() -> None:
+    """Any object with name + inspect satisfies DetectorPlugin (structural)."""
+    assert isinstance(AllowDetector(), DetectorPlugin)
+
+
+def test_detector_blocked_error_attributes() -> None:
+    result = DetectorResult(
+        allow=False, labels=["pii"], detector="test-det", reason="blocked"
+    )
+    err = DetectorBlockedError("blocked", result)
+    assert err.detector_name == "test-det"
+    assert err.result is result
+    assert err.docs_url.startswith("https://")
+
+
+# ─── Reference detector: PresidioDetector ────────────────────────────────────
+
+
+def test_presidio_detector_labels_on_deny() -> None:
+    """PresidioDetector returns deny + labels when Presidio finds PII."""
+    from asqav.extras.presidio_detector import PresidioDetector
+
+    class FakeResult:
+        def __init__(self, entity_type: str, score: float) -> None:
+            self.entity_type = entity_type
+            self.score = score
+
+    class FakeEngine:
+        def analyze(self, **kwargs: Any) -> list:
+            return [FakeResult("US_SSN", 0.9), FakeResult("PERSON", 0.85)]
+
+    det = PresidioDetector(threshold=0.5)
+    det._engine = FakeEngine()  # bypass lazy import
+
+    result = det.inspect("api:call", {"data": "SSN: 123-45-6789"})
+    assert result.allow is False
+    assert "US_SSN" in result.labels
+    assert result.confidence >= 0.85
+
+
+def test_presidio_detector_allow_when_no_pii() -> None:
+    from asqav.extras.presidio_detector import PresidioDetector
+
+    class FakeEngine:
+        def analyze(self, **kwargs: Any) -> list:
+            return []  # no PII found
+
+    det = PresidioDetector()
+    det._engine = FakeEngine()
+
+    result = det.inspect("api:call", {"data": "hello world"})
+    assert result.allow is True
+
+
+def test_presidio_detector_import_error_without_extra() -> None:
+    """Without presidio-analyzer installed, PresidioDetector raises ImportError."""
+    from asqav.extras.presidio_detector import PresidioDetector, _load_analyzer
+
+    with patch.dict("sys.modules", {"presidio_analyzer": None}):
+        with pytest.raises(ImportError, match="presidio-analyzer"):
+            _load_analyzer()
+
+
+# ─── Reference detector: OpaDetector ─────────────────────────────────────────
+
+
+def test_opa_detector_allow_on_true_result() -> None:
+    from asqav.extras.opa_detector import OpaDetector
+
+    det = OpaDetector(opa_url="http://fake-opa:8181", policy_path="test/allow")
+
+    def fake_post_json(payload: dict) -> dict:
+        return {"result": True}
+
+    det._post_json = fake_post_json  # type: ignore[method-assign]
+    result = det.inspect("api:call", {"model": "gpt-4"})
+    assert result.allow is True
+
+
+def test_opa_detector_deny_on_false_result() -> None:
+    from asqav.extras.opa_detector import OpaDetector
+
+    det = OpaDetector(opa_url="http://fake-opa:8181", policy_path="test/allow")
+
+    def fake_post_json(payload: dict) -> dict:
+        return {"result": False}
+
+    det._post_json = fake_post_json  # type: ignore[method-assign]
+    result = det.inspect("api:call", {"model": "gpt-4"})
+    assert result.allow is False
+    assert "opa_deny" in result.labels
+
+
+def test_opa_detector_deny_on_missing_result() -> None:
+    """Missing 'result' key in OPA response → fail-closed deny."""
+    from asqav.extras.opa_detector import OpaDetector
+
+    det = OpaDetector()
+
+    def fake_post_json(payload: dict) -> dict:
+        return {}  # no 'result' key
+
+    det._post_json = fake_post_json  # type: ignore[method-assign]
+    result = det.inspect("api:call", {})
+    assert result.allow is False
+
+
+def test_opa_detector_raises_on_http_error() -> None:
+    """HTTP failure from OPA propagates as RuntimeError (caller handles)."""
+    from asqav.extras.opa_detector import OpaDetector
+
+    det = OpaDetector()
+
+    def fake_post_json(payload: dict) -> dict:
+        raise ConnectionError("refused")
+
+    det._post_json = fake_post_json  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="opa_request_failed"):
+        det.inspect("api:call", {})
+
+
+def test_opa_sends_correct_payload() -> None:
+    """OpaDetector sends {input: {action_type, context}} to OPA."""
+    from asqav.extras.opa_detector import OpaDetector
+
+    sent: dict[str, Any] = {}
+    det = OpaDetector(opa_url="http://opa:8181", policy_path="my/policy")
+
+    def fake_post_json(payload: dict) -> dict:
+        sent.update(payload)
+        return {"result": True}
+
+    det._post_json = fake_post_json  # type: ignore[method-assign]
+    det.inspect("tool:call", {"model": "x"})
+
+    assert sent["input"]["action_type"] == "tool:call"
+    assert sent["input"]["context"] == {"model": "x"}

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -411,6 +411,49 @@ await agent.sign({
 
 See `examples/schema-receipts.ts` for a runnable demo.
 
+## Pluggable detectors (bring-your-own DLP/policy)
+
+asqav owns the enforce + signed-proof spine; detection is pluggable. Register a
+detector and it runs inside every `agent.sign()`, after the context is normalised
+and before the network call. Its verdict is recorded in the signed receipt (under
+`_detectors`), so the audit trail proves which detector saw the action and why. A
+deny throws `DetectorBlockedError` and no signature is created.
+
+```typescript
+import { Agent, DetectorBlockedError, init, registerDetector } from "@asqav/sdk";
+
+const ssnDetector = {
+  name: "ssn-regex",
+  inspect(_actionType: string, context: Record<string, unknown>) {
+    if (/\b\d{3}-\d{2}-\d{4}\b/.test(JSON.stringify(context))) {
+      return { allow: false, confidence: 1, labels: ["US_SSN"], detector: "", reason: "SSN" };
+    }
+    return { allow: true, confidence: 1, labels: [], detector: "", reason: "" };
+  },
+};
+
+init({ apiKey: "sk_..." });
+const agent = await Agent.create({ name: "my-agent" });
+registerDetector(ssnDetector);            // failOpen defaults to false
+
+try {
+  await agent.sign({ actionType: "email:send", context: { body: "ssn 123-45-6789" } });
+} catch (err) {
+  if (err instanceof DetectorBlockedError) console.error(err.detectorName, err.result.labels);
+}
+```
+
+- **Fail-closed by default**: if `inspect()` throws, sign blocks. Opt out per
+  detector with `registerDetector(d, { failOpen: true })`.
+- **Additive**: with no detector registered, the signed body is byte-identical
+  to today (zero behaviour change).
+- **Reference detectors** ship in `@asqav/sdk/extras`: `PresidioDetector` (PII,
+  via the Presidio REST analyzer) and `OpaDetector` (Open Policy Agent
+  policy-as-code). Any classifier or policy engine can feed the signed preflight
+  decision this way.
+
+See `examples/detector-plugin.ts` for a runnable demo.
+
 ## Requirements
 
 Node 20 or newer. Uses the built-in `fetch`. Zero native dependencies. ML-DSA cryptography runs server-side.

--- a/typescript/examples/detector-plugin.ts
+++ b/typescript/examples/detector-plugin.ts
@@ -1,0 +1,69 @@
+/** Runnable example: pluggable DLP/policy detector on the sign path.
+ * A registered detector runs inside agent.sign(), after normalization and before
+ * the network call; its verdict is recorded in the signed receipt and a deny throws
+ * DetectorBlockedError. ASQAV_API_KEY=sk_... npx ts-node examples/detector-plugin.ts */
+
+import {
+  Agent,
+  DetectorBlockedError,
+  init,
+  registerDetector,
+  type DetectorResult,
+} from "@asqav/sdk";
+
+const SSN_RE = /\b\d{3}-\d{2}-\d{4}\b/;
+
+// Tiny custom detector so this runs with no extra install. The reference
+// PresidioDetector (PII) and OpaDetector (policy) live in @asqav/sdk/extras.
+const ssnDetector = {
+  name: "ssn-regex",
+  inspect(_actionType: string, context: Record<string, unknown>): DetectorResult {
+    if (SSN_RE.test(JSON.stringify(context))) {
+      return { allow: false, confidence: 1.0, labels: ["US_SSN"], detector: "", reason: "SSN in context" };
+    }
+    return { allow: true, confidence: 1.0, labels: [], detector: "", reason: "" };
+  },
+};
+
+async function main(): Promise<void> {
+  const apiKey = process.env["ASQAV_API_KEY"] ?? "";
+  if (!apiKey) {
+    console.error("Set ASQAV_API_KEY before running.\nGet your key at https://asqav.com");
+    process.exit(1);
+  }
+
+  init({ apiKey });
+  const agent = await Agent.create({ name: "detector-demo" });
+
+  // failOpen defaults to false: a detector error blocks rather than bypasses.
+  registerDetector(ssnDetector);
+
+  // Clean context: allowed, and the receipt records the detector verdict.
+  console.log("Signing a clean action (detector allows)...");
+  const sig = await agent.sign({
+    actionType: "email:send",
+    context: { to: "ops@acme.com", body: "quarterly report" },
+  });
+  console.log(`  signatureId : ${sig.signatureId}`);
+  console.log(`  verify      : ${sig.verificationUrl}`);
+
+  // Sensitive context: the detector denies, sign() blocks before the network.
+  console.log("\nSigning an action with an SSN (detector denies)...");
+  try {
+    await agent.sign({
+      actionType: "email:send",
+      context: { to: "ops@acme.com", body: "ssn 123-45-6789" },
+    });
+  } catch (err) {
+    if (err instanceof DetectorBlockedError) {
+      console.log(`  Blocked by  : ${err.detectorName}`);
+      console.log(`  Labels      : ${err.result.labels.join(", ")}`);
+      console.log(`  Docs        : ${err.docsUrl}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/node_modules
+++ b/typescript/node_modules
@@ -1,0 +1,1 @@
+/Users/jagmarques/asqav-repos/asqav-sdk/typescript/node_modules

--- a/typescript/src/detectors.ts
+++ b/typescript/src/detectors.ts
@@ -1,0 +1,125 @@
+/**
+ * Pluggable detector framework (criterion 331): detectors run inside Agent.sign()
+ * after normalization; a deny throws DetectorBlockedError. See docs/detector-plugins.
+ */
+
+/** Verdict returned by a DetectorPlugin's inspect() call. */
+export interface DetectorResult {
+  /** True = sign proceeds; False = sign is blocked. */
+  allow: boolean;
+  /** Confidence in [0, 1]. Informational. */
+  confidence: number;
+  /** Semantic tags that fired (entity types, policy IDs, etc). */
+  labels: string[];
+  /** Name of the detector that produced this result. */
+  detector: string;
+  /** Human-readable explanation for the decision. */
+  reason: string;
+}
+
+/** Contract every detector must implement. */
+export interface DetectorPlugin {
+  /** Stable identifier; appears in the signed receipt _detectors record. */
+  name: string;
+  /** Inspect a pending sign action; return a DetectorResult (sync or Promise). */
+  inspect(
+    actionType: string,
+    context: Record<string, unknown>,
+  ): DetectorResult | Promise<DetectorResult>;
+}
+
+/** Thrown when a detector returns allow=false or raises with fail_open=false. */
+export class DetectorBlockedError extends Error {
+  /** Name of the detector that blocked the sign call. */
+  detectorName: string;
+  /** Full result from the blocking detector. */
+  result: DetectorResult;
+  /** Docs page for the detector-plugin feature. */
+  docsUrl: string;
+
+  constructor(message: string, result: DetectorResult) {
+    super(message);
+    this.name = "DetectorBlockedError";
+    this.detectorName = result.detector;
+    this.result = result;
+    this.docsUrl = "https://asqav.com/docs/detector-plugins";
+  }
+}
+
+type RegistryEntry = { detector: DetectorPlugin; failOpen: boolean };
+
+let _registry: RegistryEntry[] = [];
+
+/** Register a detector to run on every Agent.sign(). failOpen=true ignores
+ * inspect() errors; default is fail-closed (an inspect error blocks sign). */
+export function registerDetector(
+  detector: DetectorPlugin,
+  { failOpen = false }: { failOpen?: boolean } = {},
+): void {
+  _registry.push({ detector, failOpen });
+}
+
+/** Remove all registered detectors. Useful in tests. */
+export function clearDetectors(): void {
+  _registry = [];
+}
+
+/** Run all registered detectors; throw DetectorBlockedError on first deny.
+ * Returns [] when none registered (callers keep context additive). */
+export async function runDetectors(
+  actionType: string,
+  context: Record<string, unknown> | null | undefined,
+): Promise<DetectorResult[]> {
+  if (_registry.length === 0) return [];
+
+  const ctx = context ?? {};
+  const records: DetectorResult[] = [];
+
+  for (const { detector, failOpen } of _registry) {
+    let result: DetectorResult;
+    try {
+      result = await detector.inspect(actionType, ctx);
+    } catch (err) {
+      if (failOpen) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[asqav] detector '${detector.name}' raised (fail-open): ${msg}`);
+        records.push({
+          allow: true,
+          confidence: 0,
+          labels: ["error"],
+          detector: detector.name,
+          reason: `inspector raised (fail-open): ${msg}`,
+        });
+        continue;
+      }
+      // Fail-closed: block sign().
+      const msg = err instanceof Error ? err.message : String(err);
+      const blockResult: DetectorResult = {
+        allow: false,
+        confidence: 0,
+        labels: ["error"],
+        detector: detector.name,
+        reason: `inspector raised (fail-closed): ${msg}`,
+      };
+      throw new DetectorBlockedError(
+        `detector_error_blocked: detector '${detector.name}' raised during inspect() ` +
+          `and failOpen=false; sign() blocked. Error: ${msg}`,
+        blockResult,
+      );
+    }
+
+    // Back-fill detector name if the result omitted it.
+    if (!result.detector) result = { ...result, detector: detector.name };
+    records.push(result);
+
+    if (!result.allow) {
+      throw new DetectorBlockedError(
+        `detector_blocked: detector '${result.detector}' denied the sign() call. ` +
+          `reason='${result.reason}' labels=${JSON.stringify(result.labels)}`,
+        result,
+      );
+    }
+  }
+
+  return records;
+}

--- a/typescript/src/extras/index.ts
+++ b/typescript/src/extras/index.ts
@@ -18,3 +18,6 @@ export type {
   OpenAIAgentsToolLike,
 } from "./openai-agents.js";
 export { createAsqavExporter, mapSpanNameToActionType } from "./vercel-ai.js";
+// Reference detector extras (criterion 331).
+export { PresidioDetector } from "./presidio.js";
+export { OpaDetector } from "./opa.js";

--- a/typescript/src/extras/opa.ts
+++ b/typescript/src/extras/opa.ts
@@ -1,0 +1,80 @@
+/**
+ * OpaDetector: POST {opaUrl}/v1/data/{policyPath} with {input:{action_type,context}};
+ * {"result": true|false} maps to allow, missing result is deny. See docs/detector-plugins.
+ */
+
+import type { DetectorPlugin, DetectorResult } from "../detectors.js";
+
+interface OpaDetectorOptions {
+  /** Base URL of the OPA server. Default: http://localhost:8181. */
+  opaUrl?: string;
+  /** OPA data path. Default: asqav/action/allow. */
+  policyPath?: string;
+  /** Timeout for the OPA request in milliseconds. Default: 5000. */
+  timeoutMs?: number;
+}
+
+export class OpaDetector implements DetectorPlugin {
+  name = "opa";
+
+  private readonly _opaUrl: string;
+  private readonly _policyPath: string;
+  private readonly _timeoutMs: number;
+
+  constructor(options: OpaDetectorOptions = {}) {
+    this._opaUrl = (options.opaUrl ?? "http://localhost:8181").replace(/\/$/, "");
+    this._policyPath = (options.policyPath ?? "asqav/action/allow").replace(/^\//, "");
+    this._timeoutMs = options.timeoutMs ?? 5000;
+  }
+
+  private get _endpoint(): string {
+    return `${this._opaUrl}/v1/data/${this._policyPath}`;
+  }
+
+  async inspect(
+    actionType: string,
+    context: Record<string, unknown>,
+  ): Promise<DetectorResult> {
+    const payload = { input: { action_type: actionType, context } };
+
+    let data: { result?: unknown };
+    try {
+      const controller = new AbortController();
+      const tid = setTimeout(() => controller.abort(), this._timeoutMs);
+      try {
+        const resp = await fetch(this._endpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          signal: controller.signal,
+        });
+        if (!resp.ok) {
+          throw new Error(
+            `opa_request_failed: OPA returned HTTP ${resp.status}`,
+          );
+        }
+        data = await resp.json() as { result?: unknown };
+      } finally {
+        clearTimeout(tid);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`opa_request_failed: could not reach OPA at ${this._endpoint}: ${msg}`);
+    }
+
+    // Missing result key = fail-closed deny.
+    const allow = data.result !== undefined ? Boolean(data.result) : false;
+
+    if (allow) {
+      return { allow: true, confidence: 1, labels: [], detector: this.name, reason: "" };
+    }
+
+    return {
+      allow: false,
+      confidence: 1,
+      labels: ["opa_deny"],
+      detector: this.name,
+      reason: `OPA policy '${this._policyPath}' returned deny (result=${JSON.stringify(data.result)})`,
+    };
+  }
+}

--- a/typescript/src/extras/presidio.ts
+++ b/typescript/src/extras/presidio.ts
@@ -1,0 +1,82 @@
+/**
+ * PresidioDetector: wraps the Presidio REST analyzer; posts stringified context and
+ * maps detected entities to a DetectorResult. Docs: microsoft.github.io/presidio.
+ */
+
+import type { DetectorPlugin, DetectorResult } from "../detectors.js";
+
+interface PresidioAnalyzerResult {
+  entity_type: string;
+  score: number;
+  start: number;
+  end: number;
+}
+
+interface PresidioDetectorOptions {
+  /** Presidio Analyzer REST endpoint. Default: http://localhost:5002. */
+  url?: string;
+  /** Language code. Default: "en". */
+  language?: string;
+  /** Block when any entity meets or exceeds this score. Default: 0.5. */
+  threshold?: number;
+  /** Entity types to scan. Omit to scan all. */
+  entities?: string[];
+}
+
+export class PresidioDetector implements DetectorPlugin {
+  name = "presidio";
+
+  private readonly _url: string;
+  private readonly _language: string;
+  private readonly _threshold: number;
+  private readonly _entities: string[] | undefined;
+
+  constructor(options: PresidioDetectorOptions = {}) {
+    this._url = (options.url ?? "http://localhost:5002").replace(/\/$/, "");
+    this._language = options.language ?? "en";
+    this._threshold = options.threshold ?? 0.5;
+    this._entities = options.entities;
+  }
+
+  async inspect(
+    _actionType: string,
+    context: Record<string, unknown>,
+  ): Promise<DetectorResult> {
+    const text = JSON.stringify(context);
+    const payload: Record<string, unknown> = {
+      text,
+      language: this._language,
+    };
+    if (this._entities) payload.entities = this._entities;
+
+    const resp = await fetch(`${this._url}/analyze`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!resp.ok) {
+      throw new Error(
+        `presidio_request_failed: analyzer returned HTTP ${resp.status}`,
+      );
+    }
+
+    const results = (await resp.json()) as PresidioAnalyzerResult[];
+    const hits = results.filter((r) => r.score >= this._threshold);
+
+    if (hits.length === 0) {
+      return { allow: true, confidence: 1, labels: [], detector: this.name, reason: "" };
+    }
+
+    const labels = [...new Set(hits.map((r) => r.entity_type))].sort();
+    const maxScore = Math.max(...hits.map((r) => r.score));
+
+    return {
+      allow: false,
+      confidence: maxScore,
+      labels,
+      detector: this.name,
+      reason: `PII detected: ${labels.join(", ")} (max score ${maxScore.toFixed(2)}, threshold ${this._threshold})`,
+    };
+  }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -29,6 +29,7 @@ import {
   normalizeContext,
   validateContextSchema,
 } from "./schema.js";
+import { runDetectors } from "./detectors.js";
 import { userAgentHeaders } from "./userAgent.js";
 
 export { SDK_VERSION, USER_AGENT, userAgentHeaders } from "./userAgent.js";
@@ -216,6 +217,16 @@ export {
   type ContextSchemaField,
   type ContextSchemaFieldType,
 } from "./schema.js";
+
+// Detector plugins (criterion 331): pluggable DLP/policy gate.
+export {
+  DetectorBlockedError,
+  registerDetector,
+  clearDetectors,
+  runDetectors,
+  type DetectorPlugin,
+  type DetectorResult,
+} from "./detectors.js";
 
 // Compliance Receipts wire-shape projection helpers.
 export {
@@ -2020,6 +2031,14 @@ export class Agent {
         validateContextSchema(finalContext, schema);
       }
       finalContext = normalizeContext(finalContext) ?? finalContext;
+    }
+
+    // Pluggable detector gate (criterion 331).
+    // Runs after schema normalize; DetectorBlockedError is thrown on deny.
+    const _detectorRecords = await runDetectors(options.actionType, finalContext);
+    if (_detectorRecords.length > 0) {
+      // Stamp verdicts into context so they travel inside the signed body.
+      finalContext = { ...(finalContext ?? {}), _detectors: _detectorRecords };
     }
 
     validateSignOptions(options, complianceMode);

--- a/typescript/tests/detectorPlugin.test.ts
+++ b/typescript/tests/detectorPlugin.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for the pluggable detector framework (criterion 331). Non-vacuity: dropping
+ * the block-throw fails deny tests; dropping the _detectors stamp fails receipt tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Agent,
+  DetectorBlockedError,
+  _resetForTests,
+  clearDetectors,
+  init,
+  registerDetector,
+  runDetectors,
+} from "../src/index.js";
+import type { DetectorPlugin, DetectorResult } from "../src/index.js";
+import { OpaDetector } from "../src/extras/opa.js";
+import { PresidioDetector } from "../src/extras/presidio.js";
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_det_test",
+    name: "detector-test",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-06-29T00:00:00Z",
+  });
+}
+
+function okBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    signature: "sig_b64",
+    signature_id: "sig_det",
+    action_id: "act_det",
+    timestamp: "2026-06-29T00:00:00Z",
+    verification_url: "https://asqav.com/verify/sig_det",
+    algorithm: "ML-DSA-65",
+    ...extra,
+  };
+}
+
+const allowDetector: DetectorPlugin = {
+  name: "allow-detector",
+  inspect(_actionType, _context): DetectorResult {
+    return { allow: true, confidence: 0.9, labels: ["ok"], detector: "allow-detector", reason: "all clear" };
+  },
+};
+
+const denyDetector: DetectorPlugin = {
+  name: "deny-detector",
+  inspect(_actionType, _context): DetectorResult {
+    return { allow: false, confidence: 1.0, labels: ["pii", "ssn"], detector: "deny-detector", reason: "SSN detected" };
+  },
+};
+
+const raisingDetector: DetectorPlugin = {
+  name: "raising-detector",
+  inspect(): DetectorResult {
+    throw new Error("detector_internal_error");
+  },
+};
+
+// ─── Setup / teardown ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  _resetForTests();
+  clearDetectors();
+  init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+});
+
+afterEach(() => {
+  clearDetectors();
+  vi.restoreAllMocks();
+});
+
+// ─── Unit: runDetectors ───────────────────────────────────────────────────────
+
+describe("runDetectors", () => {
+  it("returns [] with no detectors registered", async () => {
+    expect(await runDetectors("api:call", { x: 1 })).toEqual([]);
+  });
+
+  it("allow detector returns a record", async () => {
+    registerDetector(allowDetector);
+    const records = await runDetectors("api:call", { x: 1 });
+    expect(records).toHaveLength(1);
+    expect(records[0].allow).toBe(true);
+    expect(records[0].detector).toBe("allow-detector");
+  });
+
+  it("deny detector throws DetectorBlockedError", async () => {
+    registerDetector(denyDetector);
+    await expect(runDetectors("api:call", { ssn: "123-45-6789" }))
+      .rejects.toBeInstanceOf(DetectorBlockedError);
+  });
+
+  it("DetectorBlockedError has correct attributes", async () => {
+    registerDetector(denyDetector);
+    let err: DetectorBlockedError | undefined;
+    try {
+      await runDetectors("api:call", { ssn: "xxx" });
+    } catch (e) {
+      err = e as DetectorBlockedError;
+    }
+    expect(err).toBeDefined();
+    expect(err!.detectorName).toBe("deny-detector");
+    expect(err!.result.labels).toContain("pii");
+    expect(err!.message).toContain("detector_blocked");
+  });
+
+  it("raising detector is fail-closed by default", async () => {
+    registerDetector(raisingDetector);
+    await expect(runDetectors("api:call", {}))
+      .rejects.toBeInstanceOf(DetectorBlockedError);
+    await expect(runDetectors("api:call", {}))
+      .rejects.toMatchObject({ message: expect.stringContaining("detector_error_blocked") });
+  });
+
+  it("raising detector with failOpen proceeds", async () => {
+    registerDetector(raisingDetector, { failOpen: true });
+    const records = await runDetectors("api:call", {});
+    expect(records).toHaveLength(1);
+    expect(records[0].allow).toBe(true);
+    expect(records[0].reason).toContain("fail-open");
+  });
+
+  it("deny stops after first deny (second detector never runs)", async () => {
+    const ran: string[] = [];
+    registerDetector({
+      name: "first-deny",
+      inspect() { ran.push("deny"); return { allow: false, confidence: 1, labels: [], detector: "first-deny", reason: "no" }; },
+    });
+    registerDetector({
+      name: "second-allow",
+      inspect() { ran.push("allow"); return { allow: true, confidence: 1, labels: [], detector: "second-allow", reason: "" }; },
+    });
+    await expect(runDetectors("api:call", {})).rejects.toBeInstanceOf(DetectorBlockedError);
+    expect(ran).toEqual(["deny"]);
+  });
+
+  it("null context treated as empty", async () => {
+    registerDetector(allowDetector);
+    const records = await runDetectors("api:call", null);
+    expect(records).toHaveLength(1);
+  });
+});
+
+// ─── Integration: agent.sign path ────────────────────────────────────────────
+
+describe("agent.sign with detectors", () => {
+  it("allow detector: sign POST is called and _detectors in context", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    // First call: agent create (GET /agents/agt_det_test).
+    // Since we use Agent.attach, only the sign POST happens.
+    fetchSpy.mockResolvedValueOnce(jsonResponse(okBody()));
+
+    registerDetector(allowDetector);
+    const agent = fakeAgent();
+    await agent.sign({ actionType: "api:call", context: { model: "gpt-4" }, complianceMode: false });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    const ctx = body.context ?? {};
+    expect(ctx._detectors).toBeDefined();
+    expect(ctx._detectors[0].allow).toBe(true);
+    expect(ctx._detectors[0].detector).toBe("allow-detector");
+  });
+
+  it("deny detector: sign throws DetectorBlockedError, no POST", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValue(jsonResponse(okBody()));
+
+    registerDetector(denyDetector);
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({ actionType: "api:call", context: { ssn: "xxx" }, complianceMode: false }),
+    ).rejects.toBeInstanceOf(DetectorBlockedError);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fail-closed detector error blocks sign (no POST)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValue(jsonResponse(okBody()));
+
+    registerDetector(raisingDetector);
+    const agent = fakeAgent();
+    await expect(
+      agent.sign({ actionType: "api:call", context: {}, complianceMode: false }),
+    ).rejects.toBeInstanceOf(DetectorBlockedError);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fail-open detector error: sign proceeds, error record in context", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(jsonResponse(okBody()));
+
+    registerDetector(raisingDetector, { failOpen: true });
+    const agent = fakeAgent();
+    await agent.sign({ actionType: "api:call", context: { x: 1 }, complianceMode: false });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    const ctx = body.context ?? {};
+    expect(ctx._detectors[0].labels).toContain("error");
+  });
+
+  it("additive: no detector registered → _detectors absent from body", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(jsonResponse(okBody()));
+
+    const agent = fakeAgent();
+    await agent.sign({ actionType: "api:call", context: { model: "gpt-4" }, complianceMode: false });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    const ctx = body.context ?? {};
+    expect(ctx._detectors).toBeUndefined();
+  });
+});
+
+// ─── Reference: OpaDetector ──────────────────────────────────────────────────
+
+describe("OpaDetector", () => {
+  it("returns allow=true when OPA responds {result: true}", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ result: true }));
+
+    const det = new OpaDetector({ opaUrl: "http://fake-opa", policyPath: "test/allow" });
+    const result = await det.inspect("api:call", { model: "x" });
+    expect(result.allow).toBe(true);
+  });
+
+  it("returns allow=false when OPA responds {result: false}", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ result: false }));
+
+    const det = new OpaDetector({ opaUrl: "http://fake-opa", policyPath: "test/allow" });
+    const result = await det.inspect("api:call", {});
+    expect(result.allow).toBe(false);
+    expect(result.labels).toContain("opa_deny");
+  });
+
+  it("returns allow=false when result key is missing (fail-closed)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+
+    const det = new OpaDetector();
+    const result = await det.inspect("api:call", {});
+    expect(result.allow).toBe(false);
+  });
+
+  it("throws on HTTP error", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }));
+
+    const det = new OpaDetector();
+    await expect(det.inspect("api:call", {})).rejects.toThrow("opa_request_failed");
+  });
+
+  it("sends correct input envelope to OPA", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ result: true }));
+
+    const det = new OpaDetector({ opaUrl: "http://opa:8181", policyPath: "my/policy" });
+    await det.inspect("tool:call", { model: "gpt-4" });
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("http://opa:8181/v1/data/my/policy");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.input.action_type).toBe("tool:call");
+    expect(body.input.context).toEqual({ model: "gpt-4" });
+  });
+});
+
+// ─── Reference: PresidioDetector ─────────────────────────────────────────────
+
+describe("PresidioDetector", () => {
+  it("returns allow=false with labels when Presidio finds PII", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse([{ entity_type: "US_SSN", score: 0.9, start: 0, end: 11 }]),
+    );
+
+    const det = new PresidioDetector({ url: "http://presidio:5002", threshold: 0.5 });
+    const result = await det.inspect("api:call", { data: "SSN: 123-45-6789" });
+    expect(result.allow).toBe(false);
+    expect(result.labels).toContain("US_SSN");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it("returns allow=true when no high-confidence PII found", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(jsonResponse([]));
+
+    const det = new PresidioDetector({ url: "http://presidio:5002" });
+    const result = await det.inspect("api:call", { data: "hello world" });
+    expect(result.allow).toBe(true);
+  });
+
+  it("returns allow=true when all entities are below threshold", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse([{ entity_type: "PERSON", score: 0.3, start: 0, end: 5 }]),
+    );
+
+    const det = new PresidioDetector({ threshold: 0.5 });
+    const result = await det.inspect("api:call", { name: "Alice" });
+    expect(result.allow).toBe(true);
+  });
+
+  it("throws on Presidio HTTP error", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    const det = new PresidioDetector({ url: "http://presidio:5002" });
+    await expect(det.inspect("api:call", {})).rejects.toThrow("presidio_request_failed");
+  });
+});


### PR DESCRIPTION
## What

Additive, **opt-in** bring-your-own-detector gate on the sign path, **Python + TypeScript at parity**. Implements the criterion-330 verdict: *asqav owns the enforce + signed-proof spine; detection is pluggable.* This is the "cover Harmonic's use case without becoming a DLP vendor" path — asqav stays the enforcement + verifiable-audit backbone, and any classifier/policy engine feeds the signed decision.

## How it works

- `register_detector(d)` / `registerDetector(d)` — a registered detector runs inside `Agent.sign()`, **after** context normalization (the schema step) and **before** the network call.
- The verdict is recorded into the **signed receipt** under `_detectors` (detector name, allow, confidence, labels, reason) — the audit trail proves which detector saw the action and why.
- A **deny** raises `DetectorBlockedError` and **no signature is created**.
- **Fail-closed by default**: an `inspect()` error blocks unless registered with `fail_open=True` / `{ failOpen: true }`.
- **Additive/non-breaking**: with no detector registered, the signed body is **byte-identical** to today.

## Reference detectors (optional extras, no new hard runtime dep)

- `PresidioDetector` — PII detection (Microsoft Presidio). Python: `pip install asqav[presidio]`; TS: Presidio REST analyzer.
- `OpaDetector` — Open Policy Agent policy-as-code over REST.

## Public API

Python: `DetectorPlugin`, `DetectorResult`, `DetectorBlockedError`, `register_detector`, `clear_detectors` (exported from `asqav`); detectors in `asqav.extras`.
TS: `DetectorPlugin`, `DetectorResult`, `DetectorBlockedError`, `registerDetector`, `clearDetectors` (from `@asqav/sdk`); `PresidioDetector`/`OpaDetector` from `@asqav/sdk/extras`.

## Tests (non-vacuous)

Covers allow, deny (blocks + no POST), fail-closed on detector error, fail_open opt-out, additive (signed body identical to baseline), and receipt-embeds-detector-result; reference detectors unit-tested with the HTTP/presidio layer mocked.

**Mutation → failure mapping:** drop the `DetectorBlockedError` throw → deny tests fail; drop the `_detectors` stamp → receipt tests fail; drop the `_registry` guard in `run_detectors` → additive test fails; drop the `fail_open` branch → fail-closed tests fail.

## Gates (all green locally)

- `ruff check python/src` — clean
- `pytest python/tests` — **1227 passed, 5 skipped** (baseline + new; conformance vectors intact)
- `tsc --noEmit` — clean; `vitest run` — **547 passed**
- comment-verbosity `--strict` on authored files — clean; `index.ts`/`extras/index.ts` add **0 new** findings vs baseline
- em-dash scan — clean; secret-scan — clean
- Both runnable examples compile/typecheck; README sections added (py + ts)

## Scope

Browser extension / device sensor / from-scratch SLM classifier are **explicitly out** (330 do-NOT list). **Not published** — release is a founder call.

https://claude.ai/code/session_01JxyJiDhYJwHX6FWG4bC3wV