### PR TITLE
chore(release): bump both SDK halves to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the Asqav SDK are documented here.
 Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
+## [0.7.0] - 2026-07-01
+
+### Added
+
+- **One-call `govern()` entrypoint (Python and TypeScript).** Composes
+  `init()` + `Agent.create()` (and hook registration) for the common case, so a
+  new integration is a single call. Strictly additive; `init`/`Agent.create`/
+  `Agent.sign` are unchanged.
+- **Schema-driven structured receipts (opt-in).** Pass `context_schema`
+  (Python) / `contextSchema` (TypeScript) to `Agent.sign()` to validate and
+  normalise the `context` before signing, so audit trails are structured and
+  queryable. Invalid context raises a clear error before any network call. No
+  schema means today's exact behaviour (byte-identical signed body). A callable
+  validator is also accepted for full JSON Schema.
+- **Pluggable detectors (bring-your-own DLP/policy).** `register_detector` /
+  `registerDetector` runs a detector inside `Agent.sign()`; its verdict is
+  recorded into the signed receipt under `_detectors`, and a deny raises
+  `DetectorBlockedError` before signing. Fail-closed on detector error by
+  default (`fail_open` / `failOpen` opts out). Ships two reference detectors
+  behind optional extras: `PresidioDetector` (PII) and `OpaDetector` (Open
+  Policy Agent policy-as-code). No new hard runtime dependency; additive.
+
 ## [0.6.5] - 2026-06-27
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.6.5"
+version = "0.7.0"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -157,7 +157,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.6.5"
+__version__ = "0.7.0"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/node_modules
+++ b/typescript/node_modules
@@ -1,1 +1,0 @@
-/Users/jagmarques/asqav-repos/asqav-sdk/typescript/node_modules

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.6.5";
+export const SDK_VERSION = "0.7.0";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Release 0.7.0. Bumps the version in all four locations (pyproject.toml, `__init__.py`, package.json, userAgent.ts) and adds the CHANGELOG 0.7.0 section.

Ships the additive features already merged to main since 0.6.5:
- One-call `govern()` entrypoint (#340)
- Opt-in schema-driven structured receipts (#341)
- Pluggable `DetectorPlugin` + Presidio/OPA reference detectors (#342)

No code changes beyond version strings + changelog. Version-consistency tests green (py + ts), tsc + build clean.

After merge, the `py-v` and `ts-v` release tags trigger `publish.yml` (PyPI trusted publishing + npm).

https://claude.ai/code/session_01JxyJiDhYJwHX6FWG4bC3wV