### PR TITLE
docs(sdk): recipe + examples for binding a declared config digest into the receipt

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ export ASQAV_API_KEY=sk_...
 | [`human_approval.py`](human_approval.py) | Request signing session for a high-risk action, wait for human approval, then sign | #64 |
 | [`dify_workflow.md`](dify_workflow.md) | Dify plugin: sign actions in a workflow, bundle the run for an auditor | #50 |
 | [`streamlit_dashboard.py`](streamlit_dashboard.py) | Streamlit dashboard: list agents, replay timelines, verify chain, export bundle | #56 |
+| [`bind_config_digest.py`](bind_config_digest.py) | Hash an agent declaration and bind its SHA-256 digest into the signed receipt via the schema-pinned context | - |
 
 ## CLI parity
 

--- a/examples/agent-manifest.example.json
+++ b/examples/agent-manifest.example.json
@@ -1,0 +1,7 @@
+{
+  "name": "invoice-refund-agent",
+  "model": "gpt-4o",
+  "tools": ["stripe.refund", "ledger.read"],
+  "allowed_actions": ["payment:refund", "data:read"],
+  "version": "1.0.0"
+}

--- a/examples/bind_config_digest.py
+++ b/examples/bind_config_digest.py
@@ -1,0 +1,71 @@
+"""Bind your agent's declared configuration into the signed receipt.
+
+Hash whatever declares what the agent is allowed to be (an agent manifest,
+an AGENTS.md, a container image digest, an SBOM) with SHA-256, put the digest
+in the sign context, and pin it with a context schema. The digest then lands
+inside the cryptographically signed receipt, so anyone can later confirm which
+declared configuration produced a given action at the public verify endpoint.
+
+This uses the existing schema-validated sign context. No new wire field.
+
+Run:
+    export ASQAV_API_KEY=sk_...
+    python examples/bind_config_digest.py
+
+Same flow at the terminal:
+    asqav sign payment:refund --context '{"config_digest":"sha256:...","config_kind":"agent-manifest"}'
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import asqav
+
+# The declaration you want bound to every receipt this agent signs. In a real
+# deployment this is your AGENTS.md, a manifest, or an image digest on disk.
+MANIFEST_PATH = Path(__file__).with_name("agent-manifest.example.json")
+
+# Pin the binding keys so a receipt that claims a config always carries both
+# the digest and what kind of artifact it hashes. Extra context keys pass through.
+CONFIG_BINDING_SCHEMA = {
+    "config_digest": {"type": "string", "required": True},
+    "config_kind": {"type": "string", "required": True},
+}
+
+
+def config_digest(path: Path) -> str:
+    """Return ``sha256:<hex>`` over the raw bytes of a declaration file."""
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> None:
+    asqav.init()
+
+    agent = asqav.Agent.create("config-binding-demo")
+
+    digest = config_digest(MANIFEST_PATH)
+    print(f"declaration : {MANIFEST_PATH.name}")
+    print(f"config_digest: {digest}")
+
+    # Bind the digest into the action the agent is signing. Anyone verifying
+    # the receipt sees exactly which declared config authorized this action.
+    sig = agent.sign(
+        "payment:refund",
+        {
+            "amount": 49.95,
+            "currency": "EUR",
+            "config_digest": digest,
+            "config_kind": "agent-manifest",
+            "config_ref": MANIFEST_PATH.name,
+        },
+        context_schema=CONFIG_BINDING_SCHEMA,
+    )
+
+    print(f"signature_id : {sig.signature_id}")
+    print(f"verify       : {sig.verification_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/README.md
+++ b/python/README.md
@@ -403,6 +403,63 @@ agent.sign("action", context, context_schema=my_validator)
 
 See `examples/schema_receipts_example.py` for a runnable demo.
 
+## Bind your agent's declared configuration into the receipt
+
+A signed action is more useful when the receipt also proves *which declared
+configuration* the agent was running when it acted. You can bind that today
+with the sign context, no extra API surface:
+
+1. Hash whatever declares the agent: an agent manifest, an `AGENTS.md`, a
+   container image digest, or an SBOM. Any bytes on disk work.
+2. Put the digest in the `context` under your own keys (for example
+   `config_digest` plus `config_kind`).
+3. Optionally pin those keys with a `context_schema` so a receipt that claims a
+   config always carries both fields.
+
+```python
+import hashlib
+from pathlib import Path
+
+import asqav
+
+def config_digest(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+CONFIG_BINDING_SCHEMA = {
+    "config_digest": {"type": "string", "required": True},
+    "config_kind":   {"type": "string", "required": True},
+}
+
+asqav.init(api_key="sk_...")
+agent = asqav.Agent.create("my-agent")
+
+digest = config_digest(Path("AGENTS.md"))
+
+sig = agent.sign(
+    "payment:refund",
+    {
+        "amount": 49.95,
+        "currency": "EUR",
+        "config_digest": digest,        # sha256:<hex> of your declaration
+        "config_kind": "agents-md",     # name the artifact you hashed
+    },
+    context_schema=CONFIG_BINDING_SCHEMA,
+)
+print(sig.verification_url)             # digest is inside the signed receipt
+```
+
+The digest is part of the signed body, so anyone can fetch the receipt at the
+public verify endpoint and confirm the action ran under that exact declaration.
+The key names and the artifact kind are yours to choose, which keeps the pattern
+generic across any declaration format.
+
+For a couple of common cases there are dedicated wire fields instead of context
+keys (`config_manifest_digest` for a runtime config snapshot, `sbom_digest` for
+an SBOM). The context recipe above is the general form for any other declaration
+you want to bind.
+
+See `examples/bind_config_digest.py` for a runnable demo.
+
 ## Pluggable detectors (bring-your-own DLP/policy)
 
 asqav owns the enforce + signed-proof spine; detection is pluggable. Register a

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -412,6 +412,63 @@ await agent.sign({
 
 See `examples/schema-receipts.ts` for a runnable demo.
 
+## Bind your agent's declared configuration into the receipt
+
+A signed action is more useful when the receipt also proves *which declared
+configuration* the agent was running when it acted. You can bind that today
+with the sign context, no extra API surface:
+
+1. Hash whatever declares the agent: an agent manifest, an `AGENTS.md`, a
+   container image digest, or an SBOM. Any bytes on disk work.
+2. Put the digest in the `context` under your own keys (for example
+   `config_digest` plus `config_kind`).
+3. Optionally pin those keys with a `contextSchema` so a receipt that claims a
+   config always carries both fields.
+
+```typescript
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { Agent, init } from "@asqav/sdk";
+
+function configDigest(path: string): string {
+  return "sha256:" + createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+const CONFIG_BINDING_SCHEMA = {
+  config_digest: { type: "string", required: true },
+  config_kind:   { type: "string", required: true },
+} as const;
+
+init({ apiKey: "sk_..." });
+const agent = await Agent.create({ name: "my-agent" });
+
+const digest = configDigest("AGENTS.md");
+
+const sig = await agent.sign({
+  actionType: "payment:refund",
+  context: {
+    amount: 49.95,
+    currency: "EUR",
+    config_digest: digest,        // sha256:<hex> of your declaration
+    config_kind: "agents-md",     // name the artifact you hashed
+  },
+  contextSchema: CONFIG_BINDING_SCHEMA,
+});
+console.log(sig.verificationUrl); // digest is inside the signed receipt
+```
+
+The digest is part of the signed body, so anyone can fetch the receipt at the
+public verify endpoint and confirm the action ran under that exact declaration.
+The key names and the artifact kind are yours to choose, which keeps the pattern
+generic across any declaration format.
+
+For a couple of common cases there are dedicated wire fields instead of context
+keys (`config_manifest_digest` for a runtime config snapshot, `sbom_digest` for
+an SBOM). The context recipe above is the general form for any other declaration
+you want to bind.
+
+See `examples/bind-config-digest.mjs` for a runnable demo.
+
 ## Pluggable detectors (bring-your-own DLP/policy)
 
 asqav owns the enforce + signed-proof spine; detection is pluggable. Register a

--- a/typescript/examples/README.md
+++ b/typescript/examples/README.md
@@ -49,6 +49,18 @@ Install:
 npm install @asqav/sdk @langchain/core @langchain/openai zod
 ```
 
+### bind-config-digest.mjs
+
+Hashes a local agent declaration (`agent-manifest.example.json`) with SHA-256 and
+binds the digest into the signed receipt through the schema-pinned sign context,
+so a verifier can confirm which declared configuration produced the action. Plain
+ESM, no framework deps. Run it with `node`:
+
+```bash
+npm install @asqav/sdk
+ASQAV_API_KEY=sk_... node examples/bind-config-digest.mjs
+```
+
 ## Pattern
 
 Both recipes follow the same rule: call `agent.sign({ actionType, context })`

--- a/typescript/examples/agent-manifest.example.json
+++ b/typescript/examples/agent-manifest.example.json
@@ -1,0 +1,7 @@
+{
+  "name": "invoice-refund-agent",
+  "model": "gpt-4o",
+  "tools": ["stripe.refund", "ledger.read"],
+  "allowed_actions": ["payment:refund", "data:read"],
+  "version": "1.0.0"
+}

--- a/typescript/examples/bind-config-digest.mjs
+++ b/typescript/examples/bind-config-digest.mjs
@@ -1,0 +1,68 @@
+/** Bind your agent's declared configuration into the signed receipt.
+ *
+ * Hash whatever declares what the agent is allowed to be (an agent manifest,
+ * an AGENTS.md, a container image digest, an SBOM) with SHA-256, put the digest
+ * in the sign context, and pin it with a context schema. The digest then lands
+ * inside the cryptographically signed receipt, so anyone can later confirm which
+ * declared configuration produced a given action at the public verify endpoint.
+ *
+ * This uses the existing schema-validated sign context. No new wire field.
+ *
+ * ASQAV_API_KEY=sk_... node examples/bind-config-digest.mjs
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { init, Agent } from "@asqav/sdk";
+
+// The declaration you want bound to every receipt this agent signs. In a real
+// deployment this is your AGENTS.md, a manifest, or an image digest on disk.
+const MANIFEST_URL = new URL("./agent-manifest.example.json", import.meta.url);
+
+// Pin the binding keys so a receipt that claims a config always carries both
+// the digest and what kind of artifact it hashes. Extra context keys pass through.
+const CONFIG_BINDING_SCHEMA = {
+  config_digest: { type: "string", required: true },
+  config_kind: { type: "string", required: true },
+};
+
+function configDigest(url) {
+  return "sha256:" + createHash("sha256").update(readFileSync(url)).digest("hex");
+}
+
+async function main() {
+  const apiKey = process.env["ASQAV_API_KEY"] ?? "";
+  if (!apiKey) {
+    console.error("Set ASQAV_API_KEY before running.\nGet your key at https://asqav.com");
+    process.exit(1);
+  }
+
+  init({ apiKey });
+  const agent = await Agent.create({ name: "config-binding-demo" });
+
+  const digest = configDigest(MANIFEST_URL);
+  console.log(`declaration : agent-manifest.example.json`);
+  console.log(`config_digest: ${digest}`);
+
+  // Bind the digest into the action the agent is signing. Anyone verifying
+  // the receipt sees exactly which declared config authorized this action.
+  const sig = await agent.sign({
+    actionType: "payment:refund",
+    context: {
+      amount: 49.95,
+      currency: "EUR",
+      config_digest: digest,
+      config_kind: "agent-manifest",
+      config_ref: "agent-manifest.example.json",
+    },
+    contextSchema: CONFIG_BINDING_SCHEMA,
+  });
+
+  console.log(`signatureId : ${sig.signatureId}`);
+  console.log(`verify      : ${sig.verificationUrl}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds a docs recipe plus two runnable examples that show how to bind an agent's
declared configuration into the cryptographically signed receipt, using the sign
context that ships today. No wire change, no `src/` change.

The pattern: hash whatever declares the agent (an agent manifest, an `AGENTS.md`,
a container image digest, an SBOM) with SHA-256, put the digest in the sign
context under your own keys (`config_digest` plus `config_kind`), and pin those
keys with a context schema. The digest becomes part of the signed body, so a
verifier can confirm which declared configuration produced a given action at the
public verify endpoint. Key names and artifact kind are the caller's choice, so
the recipe stays generic across any declaration format.

## Changes

- `python/README.md` + `typescript/README.md`: mirrored section
  "Bind your agent's declared configuration into the receipt", placed right after
  the structured-receipts (context schema) section in both.
- `examples/bind_config_digest.py` and `typescript/examples/bind-config-digest.mjs`:
  runnable demos that hash a shipped sample declaration and sign an action with the
  digest schema-pinned into the context. Each follows its language's existing
  example conventions and env-key pattern.
- Two small `agent-manifest.example.json` sample declarations for the examples to hash.
- Index entries in both example READMEs.

## Honest framing

The recipe binds a digest through the existing schema-validated context, so it
works with the shipped API. It names no third-party spec as endorsed. For two
common cases there are dedicated wire fields (`config_manifest_digest`,
`sbom_digest`), noted as such; the context recipe is the general form for any
other declaration.

## Proof of work

VERIFY-WITH:

```
$ node --check typescript/examples/bind-config-digest.mjs; echo exit=$?
exit=0

$ python3 -c "import ast;ast.parse(open('examples/bind_config_digest.py').read());print('py ast OK')"
py ast OK
```

Diff stat:

```
 8 files changed, 280 insertions(+)
 examples/README.md                              |  1 +
 examples/agent-manifest.example.json            |  7 +
 examples/bind_config_digest.py                  | 71 +
 python/README.md                                | 57 +
 typescript/README.md                            | 57 +
 typescript/examples/README.md                   | 12 +
 typescript/examples/agent-manifest.example.json |  7 +
 typescript/examples/bind-config-digest.mjs      | 68 +
```

CI: the repo CI (`ci.yml`) lints `python/src` and runs `pytest`/`vitest`;
examples sit outside the tsconfig `include` and the vitest test glob, so this
docs+examples change leaves the suites green. Checks link appears on the PR once
the run starts.

https://claude.ai/code/session_01DVhaLjXRjsMDBjetxBMund
