### PR TITLE
chore: ignore .asondy orchestration state dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ dist/
 
 # local tooling state (never commit)
 .company/
+.asondy/
 COMPANY.md
 .claude/
 .planning/


### PR DESCRIPTION
This repo already ignores \`.company/\` for local tooling state. It does not yet ignore \`.asondy/\`, a sibling directory used by local asondy orchestration runs.

This PR adds one line right after the existing \`.company/\` entry so \`.asondy/\` is ignored too. That way a stray local orchestration-state directory can never get committed by accident.

No other changes.