### PR TITLE
chore: trim internal-only extras export and a leftover example line

### DIFF
--- a/examples/dify_workflow.md
+++ b/examples/dify_workflow.md
@@ -1,7 +1,5 @@
 # Dify workflow with asqav signing
 
-Closes #50.
-
 The [asqav Dify plugin](https://github.com/jagmarques/dify-plugin-asqav) wraps
 the same backend API as this SDK. A Dify workflow can sign agent actions and
 later verify them; the SDK and CLI produce and read the exact same receipts,

--- a/typescript/src/extras/_base.ts
+++ b/typescript/src/extras/_base.ts
@@ -48,7 +48,7 @@ export interface AsqavAdapterOptions {
   observe?: boolean;
 }
 
-export interface SignActionInput {
+interface SignActionInput {
   actionType: string;
   context?: Record<string, unknown>;
 }


### PR DESCRIPTION
## What

Two source-only cosmetic trims from a ts-prune sweep of the Asqav SDK TypeScript half.

- `typescript/src/extras/_base.ts`: drop the `export` keyword from `SignActionInput`, making the type module private. It is referenced only inside `_base.ts` (the interface definition and the `signAction` parameter). The extras barrel re-exports only `AsqavAdapter`, `raiseMissingPeer` and `AsqavAdapterOptions`, and `package.json` exposes no `./extras/_base` subpath, so nothing outside the file imports it.
- `examples/dify_workflow.md`: remove a stray pull-request close-keyword line from the top of a shipped example and collapse the double blank line it left behind.

## Why

A ts-prune sweep flagged `SignActionInput` as an export used only within its own module, with no importer and no published subpath. The example carried a stray line from a pull-request body that does not belong in shipped docs.

All 126 ts-prune hits were triaged warn-first: one in-scope trim (above) and 125 intentional entry points or deferred. The `extras/index.ts` barrel docstring was checked too and left intact, because `package.json` really does publish the four `@asqav/sdk/extras/<framework>` subpaths it describes. The `./verifier` exports were logged and deferred to the verify-types work.

Source-only cleanup. No version bump, no publish, no changelog release entry.

## Proof of work

Local verification in the worktree:

```
$ ./node_modules/.bin/tsc --noEmit
TSC_EXIT=0

$ npm run test        # vitest run
 Test Files  43 passed (43)
      Tests  578 passed (578)

$ npm run build       # tsup
DTS Build success in 19232ms   (all dts entry points generated)
```

Contract VERIFY-WITH results:

```
rg -c "VERDICT: (TRUE|FALSE)-POSITIVE" <triage file>        -> 129
! git grep -q "<close-keyword>" HEAD -- examples/dify_workflow.md   -> absent (grep exits 1)
gh pr list --head chore/c57-sdk-deadcode --state open              -> this PR
```

Diff stat:

```
 examples/dify_workflow.md      | 2 --
 typescript/src/extras/_base.ts | 2 +-
 2 files changed, 1 insertion(+), 3 deletions(-)
```

CI: https://github.com/jagmarques/asqav-sdk/actions?query=branch%3Achore%2Fc57-sdk-deadcode

