### PR TITLE
chore(release): bump both SDK halves to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the Asqav SDK are documented here.
 Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
+## [0.8.0] - 2026-07-03
+
+### Added
+
+- **Standards-interop doors (Python and TypeScript).** Additive utilities that
+  take one Asqav receipt and return it wrapped as the envelopes agent builders
+  already consume, with one byte-identical inner receipt inside each. Envelopes:
+  W3C Verifiable Credential 2.0, CloudEvents 1.0, an OpenTelemetry GenAI
+  attribute map, a C2PA third-party assertion, and an ERC-8004 validation
+  request shape. Every door has an inverse, and `extract_receipt` /
+  `extractReceipt` recovers the inner receipt from any envelope. Pure and
+  offline: no signing, no network, no input mutation. Presentation only; the
+  authoritative signature stays inside the embedded receipt.
+- Cross-SDK parity holds on the JSON Canonicalization Scheme safe input domain
+  (object keys in the Basic Multilingual Plane, integers within the IEEE-754
+  safe range), pinned by a shared golden both suites assert against. Outside
+  that domain the two halves can diverge, which the doors docs state plainly.
+
 ## [0.7.0] - 2026-07-01
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.7.0"
+version = "0.8.0"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "MIT"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -158,7 +158,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.7.0";
+export const SDK_VERSION = "0.8.0";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Release 0.8.0 of both SDK halves. This ships the standards-interop doors merged in #352: additive utilities that wrap one Asqav receipt as W3C Verifiable Credential 2.0, CloudEvents 1.0, an OpenTelemetry GenAI attribute map, a C2PA third-party assertion, and an ERC-8004 validation request, each with a byte-identical inner receipt and an inverse extractor. Bumps package.json, pyproject.toml, __init__.py, and userAgent.ts to 0.8.0 and adds the CHANGELOG section. Publishing runs on the py- and ts- release tags after merge.