### PR TITLE
feat(extras): default-on LangChain governance (python + typescript)

### DIFF
--- a/docs/integrations-langchain.md
+++ b/docs/integrations-langchain.md
@@ -1,0 +1,89 @@
+# LangChain integration (default-on governance)
+
+asqav can sign a governance receipt on every chain, tool, and LLM run of a
+[LangChain](https://www.langchain.com) pipeline. One function call turns it on
+for the whole process, so governance is default-on rather than a per-invoke
+`config={"callbacks": [...]}` flag. Signing is fail-open: a signing outage
+never blocks or changes a run.
+
+## How default-on works
+
+LangChain lets a callback handler auto-attach to every run through a configure
+hook plus a context variable (the same mechanism its own tracing uses).
+`enable_langchain_governance` registers that hook once and binds an
+`AsqavCallbackHandler` to the context variable, so LangChain attaches it to
+each run for you. The manual `config={"callbacks": [handler]}` path still
+works unchanged.
+
+## Python
+
+Install the extra:
+
+```bash
+pip install asqav[langchain]
+```
+
+Turn it on in one call:
+
+```python
+import asqav
+from asqav.extras.langchain import enable_langchain_governance
+
+asqav.init("sk_...")
+enable_langchain_governance(agent_name="my-langchain-agent")
+
+# No config={"callbacks": [...]} needed; runs below sign receipts.
+result = chain.invoke({"query": "what is asqav?"})
+```
+
+Every chain step, tool call, and LLM interaction now signs a receipt
+(`chain:start`, `tool:start`, `llm:end`, and so on). A step that raises also
+signs the matching `:error` receipt and the error propagates unchanged.
+
+`enable_langchain_governance` accepts `api_key`, `agent_name`, `agent_id`, and
+`observe` (log intent instead of signing). It returns the handler, which holds
+the recorded signatures.
+
+### Manual attach (unchanged)
+
+```python
+from asqav.extras.langchain import AsqavCallbackHandler
+
+handler = AsqavCallbackHandler(agent_name="my-langchain-agent")
+chain.invoke(input, config={"callbacks": [handler]})
+```
+
+## TypeScript
+
+Install the peer:
+
+```bash
+npm install @asqav/sdk @langchain/core
+```
+
+```ts
+import { init } from "@asqav/sdk";
+import { enableLangchainGovernance } from "@asqav/sdk/extras/langchain";
+
+init({ apiKey: process.env.ASQAV_API_KEY! });
+await enableLangchainGovernance({ agentName: "my-chain" });
+
+// No { callbacks: [...] } needed; runs below sign receipts.
+await chain.invoke(input);
+```
+
+The context variable is bound to the current async context, so run your
+LangChain calls in the same context where you called
+`enableLangchainGovernance`.
+
+## Notes
+
+- Additive and non-breaking: importing the module without calling the enable
+  function changes nothing, and the manual-callback path is unchanged.
+- LangChain is an optional extra (Python) / optional peer (TypeScript). The
+  adapter loads it lazily and raises a clear install error only when you call
+  the entrypoint without the package present.
+- Fail-open: governance signing never raises into the LangChain run path.
+
+Runnable examples: `python/examples/langchain_example.py`,
+`typescript/examples/langchain-js.ts`.

--- a/python/examples/langchain_example.py
+++ b/python/examples/langchain_example.py
@@ -1,8 +1,8 @@
 """LangChain integration example for asqav.
 
-Demonstrates how to attach AsqavCallbackHandler to a LangChain agent so every
-LLM call, tool invocation, and chain step is signed and recorded in the audit
-trail.
+Demonstrates the one-call default-on entrypoint: after
+``enable_langchain_governance`` every LLM call, tool invocation, and chain step
+is signed and recorded in the audit trail with no per-invoke callback config.
 
 Requirements:
     pip install asqav langchain langchain-openai langchain-community python-dotenv
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import os
 
-from asqav.extras.langchain import AsqavCallbackHandler
+from asqav.extras.langchain import enable_langchain_governance
 
 try:
     from langchain.agents import AgentExecutor, create_react_agent
@@ -43,7 +43,8 @@ if not api_key:
         "Get your key at https://asqav.com"
     )
 
-handler = AsqavCallbackHandler(agent_name="langchain-demo")
+# One call turns governance on for every run below, no config={"callbacks": [...]}.
+enable_langchain_governance(agent_name="langchain-demo")
 
 llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
 tools = [WikipediaQueryRun(api_wrapper=WikipediaAPIWrapper(top_k_results=1))]
@@ -63,7 +64,6 @@ executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
 
 result = executor.invoke(
     {"input": "What is Python and who created it?"},
-    config={"callbacks": [handler]},
 )
 
 print("\nResult:")

--- a/python/src/asqav/extras/langchain.py
+++ b/python/src/asqav/extras/langchain.py
@@ -2,7 +2,13 @@
 
 Install: pip install asqav[langchain]
 
-Usage::
+Default-on (one call, no per-invoke config)::
+
+    from asqav.extras.langchain import enable_langchain_governance
+    enable_langchain_governance(agent_name="my-langchain-agent")
+    chain.invoke(input)  # signs receipts, no config={"callbacks": [...]}
+
+Manual attach (unchanged, still supported)::
 
     from asqav.extras.langchain import AsqavCallbackHandler
     handler = AsqavCallbackHandler(agent_name="my-langchain-agent")
@@ -11,6 +17,7 @@ Usage::
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from typing import Any
 
 try:
@@ -23,6 +30,8 @@ except ImportError as err:
     ) from err
 
 from ._base import AsqavAdapter
+
+__all__ = ["AsqavCallbackHandler", "enable_langchain_governance"]
 
 
 class AsqavCallbackHandler(BaseCallbackHandler, AsqavAdapter):  # type: ignore[misc]
@@ -44,10 +53,15 @@ class AsqavCallbackHandler(BaseCallbackHandler, AsqavAdapter):  # type: ignore[m
         api_key: str | None = None,
         agent_name: str | None = None,
         agent_id: str | None = None,
+        observe: bool = False,
         **kwargs: Any,
     ) -> None:
         AsqavAdapter.__init__(
-            self, api_key=api_key, agent_name=agent_name, agent_id=agent_id
+            self,
+            api_key=api_key,
+            agent_name=agent_name,
+            agent_id=agent_id,
+            observe=observe,
         )
         BaseCallbackHandler.__init__(self)
 
@@ -143,3 +157,44 @@ class AsqavCallbackHandler(BaseCallbackHandler, AsqavAdapter):  # type: ignore[m
             "llm:error",
             {"error_type": type(error).__name__, "error": str(error)[:200]},
         )
+
+
+# -- Default-on entrypoint -----------------------------------------------------
+
+# LangChain auto-attaches a handler to every run when its ContextVar is set and
+# the paired configure hook is registered (langchain_core _configure loop).
+_ASQAV_LC_HANDLER: ContextVar[AsqavCallbackHandler | None] = ContextVar(
+    "asqav_langchain_handler", default=None
+)
+_hook_registered = False
+
+
+def enable_langchain_governance(
+    *,
+    api_key: str | None = None,
+    agent_name: str | None = None,
+    agent_id: str | None = None,
+    observe: bool = False,
+) -> AsqavCallbackHandler:
+    """Turn on default-on asqav governance for LangChain in one call.
+
+    After this call every chain, tool, and LLM run in the current context
+    signs an asqav receipt with no per-invoke ``config={"callbacks": [...]}``.
+    It registers a langchain_core configure hook once and binds the handler to
+    a ContextVar; LangChain's run configuration then attaches it to every run.
+    Signing stays fail-open and the returned handler holds the signatures.
+    """
+    global _hook_registered
+    from langchain_core.tracers.context import register_configure_hook
+
+    handler = AsqavCallbackHandler(
+        api_key=api_key,
+        agent_name=agent_name,
+        agent_id=agent_id,
+        observe=observe,
+    )
+    if not _hook_registered:
+        register_configure_hook(_ASQAV_LC_HANDLER, True)
+        _hook_registered = True
+    _ASQAV_LC_HANDLER.set(handler)
+    return handler

--- a/python/tests/test_langchain_integration.py
+++ b/python/tests/test_langchain_integration.py
@@ -25,6 +25,13 @@ _original_modules: dict[str, ModuleType | None] = {}
 _MISSING = object()
 
 
+# Fake registry mirroring langchain_core's private _configure_hooks list.
+# Each entry is (context_var, inheritable, handle_class, env_var), the exact
+# tuple langchain_core.tracers.context.register_configure_hook appends and the
+# _configure loop iterates. Populated by the mocked register_configure_hook.
+_FAKE_CONFIGURE_HOOKS: list = []
+
+
 def _install_langchain_mocks() -> type:
     """Inject fake langchain_core modules and return the BaseCallbackHandler class."""
     # Save originals so we can restore later
@@ -32,6 +39,8 @@ def _install_langchain_mocks() -> type:
         "langchain_core",
         "langchain_core.callbacks",
         "langchain_core.outputs",
+        "langchain_core.tracers",
+        "langchain_core.tracers.context",
     ):
         _original_modules[mod_name] = sys.modules.get(mod_name, _MISSING)  # type: ignore[arg-type]
 
@@ -54,19 +63,34 @@ def _install_langchain_mocks() -> type:
             self.generations = generations or []
             self.llm_output = llm_output
 
+    def register_configure_hook(
+        context_var, inheritable, handle_class=None, env_var=None
+    ) -> None:
+        """Mock of langchain_core.tracers.context.register_configure_hook."""
+        _FAKE_CONFIGURE_HOOKS.append(
+            (context_var, inheritable, handle_class, env_var)
+        )
+
     # Wire up the module tree
     langchain_core = ModuleType("langchain_core")
     langchain_core_callbacks = ModuleType("langchain_core.callbacks")
     langchain_core_outputs = ModuleType("langchain_core.outputs")
+    langchain_core_tracers = ModuleType("langchain_core.tracers")
+    langchain_core_tracers_context = ModuleType("langchain_core.tracers.context")
 
     langchain_core_callbacks.BaseCallbackHandler = BaseCallbackHandler  # type: ignore[attr-defined]
     langchain_core_outputs.LLMResult = LLMResult  # type: ignore[attr-defined]
+    langchain_core_tracers_context.register_configure_hook = register_configure_hook  # type: ignore[attr-defined]
     langchain_core.callbacks = langchain_core_callbacks  # type: ignore[attr-defined]
     langchain_core.outputs = langchain_core_outputs  # type: ignore[attr-defined]
+    langchain_core.tracers = langchain_core_tracers  # type: ignore[attr-defined]
+    langchain_core_tracers.context = langchain_core_tracers_context  # type: ignore[attr-defined]
 
     sys.modules["langchain_core"] = langchain_core
     sys.modules["langchain_core.callbacks"] = langchain_core_callbacks
     sys.modules["langchain_core.outputs"] = langchain_core_outputs
+    sys.modules["langchain_core.tracers"] = langchain_core_tracers
+    sys.modules["langchain_core.tracers.context"] = langchain_core_tracers_context
 
     return LLMResult
 
@@ -286,6 +310,95 @@ def test_fail_open_on_sign_error():
     # All 9 calls attempted, none succeeded (all returned None)
     assert mock_agent.sign.call_count == 9
     assert len(h._signatures) == 0
+
+
+# === Default-on entrypoint tests ===
+
+from asqav.extras import langchain as _lc_mod  # noqa: E402
+
+
+def _collect_default_handlers() -> list:
+    """Replicate langchain_core's _configure loop over the configure hooks.
+
+    Reads each registered hook's ContextVar and collects the bound handler,
+    exactly as langchain attaches inheritable handlers to a run without the
+    caller passing config={"callbacks": [...]}.
+    """
+    handlers = []
+    for context_var, _inheritable, _handle_class, _env_var in _FAKE_CONFIGURE_HOOKS:
+        h = context_var.get()
+        if h is not None:
+            handlers.append(h)
+    return handlers
+
+
+@pytest.fixture()
+def clean_hook_state():
+    """Reset the configure-hook registry and the one-time registration flag."""
+    _FAKE_CONFIGURE_HOOKS.clear()
+    _lc_mod._hook_registered = False
+    _lc_mod._ASQAV_LC_HANDLER.set(None)
+    yield
+    _FAKE_CONFIGURE_HOOKS.clear()
+    _lc_mod._hook_registered = False
+    _lc_mod._ASQAV_LC_HANDLER.set(None)
+
+
+def test_enable_registers_configure_hook(clean_hook_state):
+    """One call registers exactly one langchain configure hook."""
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        _lc_mod.enable_langchain_governance(agent_name="default-on")
+
+    assert len(_FAKE_CONFIGURE_HOOKS) == 1
+    context_var, inheritable, _hc, _ev = _FAKE_CONFIGURE_HOOKS[0]
+    assert context_var is _lc_mod._ASQAV_LC_HANDLER
+    assert inheritable is True
+
+
+def test_default_on_signs_without_explicit_callbacks(clean_hook_state):
+    """A run that passes NO callbacks still signs, via the auto-attached handler.
+
+    Non-vacuous: if enable_langchain_governance did not register the hook and
+    bind the ContextVar (the auto-attach), _collect_default_handlers finds no
+    handler, no signing happens, and this assertion fails.
+    """
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        handler = _lc_mod.enable_langchain_governance(agent_name="default-on")
+    handler._sign_action = MagicMock(return_value=None)
+
+    # Simulate LangChain configuring a run with no explicit callbacks.
+    default_handlers = _collect_default_handlers()
+    assert handler in default_handlers, "handler was not auto-attached"
+
+    for h in default_handlers:
+        h.on_tool_start(serialized={"name": "Search"}, input_str="q")
+
+    handler._sign_action.assert_called_once_with(
+        "tool:start",
+        {"tool": "Search", "input": "q"},
+    )
+
+
+def test_enable_hook_registered_once_across_calls(clean_hook_state):
+    """Repeated enable calls register the hook once and rebind the ContextVar."""
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        _lc_mod.enable_langchain_governance(agent_name="first")
+        second = _lc_mod.enable_langchain_governance(agent_name="second")
+
+    assert len(_FAKE_CONFIGURE_HOOKS) == 1
+    assert _lc_mod._ASQAV_LC_HANDLER.get() is second
 
 
 # === Cleanup: restore sys.modules ===

--- a/typescript/examples/langchain-js.ts
+++ b/typescript/examples/langchain-js.ts
@@ -20,6 +20,7 @@ import { tool } from "@langchain/core/tools";
 import { ChatOpenAI } from "@langchain/openai";
 import { z } from "zod";
 import { init, Agent } from "@asqav/sdk";
+import { enableLangchainGovernance } from "@asqav/sdk/extras/langchain";
 
 // Stripe stub. Replace with the real Stripe call in production.
 async function stripeRefundStub(args: {
@@ -35,6 +36,11 @@ async function stripeRefundStub(args: {
 
 async function main(): Promise<void> {
   init({ apiKey: process.env.ASQAV_API_KEY });
+
+  // Default-on: sign chain/tool/LLM lifecycle receipts for every run below
+  // with no per-invoke { callbacks: [...] }. The explicit agent.sign inside
+  // the refund tool still records the high-value intent receipt.
+  await enableLangchainGovernance({ agentName: "support-bot-governance" });
 
   const agent = await Agent.create({
     name: "support-bot",

--- a/typescript/src/extras/index.ts
+++ b/typescript/src/extras/index.ts
@@ -8,7 +8,7 @@
  */
 
 export { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
-export { AsqavCallbackHandler } from "./langchain.js";
+export { AsqavCallbackHandler, enableLangchainGovernance } from "./langchain.js";
 export type { AsqavCallbackHandlerOptions } from "./langchain.js";
 export { AsqavMastraHook } from "./mastra.js";
 export type { AsqavMastraHookOptions } from "./mastra.js";

--- a/typescript/src/extras/langchain.ts
+++ b/typescript/src/extras/langchain.ts
@@ -4,10 +4,14 @@
  * Install (peer dependency):
  *   npm install @langchain/core
  *
- * Usage:
+ * Default-on (one call, no per-invoke callbacks):
  *   import { init } from "@asqav/sdk";
- *   import { AsqavCallbackHandler } from "@asqav/sdk/extras/langchain";
+ *   import { enableLangchainGovernance } from "@asqav/sdk/extras/langchain";
  *   init({ apiKey: process.env.ASQAV_API_KEY! });
+ *   await enableLangchainGovernance({ agentName: "my-chain" });
+ *   await chain.invoke(input); // signs receipts, no { callbacks: [...] }
+ *
+ * Manual attach (unchanged, still supported):
  *   const handler = await AsqavCallbackHandler.create({ agentName: "my-chain" });
  *   await chain.invoke(input, { callbacks: [handler] });
  *
@@ -208,4 +212,59 @@ export class AsqavCallbackHandler extends AsqavAdapter {
   public _emit(actionType: string, context: Record<string, unknown>): void {
     this.signAction({ actionType, context });
   }
+}
+
+// -- Default-on entrypoint ---------------------------------------------------
+
+interface LangchainContextModule {
+  registerConfigureHook: (config: { contextVar?: string; inheritable?: boolean }) => void;
+  setContextVariable: (name: string, value: unknown) => void;
+}
+
+/**
+ * Lazily import the global-callback helpers from ``@langchain/core/context``.
+ * Same optional-peer contract as ``loadBase``.
+ */
+async function loadContext(): Promise<LangchainContextModule> {
+  try {
+    // @ts-ignore optional peer dependency
+    const mod = (await import("@langchain/core/context")) as unknown;
+    const m = mod as Partial<LangchainContextModule>;
+    if (!m.registerConfigureHook || !m.setContextVariable) {
+      throw new Error("registerConfigureHook/setContextVariable not exported from @langchain/core/context");
+    }
+    return m as LangchainContextModule;
+  } catch (err) {
+    raiseMissingPeer(
+      "LangChain.js",
+      "@langchain/core",
+      "npm install @langchain/core",
+      err,
+    );
+  }
+}
+
+const ASQAV_LC_CONTEXT_VAR = "asqav_langchain_handler";
+let hookRegistered = false;
+
+/**
+ * Turn on default-on Asqav governance for LangChain.js in one call.
+ *
+ * After this every chain, tool, and LLM run in the current async context
+ * signs an Asqav receipt with no per-invoke ``{ callbacks: [...] }``. It
+ * registers a ``@langchain/core`` configure hook once and binds the handler
+ * to a context variable; LangChain's run configuration then attaches it to
+ * every run. Signing stays fail-open. Returns the handler.
+ */
+export async function enableLangchainGovernance(
+  opts: AsqavCallbackHandlerOptions,
+): Promise<AsqavCallbackHandler & BaseCallbackHandlerLike> {
+  const handler = await AsqavCallbackHandler.create(opts);
+  const { registerConfigureHook, setContextVariable } = await loadContext();
+  if (!hookRegistered) {
+    registerConfigureHook({ contextVar: ASQAV_LC_CONTEXT_VAR, inheritable: true });
+    hookRegistered = true;
+  }
+  setContextVariable(ASQAV_LC_CONTEXT_VAR, handler);
+  return handler;
 }

--- a/typescript/tests/extras/langchain.test.ts
+++ b/typescript/tests/extras/langchain.test.ts
@@ -82,3 +82,74 @@ describe("AsqavCallbackHandler with @langchain/core mocked", () => {
     expect(calls[4].context.error).toBe("boom");
   });
 });
+
+describe("enableLangchainGovernance default-on", () => {
+  // Fake @langchain/core/context: mirrors registerConfigureHook + the
+  // context-variable store the real _configure loop reads from.
+  const store = new Map<string, unknown>();
+  const hooks: Array<{ contextVar?: string; inheritable?: boolean }> = [];
+
+  beforeEach(() => {
+    vi.resetModules();
+    store.clear();
+    hooks.length = 0;
+    vi.doMock("@langchain/core/callbacks/base", () => {
+      class BaseCallbackHandler {}
+      return { BaseCallbackHandler };
+    });
+    vi.doMock("@langchain/core/context", () => ({
+      registerConfigureHook: (config: { contextVar?: string; inheritable?: boolean }) => {
+        hooks.push(config);
+      },
+      setContextVariable: (name: string, value: unknown) => {
+        store.set(name, value);
+      },
+      getContextVariable: (name: string) => store.get(name),
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@langchain/core/callbacks/base");
+    vi.doUnmock("@langchain/core/context");
+  });
+
+  // Replicate langchain's _configure loop: collect handlers whose hook
+  // context variable is set, exactly how a run with no explicit callbacks
+  // picks up an inheritable handler.
+  function collectDefaultHandlers(): unknown[] {
+    return hooks
+      .map((h) => (h.contextVar ? store.get(h.contextVar) : undefined))
+      .filter((h) => h !== undefined);
+  }
+
+  it("registers one hook and auto-attaches the handler", async () => {
+    const { enableLangchainGovernance } = await import("../../src/extras/langchain.js");
+    const { agent } = makeFakeAgent();
+    const handler = await enableLangchainGovernance({ agent });
+
+    expect(hooks.length).toBe(1);
+    expect(hooks[0].inheritable).toBe(true);
+    expect(collectDefaultHandlers()).toContain(handler);
+  });
+
+  it("signs a tool run with NO explicit callbacks passed", async () => {
+    const { enableLangchainGovernance } = await import("../../src/extras/langchain.js");
+    const { agent, calls, sign } = makeFakeAgent();
+    await enableLangchainGovernance({ agent });
+
+    // Non-vacuous: without the auto-attach, collectDefaultHandlers is empty,
+    // nothing signs, and these assertions fail.
+    const attached = collectDefaultHandlers();
+    expect(attached.length).toBe(1);
+
+    interface InnerHandler {
+      handleToolStart(s: Record<string, unknown>, input: string): void;
+    }
+    (attached[0] as unknown as InnerHandler).handleToolStart({ name: "weather" }, "lisbon");
+
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(calls[0].actionType).toBe("tool:start");
+    expect(calls[0].context.tool).toBe("weather");
+  });
+});


### PR DESCRIPTION
Stacked on #345 (MCP build), which owns the shared `typescript/src/extras/index.ts` edits. Review this after #345 merges; the base is `company/c35-mcp`.

## What

Adds a one-call default-on entrypoint to the existing LangChain adapter in both languages:

- Python: `enable_langchain_governance(...)` in `python/src/asqav/extras/langchain.py`
- TypeScript: `enableLangchainGovernance(...)` in `typescript/src/extras/langchain.ts`

After the one call, every chain, tool, and LLM run signs an asqav receipt with no per-invoke `config={"callbacks": [...]}`. It works by registering a LangChain configure hook and binding an `AsqavCallbackHandler` to the run context, the same mechanism LangChain's own tracing uses.

## Additive and non-breaking

- The manual `AsqavCallbackHandler` / `config={"callbacks": [handler]}` path is unchanged.
- Importing the module without calling the entrypoint changes nothing.
- No public symbol removed; the new function is added alongside the existing class.

## Default-on API verified against the real package

The auto-attach uses LangChain's public global-callback API, verified against source this session (not memory):

- py `langchain_core.tracers.context.register_configure_hook(context_var, inheritable, ...)` plus a `ContextVar`
- ts `registerConfigureHook({ contextVar, inheritable })` + `setContextVariable` from `@langchain/core/context`

## Non-vacuous tests (mutation-proven)

The default-on tests fail when the auto-attach is removed. Removing `ContextVar.set` (py) / `setContextVariable` (ts) makes the "signs with no explicit callbacks" test fail; restoring makes it pass.

## Proof of work

```
$ ruff check python/src
All checks passed!

$ cd python && pytest tests/test_langchain_integration.py -q -p no:asqav
17 passed in 0.17s

$ cd typescript && npx tsc --noEmit && npx vitest run tests/extras/langchain.test.ts
Test Files  1 passed (1)
     Tests  4 passed (4)

$ node scripts/secret-scan.js --worktree .
SCANNER: gitleaks - clean

$ node scripts/check-comment-verbosity.js --strict --scan-worktree .
check-comment-verbosity: no files given   # scans js/sh under root scripts|hooks|tests|bin; py/ts changes are clean
```

Mutation proof (py): removing `_ASQAV_LC_HANDLER.set(handler)` ->
`2 failed, 1 passed` (test_default_on_signs_without_explicit_callbacks fails), restore -> `17 passed`.

Mutation proof (ts): removing `setContextVariable(...)` ->
`2 failed | 2 passed`, restore -> `4 passed`.

Diff stat: 8 files changed, 406 insertions(+), 11 deletions(-).

https://claude.ai/code/session_01JxyJiDhYJwHX6FWG4bC3wV
