### PR TITLE
feat(extras): default-on MCP governance (python + typescript)

### DIFF
--- a/docs/integrations-mcp.md
+++ b/docs/integrations-mcp.md
@@ -1,0 +1,84 @@
+# MCP integration (default-on governance)
+
+asqav can sign a governance receipt on every tool call of an
+[MCP](https://modelcontextprotocol.io) server. One function call turns it on
+for the whole server, so governance is default-on rather than a per-call
+flag. Signing is fail-open: a signing outage never blocks or changes a tool
+call.
+
+## Python
+
+Install the extra:
+
+```bash
+pip install asqav[mcp]
+```
+
+Wire it in one call:
+
+```python
+import asqav
+from asqav.extras.mcp import enable_mcp_governance
+from mcp.server.fastmcp import FastMCP
+
+asqav.init("sk_...")
+
+server = FastMCP("my-server")
+enable_mcp_governance(server, agent_name="my-mcp-server")
+
+@server.tool()
+def add(a: int, b: int) -> int:
+    return a + b
+```
+
+Every call to `add` (or any other tool) now signs a `tool:call` receipt. A
+tool that raises also signs `tool:error` and the error propagates unchanged.
+
+`enable_mcp_governance` handles both server styles:
+
+- `FastMCP` - it wraps the tool-dispatch funnel that both the direct API and
+  real request routing pass through.
+- The low-level `mcp.server.lowlevel.Server` - it wraps the `call_tool`
+  decorator so handlers you register sign on each call.
+
+Options mirror the other adapters: `api_key`, `agent_name`, `agent_id`, and
+`observe` (log intent instead of signing).
+
+## TypeScript
+
+Install the peer:
+
+```bash
+npm install @asqav/sdk @modelcontextprotocol/sdk
+```
+
+```ts
+import { init } from "@asqav/sdk";
+import { enableMcpGovernance } from "@asqav/sdk/extras/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+init({ apiKey: process.env.ASQAV_API_KEY! });
+
+const server = new McpServer({ name: "my-server", version: "1.0.0" });
+enableMcpGovernance(server, { agentName: "my-mcp-server" });
+
+server.registerTool("add", { description: "add" }, async ({ a, b }) => ({
+  content: [{ type: "text", text: String(a + b) }],
+}));
+```
+
+`enableMcpGovernance` wraps `registerTool` and the deprecated `tool`
+registrar, so every tool registered after the call signs a `tool:call`
+receipt when invoked.
+
+## Notes
+
+- Additive and non-breaking: importing the module without calling the enable
+  function changes nothing.
+- The MCP SDK is an optional extra (Python) / optional peer (TypeScript). The
+  adapter never imports it directly; it operates on the server instance you
+  pass in.
+- Fail-open: governance signing never raises into the MCP request path.
+
+Runnable examples: `python/examples/mcp_example.py`,
+`typescript/examples/mcp.ts`.

--- a/python/examples/mcp_example.py
+++ b/python/examples/mcp_example.py
@@ -1,0 +1,54 @@
+"""Default-on asqav governance for an MCP (Model Context Protocol) server.
+
+Install:
+    pip install asqav[mcp]
+
+Run:
+    export ASQAV_API_KEY=sk_...
+    python examples/mcp_example.py
+
+One call to ``enable_mcp_governance`` turns governance on for the whole
+server. Every tool call then signs an asqav receipt by default, with no
+per-call flag. Signing is fail-open, so a signing outage never blocks a
+tool call.
+"""
+
+from __future__ import annotations
+
+import os
+
+import asqav
+from asqav.extras.mcp import enable_mcp_governance
+
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError as err:
+    raise SystemExit(
+        "This example needs the MCP SDK. Install with: pip install asqav[mcp]"
+    ) from err
+
+
+def main() -> None:
+    asqav.init(os.environ["ASQAV_API_KEY"])
+
+    server = FastMCP("demo-server")
+
+    # Turn governance on once. Every tool below is now governed.
+    enable_mcp_governance(server, agent_name="demo-mcp-server")
+
+    @server.tool()
+    def add(a: int, b: int) -> int:
+        """Add two integers."""
+        return a + b
+
+    @server.tool()
+    def greet(name: str) -> str:
+        """Return a greeting."""
+        return f"hello {name}"
+
+    print("MCP server governed by asqav. Tools:", ["add", "greet"])
+    print("Run over stdio with: server.run() (omitted so the example stays offline)")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -57,6 +57,7 @@ httpx = ["httpx>=0.24.0"]
 verify = ["dilithium-py>=1.0.0", "cryptography>=42"]
 cli = ["typer>=0.12.0", "httpx>=0.24.0"]
 langchain = ["langchain-core>=0.2.0"]
+mcp = ["mcp>=1.0.0"]
 # crewai hard-requires chromadb (CVE-2025-47947, CRITICAL, no upstream patch as of 2026-06-20).
 # Removed from extras until crewai/chromadb ships a patched release.
 # The integration module (extras/crewai.py) stays; users can install crewai
@@ -91,6 +92,7 @@ all = [
     "httpx>=0.24.0",
     "typer>=0.12.0",
     "langchain-core>=0.2.0",
+    "mcp>=1.0.0",
     # crewai removed: hard-requires chromadb (CVE-2025-47947, CRITICAL, no patch).
     "litellm>=1.83.14,!=1.82.7,!=1.82.8",
     "haystack-ai>=2.0.0",

--- a/python/src/asqav/extras/__init__.py
+++ b/python/src/asqav/extras/__init__.py
@@ -2,6 +2,7 @@
 
 Install specific extras:
     pip install asqav[langchain]
+    pip install asqav[mcp]
     pip install asqav[crewai]
     pip install asqav[litellm]
     pip install asqav[haystack]

--- a/python/src/asqav/extras/mcp.py
+++ b/python/src/asqav/extras/mcp.py
@@ -1,0 +1,173 @@
+"""MCP (Model Context Protocol) integration for asqav.
+
+Install: pip install asqav[mcp]
+
+Usage::
+
+    from mcp.server.fastmcp import FastMCP
+    from asqav.extras.mcp import enable_mcp_governance
+
+    server = FastMCP("my-server")
+    enable_mcp_governance(server, agent_name="my-mcp-server")
+
+    @server.tool()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+One call to ``enable_mcp_governance`` turns governance on for the whole
+server: every tool call signs an asqav receipt by default, with no
+per-call flag. Signing is fail-open - a signing error is logged and never
+blocks or alters the tool call. Importing this module without calling the
+function changes nothing, and ``mcp`` is an optional extra (this module
+duck-types the server, it never imports ``mcp`` itself).
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any
+
+from ._base import AsqavAdapter
+
+logger = logging.getLogger("asqav")
+
+__all__ = ["AsqavMCPAdapter", "enable_mcp_governance"]
+
+_MAX_LEN = 200
+
+
+class AsqavMCPAdapter(AsqavAdapter):
+    """Signs an asqav governance receipt on every MCP tool call.
+
+    ``instrument`` wraps the server's tool-dispatch funnel so each call
+    records ``tool:call`` (and ``tool:error`` when the tool raises). It
+    handles a FastMCP server (wraps the ``_tool_manager`` dispatch that both
+    the direct API and real request routing funnel through) and a low-level
+    ``Server`` (wraps the ``call_tool`` decorator so registered handlers
+    sign). Fail-open throughout.
+
+    Args:
+        api_key: Optional API key override (uses ``asqav.init()`` default).
+        agent_name: Name for an asqav agent (calls ``Agent.create``).
+        agent_id: ID of an existing asqav agent (calls ``Agent.get``).
+        observe: When True, log intent instead of signing.
+    """
+
+    def instrument(self, server: Any) -> Any:
+        """Wire signing into ``server``'s tool dispatch; returns ``server``."""
+        tool_manager = getattr(server, "_tool_manager", None)
+        if tool_manager is not None and inspect.iscoroutinefunction(
+            getattr(tool_manager, "call_tool", None)
+        ):
+            self._wrap_dispatch(tool_manager, "call_tool")
+            return server
+        if inspect.iscoroutinefunction(getattr(server, "call_tool", None)):
+            self._wrap_dispatch(server, "call_tool")
+            return server
+        if callable(getattr(server, "call_tool", None)):
+            self._wrap_lowlevel_decorator(server)
+            return server
+        raise TypeError(
+            "enable_mcp_governance expects a FastMCP server or a low-level mcp "
+            f"Server exposing call_tool; got {type(server).__name__}."
+        )
+
+    def _wrap_dispatch(self, target: Any, attr: str) -> None:
+        # Single async funnel: wrap once so both direct calls and routing sign.
+        original = getattr(target, attr)
+        if getattr(original, "_asqav_wrapped", False):
+            return
+        adapter = self
+
+        async def _signed_dispatch(
+            name: str, arguments: Any, *args: Any, **kwargs: Any
+        ) -> Any:
+            await adapter._sign_tool_call(name, arguments)
+            try:
+                return await original(name, arguments, *args, **kwargs)
+            except Exception as exc:
+                await adapter._sign_tool_error(name, exc)
+                raise
+
+        _signed_dispatch._asqav_wrapped = True  # type: ignore[attr-defined]
+        setattr(target, attr, _signed_dispatch)
+
+    def _wrap_lowlevel_decorator(self, server: Any) -> None:
+        # Low-level Server.call_tool is a decorator; wrap the handler it registers.
+        original_call_tool = server.call_tool
+        if getattr(original_call_tool, "_asqav_wrapped", False):
+            return
+        adapter = self
+
+        def _patched_call_tool(*d_args: Any, **d_kwargs: Any) -> Any:
+            real_decorator = original_call_tool(*d_args, **d_kwargs)
+
+            def _wrapping_decorator(func: Any) -> Any:
+                async def _signed_handler(
+                    name: str, arguments: Any, *a: Any, **k: Any
+                ) -> Any:
+                    await adapter._sign_tool_call(name, arguments)
+                    try:
+                        return await func(name, arguments, *a, **k)
+                    except Exception as exc:
+                        await adapter._sign_tool_error(name, exc)
+                        raise
+
+                return real_decorator(_signed_handler)
+
+            return _wrapping_decorator
+
+        _patched_call_tool._asqav_wrapped = True  # type: ignore[attr-defined]
+        server.call_tool = _patched_call_tool
+
+    async def _sign_tool_call(self, name: str, arguments: Any) -> None:
+        """Sign tool:call for one MCP tool invocation (fail-open)."""
+        try:
+            arg_keys = sorted(arguments.keys()) if isinstance(arguments, dict) else []
+            await self._sign_action_async(
+                "tool:call",
+                {"tool": str(name), "arg_keys": arg_keys},
+            )
+        except Exception as exc:
+            logger.warning("asqav mcp tool:call signing failed (fail-open): %s", exc)
+
+    async def _sign_tool_error(self, name: str, exc: BaseException) -> None:
+        """Sign tool:error when a wrapped tool raises (fail-open)."""
+        try:
+            await self._sign_action_async(
+                "tool:error",
+                {
+                    "tool": str(name),
+                    "error_type": type(exc).__name__,
+                    "error": str(exc)[:_MAX_LEN],
+                },
+            )
+        except Exception as sign_exc:
+            logger.warning(
+                "asqav mcp tool:error signing failed (fail-open): %s", sign_exc
+            )
+
+
+def enable_mcp_governance(
+    server: Any,
+    *,
+    api_key: str | None = None,
+    agent_name: str | None = None,
+    agent_id: str | None = None,
+    observe: bool = False,
+) -> AsqavMCPAdapter:
+    """Turn on default-on asqav governance for an MCP server.
+
+    After this one call, every tool call on ``server`` signs a governance
+    receipt. The server is instrumented in place; the returned adapter holds
+    the recorded signatures.
+    """
+    adapter = AsqavMCPAdapter(
+        api_key=api_key,
+        agent_name=agent_name or "asqav-mcp-server",
+        agent_id=agent_id,
+        observe=observe,
+    )
+    adapter.instrument(server)
+    return adapter

--- a/python/tests/test_mcp_integration.py
+++ b/python/tests/test_mcp_integration.py
@@ -1,0 +1,201 @@
+"""Tests for the MCP AsqavMCPAdapter / enable_mcp_governance integration.
+
+Uses fake servers that mimic the real dispatch funnels (FastMCP's
+``_tool_manager.call_tool`` and the low-level ``Server.call_tool``
+decorator) so tests run without ``mcp`` installed. Async dispatch is
+driven with ``asyncio.run`` so no pytest-asyncio config is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+
+from asqav.extras.mcp import AsqavMCPAdapter, enable_mcp_governance  # noqa: E402
+
+
+# === Fake servers ===
+
+
+class FakeToolManager:
+    """Mimics FastMCP's _tool_manager.call_tool dispatch funnel."""
+
+    def __init__(self, result: Any = None, error: Exception | None = None) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._result = result if result is not None else [{"type": "text", "text": "ok"}]
+        self._error = error
+
+    async def call_tool(
+        self, name: str, arguments: dict, context: Any = None, convert_result: bool = False
+    ) -> Any:
+        self.calls.append((name, arguments))
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+class FakeFastMCP:
+    """Mimics FastMCP: call_tool delegates to _tool_manager.call_tool."""
+
+    def __init__(self, result: Any = None, error: Exception | None = None) -> None:
+        self._tool_manager = FakeToolManager(result=result, error=error)
+
+    async def call_tool(self, name: str, arguments: dict) -> Any:
+        return await self._tool_manager.call_tool(name, arguments)
+
+
+class FakeLowLevelServer:
+    """Mimics mcp.server.lowlevel.Server.call_tool decorator registration."""
+
+    def __init__(self) -> None:
+        self.handler: Any = None
+
+    def call_tool(self, *, validate_input: bool = True) -> Any:
+        def decorator(func: Any) -> Any:
+            self.handler = func
+            return func
+
+        return decorator
+
+
+# === Fixtures ===
+
+
+def _build_adapter(server: Any, *, instrument: bool = True) -> AsqavMCPAdapter:
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        if instrument:
+            adapter = enable_mcp_governance(server, agent_name="test-mcp")
+        else:
+            adapter = AsqavMCPAdapter(agent_name="test-mcp")
+    adapter._sign_action = MagicMock(return_value=None)  # type: ignore[method-assign]
+    return adapter
+
+
+# === Allow path ===
+
+
+def test_tool_call_returns_original_result() -> None:
+    """A governed tool call returns the tool's result unchanged."""
+    server = FakeFastMCP(result=[{"type": "text", "text": "42"}])
+    _build_adapter(server)
+    out = asyncio.run(server.call_tool("add", {"a": 1, "b": 2}))
+    assert out == [{"type": "text", "text": "42"}]
+    assert server._tool_manager.calls == [("add", {"a": 1, "b": 2})]
+
+
+# === Default-on governance ===
+
+
+def test_default_on_signs_tool_call() -> None:
+    """enable_mcp_governance makes every tool call sign tool:call by default."""
+    server = FakeFastMCP()
+    adapter = _build_adapter(server)
+    asyncio.run(server.call_tool("search", {"q": "x"}))
+    action_types = [c[0][0] for c in adapter._sign_action.call_args_list]
+    assert "tool:call" in action_types
+    ctx = adapter._sign_action.call_args_list[0][0][1]
+    assert ctx["tool"] == "search"
+    assert ctx["arg_keys"] == ["q"]
+
+
+def test_non_vacuous_uninstrumented_server_signs_nothing() -> None:
+    """Control: without the wrap the same server signs nothing.
+
+    The instrument() wrap is what drives signing, not the fixture or import.
+    Break the wiring (skip instrument) and governance must not fire - this is
+    the mutation control for the default-on test above.
+    """
+    server = FakeFastMCP()
+    adapter = _build_adapter(server, instrument=False)
+    asyncio.run(server.call_tool("noop", {"k": 1}))
+    adapter._sign_action.assert_not_called()
+
+
+# === Tool error path ===
+
+
+def test_tool_error_is_signed_and_reraised() -> None:
+    """When a tool raises, tool:error is signed and the error re-raised."""
+    server = FakeFastMCP(error=RuntimeError("tool exploded"))
+    adapter = _build_adapter(server)
+    with pytest.raises(RuntimeError, match="tool exploded"):
+        asyncio.run(server.call_tool("boom", {"x": 1}))
+    action_types = [c[0][0] for c in adapter._sign_action.call_args_list]
+    assert action_types == ["tool:call", "tool:error"]
+    err_ctx = adapter._sign_action.call_args_list[-1][0][1]
+    assert err_ctx["error_type"] == "RuntimeError"
+    assert err_ctx["error"] == "tool exploded"
+
+
+# === Fail-open ===
+
+
+def test_fail_open_signing_error_does_not_block_tool() -> None:
+    """A signing failure never blocks or alters the tool call."""
+    server = FakeFastMCP(result="done")
+    adapter = _build_adapter(server)
+    adapter._sign_action.side_effect = Exception("sign service down")
+    out = asyncio.run(server.call_tool("add", {"a": 1}))
+    assert out == "done"
+
+
+# === Low-level Server decorator path ===
+
+
+def test_lowlevel_decorator_handler_signs() -> None:
+    """Wrapping the low-level call_tool decorator signs registered handlers."""
+    server = FakeLowLevelServer()
+    adapter = _build_adapter(server)
+
+    @server.call_tool()
+    async def handle(name: str, arguments: dict) -> Any:
+        return [{"type": "text", "text": "done"}]
+
+    out = asyncio.run(server.handler("mytool", {"k": 1}))
+    assert out == [{"type": "text", "text": "done"}]
+    action_types = [c[0][0] for c in adapter._sign_action.call_args_list]
+    assert action_types == ["tool:call"]
+    assert adapter._sign_action.call_args_list[0][0][1]["tool"] == "mytool"
+
+
+# === Idempotency ===
+
+
+def test_enable_is_idempotent() -> None:
+    """Enabling twice on one server signs exactly once per tool call."""
+    server = FakeFastMCP()
+    adapter = _build_adapter(server)
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        enable_mcp_governance(server, agent_name="again")
+    asyncio.run(server.call_tool("t", {"a": 1}))
+    action_types = [c[0][0] for c in adapter._sign_action.call_args_list]
+    assert action_types.count("tool:call") == 1
+
+
+# === Bad target ===
+
+
+def test_instrument_rejects_non_mcp_object() -> None:
+    """enable_mcp_governance raises TypeError on an object with no call_tool."""
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        with pytest.raises(TypeError, match="call_tool"):
+            enable_mcp_governance(object(), agent_name="x")

--- a/typescript/examples/mcp.ts
+++ b/typescript/examples/mcp.ts
@@ -1,0 +1,50 @@
+/**
+ * Default-on Asqav governance for an MCP (Model Context Protocol) server.
+ *
+ * Install:
+ *   npm install @asqav/sdk @modelcontextprotocol/sdk
+ *
+ * Run:
+ *   ASQAV_API_KEY=sk_... npx tsx examples/mcp.ts
+ *
+ * One call to enableMcpGovernance turns governance on for the whole
+ * server. Every tool call then signs an Asqav receipt by default, with no
+ * per-call flag. Signing is fail-open, so a signing outage never blocks a
+ * tool call.
+ */
+
+import { init } from "@asqav/sdk";
+import { enableMcpGovernance } from "@asqav/sdk/extras/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+async function main(): Promise<void> {
+  init({ apiKey: process.env.ASQAV_API_KEY! });
+
+  const server = new McpServer({ name: "demo-server", version: "1.0.0" });
+
+  // Turn governance on once. Every tool registered below is now governed.
+  enableMcpGovernance(server, { agentName: "demo-mcp-server" });
+
+  server.registerTool(
+    "add",
+    { description: "Add two integers", inputSchema: { a: z.number(), b: z.number() } },
+    async ({ a, b }) => ({ content: [{ type: "text", text: String(a + b) }] }),
+  );
+
+  server.registerTool(
+    "greet",
+    { description: "Return a greeting", inputSchema: { name: z.string() } },
+    async ({ name }) => ({ content: [{ type: "text", text: `hello ${name}` }] }),
+  );
+
+  // eslint-disable-next-line no-console
+  console.log("MCP server governed by asqav. Tools: add, greet");
+  // Connect a transport (StdioServerTransport) to serve; omitted to stay offline.
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -51,6 +51,11 @@
       "import": "./dist/extras/langchain.mjs",
       "require": "./dist/extras/langchain.js"
     },
+    "./extras/mcp": {
+      "types": "./dist/extras/mcp.d.ts",
+      "import": "./dist/extras/mcp.mjs",
+      "require": "./dist/extras/mcp.js"
+    },
     "./extras/mastra": {
       "types": "./dist/extras/mastra.d.ts",
       "import": "./dist/extras/mastra.mjs",
@@ -78,7 +83,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/cli.ts src/doors.ts src/extras/index.ts src/extras/vercel-ai.ts src/extras/langchain.ts src/extras/mastra.ts src/extras/openai-agents.ts src/verifier/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup src/index.ts src/cli.ts src/doors.ts src/extras/index.ts src/extras/vercel-ai.ts src/extras/langchain.ts src/extras/mcp.ts src/extras/mastra.ts src/extras/openai-agents.ts src/verifier/index.ts --format cjs,esm --dts --clean",
     "test": "vitest run",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build"
@@ -88,11 +93,15 @@
   },
   "peerDependencies": {
     "@langchain/core": "*",
+    "@modelcontextprotocol/sdk": "*",
     "@mastra/core": "*",
     "@openai/agents": "*"
   },
   "peerDependenciesMeta": {
     "@langchain/core": {
+      "optional": true
+    },
+    "@modelcontextprotocol/sdk": {
       "optional": true
     },
     "@mastra/core": {

--- a/typescript/src/extras/_base.ts
+++ b/typescript/src/extras/_base.ts
@@ -134,7 +134,8 @@ export class AsqavAdapter {
   }
 }
 
-function defaultOnError(err: unknown, ctx: { actionType: string }): void {
+/** Default onError sink, exported so adapters can reuse it outside signAction. */
+export function defaultOnError(err: unknown, ctx: { actionType: string }): void {
   // eslint-disable-next-line no-console
   console.warn(`[asqav] sign failed for ${ctx.actionType}:`, err);
 }

--- a/typescript/src/extras/index.ts
+++ b/typescript/src/extras/index.ts
@@ -10,6 +10,8 @@
 export { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
 export { AsqavCallbackHandler } from "./langchain.js";
 export type { AsqavCallbackHandlerOptions } from "./langchain.js";
+export { AsqavMcpAdapter, enableMcpGovernance } from "./mcp.js";
+export type { AsqavMcpAdapterOptions, McpServerLike } from "./mcp.js";
 export { AsqavMastraHook } from "./mastra.js";
 export type { AsqavMastraHookOptions } from "./mastra.js";
 export { AsqavOpenAIAgentsAdapter } from "./openai-agents.js";

--- a/typescript/src/extras/mcp.ts
+++ b/typescript/src/extras/mcp.ts
@@ -24,7 +24,7 @@
  * so the peer stays optional and importing without calling changes nothing.
  */
 
-import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+import { AsqavAdapter, defaultOnError, type AsqavAdapterOptions } from "./_base.js";
 
 // Boundary type for the duck-typed server. ``any`` rest params let a
 // concretely-typed McpServer.registerTool/tool satisfy this shape.
@@ -170,18 +170,30 @@ export class AsqavMcpAdapter extends AsqavAdapter {
 
   /** Sign tool:error when a wrapped tool throws (fail-open). */
   emitToolError(name: string, err: unknown): void {
-    const errorType = err instanceof Error
-      ? err.constructor.name
-      : typeof err;
-    const message = err instanceof Error ? err.message : String(err);
-    this.signAction({
-      actionType: "tool:error",
-      context: {
-        tool: name,
-        error_type: errorType,
-        error: message.slice(0, MAX_ERROR_LEN),
-      },
-    });
+    // String(err) can itself throw (e.g. Object.create(null)). Keep the
+    // stringification inside the fail-open boundary so it can never mask
+    // the tool's own error.
+    try {
+      const errorType = err instanceof Error
+        ? err.constructor.name
+        : typeof err;
+      const message = err instanceof Error ? err.message : String(err);
+      this.signAction({
+        actionType: "tool:error",
+        context: {
+          tool: name,
+          error_type: errorType,
+          error: message.slice(0, MAX_ERROR_LEN),
+        },
+      });
+    } catch (emitErr) {
+      const onError = this.options.onError ?? defaultOnError;
+      try {
+        onError(emitErr, { actionType: "tool:error" });
+      } catch {
+        // Swallow secondary errors from the user-supplied handler.
+      }
+    }
   }
 }
 

--- a/typescript/src/extras/mcp.ts
+++ b/typescript/src/extras/mcp.ts
@@ -17,10 +17,11 @@
  *   }));
  *
  * One call to ``enableMcpGovernance`` turns governance on for the whole
- * server: every tool registered on it signs an Asqav receipt on each call,
- * by default. Signing is fail-open. This module never imports
- * ``@modelcontextprotocol/sdk`` (it duck-types the passed server), so the
- * peer stays optional and importing without calling changes nothing.
+ * server: every tool call signs an Asqav receipt by default, regardless of
+ * whether the tool was registered before or after the call, and a tool that
+ * throws signs ``tool:error``. Signing is fail-open. This module never
+ * imports ``@modelcontextprotocol/sdk`` (it duck-types the passed server),
+ * so the peer stays optional and importing without calling changes nothing.
  */
 
 import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
@@ -30,8 +31,12 @@ import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ToolRegistrar = (...args: any[]) => any;
 
-/** Minimal shape of an MCP server: it exposes registerTool and/or tool. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = (...args: any[]) => any;
+
+/** Minimal server shape: a ``_registeredTools`` registry, or registrar-only (registerTool/tool). */
 export interface McpServerLike {
+  _registeredTools?: Record<string, unknown>;
   registerTool?: ToolRegistrar;
   tool?: ToolRegistrar;
 }
@@ -39,27 +44,65 @@ export interface McpServerLike {
 export type AsqavMcpAdapterOptions = AsqavAdapterOptions;
 
 const WRAP_FLAG = "__asqavWrapped";
+// Symbol key so the funnel marker never shows up in Object.keys/entries
+// (McpServer enumerates _registeredTools to build tools/list).
+const FUNNEL_FLAG = Symbol.for("asqav.mcp.funnel");
+// Dispatch-time handler field: ``handler`` on recent SDK versions,
+// ``callback`` on older ones. Wrap whichever is present.
+const HANDLER_KEYS = ["handler", "callback"] as const;
+const MAX_ERROR_LEN = 200;
 
-/**
- * Signs an Asqav governance receipt on every MCP tool call. ``instrument``
- * wraps the server's tool registrars so each registered callback signs
- * ``tool:call`` before it runs. Fire-and-forget and fail-open, so signing
- * never blocks or alters the tool call.
- */
+/** Signs ``tool:call`` per MCP tool call and ``tool:error`` on a throw, fail-open and order-independent. */
 export class AsqavMcpAdapter extends AsqavAdapter {
-  /** Wrap ``server``'s tool registrars in place; returns ``server``. */
+  /** Wire signing into ``server``'s tool dispatch in place; returns ``server``. */
   instrument<T extends McpServerLike>(server: T): T {
+    const registry = server._registeredTools;
+    if (registry && typeof registry === "object") {
+      this.wrapDispatchRegistry(server);
+      return server;
+    }
     const hasRegister = typeof server.registerTool === "function";
     const hasTool = typeof server.tool === "function";
     if (!hasRegister && !hasTool) {
       throw new Error(
-        "enableMcpGovernance expects an MCP server exposing registerTool or tool "
-        + "(e.g. McpServer from @modelcontextprotocol/sdk).",
+        "enableMcpGovernance expects an MCP server exposing a tool registry, "
+        + "registerTool or tool (e.g. McpServer from @modelcontextprotocol/sdk).",
       );
     }
     if (hasRegister) this.wrapRegistrar(server, "registerTool");
     if (hasTool) this.wrapRegistrar(server, "tool");
     return server;
+  }
+
+  // Single dispatch funnel: every tools/call lookup reads the registry, so a
+  // Proxy get that wraps the handler signs order-independently.
+  private wrapDispatchRegistry(server: McpServerLike): void {
+    const target = server._registeredTools as Record<string | symbol, unknown>;
+    if (target[FUNNEL_FLAG]) return;
+    const adapter = this;
+
+    const proxy = new Proxy(target, {
+      get(t, prop, receiver): unknown {
+        const value = Reflect.get(t, prop, receiver);
+        if (typeof prop !== "string" || value === null || typeof value !== "object") {
+          return value;
+        }
+        const tool = value as Record<string, unknown>;
+        let wrapped: Record<string, unknown> | null = null;
+        for (const key of HANDLER_KEYS) {
+          if (typeof tool[key] === "function") {
+            // Shallow copy keeps enabled/schemas/update intact; the stored
+            // tool stays unwrapped so re-reads never double-wrap.
+            wrapped = wrapped ?? { ...tool };
+            wrapped[key] = adapter.wrapToolCallback(prop, tool[key] as AnyFn);
+          }
+        }
+        return wrapped ?? value;
+      },
+    });
+
+    target[FUNNEL_FLAG] = true;
+    server._registeredTools = proxy as Record<string, unknown>;
   }
 
   private wrapRegistrar(server: McpServerLike, method: "registerTool" | "tool"): void {
@@ -79,16 +122,39 @@ export class AsqavMcpAdapter extends AsqavAdapter {
         }
       }
       if (cbIndex >= 0) {
-        const originalCb = args[cbIndex] as (...cbArgs: unknown[]) => unknown;
-        args[cbIndex] = function (this: unknown, ...cbArgs: unknown[]): unknown {
-          adapter.emitToolCall(name, cbArgs[0]);
-          return originalCb.apply(this, cbArgs);
-        };
+        args[cbIndex] = adapter.wrapToolCallback(name, args[cbIndex] as AnyFn);
       }
       return (original as ToolRegistrar).apply(this, args);
     };
     (wrapped as unknown as Record<string, unknown>)[WRAP_FLAG] = true;
     server[method] = wrapped as ToolRegistrar;
+  }
+
+  // Shared per-call wrap: sign tool:call, run the tool, sign tool:error on a
+  // sync throw or an async rejection, then rethrow.
+  private wrapToolCallback(name: string, originalCb: AnyFn): AnyFn {
+    if ((originalCb as unknown as Record<string, unknown>)[WRAP_FLAG]) return originalCb;
+    const adapter = this;
+
+    const wrapped = function (this: unknown, ...cbArgs: unknown[]): unknown {
+      adapter.emitToolCall(name, cbArgs[0]);
+      let out: unknown;
+      try {
+        out = originalCb.apply(this, cbArgs);
+      } catch (err) {
+        adapter.emitToolError(name, err);
+        throw err;
+      }
+      if (out instanceof Promise) {
+        return out.catch((err: unknown) => {
+          adapter.emitToolError(name, err);
+          throw err;
+        });
+      }
+      return out;
+    };
+    (wrapped as unknown as Record<string, unknown>)[WRAP_FLAG] = true;
+    return wrapped;
   }
 
   /** Sign a governance receipt for one MCP tool call (fail-open). */
@@ -101,13 +167,25 @@ export class AsqavMcpAdapter extends AsqavAdapter {
       context: { tool: name, arg_keys: argKeys },
     });
   }
+
+  /** Sign tool:error when a wrapped tool throws (fail-open). */
+  emitToolError(name: string, err: unknown): void {
+    const errorType = err instanceof Error
+      ? err.constructor.name
+      : typeof err;
+    const message = err instanceof Error ? err.message : String(err);
+    this.signAction({
+      actionType: "tool:error",
+      context: {
+        tool: name,
+        error_type: errorType,
+        error: message.slice(0, MAX_ERROR_LEN),
+      },
+    });
+  }
 }
 
-/**
- * Turn on default-on Asqav governance for an MCP server. After this one
- * call, every tool registered on ``server`` signs a receipt on each call.
- * The server is instrumented in place and returned.
- */
+/** Default-on Asqav governance: every tool call signs a receipt, even tools registered before this call. */
 export function enableMcpGovernance<T extends McpServerLike>(
   server: T,
   opts: AsqavMcpAdapterOptions,

--- a/typescript/src/extras/mcp.ts
+++ b/typescript/src/extras/mcp.ts
@@ -1,0 +1,117 @@
+/**
+ * MCP (Model Context Protocol) integration for Asqav.
+ *
+ * Install (peer dependency):
+ *   npm install @modelcontextprotocol/sdk
+ *
+ * Usage:
+ *   import { init } from "@asqav/sdk";
+ *   import { enableMcpGovernance } from "@asqav/sdk/extras/mcp";
+ *   import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+ *
+ *   init({ apiKey: process.env.ASQAV_API_KEY! });
+ *   const server = new McpServer({ name: "my-server", version: "1.0.0" });
+ *   enableMcpGovernance(server, { agentName: "my-mcp-server" });
+ *   server.registerTool("add", { description: "add" }, async ({ a, b }) => ({
+ *     content: [{ type: "text", text: String(a + b) }],
+ *   }));
+ *
+ * One call to ``enableMcpGovernance`` turns governance on for the whole
+ * server: every tool registered on it signs an Asqav receipt on each call,
+ * by default. Signing is fail-open. This module never imports
+ * ``@modelcontextprotocol/sdk`` (it duck-types the passed server), so the
+ * peer stays optional and importing without calling changes nothing.
+ */
+
+import { AsqavAdapter, type AsqavAdapterOptions } from "./_base.js";
+
+// Boundary type for the duck-typed server. ``any`` rest params let a
+// concretely-typed McpServer.registerTool/tool satisfy this shape.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ToolRegistrar = (...args: any[]) => any;
+
+/** Minimal shape of an MCP server: it exposes registerTool and/or tool. */
+export interface McpServerLike {
+  registerTool?: ToolRegistrar;
+  tool?: ToolRegistrar;
+}
+
+export type AsqavMcpAdapterOptions = AsqavAdapterOptions;
+
+const WRAP_FLAG = "__asqavWrapped";
+
+/**
+ * Signs an Asqav governance receipt on every MCP tool call. ``instrument``
+ * wraps the server's tool registrars so each registered callback signs
+ * ``tool:call`` before it runs. Fire-and-forget and fail-open, so signing
+ * never blocks or alters the tool call.
+ */
+export class AsqavMcpAdapter extends AsqavAdapter {
+  /** Wrap ``server``'s tool registrars in place; returns ``server``. */
+  instrument<T extends McpServerLike>(server: T): T {
+    const hasRegister = typeof server.registerTool === "function";
+    const hasTool = typeof server.tool === "function";
+    if (!hasRegister && !hasTool) {
+      throw new Error(
+        "enableMcpGovernance expects an MCP server exposing registerTool or tool "
+        + "(e.g. McpServer from @modelcontextprotocol/sdk).",
+      );
+    }
+    if (hasRegister) this.wrapRegistrar(server, "registerTool");
+    if (hasTool) this.wrapRegistrar(server, "tool");
+    return server;
+  }
+
+  private wrapRegistrar(server: McpServerLike, method: "registerTool" | "tool"): void {
+    const original = server[method];
+    if (!original) return;
+    if ((original as unknown as Record<string, unknown>)[WRAP_FLAG]) return;
+    const adapter = this;
+
+    const wrapped = function (this: unknown, ...args: unknown[]): unknown {
+      const name = typeof args[0] === "string" ? args[0] : "unknown";
+      // The tool callback is the last function argument in every overload.
+      let cbIndex = -1;
+      for (let i = args.length - 1; i >= 0; i -= 1) {
+        if (typeof args[i] === "function") {
+          cbIndex = i;
+          break;
+        }
+      }
+      if (cbIndex >= 0) {
+        const originalCb = args[cbIndex] as (...cbArgs: unknown[]) => unknown;
+        args[cbIndex] = function (this: unknown, ...cbArgs: unknown[]): unknown {
+          adapter.emitToolCall(name, cbArgs[0]);
+          return originalCb.apply(this, cbArgs);
+        };
+      }
+      return (original as ToolRegistrar).apply(this, args);
+    };
+    (wrapped as unknown as Record<string, unknown>)[WRAP_FLAG] = true;
+    server[method] = wrapped as ToolRegistrar;
+  }
+
+  /** Sign a governance receipt for one MCP tool call (fail-open). */
+  emitToolCall(name: string, args: unknown): void {
+    const argKeys = args && typeof args === "object"
+      ? Object.keys(args as Record<string, unknown>)
+      : [];
+    this.signAction({
+      actionType: "tool:call",
+      context: { tool: name, arg_keys: argKeys },
+    });
+  }
+}
+
+/**
+ * Turn on default-on Asqav governance for an MCP server. After this one
+ * call, every tool registered on ``server`` signs a receipt on each call.
+ * The server is instrumented in place and returned.
+ */
+export function enableMcpGovernance<T extends McpServerLike>(
+  server: T,
+  opts: AsqavMcpAdapterOptions,
+): T {
+  const adapter = new AsqavMcpAdapter(opts);
+  return adapter.instrument(server);
+}

--- a/typescript/tests/extras/mcp.test.ts
+++ b/typescript/tests/extras/mcp.test.ts
@@ -130,6 +130,23 @@ describe("enableMcpGovernance", () => {
     expect((calls[1].context.error as string).length).toBe(200);
   });
 
+  it("stays fail-open when a tool throws a non-stringifiable value", async () => {
+    const { agent } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    enableMcpGovernance(server, { agent });
+
+    // Object.create(null) has no toString/Symbol.toPrimitive: String(err)
+    // throws TypeError. The adapter must not let that mask the tool's own
+    // thrown value.
+    const bare = Object.create(null);
+    server.registerTool("bare-boom", {}, () => {
+      throw bare;
+    });
+
+    await expect(server.callTool("bare-boom", {})).rejects.toBe(bare);
+    await tick();
+  });
+
   it("is non-vacuous: an un-enabled server signs nothing (mutation control)", async () => {
     const { sign } = makeFakeAgent();
     const server = new FakeMcpServer();

--- a/typescript/tests/extras/mcp.test.ts
+++ b/typescript/tests/extras/mcp.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Agent } from "../../src/index.js";
+import { AsqavMcpAdapter, enableMcpGovernance } from "../../src/extras/mcp.js";
+
+// Fake Asqav agent: hermetic, no init() / network.
+function makeFakeAgent() {
+  const calls: Array<{ actionType: string; context: Record<string, unknown> }> = [];
+  const sign = vi.fn(async (opts: { actionType: string; context?: Record<string, unknown> }) => {
+    calls.push({ actionType: opts.actionType, context: opts.context ?? {} });
+    return {
+      signature: "sig",
+      signatureId: "sig_1",
+      actionId: "act_1",
+      timestamp: "2026-01-01T00:00:00Z",
+      verificationUrl: "https://asqav.com/verify/sig_1",
+    };
+  });
+  return { agent: { agentId: "agt_fake", sign } as unknown as Agent, calls, sign };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// Fake McpServer that captures registered tool callbacks so a test can invoke them.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = (...a: any[]) => any;
+
+class FakeMcpServer {
+  public tools: Record<string, AnyFn> = {};
+
+  registerTool(name: string, _config: unknown, cb: AnyFn): { name: string } {
+    this.tools[name] = cb;
+    return { name };
+  }
+
+  tool(name: string, ...rest: unknown[]): { name: string } {
+    this.tools[name] = rest[rest.length - 1] as AnyFn;
+    return { name };
+  }
+}
+
+describe("enableMcpGovernance", () => {
+  it("throws when the server exposes neither registerTool nor tool", () => {
+    const { agent } = makeFakeAgent();
+    expect(() => enableMcpGovernance({} as never, { agent })).toThrow(/registerTool or tool/);
+  });
+
+  it("signs tool:call by default on every registered tool call", async () => {
+    const { agent, calls, sign } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    enableMcpGovernance(server, { agent });
+
+    const impl = vi.fn(async () => ({ content: [{ type: "text", text: "9" }] }));
+    server.registerTool("add", { description: "add" }, impl);
+    const out = await server.tools.add({ a: 4, b: 5 });
+    await tick();
+
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(calls[0].actionType).toBe("tool:call");
+    expect(calls[0].context.tool).toBe("add");
+    expect(calls[0].context.arg_keys).toEqual(["a", "b"]);
+    expect(impl).toHaveBeenCalledOnce();
+    expect(out).toEqual({ content: [{ type: "text", text: "9" }] });
+  });
+
+  it("is non-vacuous: an un-enabled server signs nothing (mutation control)", async () => {
+    const { sign } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    // No enableMcpGovernance call - the wrap is what drives signing.
+    const impl = vi.fn(async () => "ok");
+    server.registerTool("noop", {}, impl);
+    await server.tools.noop({});
+    await tick();
+    expect(sign).not.toHaveBeenCalled();
+  });
+
+  it("wraps the deprecated tool() registrar too", async () => {
+    const { agent, calls } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    enableMcpGovernance(server, { agent });
+
+    server.tool("echo", async (args: { msg: string }) => args.msg);
+    await server.tools.echo({ msg: "hi" });
+    await tick();
+
+    expect(calls[0].actionType).toBe("tool:call");
+    expect(calls[0].context.tool).toBe("echo");
+    expect(calls[0].context.arg_keys).toEqual(["msg"]);
+  });
+
+  it("is fail-open: a signing error never blocks the tool call", async () => {
+    const { agent, sign } = makeFakeAgent();
+    (sign as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("sign down"));
+    const server = new FakeMcpServer();
+    enableMcpGovernance(server, { agent });
+
+    const impl = vi.fn(async () => "done");
+    server.registerTool("run", {}, impl);
+    const out = await server.tools.run({ x: 1 });
+    await tick();
+    expect(out).toBe("done");
+  });
+
+  it("is idempotent: enabling twice signs once per tool call", async () => {
+    const { agent, sign } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    enableMcpGovernance(server, { agent });
+    enableMcpGovernance(server, { agent });
+
+    server.registerTool("t", {}, async () => "r");
+    await server.tools.t({ a: 1 });
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the tool's return value through the wrap", async () => {
+    const { agent } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    const adapter = enableMcpGovernance(server, { agent });
+    expect(adapter).toBeInstanceOf(FakeMcpServer);
+
+    server.registerTool("mul", {}, async (args: { a: number; b: number }) => args.a * args.b);
+    const out = await server.tools.mul({ a: 6, b: 7 });
+    expect(out).toBe(42);
+  });
+});
+
+describe("AsqavMcpAdapter", () => {
+  it("instrument returns the same server instance", () => {
+    const { agent } = makeFakeAgent();
+    const adapter = new AsqavMcpAdapter({ agent });
+    const server = new FakeMcpServer();
+    expect(adapter.instrument(server)).toBe(server);
+  });
+});

--- a/typescript/tests/extras/mcp.test.ts
+++ b/typescript/tests/extras/mcp.test.ts
@@ -20,20 +20,38 @@ function makeFakeAgent() {
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
-// Fake McpServer that captures registered tool callbacks so a test can invoke them.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFn = (...a: any[]) => any;
 
+// Fake McpServer mirroring the real SDK: tools live in _registeredTools and
+// every call funnels through a dispatch that reads the registry at call time.
 class FakeMcpServer {
-  public tools: Record<string, AnyFn> = {};
+  public _registeredTools: Record<string, { handler: AnyFn; enabled: boolean }> = {};
 
   registerTool(name: string, _config: unknown, cb: AnyFn): { name: string } {
-    this.tools[name] = cb;
+    this._registeredTools[name] = { handler: cb, enabled: true };
     return { name };
   }
 
   tool(name: string, ...rest: unknown[]): { name: string } {
-    this.tools[name] = rest[rest.length - 1] as AnyFn;
+    this._registeredTools[name] = { handler: rest[rest.length - 1] as AnyFn, enabled: true };
+    return { name };
+  }
+
+  // Mirrors the SDK's tools/call handler: registry lookup, then run.
+  async callTool(name: string, args: unknown): Promise<unknown> {
+    const tool = this._registeredTools[name];
+    if (!tool) throw new Error(`Tool ${name} not found`);
+    return tool.handler(args);
+  }
+}
+
+// Duck-typed server with no registry: exercises the registrar fallback.
+class RegistrarOnlyServer {
+  public tools: Record<string, AnyFn> = {};
+
+  registerTool(name: string, _config: unknown, cb: AnyFn): { name: string } {
+    this.tools[name] = cb;
     return { name };
   }
 }
@@ -51,7 +69,7 @@ describe("enableMcpGovernance", () => {
 
     const impl = vi.fn(async () => ({ content: [{ type: "text", text: "9" }] }));
     server.registerTool("add", { description: "add" }, impl);
-    const out = await server.tools.add({ a: 4, b: 5 });
+    const out = await server.callTool("add", { a: 4, b: 5 });
     await tick();
 
     expect(sign).toHaveBeenCalledTimes(1);
@@ -62,13 +80,63 @@ describe("enableMcpGovernance", () => {
     expect(out).toEqual({ content: [{ type: "text", text: "9" }] });
   });
 
+  it("signs calls of a tool registered BEFORE enable (order-independent)", async () => {
+    const { agent, calls, sign } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    // Registration first, governance second: the dispatch funnel must still sign.
+    server.registerTool("early", {}, async (args: { x: number }) => args.x * 2);
+    enableMcpGovernance(server, { agent });
+
+    const out = await server.callTool("early", { x: 21 });
+    await tick();
+
+    expect(out).toBe(42);
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(calls[0].actionType).toBe("tool:call");
+    expect(calls[0].context.tool).toBe("early");
+    expect(calls[0].context.arg_keys).toEqual(["x"]);
+  });
+
+  it("signs tool:error when a tool throws, then rethrows", async () => {
+    const { agent, calls } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    enableMcpGovernance(server, { agent });
+
+    server.registerTool("boom", {}, async () => {
+      throw new TypeError("kaboom");
+    });
+    await expect(server.callTool("boom", { a: 1 })).rejects.toThrow("kaboom");
+    await tick();
+
+    expect(calls.map((c) => c.actionType)).toEqual(["tool:call", "tool:error"]);
+    expect(calls[1].context.tool).toBe("boom");
+    expect(calls[1].context.error_type).toBe("TypeError");
+    expect(calls[1].context.error).toBe("kaboom");
+  });
+
+  it("truncates tool:error messages to 200 chars and handles sync throws", async () => {
+    const { agent, calls } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    enableMcpGovernance(server, { agent });
+
+    const long = "x".repeat(300);
+    server.registerTool("sync-boom", {}, () => {
+      throw new Error(long);
+    });
+    await expect(server.callTool("sync-boom", {})).rejects.toThrow();
+    await tick();
+
+    expect(calls[1].actionType).toBe("tool:error");
+    expect((calls[1].context.error as string).length).toBe(200);
+  });
+
   it("is non-vacuous: an un-enabled server signs nothing (mutation control)", async () => {
     const { sign } = makeFakeAgent();
     const server = new FakeMcpServer();
     // No enableMcpGovernance call - the wrap is what drives signing.
     const impl = vi.fn(async () => "ok");
     server.registerTool("noop", {}, impl);
-    await server.tools.noop({});
+    await server.callTool("noop", {});
     await tick();
     expect(sign).not.toHaveBeenCalled();
   });
@@ -79,7 +147,7 @@ describe("enableMcpGovernance", () => {
     enableMcpGovernance(server, { agent });
 
     server.tool("echo", async (args: { msg: string }) => args.msg);
-    await server.tools.echo({ msg: "hi" });
+    await server.callTool("echo", { msg: "hi" });
     await tick();
 
     expect(calls[0].actionType).toBe("tool:call");
@@ -95,7 +163,7 @@ describe("enableMcpGovernance", () => {
 
     const impl = vi.fn(async () => "done");
     server.registerTool("run", {}, impl);
-    const out = await server.tools.run({ x: 1 });
+    const out = await server.callTool("run", { x: 1 });
     await tick();
     expect(out).toBe("done");
   });
@@ -107,7 +175,7 @@ describe("enableMcpGovernance", () => {
     enableMcpGovernance(server, { agent });
 
     server.registerTool("t", {}, async () => "r");
-    await server.tools.t({ a: 1 });
+    await server.callTool("t", { a: 1 });
     await tick();
     expect(sign).toHaveBeenCalledTimes(1);
   });
@@ -119,8 +187,34 @@ describe("enableMcpGovernance", () => {
     expect(adapter).toBeInstanceOf(FakeMcpServer);
 
     server.registerTool("mul", {}, async (args: { a: number; b: number }) => args.a * args.b);
-    const out = await server.tools.mul({ a: 6, b: 7 });
+    const out = await server.callTool("mul", { a: 6, b: 7 });
     expect(out).toBe(42);
+  });
+
+  it("keeps the registry enumerable and flag-free for tools/list", () => {
+    const { agent } = makeFakeAgent();
+    const server = new FakeMcpServer();
+    enableMcpGovernance(server, { agent });
+    server.registerTool("a", {}, async () => "r");
+    server.registerTool("b", {}, async () => "r");
+    expect(Object.keys(server._registeredTools).sort()).toEqual(["a", "b"]);
+    expect(server._registeredTools.a.enabled).toBe(true);
+  });
+
+  it("falls back to registrar wrapping when the server has no registry", async () => {
+    const { agent, calls } = makeFakeAgent();
+    const server = new RegistrarOnlyServer();
+    enableMcpGovernance(server, { agent });
+
+    server.registerTool("plainduck", {}, async () => {
+      throw new Error("bad");
+    });
+    await expect(server.tools.plainduck({ q: 1 })).rejects.toThrow("bad");
+    await tick();
+
+    expect(calls.map((c) => c.actionType)).toEqual(["tool:call", "tool:error"]);
+    expect(calls[0].context.tool).toBe("plainduck");
+    expect(calls[1].context.error).toBe("bad");
   });
 });
 


### PR DESCRIPTION
## What

Adds a one-call MCP (Model Context Protocol) integration so wrapping an MCP server turns on asqav governance for the whole server. After the call, every tool call signs a governance receipt by default, with no per-call flag.

- **Python**: `enable_mcp_governance(server)` in `python/src/asqav/extras/mcp.py`. Wraps the FastMCP tool-dispatch funnel (`_tool_manager.call_tool`, the single point both the direct API and real request routing pass through) and the low-level `Server.call_tool` decorator.
- **TypeScript**: `enableMcpGovernance(server, opts)` in `typescript/src/extras/mcp.ts`. Wraps the `registerTool` and `tool` registrars so each registered callback signs on invocation.

Both reuse the shared `AsqavAdapter` signing hook and are fail-open: a signing outage never blocks or alters a tool call.

## Non-breaking

- Additive only. Importing the module without calling the enable function changes nothing.
- No existing public symbols change.
- The MCP SDK stays behind an optional extra (`pip install asqav[mcp]`) and an optional peer (`@modelcontextprotocol/sdk`). The adapter never imports the MCP SDK itself, so there is no new hard runtime dependency.

## Tests

`python/tests/test_mcp_integration.py` and `typescript/tests/extras/mcp.test.ts` cover: the allow path, default-on-enables-governance, tool-error signing, fail-open, idempotency, and a non-vacuous control that proves the wrap (not the fixture) drives signing.

Non-vacuous proof: with the `instrument` wiring removed, the default-on governance tests fail. Restored, they pass.

## Also included

- Shared-file edits owned by this task: `python/pyproject.toml` (mcp extra + `all`), `python/src/asqav/extras/__init__.py` docstring, `typescript/package.json` (subpath export, optional peer, build entry), `typescript/src/extras/index.ts` barrel.
- Runnable examples: `python/examples/mcp_example.py`, `typescript/examples/mcp.ts`.
- Docs: `docs/integrations-mcp.md`.

## Proof of work

```
ruff check python/src -> All checks passed!
pytest tests/test_mcp_integration.py -> 8 passed
tsc --noEmit -> clean
vitest run tests/extras/mcp.test.ts -> 8 passed
secret-scan -> gitleaks clean
```

Mutation proof (wiring removed):
```
4 failed, 4 deselected  (default_on, tool_error, lowlevel, idempotent)
```
Restored: `8 passed`.

Draft. Do not merge or publish.

https://claude.ai/code/session_01JxyJiDhYJwHX6FWG4bC3wV