### PR TITLE
Block offline backdating on revoked keys

### DIFF
--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -178,7 +178,9 @@ class AsqavNativeAdapter(FormatAdapter):
         else:
             issued_at = _payload(doc).get("issued_at", "")
         revoked_at = _vr.resolve_revoked_at(jwks, kid)
-        res, note = _vr.check_key_status(status, issued_at, revoked_at)
+        _env = _vr.normalise_envelope(doc)
+        _has_anchor = bool(_env.get("anchors"))
+        res, note = _vr.check_key_status(status, issued_at, revoked_at, _has_anchor)
         return [("key_status", res, note)]
 
     def attestation(self, doc: dict) -> dict[str, Any]:

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -213,7 +213,7 @@ def resolve_revoked_at(jwks: dict, kid: str):
 REVOKED_KEY_STATUSES = {"revoked", "suspended", "compromised"}
 
 
-def check_key_status(status, issued_at: str, revoked_at=None):
+def check_key_status(status, issued_at: str, revoked_at=None, has_trusted_anchor: bool = False):
     """Gate the verdict on the signing key's published status.
 
     The public JWKS marks a key revoked once its agent is revoked. A receipt
@@ -223,6 +223,11 @@ def check_key_status(status, issued_at: str, revoked_at=None):
     check so a receipt signed BEFORE revocation still PASSes (historical verify).
     The JWKS today publishes status only, so without revoked_at any revoked key
     fails the axis.
+
+    Without a trusted time anchor the signed issued_at is self-attested: a holder
+    of the compromised key can backdate. Downgrade that exact case to SKIPPED so
+    the verdict is INCOMPLETE, never a hiding PASS. Default False so callers that
+    ignore the parameter never hide behind a self-attested timestamp.
     """
     s = (status or "").lower()
     if s not in REVOKED_KEY_STATUSES:
@@ -239,6 +244,12 @@ def check_key_status(status, issued_at: str, revoked_at=None):
             iss = iss.replace(tzinfo=timezone.utc)
         if rev <= iss:
             return "FAIL", f"signing key revoked at {revoked_at} on/before issuance {issued_at}"
+        if not has_trusted_anchor:
+            return (
+                "SKIPPED",
+                f"signing key revoked at {revoked_at}; issued_at {issued_at} is "
+                f"self-attested, no anchor proves pre-revocation timing",
+            )
         return "PASS", f"signing key revoked at {revoked_at}, after issuance {issued_at}"
     return "FAIL", f"signing key status {status!r}; receipt cannot be trusted"
 
@@ -351,8 +362,9 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
     else:
         results.append(("issuer_key", "PASS", f"resolved kid {kid} (status={status})"))
         revoked_at = resolve_revoked_at(jwks, kid)
+        _has_anchor = bool(envelope.get("anchors"))
         results.append(
-            ("key_status", *check_key_status(status, payload.get("issued_at", ""), revoked_at))
+            ("key_status", *check_key_status(status, payload.get("issued_at", ""), revoked_at, _has_anchor))
         )
         sig = _b64decode(sig_obj.get("sig", ""))
         results.append(("signature", *verify_signature(pk, msg, sig, alg or jwks_alg)))
@@ -465,8 +477,9 @@ def run_structured(
             }
         )
         revoked_at = resolve_revoked_at(jwks, kid)
+        _has_anchor = bool(envelope.get("anchors"))
         ks_r, ks_n = check_key_status(
-            status, payload.get("issued_at", ""), revoked_at
+            status, payload.get("issued_at", ""), revoked_at, _has_anchor
         )
         axes.append({"name": "key_status", "result": ks_r, "note": ks_n})
         sig_bytes = _b64decode(sig_obj.get("sig", ""))

--- a/python/tests/test_verify_receipt_revoked_key.py
+++ b/python/tests/test_verify_receipt_revoked_key.py
@@ -58,10 +58,20 @@ def test_check_key_status_revoked_before_issuance_fails():
     assert res == "FAIL"
 
 
-def test_check_key_status_revoked_after_issuance_passes():
-    """A receipt signed before the key was revoked still verifies (historical)."""
-    res, _ = v.check_key_status(
+def test_check_key_status_revoked_after_issuance_skipped_without_anchor():
+    """No anchor means issued_at is self-attested; backdating is undetectable."""
+    res, note = v.check_key_status(
         "revoked", "2026-05-01T00:00:00Z", revoked_at="2026-06-01T00:00:00Z"
+    )
+    assert res == "SKIPPED"
+    assert "anchor" in note.lower()
+
+
+def test_check_key_status_revoked_after_issuance_passes_with_anchor():
+    """A pre-revocation receipt with a trusted anchor still verifies."""
+    res, _ = v.check_key_status(
+        "revoked", "2026-05-01T00:00:00Z", revoked_at="2026-06-01T00:00:00Z",
+        has_trusted_anchor=True,
     )
     assert res == "PASS"
 
@@ -127,12 +137,29 @@ def test_run_structured_active_key_has_key_status_pass_axis():
     assert ks["result"] == "PASS", f"expected PASS, got {ks['result']!r}"
 
 
-def test_run_structured_revoked_at_after_issuance_passes_key_status():
-    """Key revoked after issuance: key_status PASS (historical verify ok)."""
+def test_run_structured_revoked_at_after_issuance_skipped_without_anchor():
+    """No anchor: key_status SKIPPED (issued_at self-attested, backdating risk).
+    The placeholder sig FAILs so the verdict is FAIL (or INCOMPLETE); the point
+    is key_status is never PASS and the verdict is never PASS."""
     envelope = {
         "payload": _payload(),
         "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
         "anchors": [],
+    }
+    result = v.run_structured(
+        envelope, _jwks("revoked", revoked_at="2026-07-01T00:00:00Z"), None
+    )
+    ks = next(a for a in result["axes"] if a["name"] == "key_status")
+    assert ks["result"] == "SKIPPED"
+    assert result["verdict"] != "PASS"
+
+
+def test_run_structured_revoked_at_after_issuance_passes_with_anchor():
+    """With a trusted anchor, pre-revocation receipts still PASS."""
+    envelope = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [{"type": "rfc3161", "value": "dGVzdA=="}],
     }
     result = v.run_structured(
         envelope, _jwks("revoked", revoked_at="2026-07-01T00:00:00Z"), None

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -193,7 +193,9 @@ export class AsqavNativeAdapter extends FormatAdapter {
       ? String(doc.server_timestamp ?? "")
       : String(payloadOf(doc).issued_at ?? "");
     const revokedAt = resolveRevokedAt(jwks, kid);
-    const [res, note] = checkKeyStatus(status, issuedAt, revokedAt);
+    const env = normaliseEnvelope(doc);
+    const anchors = Array.isArray(env.anchors) ? (env.anchors as unknown[]) : [];
+    const [res, note] = checkKeyStatus(status, issuedAt, revokedAt, anchors.length > 0);
     return [["key_status", res, note]];
   }
 

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -8,6 +8,8 @@
  * first-receipt seed constant.
  */
 
+import type { VerifyState } from "./crypto.js";
+
 /** Mirrors `core/integrity.py` FIRST_RECEIPT_SEED (64 zeros). */
 export const FIRST_RECEIPT_SEED = "0".repeat(64);
 
@@ -120,13 +122,17 @@ export function resolveRevokedAt(jwks: Record<string, unknown> | null, kid: stri
 const REVOKED_KEY_STATUSES = new Set(["revoked", "suspended", "compromised"]);
 
 // Gate on the key's JWKS status (mirrors `check_key_status`).
-// With revoked_at, receipts signed before revocation still PASS.
+// With revoked_at and a trusted anchor, receipts signed before revocation PASS.
 // Without revoked_at, any revoked-status key FAILs the axis.
+// Without an anchor, a pre-revocation issued_at is self-attested and cannot be
+// trusted: a holder of the compromised key can backdate. Downgrade to SKIPPED so
+// the verdict is INCOMPLETE, never a hiding PASS.
 export function checkKeyStatus(
   status: string | null,
   issuedAt: string,
   revokedAt: string | null,
-): readonly ["PASS" | "FAIL", string] {
+  hasTrustedAnchor: boolean,
+): readonly [VerifyState, string] {
   const s = (status ?? "").toLowerCase();
   if (!REVOKED_KEY_STATUSES.has(s)) {
     return ["PASS", `signing key status ${JSON.stringify(status)} is active`];
@@ -140,6 +146,9 @@ export function checkKeyStatus(
       }
       if (rev <= iss) {
         return ["FAIL", `signing key revoked at ${revokedAt} on/before issuance ${issuedAt}`];
+      }
+      if (!hasTrustedAnchor) {
+        return ["SKIPPED", `signing key revoked at ${revokedAt}; issued_at ${issuedAt} is self-attested, no anchor proves pre-revocation timing`];
       }
       return ["PASS", `signing key revoked at ${revokedAt}, after issuance ${issuedAt}`];
     } catch {

--- a/typescript/tests/offline-verify.test.ts
+++ b/typescript/tests/offline-verify.test.ts
@@ -171,17 +171,51 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     expect(keyAxis?.result).toBe("FAIL");
   });
 
-  it("revoked key with revoked_at AFTER issuance passes (historical verify semantics)", () => {
+  it("revoked key with revoked_at AFTER issuance INCOMPLETE without anchor (c386 backdating fix)", () => {
     const receipt = loadJson(REVOKED_DIR, "receipt.json");
     const revokedJwks = loadJson(REVOKED_DIR, "jwks.json");
     // issued_at is 2026-06-01T12:00:00+00:00; revoked_at is after that.
+    // The vector receipt ships anchors:[] so issued_at is self-attested.
+    // Without an anchor a holder of the compromised key can backdate, so the
+    // verdict must be INCOMPLETE, never a hiding PASS.
     const futureJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
     ((futureJwks.keys as Array<Record<string, unknown>>)[0]).revoked_at = "2026-12-01T00:00:00+00:00";
     const result = verifyReceiptOffline(receipt, futureJwks);
+    expect(result.verdict).toBe("INCOMPLETE");
+    const keyAxis = result.axes.find((a) => a.axis === "key_status");
+    expect(keyAxis?.result).toBe("SKIPPED");
+    expect(keyAxis?.note).toMatch(/no anchor/i);
+  });
+
+  it("revoked key with revoked_at AFTER issuance PASSes WITH a trusted anchor (c386)", () => {
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const revokedJwks = loadJson(REVOKED_DIR, "jwks.json");
+    const futureJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
+    ((futureJwks.keys as Array<Record<string, unknown>>)[0]).revoked_at = "2026-12-01T00:00:00+00:00";
+    // Attach a TSA anchor. Anchors are NOT part of the signed payload, so the
+    // original signature still validates and the timing is now corroborated.
+    const anchored = JSON.parse(JSON.stringify(receipt)) as Record<string, unknown>;
+    anchored.anchors = [{ type: "rfc3161", value: "dGVzdC10c3ItY29va2ll", tsa_url: "https://tsa.example/timestamp" }];
+    const result = verifyReceiptOffline(anchored, futureJwks);
     expect(result.verdict).toBe("PASS");
     const keyAxis = result.axes.find((a) => a.axis === "key_status");
     expect(keyAxis?.result).toBe("PASS");
     expect(keyAxis?.note).toMatch(/after issuance/i);
+  });
+
+  it("c386: compromised-key backdated receipt, offline, no anchor, must NOT PASS", () => {
+    // A receipt whose key is now compromised (status=compromised) but whose
+    // signed issued_at is BEFORE revoked_at. Offline with no anchor the
+    // self-attested issued_at is forgeable, so PASS is forbidden.
+    const receipt = loadJson(REVOKED_DIR, "receipt.json");
+    const compromisedJwks = JSON.parse(JSON.stringify(loadJson(REVOKED_DIR, "jwks.json"))) as Record<string, unknown>;
+    ((compromisedJwks.keys as Array<Record<string, unknown>>)[0]).status = "compromised";
+    ((compromisedJwks.keys as Array<Record<string, unknown>>)[0]).revoked_at = "2026-12-01T00:00:00+00:00";
+    const result = verifyReceiptOffline(receipt, compromisedJwks);
+    expect(result.verdict).not.toBe("PASS");
+    expect(result.verdict).toBe("INCOMPLETE");
+    const keyAxis = result.axes.find((a) => a.axis === "key_status");
+    expect(keyAxis?.result).toBe("SKIPPED");
   });
 
   it("revoked key with revoked_at AT issuance fails (at-or-before rule)", () => {


### PR DESCRIPTION
## What

Offline receipt verification let a revoked-with-timestamp signing key PASS any receipt whose self-attested `issued_at` predates `revoked_at`. An attacker holding the compromised key re-signs with a backdated `issued_at` and reads PASS offline, with no cloud roundtrip to contradict the timestamp.

This downgrades that exact branch to SKIPPED (verdict INCOMPLETE): a trusted time anchor (RFC3161 / OTS) is now required to corroborate pre-revocation timing. Without one the verifier refuses to attest.

## What changed

`checkKeyStatus` (TS `vrShim.ts`) and `check_key_status` (Python `verify_receipt.py`) gain a `hasTrustedAnchor` parameter. On the revoked + `revoked_at`-set + `issued_at < revoked_at` branch, a missing anchor returns SKIPPED instead of PASS. A SKIPPED non-chain axis drives the aggregate verdict to INCOMPLETE in both cores.

The adapters pass anchor presence from the normalised envelope:
- TS `asqavNative.ts` `extraAxes`: `normaliseEnvelope(doc).anchors.length > 0`
- Python `asqav_native.py` `extra_axes`: `bool(normalise_envelope(doc).get("anchors"))`
- Python `run` / `run_structured`: `bool(envelope.get("anchors"))`

## Unchanged paths

- The online / hosted `/verify` path (DB `signed_at` is authoritative there).
- The un-revoked-key path (active keys still PASS).
- The no-`revoked_at` path (any revoked status still FAILs).
- The on-or-before-issuance branch (`revoked_at <= issued_at` still FAILs).
- The 50/50 conformance-vector parity gate (`asqav-07-revoked-key` has no `revoked_at`, still FAILs).

## Tests

- TS: 578 passed (vitest), `tsc --noEmit` clean. Updated the existing "revoked_at after issuance" test to expect INCOMPLETE without an anchor, added a mirrored test that PASSes WITH an anchor, and added the regression test for the compromised-key backdated case.
- Python: 1272 passed, 2 skipped (pytest). Same split: no-anchor SKIPPED, with-anchor PASS, at both the unit and `run_structured` levels.

The new regression test FAILS against the old code (it asserts INCOMPLETE where the old code returned PASS) and PASSes against the fix.

## THREAT_MODEL

**Attack surface:** `verifyReceiptOffline` / `run_structured` when the JWKS publishes a key as revoked/compromised with a `revoked_at` timestamp and the receipt envelope carries no trusted time anchor. The `issued_at` field is inside the signed payload but signed by the same (now-compromised) key, so the holder of the private key can mint a receipt with any timestamp they choose.

**Existing guard:** `checkKeyStatus` compared `issued_at < revoked_at` and returned PASS, trusting the self-attested timestamp. This is sound against an honest signer whose clock drifted, but defeatable by a malicious holder of the compromised key. The cloud path was unaffected because the hosted `/verify` uses the DB-stored `signed_at` (server-side, immutable), not the payload `issued_at`.

**New test:** `c386: compromised-key backdated receipt, offline, no anchor, must NOT PASS` asserts verdict INCOMPLETE (not PASS) for a `status=compromised` key with `revoked_at` after the signed `issued_at` and `anchors: []`. A companion test confirms the same receipt WITH an anchor still PASSes.

**Trust boundary change:** the `key_status` axis refuses to trust a self-attested `issued_at` to prove pre-revocation timing when no anchor exists. The boundary tightens from "valid signature + plausible timestamp = PASS" to "valid signature + corroborated timestamp = PASS; valid signature + uncorroborated timestamp = INCOMPLETE". A receipt with a real anchor retains its PASS; only the un-anchored self-attested case is affected.