### PR TITLE
Mirror execution_evidence on the verify response types (python and typescript)

### DIFF
--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -60,6 +60,7 @@ from .client import (
     CertificateResponse,
     ComplianceReceiptVerification,
     DelegationResponse,
+    ExecutionEvidence,
     GroupKeypairResponse,
     GroupSignResponse,
     KeyRefreshResponse,
@@ -230,6 +231,7 @@ __all__ = [
     "verify_signature",
     "verify_output",
     "VerificationDetail",
+    "ExecutionEvidence",
     "BitcoinAnchorStatus",
     # May 2026 release helpers
     "post_applied_attestation",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -567,6 +567,24 @@ class VerificationDetail:
 
 
 @dataclass
+class ExecutionEvidence:
+    """Execution-evidence projection on a verification response.
+
+    `present` answers whether the receipt bound execution output.
+    `label` vocabulary: result_bound, digest_present, none_by_design,
+    absent. `result_digest` echoes the bound `sha256:<hex>` for offline
+    re-check. `none_by_design` marks a decision receipt, which records
+    the decision and no execution outcome per the boundary.
+    """
+
+    present: bool
+    label: str
+    result_digest: str | None = None
+    result_bound: bool = False
+    none_by_design: bool = False
+
+
+@dataclass
 class BitcoinAnchorStatus:
     """Anchor attestation state on a verification response.
 
@@ -608,6 +626,7 @@ class VerificationResponse:
     verified: bool
     verification_url: str
     verification_detail: VerificationDetail | None = None
+    execution_evidence: ExecutionEvidence | None = None
     type: str = "signature"
     bitcoin_anchor: BitcoinAnchorStatus | None = None
     signature_envelope: dict[str, str] | None = None
@@ -3325,6 +3344,18 @@ def verify_signature(signature_id: str) -> VerificationResponse:
         if isinstance(detail_raw, dict)
         else None
     )
+    evidence_raw = data.get("execution_evidence")
+    execution_evidence = (
+        ExecutionEvidence(
+            present=evidence_raw["present"],
+            label=evidence_raw["label"],
+            result_digest=evidence_raw.get("result_digest"),
+            result_bound=evidence_raw.get("result_bound", False),
+            none_by_design=evidence_raw.get("none_by_design", False),
+        )
+        if isinstance(evidence_raw, dict)
+        else None
+    )
     anchor_raw = data.get("bitcoin_anchor")
     bitcoin_anchor = (
         BitcoinAnchorStatus(
@@ -3348,6 +3379,7 @@ def verify_signature(signature_id: str) -> VerificationResponse:
         verified=data["verified"],
         verification_url=data["verification_url"],
         verification_detail=detail,
+        execution_evidence=execution_evidence,
         type=data.get("type", "signature"),
         bitcoin_anchor=bitcoin_anchor,
         signature_envelope=data.get("signature_envelope"),

--- a/python/tests/test_verify_response_fields.py
+++ b/python/tests/test_verify_response_fields.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from asqav.client import (
     BitcoinAnchorStatus,
+    ExecutionEvidence,
     VerificationDetail,
     VerificationResponse,
     verify_signature,
@@ -68,6 +69,13 @@ def _full_cloud_payload() -> dict:
             {"type": "opentimestamps", "value": "b3RzZmFrZQ=="},
         ],
         "algorithm_registry_version": "2026-05",
+        "execution_evidence": {
+            "present": True,
+            "label": "result_bound",
+            "result_digest": "sha256:" + "a" * 64,
+            "result_bound": True,
+            "none_by_design": False,
+        },
     }
 
 
@@ -97,6 +105,22 @@ def test_verification_response_exposes_ietf_projection_fields() -> None:
     assert response.anchors[0]["type"] == "rfc3161"
     assert response.anchors[1]["type"] == "opentimestamps"
     assert response.algorithm_registry_version == "2026-05"
+
+
+def test_execution_evidence_parses_from_cloud_payload() -> None:
+    """`execution_evidence` parses into the ExecutionEvidence dataclass,
+    mirroring the cloud's projection (result_bound, result_digest)."""
+    payload = _full_cloud_payload()
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        response = verify_signature("sig_test_full")
+
+    evidence = response.execution_evidence
+    assert isinstance(evidence, ExecutionEvidence)
+    assert evidence.present is True
+    assert evidence.label == "result_bound"
+    assert evidence.result_digest == "sha256:" + "a" * 64
+    assert evidence.result_bound is True
+    assert evidence.none_by_design is False
 
 
 def test_verification_detail_exposes_extra_sub_axes() -> None:
@@ -139,6 +163,7 @@ def test_minimal_response_leaves_new_fields_none() -> None:
     assert response.anchors is None
     assert response.algorithm_registry_version is None
     assert response.verification_detail is None
+    assert response.execution_evidence is None
 
 
 def test_regimes_satisfied_present() -> None:

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -818,6 +818,17 @@ export interface VerificationDetail {
   regimesSatisfied?: string[];
 }
 
+/** Execution-evidence projection on a verification response. `label`
+ * vocabulary: result_bound | digest_present | none_by_design | absent.
+ * `present` is the top-line boolean; `resultDigest` echoes the bound hash. */
+export interface ExecutionEvidence {
+  present: boolean;
+  label: "result_bound" | "digest_present" | "none_by_design" | "absent" | string;
+  resultDigest?: string | null;
+  resultBound?: boolean;
+  noneByDesign?: boolean;
+}
+
 /** Anchor attestation state on a verification response. `status`
  * vocabulary: none | pending | confirmed | failed. `anchorTxRef` and
  * `anchorBlockHeight` populate once the OpenTimestamps proof upgrades
@@ -842,6 +853,9 @@ export interface VerificationResponse {
   verified: boolean;
   verificationUrl?: string;
   verificationDetail?: VerificationDetail;
+  /** Execution-evidence projection: whether the receipt captured
+   * execution output, or none by design on a decision receipt. */
+  executionEvidence?: ExecutionEvidence;
   /** Receipt kind. Always `"signature"` for this response shape. */
   type?: string;
   /** Bitcoin anchor state; `status: "none"` when the receipt has no anchor. */
@@ -2280,6 +2294,13 @@ export async function verifySignature(signatureId: string): Promise<Verification
       duplicate_emission_candidate?: boolean | string;
       regimes_satisfied?: string[];
     };
+    execution_evidence?: {
+      present: boolean;
+      label: string;
+      result_digest?: string | null;
+      result_bound?: boolean;
+      none_by_design?: boolean;
+    };
     type?: string;
     bitcoin_anchor?: {
       status: string;
@@ -2325,6 +2346,15 @@ export async function verifySignature(signatureId: string): Promise<Verification
           policyDigestResolved: data.verification_detail.policy_digest_resolved,
           duplicateEmissionCandidate: data.verification_detail.duplicate_emission_candidate,
           regimesSatisfied: data.verification_detail.regimes_satisfied,
+        }
+      : undefined,
+    executionEvidence: data.execution_evidence
+      ? {
+          present: data.execution_evidence.present,
+          label: data.execution_evidence.label,
+          resultDigest: data.execution_evidence.result_digest,
+          resultBound: data.execution_evidence.result_bound,
+          noneByDesign: data.execution_evidence.none_by_design,
         }
       : undefined,
     type: data.type,

--- a/typescript/tests/verify-response-fields.test.ts
+++ b/typescript/tests/verify-response-fields.test.ts
@@ -69,6 +69,13 @@ function fullCloudPayload() {
       { type: "opentimestamps", value: "b3RzZmFrZQ==" },
     ],
     algorithm_registry_version: "2026-05",
+    execution_evidence: {
+      present: true,
+      label: "result_bound",
+      result_digest: "sha256:" + "a".repeat(64),
+      result_bound: true,
+      none_by_design: false,
+    },
   };
 }
 
@@ -122,6 +129,21 @@ describe("verifySignature response fields", () => {
     expect(detail?.duplicateEmissionCandidate).toBe(false);
   });
 
+  it("exposes executionEvidence parsed from the cloud payload", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(fullCloudPayload()),
+    );
+
+    const response = await verifySignature("sig_test_full");
+    const evidence = response.executionEvidence;
+
+    expect(evidence?.present).toBe(true);
+    expect(evidence?.label).toBe("result_bound");
+    expect(evidence?.resultDigest).toBe("sha256:" + "a".repeat(64));
+    expect(evidence?.resultBound).toBe(true);
+    expect(evidence?.noneByDesign).toBe(false);
+  });
+
   it("leaves new fields undefined when the server omits them", async () => {
     const minimalPayload = {
       signature_id: "sig_minimal",
@@ -147,6 +169,7 @@ describe("verifySignature response fields", () => {
     expect(response.anchors).toBeUndefined();
     expect(response.algorithmRegistryVersion).toBeUndefined();
     expect(response.verificationDetail).toBeUndefined();
+    expect(response.executionEvidence).toBeUndefined();
   });
 
   it("test_regimes_satisfied_present", async () => {


### PR DESCRIPTION
## Summary
- Mirrors the asqav cloud's new `/verify` `execution_evidence` field on both SDK halves: `ExecutionEvidence` dataclass + parser wiring in python/src/asqav/client.py (re-exported from asqav/__init__.py), and an `ExecutionEvidence` interface + camelCase parser wiring in typescript/src/index.ts.
- Extends both `verify-response-fields` test files with the new field's full-payload and minimal-payload (back-compat, field stays undefined/None) cases.

## Cross-repo dependency (rule 2.13)
Companion to jagmarques/asqav#1056, which adds `execution_evidence` to the public GET /verify/{id} response. Land together; this PR's field names and vocabulary (result_bound, digest_present, none_by_design, absent) are pinned 1:1 to that PR's projection.

## Test plan
- [x] Python: red run (ImportError on ExecutionEvidence) then green (7 passed) on python/tests/test_verify_response_fields.py; full suite 1274 passed, 1 skipped.
- [x] TypeScript: red run (assertion failure) then green (7 passed) on typescript/tests/verify-response-fields.test.ts; full suite 579 passed across 43 files; tsc --noEmit clean.

## Proof of work
Python OBSERVE (red): ImportError: cannot import name 'ExecutionEvidence' from 'asqav.client' (1 error in 2.46s)
Python OBSERVE (green): 7 passed in 1.46s
TypeScript OBSERVE (red): AssertionError: expected undefined to be true (1 failed | 6 passed)
TypeScript OBSERVE (green): Tests  7 passed (7)
Diffstat: 5 files changed, 112 insertions(+)
