### PR TITLE
docs: drop withdrawn asqav-mcp references from shipped docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,3 @@ contact_links:
   - name: PyPI Package
     url: https://pypi.org/project/asqav/
     about: Install the latest version from PyPI
-  - name: MCP Server
-    url: https://github.com/jagmarques/asqav-mcp
-    about: For MCP-specific issues, use the asqav-mcp repo

--- a/README.md
+++ b/README.md
@@ -367,14 +367,13 @@ Both SDKs ship to different registries on independent cadences, driven by prefix
 
 * [`asqav` (PyPI)](https://pypi.org/project/asqav/): the Python SDK.
 * [`@asqav/sdk` (npm)](https://www.npmjs.com/package/@asqav/sdk): the TypeScript SDK.
-* [asqav-mcp](https://github.com/jagmarques/asqav-mcp): MCP server for Claude Desktop, Claude Code, and Cursor.
 * [asqav-compliance](https://github.com/jagmarques/asqav-compliance): CI/CD compliance scanner.
 
 ## Plans
 
 Asqav has two plans: Free and Enterprise.
 
-Free covers 5,000 signatures/month, 10 agents, 10 policies, 3 team members, and 30-day log retention. Most features are included: OpenTimestamps anchoring, the MCP server, audit export, framework integrations, content scanning, OpenTelemetry export, the Replay API, approvals, governance query and attestation, and 2 compliance reports/month.
+Free covers 5,000 signatures/month, 10 agents, 10 policies, 3 team members, and 30-day log retention. Most features are included: OpenTimestamps anchoring, audit export, framework integrations, content scanning, OpenTelemetry export, the Replay API, approvals, governance query and attestation, and 2 compliance reports/month.
 
 Enterprise adds RFC 3161 timestamps, SSO/SAML, managed and bring-your-own KMS, SD-JWT selective disclosure, IP allowlists, multi-party quorum signing, quarantine and incident management, a self-hosted signer, and dedicated support. See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
 


### PR DESCRIPTION
The asqav-mcp repo is withdrawn (GitHub 404, no installable PyPI release, Smithery not found), so two shipped-doc links point at a dead resource in the ecosystem.

This removes:
- the asqav-mcp line in the README Ecosystem list
- the "MCP Server" contact link in `.github/ISSUE_TEMPLATE/config.yml` (a live 404 in the GitHub new-issue chooser)
- the "MCP server" mention in the Free-plan feature list

Protocol references to MCP server lifecycle in the per-language READMEs are wire-vocabulary, not the product, and stay as-is. The CHANGELOG "Removed" entry recording the drop stays as factual history.

Docs-only. The PyPI and npm README copies refresh at the next publish.

## Proof of work

VERIFY-WITH: `rg -n "asqav-mcp" .` over the whole worktree post-fix:
```
(no dead-link hits; the one remaining match is the factual CHANGELOG "Removed" line)
./CHANGELOG.md:117:- **Dropped the `asqav-mcp` config generation** from the SDK.
```

Diff stat:
```
 .github/ISSUE_TEMPLATE/config.yml | 3 ---
 README.md                         | 3 +--
 2 files changed, 1 insertion(+), 5 deletions(-)
```

https://claude.ai/code/session_01DVhaLjXRjsMDBjetxBMund