### PR TITLE
chore: relicense SDK to Elastic License 2.0 going forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the Asqav SDK are documented here.
 Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
+## [Unreleased] - License change
+
+### Changed
+
+- Relicensed asqav-sdk from MIT to Elastic License 2.0 (ELv2) for versions
+  released after 0.8.0. ELv2 permits free use and modification but restricts
+  offering the SDK as a hosted or managed service to third parties.
+  Version 0.8.0 and all versions published before it remain MIT-licensed
+  irrevocably. The conformance test vectors in `conformance/` remain
+  Apache-2.0 licensed.
+
 ## [0.8.0] - 2026-07-03
 
 ### Added
@@ -20,7 +31,6 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   (object keys in the Basic Multilingual Plane, integers within the IEEE-754
   safe range), pinned by a shared golden both suites assert against. Outside
   that domain the two halves can diverge, which the doors docs state plainly.
-
 ## [0.7.0] - 2026-07-01
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,95 @@
-MIT License
-
 Copyright (c) 2026 Asqav
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Elastic License 2.0
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+URL: https://www.elastic.co/licensing/elastic-license
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## Acceptance
 
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://pypi.org/project/asqav/"><img src="https://img.shields.io/pypi/v/asqav?style=flat-square&logo=pypi&logoColor=white&label=pypi" alt="PyPI version"></a>
   <a href="https://www.npmjs.com/package/@asqav/sdk"><img src="https://img.shields.io/npm/v/%40asqav%2Fsdk?style=flat-square&logo=npm&logoColor=white&label=npm" alt="npm version"></a>
   <a href="https://github.com/jagmarques/asqav-sdk/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/jagmarques/asqav-sdk/ci.yml?style=flat-square&logo=github&logoColor=white" alt="CI"></a>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square&logo=opensourceinitiative&logoColor=white" alt="License: MIT"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Elastic%202.0-blue.svg?style=flat-square" alt="License: Elastic 2.0"></a>
   <a href="https://github.com/jagmarques/asqav-sdk"><img src="https://img.shields.io/github/stars/jagmarques/asqav-sdk?style=social" alt="GitHub stars"></a>
 </p>
 <p align="center">
@@ -390,7 +390,13 @@ Machine-readable service descriptor at [`https://asqav.com/.well-known/governanc
 
 ## License
 
-MIT - see [LICENSE](LICENSE) for details.
+Starting with the releases that come after 0.8.0, the asqav SDK is licensed under
+the [Elastic License 2.0](LICENSE) (ELv2). ELv2 allows free use, modification, and
+distribution but restricts offering the SDK as a hosted or managed service.
+
+Version 0.8.0 and all versions published before it remain under the MIT license
+irrevocably. The conformance test vectors in `conformance/` are Apache-2.0
+licensed; see [conformance/LICENSE](conformance/LICENSE) for details.
 
 ---
 

--- a/conformance/LICENSE
+++ b/conformance/LICENSE
@@ -1,0 +1,188 @@
+NOTICE: Conformance Vectors License
+
+The files in this directory (conformance/vectors.json and subdirectories
+under verifier/conformance-vectors/) are licensed under the Apache License,
+Version 2.0. The interoperability test corpus is kept permissively licensed
+so that any implementation can independently verify receipt formats.
+
+The rest of the asqav-sdk repository is licensed under the Elastic License 2.0.
+See the top-level LICENSE file for details.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work, any work of authorship, including the original version of
+      the Work and any modifications or additions to that Work or Derivative
+      Works of the Work.
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and subsequently
+      incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or as an addendum to
+          the NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, reproduce, modify,
+      and distribute Your modifications, or for such Derivative Works as
+      a whole, under terms of Your choice, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any conditions of TITLE,
+      NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR
+      PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Liability. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and
+      on Your sole responsibility, not on behalf of any other Contributor,
+      and only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or
+      liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright (c) 2026 Asqav
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "asqav"
 version = "0.8.0"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
-license = "MIT"
+license = "LicenseRef-Elastic-License-2.0"
 requires-python = ">=3.10"
 authors = [
     { name = "Asqav", email = "info@asqav.com" }
@@ -35,7 +35,7 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: Other/Proprietary License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -11,7 +11,7 @@
     "ml-dsa",
     "policy-enforcement"
   ],
-  "license": "MIT",
+  "license": "LicenseRef-Elastic-License-2.0",
   "author": "Asqav <info@asqav.com>",
   "homepage": "https://asqav.com",
   "repository": {


### PR DESCRIPTION
## Summary

- Replace the MIT `LICENSE` with verbatim Elastic License 2.0 text (licensor: Asqav, Copyright 2026 Asqav). The text was fetched from the canonical source at https://www.elastic.co/licensing/elastic-license and checked against the Elasticsearch GitHub raw file. Both sources match on every section heading and clause.
- Set `license = "LicenseRef-Elastic-License-2.0"` in `python/pyproject.toml` and `"license": "LicenseRef-Elastic-License-2.0"` in `typescript/package.json`. ELv2 has no SPDX short identifier, so the LicenseRef form is the standard convention for non-SPDX licenses in manifests.
- Add `conformance/LICENSE` with the full Apache-2.0 text and a NOTICE header keeping the conformance test vectors (`conformance/vectors.json`, `verifier/conformance-vectors/`) permissively licensed. The interoperability corpus stays Apache-2.0 so any independent verifier implementation can use it freely.
- Update the README license section and CHANGELOG with the honest boundary: 0.8.0 and all versions published before it remain MIT irrevocably, and Elastic License 2.0 covers releases that come after.

Zero `.py` or `.ts` source files changed. This is a metadata and docs-only relicense.

## Test plan

- [ ] `grep -q "Elastic License 2.0" LICENSE` passes
- [ ] `grep -q "LicenseRef-Elastic-License-2.0" python/pyproject.toml typescript/package.json` passes
- [ ] `grep -riq "Apache" conformance` passes
- [ ] `git diff --name-only origin/main | grep -E '[.](py|ts)$'` returns empty
- [ ] `secret-scan.js --worktree .` exits 0

## Proof of work

```
$ grep -q "Elastic License 2.0" LICENSE && grep -q "LicenseRef-Elastic-License-2.0" python/pyproject.toml typescript/package.json && grep -riq "Apache" conformance && test -z "$(git diff --name-only origin/main | grep -E '[.](py|ts)$')" && echo "docs/metadata only"
docs/metadata only

$ git diff --stat origin/main
 CHANGELOG.md            |  11 +++
 LICENSE                 | 107 ++++++++++++++++++++++-----
 README.md               |  12 +++-
 conformance/LICENSE     | 188 ++++++++++++++++++++++++++++++++++++++++++++++++
 python/pyproject.toml   |   4 +-
 typescript/package.json |   2 +-
 6 files changed, 300 insertions(+), 23 deletions(-)
```

ELv2 text sources verified:
1. https://raw.githubusercontent.com/elastic/elasticsearch/main/licenses/ELASTIC-LICENSE-2.0.txt (fetched this session)
2. https://www.elastic.co/licensing/elastic-license (fetched this session)

Both sources agree on all section headings and clause wording.

DO NOT MERGE - gated draft PR for review.
