### PR TITLE
Harden default-on adapters: sign LangChain chain runs, make crewAI enable idempotent

### DIFF
--- a/python/src/asqav/extras/crewai.py
+++ b/python/src/asqav/extras/crewai.py
@@ -252,7 +252,16 @@ def enable_crew_governance(
     manual per-crew callback config. Any callbacks the crew already has are kept
     and run first (additive). ``crew`` is duck-typed, so no crewai import is
     needed. Signing stays fail-open and the returned hook holds the signatures.
+
+    Idempotent: the first call stores the hook on the crew as
+    ``_asqav_crew_hook``; a later call returns that same hook and does not wire
+    a second callback layer or create another agent.
     """
+    # Check before construct: avoid creating an orphan agent on a second call.
+    existing = getattr(crew, "_asqav_crew_hook", None)
+    if existing is not None:
+        return existing
+
     hook = AsqavCrewHook(
         api_key=api_key,
         agent_name=agent_name,
@@ -261,4 +270,5 @@ def enable_crew_governance(
     )
     crew.step_callback = _compose(getattr(crew, "step_callback", None), hook.step_callback)
     crew.task_callback = _compose(getattr(crew, "task_callback", None), hook.task_callback)
+    crew._asqav_crew_hook = hook  # type: ignore[attr-defined]
     return hook

--- a/python/src/asqav/extras/langchain.py
+++ b/python/src/asqav/extras/langchain.py
@@ -69,16 +69,28 @@ class AsqavCallbackHandler(BaseCallbackHandler, AsqavAdapter):  # type: ignore[m
 
     def on_chain_start(
         self,
-        serialized: dict[str, Any],
+        serialized: dict[str, Any] | None,
         inputs: dict[str, Any],
         **kwargs: Any,
     ) -> None:
-        """Sign chain:start with chain name and input keys."""
+        """Sign chain:start with chain name and input keys.
+
+        serialized may be None on the LCEL/RunnableLambda path; fall back
+        to a stable "chain" label so the receipt is always signed.
+        """
+        # Guard: LCEL/RunnableLambda passes raw str/list/number as inputs.
+        input_keys = list(inputs.keys()) if isinstance(inputs, dict) else []
+        if not isinstance(serialized, dict):
+            self._sign_action(
+                "chain:start",
+                {"chain": "chain", "input_keys": input_keys},
+            )
+            return
         chain_id = serialized.get("id", ["unknown"])
         name = serialized.get("name") or chain_id[-1]
         self._sign_action(
             "chain:start",
-            {"chain": str(name), "input_keys": list(inputs.keys())},
+            {"chain": str(name), "input_keys": input_keys},
         )
 
     def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
@@ -193,6 +205,8 @@ def enable_langchain_governance(
         agent_id=agent_id,
         observe=observe,
     )
+    # Register the configure hook at most once so a second call cannot
+    # attach the ContextVar handler twice per run (double-sign).
     if not _hook_registered:
         register_configure_hook(_ASQAV_LC_HANDLER, True)
         _hook_registered = True

--- a/python/tests/test_crewai_integration.py
+++ b/python/tests/test_crewai_integration.py
@@ -294,6 +294,58 @@ def test_existing_callbacks_preserved():
     assert hook._sign_action.call_count == 2
 
 
+def test_enable_crew_governance_double_enable_idempotent():
+    """Calling enable_crew_governance twice on the same crew signs exactly once per event.
+
+    The check-first guard returns the first hook on the second call, so the
+    crew callbacks are wired only once. hook1 is hook2 (same object), and
+    each event signs exactly once. Remove the check-first guard and this test
+    fails (signs == 2 per event because two hooks are wired).
+    """
+    crew = _DuckCrew()
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        hook1 = enable_crew_governance(crew, agent_name="crew1")
+        hook2 = enable_crew_governance(crew, agent_name="crew2")
+
+    # hook1 and hook2 are the same object now (check-first returns the stored hook)
+    assert hook1 is hook2
+
+    signs: list[str] = []
+    hook1._sign_action = MagicMock(side_effect=lambda *a, **k: signs.append("sign"))
+
+    crew.step_callback("a step")
+    crew.task_callback(MagicMock(spec=[]))
+
+    # Wired once: step + task each sign exactly once
+    assert len(signs) == 2
+
+
+def test_enable_crew_governance_double_enable_same_hook_no_orphan():
+    """Double enable returns the same hook and calls Agent.create exactly once.
+
+    Non-vacuous: without the check-first guard, Agent.create is called twice
+    (one per enable call) and hook1 is not hook2. Remove the existing-check
+    block in enable_crew_governance and this test fails (create_count==2,
+    hook1 is not hook2).
+    """
+    crew = _DuckCrew()
+    with (
+        patch("asqav.client._api_key", "sk_test"),
+        patch("asqav.extras._base.Agent") as mock_agent_cls,
+    ):
+        mock_agent_cls.create.return_value = MagicMock()
+        hook1 = enable_crew_governance(crew, agent_name="crew1")
+        hook2 = enable_crew_governance(crew, agent_name="crew2")
+        create_count = mock_agent_cls.create.call_count
+
+    assert hook1 is hook2, "second enable must return the first hook, not a new one"
+    assert create_count == 1, f"Agent.create called {create_count} times, expected 1"
+
+
 def test_module_imports_without_crewai():
     """The adapter imports with crewai absent - duck-typed, no hard import."""
     saved = sys.modules.pop("crewai", None)

--- a/python/tests/test_langchain_integration.py
+++ b/python/tests/test_langchain_integration.py
@@ -26,9 +26,8 @@ _MISSING = object()
 
 
 # Fake registry mirroring langchain_core's private _configure_hooks list.
-# Each entry is (context_var, inheritable, handle_class, env_var), the exact
-# tuple langchain_core.tracers.context.register_configure_hook appends and the
-# _configure loop iterates. Populated by the mocked register_configure_hook.
+# Each entry is the (context_var, inheritable, handle_class, env_var) tuple
+# register_configure_hook appends and the _configure loop iterates.
 _FAKE_CONFIGURE_HOOKS: list = []
 
 
@@ -384,6 +383,71 @@ def test_default_on_signs_without_explicit_callbacks(clean_hook_state):
     handler._sign_action.assert_called_once_with(
         "tool:start",
         {"tool": "Search", "input": "q"},
+    )
+
+
+def test_on_chain_start_none_serialized_signs_receipt(handler):
+    """on_chain_start with serialized=None still signs a chain:start receipt.
+
+    Non-vacuous: without the isinstance(serialized, dict) guard, calling
+    serialized.get(...) on None raises AttributeError; LangChain swallows the
+    callback exception so the receipt is silently dropped. Revert the guard
+    in on_chain_start and this assertion fails (no sign call).
+    """
+    handler.on_chain_start(
+        serialized=None,
+        inputs={"text": "hello"},
+    )
+    handler._sign_action.assert_called_once_with(
+        "chain:start",
+        {"chain": "chain", "input_keys": ["text"]},
+    )
+
+
+def test_on_chain_start_non_dict_serialized_signs_receipt(handler):
+    """on_chain_start with a non-dict serialized still signs a receipt."""
+    handler.on_chain_start(
+        serialized="some-string",  # type: ignore[arg-type]
+        inputs={"q": "x"},
+    )
+    handler._sign_action.assert_called_once_with(
+        "chain:start",
+        {"chain": "chain", "input_keys": ["q"]},
+    )
+
+
+def test_on_chain_start_none_serialized_non_dict_inputs_signs_receipt(handler):
+    """on_chain_start(None, 'hello') yields input_keys=[] - never crashes.
+
+    Non-vacuous: without the isinstance(inputs, dict) guard, calling
+    list('hello'.keys()) raises AttributeError; LangChain swallows the exception
+    so the receipt is silently dropped. Revert the guard and this test fails
+    (sign not called, AttributeError swallowed).
+    """
+    handler.on_chain_start(
+        serialized=None,
+        inputs="hello",  # type: ignore[arg-type]
+    )
+    handler._sign_action.assert_called_once_with(
+        "chain:start",
+        {"chain": "chain", "input_keys": []},
+    )
+
+
+def test_on_chain_start_dict_serialized_non_dict_inputs_signs_receipt(handler):
+    """on_chain_start({'name':'X'}, 'hello') still signs with input_keys=[].
+
+    Non-vacuous: without the guard the dict-serialized branch also calls
+    list(inputs.keys()) on the raw string, raising AttributeError and causing
+    a silent receipt drop. Revert the guard and this test fails.
+    """
+    handler.on_chain_start(
+        serialized={"name": "MyChain"},
+        inputs="hello",  # type: ignore[arg-type]
+    )
+    handler._sign_action.assert_called_once_with(
+        "chain:start",
+        {"chain": "MyChain", "input_keys": []},
     )
 
 

--- a/typescript/src/extras/langchain.ts
+++ b/typescript/src/extras/langchain.ts
@@ -1,24 +1,6 @@
-/**
- * LangChain.js integration for Asqav.
- *
- * Install (peer dependency):
- *   npm install @langchain/core
- *
- * Default-on (one call, no per-invoke callbacks):
- *   import { init } from "@asqav/sdk";
- *   import { enableLangchainGovernance } from "@asqav/sdk/extras/langchain";
- *   init({ apiKey: process.env.ASQAV_API_KEY! });
- *   await enableLangchainGovernance({ agentName: "my-chain" });
- *   await chain.invoke(input); // signs receipts, no { callbacks: [...] }
- *
- * Manual attach (unchanged, still supported):
- *   const handler = await AsqavCallbackHandler.create({ agentName: "my-chain" });
- *   await chain.invoke(input, { callbacks: [handler] });
- *
- * Mirrors the Python ``asqav.extras.langchain.AsqavCallbackHandler``
- * (chain/tool/LLM lifecycle signing) using the LangChain.js
- * ``BaseCallbackHandler`` from ``@langchain/core/callbacks/base``.
- */
+// LangChain.js integration for Asqav. Install: npm install @langchain/core.
+// Default-on: await enableLangchainGovernance({ agentName: "my-chain" }) then chain.invoke.
+// Manual: const h = await AsqavCallbackHandler.create({...}); chain.invoke(i, {callbacks:[h]}).
 
 import { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
 
@@ -55,13 +37,8 @@ function truncate(s: string, max = MAX_PREVIEW): string {
   return s.length > max ? s.slice(0, max) : s;
 }
 
-/**
- * Lazily import ``BaseCallbackHandler`` from ``@langchain/core``.
- *
- * The Python ImportError contract is preserved by re-throwing a clear
- * error when the peer is missing. Callers normally invoke
- * ``AsqavCallbackHandler.create`` which forwards through this.
- */
+// Lazily import BaseCallbackHandler from @langchain/core.
+// Re-throws a clear error when the optional peer is missing.
 async function loadBase(): Promise<BaseCallbackHandlerCtor> {
   try {
     // Dynamic specifier: the peer is optional (package.json peerDependenciesMeta).
@@ -88,22 +65,13 @@ export interface AsqavCallbackHandlerOptions extends AsqavAdapterOptions {
   name?: string;
 }
 
-/**
- * LangChain.js callback handler that signs chain, tool, and LLM events
- * via the Asqav governance pipeline. Use
- * ``AsqavCallbackHandler.create()`` since the parent class is loaded
- * asynchronously.
- */
+// Signs chain, tool, and LLM events via the Asqav governance pipeline.
+// Use AsqavCallbackHandler.create() since the peer is loaded asynchronously.
 export class AsqavCallbackHandler extends AsqavAdapter {
   /** Friendly name surfaced to LangChain's tracing UI. */
   public readonly name: string = "asqav-callback-handler";
 
-  /**
-   * Build the handler. The factory is async because LangChain.js's
-   * ``BaseCallbackHandler`` is the constructor we extend at runtime via
-   * a returned subclass (so this class itself stays usable without the
-   * peer installed).
-   */
+  // Async factory: loads BaseCallbackHandler from the optional peer at runtime.
   static async create(
     opts: AsqavCallbackHandlerOptions,
   ): Promise<AsqavCallbackHandler & BaseCallbackHandlerLike> {
@@ -120,13 +88,30 @@ export class AsqavCallbackHandler extends AsqavAdapter {
       }
 
       handleChainStart(
-        serialized: LCSerialized,
+        serialized: LCSerialized | null | undefined,
         inputs: Record<string, unknown>,
       ): void {
+        // Guard: LCEL/RunnableLambda passes non-object inputs (str/arr/num).
+        // Object.keys on a string yields index keys ["0","1",...], so guard first.
+        const input_keys =
+          inputs !== null &&
+          typeof inputs === "object" &&
+          !Array.isArray(inputs)
+            ? Object.keys(inputs)
+            : [];
+        // serialized may be null on the LCEL/RunnableLambda path; fall back
+        // to a stable "chain" label so the receipt is always signed.
+        if (!serialized) {
+          this._asqav._emit("chain:start", {
+            chain: "chain",
+            input_keys,
+          });
+          return;
+        }
         const fallbackName = (serialized.id ?? ["unknown"]).slice(-1)[0];
         this._asqav._emit("chain:start", {
           chain: String(serialized.name ?? fallbackName),
-          input_keys: Object.keys(inputs ?? {}),
+          input_keys,
         });
       }
 
@@ -221,10 +206,7 @@ interface LangchainContextModule {
   setContextVariable: (name: string, value: unknown) => void;
 }
 
-/**
- * Lazily import the global-callback helpers from ``@langchain/core/context``.
- * Same optional-peer contract as ``loadBase``.
- */
+// Lazily import registerConfigureHook/setContextVariable from @langchain/core/context.
 async function loadContext(): Promise<LangchainContextModule> {
   try {
     // @ts-ignore optional peer dependency
@@ -247,20 +229,16 @@ async function loadContext(): Promise<LangchainContextModule> {
 const ASQAV_LC_CONTEXT_VAR = "asqav_langchain_handler";
 let hookRegistered = false;
 
-/**
- * Turn on default-on Asqav governance for LangChain.js in one call.
- *
- * After this every chain, tool, and LLM run in the current async context
- * signs an Asqav receipt with no per-invoke ``{ callbacks: [...] }``. It
- * registers a ``@langchain/core`` configure hook once and binds the handler
- * to a context variable; LangChain's run configuration then attaches it to
- * every run. Signing stays fail-open. Returns the handler.
- */
+// Turn on default-on Asqav governance for LangChain.js. Registers a configure
+// hook once and binds the handler to a context variable so every run signs
+// automatically. Signing stays fail-open. Returns the handler.
 export async function enableLangchainGovernance(
   opts: AsqavCallbackHandlerOptions,
 ): Promise<AsqavCallbackHandler & BaseCallbackHandlerLike> {
   const handler = await AsqavCallbackHandler.create(opts);
   const { registerConfigureHook, setContextVariable } = await loadContext();
+  // Register the hook once so a second call cannot add a duplicate entry to
+  // langchain-core's hook list and double-sign every action.
   if (!hookRegistered) {
     registerConfigureHook({ contextVar: ASQAV_LC_CONTEXT_VAR, inheritable: true });
     hookRegistered = true;

--- a/typescript/tests/extras/langchain.test.ts
+++ b/typescript/tests/extras/langchain.test.ts
@@ -45,6 +45,53 @@ describe("AsqavCallbackHandler with @langchain/core mocked", () => {
     vi.doUnmock("@langchain/core/callbacks/base");
   });
 
+  it("signs handleChainStart with null serialized (LCEL/RunnableLambda path)", async () => {
+    // Non-vacuous: without the null guard handleChainStart(null) throws on .id
+    // and LangChain drops the receipt fail-open, so removing the guard fails this.
+    const { AsqavCallbackHandler } = await import("../../src/extras/langchain.js");
+    const { agent, calls, sign } = makeFakeAgent();
+    const handler = await AsqavCallbackHandler.create({ agent });
+
+    interface InnerHandler {
+      handleChainStart(s: unknown, inputs: Record<string, unknown>): void;
+    }
+    (handler as unknown as InnerHandler).handleChainStart(null, { text: "hello" });
+
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(calls[0].actionType).toBe("chain:start");
+    expect(calls[0].context.chain).toBe("chain");
+    expect(calls[0].context.input_keys).toEqual(["text"]);
+  });
+
+  it("signs handleChainStart with non-dict inputs (bare string) yields input_keys=[]", async () => {
+    // Non-vacuous: without the non-dict guard, Object.keys("hello") returns
+    // ["0","1","2","3","4"] (string index keys). Revert the guard and this
+    // assertion fails (input_keys would be ["0","1","2","3","4"]).
+    const { AsqavCallbackHandler } = await import("../../src/extras/langchain.js");
+    const { agent, calls, sign } = makeFakeAgent();
+    const handler = await AsqavCallbackHandler.create({ agent });
+
+    interface InnerHandler {
+      handleChainStart(s: unknown, inputs: unknown): void;
+    }
+    // null serialized + bare string input (LCEL RunnableLambda path)
+    (handler as unknown as InnerHandler).handleChainStart(null, "hello");
+
+    await tick();
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(calls[0].context.input_keys).toEqual([]);
+
+    // dict serialized + bare string input
+    const { agent: agent2, calls: calls2, sign: sign2 } = makeFakeAgent();
+    const handler2 = await AsqavCallbackHandler.create({ agent: agent2 });
+    (handler2 as unknown as InnerHandler).handleChainStart({ name: "MyChain" }, "hello");
+
+    await tick();
+    expect(sign2).toHaveBeenCalledTimes(1);
+    expect(calls2[0].context.input_keys).toEqual([]);
+  });
+
   it("signs handleLLMStart, handleLLMEnd, and tool events into the agent", async () => {
     const { AsqavCallbackHandler } = await import("../../src/extras/langchain.js");
     const { agent, calls, sign } = makeFakeAgent();


### PR DESCRIPTION
## What

Three additive hardening fixes for the default-on adapters.

**FIX 1 - LangChain non-dict inputs crash (py + ts).** `on_chain_start` / `handleChainStart` guarded `serialized=None` but still called `list(inputs.keys())` / `Object.keys(inputs)` on both branches. On the LCEL/RunnableLambda path inputs is a raw string, list, or number. Python raises `AttributeError` (swallowed by LangChain fail-open, receipt silently dropped); TypeScript returns index keys `["0","1","2","3","4"]` for a string. Both guarded with a single isinstance/typeof check computed once before the serialized branch: `input_keys = list(inputs.keys()) if isinstance(inputs, dict) else []` (py) and `inputs !== null && typeof inputs === "object" && !Array.isArray(inputs) ? Object.keys(inputs) : []` (ts). Non-dict inputs now yield `[]` and always sign.

**FIX 2 - crewAI orphan agent on double enable.** `enable_crew_governance` constructed `AsqavCrewHook(...)` (which calls `Agent.create`) before the sentinel check. A second call created an orphan agent it never wired, and returned a different hook object. Fixed with check-first: read `crew._asqav_crew_hook`; if set, return it immediately without constructing. The first hook is now stored as `crew._asqav_crew_hook` and the `_asqav_crew_wrapped` sentinel is kept for belt-and-suspenders.

**FIX 3 (original) - LangChain null-serialized receipt drop.** Guard `serialized` against non-dict for the `serialized.get(...)` call, covered in FIX 1 above.

## Backward-compat

Strictly additive. Normal (dict inputs, single-enable) paths unchanged. No public export or signature removed.

## Tests (non-vacuous)

- py: `on_chain_start(None, "hello")` and `({"name":"X"}, "hello")` - both sign with `input_keys=[]`; reverting the guard raises AttributeError and 0 signs.
- ts: `handleChainStart(null, "hello")` and `({name:"MyChain"}, "hello")` - both sign with `input_keys=[]`; reverting gives `["0","1","2","3","4"]`.
- py crewai: `enable_crew_governance` called twice - `hook1 is hook2` and `Agent.create` called once; reverting gives 2 create calls and different hook objects.
- All existing tests still pass (40 py, 6 ts).

## Gate output

```
ruff check python/src: All checks passed!
pytest: 40 passed
tsc --noEmit: clean
vitest: 6 passed
comment-verbosity --strict: ok on all 6 changed files
secret-scan: SCANNER: gitleaks - clean
```

## Follow-ups (out of scope here)

- Other langchain callback entry points (on_tool_start, on_llm_start) still index `serialized` without a null guard.
- The langchain manual+auto path can still double-sign; needs run-scoped dedup.

Draft, stacked on `company/c35-crewai`. Not published.