### PR TITLE
fix(py): resolve action_ref and previous_receipt_hash from the sign payload

### DIFF
--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -20,6 +20,8 @@ from .client import (
     _api_key,
     _parse_bitcoin_anchor,
     _parse_timestamp,
+    _resolve_action_ref,
+    _resolve_previous_receipt_hash,
 )
 from .patterns import resolve_pattern
 from .retry import with_async_retry
@@ -232,6 +234,8 @@ class AsyncAgent:
             co_signatures=data.get("co_signatures"),
             countersign_url=data.get("countersign_url"),
             user_intent_verified=data.get("user_intent_verified"),
+            action_ref=_resolve_action_ref(data),
+            previous_receipt_hash=_resolve_previous_receipt_hash(data),
         )
 
     async def countersign(self, signature_id: str) -> SignatureResponse:

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -350,6 +350,33 @@ def _map_policy_decision_to_decision(policy_decision: str | None) -> str:
     return DECISION_MAP.get((policy_decision or "").lower(), "deny")
 
 
+def _payload_field(data: dict[str, Any], key: str) -> str | None:
+    """Read a string ``key`` from the sign response ``payload`` object, else None."""
+    payload = data.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _resolve_action_ref(data: dict[str, Any]) -> str | None:
+    """Top-level ``action_ref`` wins; compliance-mode clouds nest it under payload."""
+    top = data.get("action_ref")
+    if top is not None:
+        return top
+    return _payload_field(data, "action_ref")
+
+
+def _resolve_previous_receipt_hash(data: dict[str, Any]) -> str | None:
+    """Either casing at top level wins; fall back to the copy nested under payload."""
+    return (
+        data.get("previousReceiptHash")
+        or data.get("previous_receipt_hash")
+        or _payload_field(data, "previousReceiptHash")
+        or _payload_field(data, "previous_receipt_hash")
+    )
+
+
 #: REQUIRED fields on a Compliance Receipt envelope (wire form); top-level
 #: discriminator is ``type``. Used by `verify_compliance_receipt`.
 _COMPLIANCE_REQUIRED_FIELDS: tuple[str, ...] = (
@@ -2206,7 +2233,7 @@ class Agent:
             # Accept both camelCase `previousReceiptHash` and snake_case alias on the wire.
             compliance_mode=bool(data.get("compliance_mode", False)),
             receipt_type=data.get("receipt_type"),
-            action_ref=data.get("action_ref"),
+            action_ref=_resolve_action_ref(data),
             payload_digest=data.get("payload_digest"),
             issuer_id=data.get("issuer_id"),
             iteration_id=data.get("iteration_id"),
@@ -2214,9 +2241,7 @@ class Agent:
             risk_class=data.get("risk_class"),
             incident_class=data.get("incident_class"),
             reason=data.get("reason"),
-            previous_receipt_hash=(
-                data.get("previousReceiptHash") or data.get("previous_receipt_hash")
-            ),
+            previous_receipt_hash=_resolve_previous_receipt_hash(data),
             # Spec-shape `decision`; fall back to local translation for
             # older clouds that only emit `policy_decision`.
             decision=(

--- a/python/tests/test_payload_field_fallback.py
+++ b/python/tests/test_payload_field_fallback.py
@@ -1,0 +1,103 @@
+"""The sign response resolves action_ref and previous_receipt_hash from payload.
+
+Compliance-mode clouds nest ``action_ref`` and ``previousReceiptHash`` inside
+the receipt ``payload`` rather than at the top level of the sign response, so a
+top-level-only read surfaced None for both on the quickstart flow. The client
+reads the top level first, then falls back to the payload copy, and leaves the
+payload object itself unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav
+from asqav.async_client import AsyncAgent
+
+_ACTION_REF = "sha256:" + "a" * 64
+_PREV_HASH = "0" * 64
+
+
+def _agent() -> "asqav.Agent":
+    return asqav.Agent(
+        agent_id="agent_001",
+        name="test-agent",
+        public_key="pk_xxx",
+        key_id="key_001",
+        algorithm="ML-DSA-65",
+        capabilities=["api:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _async_agent() -> AsyncAgent:
+    return AsyncAgent(
+        agent_id="agent_001",
+        name="test-agent",
+        public_key="pk_xxx",
+        key_id="key_001",
+        algorithm="ML-DSA-65",
+        capabilities=["api:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _wire_with_payload_only() -> dict:
+    """Compliance-mode sign response: the two fields live only inside payload."""
+    return {
+        "signature": "sig_b64",
+        "signature_id": "sig_abc",
+        "action_id": "act_abc",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://asqav.com/verify/sig_abc",
+        "algorithm": "ML-DSA-65",
+        "compliance_mode": True,
+        "payload": {
+            "v": 1,
+            "action_ref": _ACTION_REF,
+            "previousReceiptHash": _PREV_HASH,
+        },
+    }
+
+
+def test_sync_sign_resolves_action_ref_and_prev_hash_from_payload() -> None:
+    with patch("asqav.client._post", return_value=_wire_with_payload_only()):
+        resp = _agent().sign("api:call", {"k": "v"}, compliance_mode=True)
+    assert resp.action_ref == _ACTION_REF
+    assert resp.previous_receipt_hash == _PREV_HASH
+
+
+def test_sync_top_level_wins_over_payload() -> None:
+    """A top-level value is authoritative; the payload copy is only a fallback."""
+    wire = _wire_with_payload_only()
+    wire["action_ref"] = "sha256:" + "b" * 64
+    wire["previous_receipt_hash"] = "1" * 64
+    with patch("asqav.client._post", return_value=wire):
+        resp = _agent().sign("api:call", {"k": "v"}, compliance_mode=True)
+    assert resp.action_ref == "sha256:" + "b" * 64
+    assert resp.previous_receipt_hash == "1" * 64
+
+
+def test_sync_payload_object_returned_untouched() -> None:
+    with patch("asqav.client._post", return_value=_wire_with_payload_only()):
+        resp = _agent().sign("api:call", {"k": "v"}, compliance_mode=True)
+    assert resp.payload == {
+        "v": 1,
+        "action_ref": _ACTION_REF,
+        "previousReceiptHash": _PREV_HASH,
+    }
+
+
+@pytest.mark.asyncio
+@patch("asqav.async_client._async_post", new_callable=AsyncMock)
+async def test_async_sign_resolves_from_payload(mock_post: AsyncMock) -> None:
+    mock_post.return_value = _wire_with_payload_only()
+    resp = await _async_agent().sign(action_type="api:call", context={"k": "v"})
+    assert resp.action_ref == _ACTION_REF
+    assert resp.previous_receipt_hash == _PREV_HASH


### PR DESCRIPTION
## What

The Python `sign()` parsers, sync and async, read `action_ref` and `previous_receipt_hash` from the top level of the sign response only. The compliance-mode wire nests both inside the receipt `payload`, so a fresh quickstart printed `None` for `sig.action_ref` and `sig.previous_receipt_hash` on the exact flow the Python README headlines.

This mirrors the TypeScript payload fallback in `mapSignWireToResponse` (#356): read the top level first, then fall back to the `payload` copy. The top-level value keeps winning and the `payload` object is returned untouched. The async sign response gains both fields so it matches the sync path.

The wire shape is the ground truth from the cloud envelope construction: the receipt `payload` carries `action_ref` (snake) and `previousReceiptHash` (camelCase) as sibling keys.

## Scope

Strictly additive. No field removed, the signed request body is byte-identical (only response parsing changed). The two resolver helpers live once in `client.py` and are imported by `async_client.py`, so the fallback is not duplicated.

## Tests

`python/tests/test_payload_field_fallback.py` covers both clients. The two payload-resolution cases were run against the unfixed parsers first and failed (`action_ref` came back `None`), then pass once the fallback lands. Two extra cases pin that the top-level value wins over the payload copy and that `payload` is returned unchanged.

## Proof of work

Full Python suite is not runnable locally on this box (some optional deps have no wheel for the local interpreter), so the local proof is the new plus touched files and ruff; CI runs the full matrix on this PR.

`ruff check` on changed files: `All checks passed!`

Non-vacuous check (new tests vs unfixed src):
```
FAILED test_payload_field_fallback.py::test_sync_sign_resolves_action_ref_and_prev_hash_from_payload
FAILED test_payload_field_fallback.py::test_async_sign_resolves_from_payload
2 failed, 2 passed
```

Fixed src:
```
python/tests/test_payload_field_fallback.py ....  4 passed
```

Regression batch (sign, response, replay, chain, counterparty): `128 passed`.

Diff stat:
```
 python/src/asqav/async_client.py |  4 ++++
 python/src/asqav/client.py       | 33 +++++++++++++++++++++++++++++----
 python/tests/test_payload_field_fallback.py | new
```

Do not merge until every check is green.

https://claude.ai/code/session_01DVhaLjXRjsMDBjetxBMund