### PR TITLE
SDK 0.8.1: required-field deserializer guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,23 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   compromised key cannot re-sign with a backdated timestamp and read PASS
   offline. (#362)
 
+## [0.8.1] - 2026-07-08
+
+### Fixed
+
+- Required-field deserializer guards (Python + TypeScript). `Agent.sign()`,
+  `Agent.countersign()`, `verify_signature()` / `verifySignature()`, and
+  `Agent.create()` / `Agent.get()` (plus their async, batch, and
+  session-listing counterparts) now raise a typed `AsqavResponseError` when
+  the cloud response omits a required field, instead of a raw `KeyError`
+  (Python) or a silently `undefined` value (TypeScript). Both languages
+  route through one shared guard, `require_field()` / `requireField()`.
+
+### Added
+
+- Added `tsx` as a TypeScript devDependency. It is the runner the
+  quickstart example already documents (`npx tsx quickstart.ts`).
+
 ## [0.8.0] - 2026-07-03
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.8.0"
+version = "0.8.1"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -51,6 +51,7 @@ from .client import (
     APIError,
     ApprovalResponse,
     AsqavError,
+    AsqavResponseError,
     AsqavValidationError,
     AuthenticationError,
     AuthoredBy,
@@ -159,7 +160,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __all__ = [
     # Initialization
     "init",
@@ -304,6 +305,7 @@ __all__ = [
     # Exceptions
     "AsqavError",
     "AsqavValidationError",
+    "AsqavResponseError",
     "AuthenticationError",
     "RateLimitError",
     "APIError",

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -22,6 +22,7 @@ from .client import (
     _parse_timestamp,
     _resolve_action_ref,
     _resolve_previous_receipt_hash,
+    require_field,
 )
 from .patterns import resolve_pattern
 from .retry import with_async_retry
@@ -157,13 +158,13 @@ class AsyncAgent:
         )
 
         return cls(
-            agent_id=data["agent_id"],
-            name=data["name"],
-            public_key=data["public_key"],
-            key_id=data["key_id"],
-            algorithm=data["algorithm"],
-            capabilities=data["capabilities"],
-            created_at=_parse_timestamp(data["created_at"]),
+            agent_id=require_field(data, "agent_id"),
+            name=require_field(data, "name"),
+            public_key=require_field(data, "public_key"),
+            key_id=require_field(data, "key_id"),
+            algorithm=require_field(data, "algorithm"),
+            capabilities=require_field(data, "capabilities"),
+            created_at=_parse_timestamp(require_field(data, "created_at")),
         )
 
     @classmethod
@@ -172,13 +173,13 @@ class AsyncAgent:
         data = await _async_get(f"/agents/{agent_id}")
 
         return cls(
-            agent_id=data["agent_id"],
-            name=data["name"],
-            public_key=data["public_key"],
-            key_id=data["key_id"],
-            algorithm=data["algorithm"],
-            capabilities=data["capabilities"],
-            created_at=_parse_timestamp(data["created_at"]),
+            agent_id=require_field(data, "agent_id"),
+            name=require_field(data, "name"),
+            public_key=require_field(data, "public_key"),
+            key_id=require_field(data, "key_id"),
+            algorithm=require_field(data, "algorithm"),
+            capabilities=require_field(data, "capabilities"),
+            created_at=_parse_timestamp(require_field(data, "created_at")),
         )
 
     async def sign(
@@ -216,11 +217,11 @@ class AsyncAgent:
         data = await _async_post(f"/agents/{self.agent_id}/sign", body)
 
         return SignatureResponse(
-            signature=data["signature"],
-            signature_id=data["signature_id"],
-            action_id=data["action_id"],
-            timestamp=data["timestamp"],
-            verification_url=data["verification_url"],
+            signature=require_field(data, "signature"),
+            signature_id=require_field(data, "signature_id"),
+            action_id=require_field(data, "action_id"),
+            timestamp=require_field(data, "timestamp"),
+            verification_url=require_field(data, "verification_url"),
             algorithm=data.get("algorithm"),
             chain_hash=data.get("chain_hash") or data.get("record_hash"),
             rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
@@ -245,11 +246,11 @@ class AsyncAgent:
             {},
         )
         return SignatureResponse(
-            signature=data["signature"],
-            signature_id=data["signature_id"],
-            action_id=data["action_id"],
-            timestamp=data["timestamp"],
-            verification_url=data["verification_url"],
+            signature=require_field(data, "signature"),
+            signature_id=require_field(data, "signature_id"),
+            action_id=require_field(data, "action_id"),
+            timestamp=require_field(data, "timestamp"),
+            verification_url=require_field(data, "verification_url"),
             algorithm=data.get("algorithm"),
             chain_hash=data.get("chain_hash") or data.get("record_hash"),
             rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
@@ -393,15 +394,15 @@ class AsyncAgent:
             data: dict[str, Any] = response.json()
 
         return VerificationResponse(
-            signature_id=data["signature_id"],
-            agent_id=data["agent_id"],
-            agent_name=data["agent_name"],
-            action_id=data["action_id"],
-            action_type=data["action_type"],
+            signature_id=require_field(data, "signature_id"),
+            agent_id=require_field(data, "agent_id"),
+            agent_name=require_field(data, "agent_name"),
+            action_id=require_field(data, "action_id"),
+            action_type=require_field(data, "action_type"),
             payload=data.get("payload"),
-            signature=data["signature"],
-            algorithm=data["algorithm"],
-            signed_at=_parse_timestamp(data["signed_at"]),
-            verified=data["verified"],
-            verification_url=data["verification_url"],
+            signature=require_field(data, "signature"),
+            algorithm=require_field(data, "algorithm"),
+            signed_at=_parse_timestamp(require_field(data, "signed_at")),
+            verified=require_field(data, "verified"),
+            verification_url=require_field(data, "verification_url"),
         )

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -171,6 +171,38 @@ class AsqavValidationError(ValueError):
         self.docs_url = docs_url
 
 
+class AsqavResponseError(AsqavError):
+    """Raised when a cloud response omits a field the SDK requires (rule 3.9).
+
+    Replaces a raw ``KeyError`` so callers can catch one asqav-owned type
+    with a clear message naming the missing field, instead of a bare
+    traceback pointing at an internal dict index.
+    """
+
+    def __init__(self, message: str, *, docs_url: str) -> None:
+        super().__init__(message)
+        self.docs_url = docs_url
+
+
+#: Docs page anchoring missing-required-field response errors (rule 3.9).
+RESPONSE_ERROR_DOCS_URL: str = "https://asqav.com/docs/sdk-errors"
+
+
+def require_field(data: dict[str, Any], name: str) -> Any:
+    """Return ``data[name]`` or raise ``AsqavResponseError`` if absent.
+
+    Centralizes required-field response parsing so a cloud response
+    missing e.g. ``action_id`` raises one typed, catchable error instead
+    of a raw ``KeyError`` at a random dict index.
+    """
+    if name not in data:
+        raise AsqavResponseError(
+            f"response missing required field '{name}'",
+            docs_url=RESPONSE_ERROR_DOCS_URL,
+        )
+    return data[name]
+
+
 @dataclass
 class AgentResponse:
     """Response from agent creation."""
@@ -1535,13 +1567,13 @@ class Agent:
         )
 
         return cls(
-            agent_id=data["agent_id"],
-            name=data["name"],
-            public_key=data["public_key"],
-            key_id=data["key_id"],
-            algorithm=data["algorithm"],
-            capabilities=data["capabilities"],
-            created_at=_parse_timestamp(data["created_at"]),
+            agent_id=require_field(data, "agent_id"),
+            name=require_field(data, "name"),
+            public_key=require_field(data, "public_key"),
+            key_id=require_field(data, "key_id"),
+            algorithm=require_field(data, "algorithm"),
+            capabilities=require_field(data, "capabilities"),
+            created_at=_parse_timestamp(require_field(data, "created_at")),
         )
 
     @classmethod
@@ -1557,13 +1589,13 @@ class Agent:
         data = _get(f"/agents/{agent_id}")
 
         return cls(
-            agent_id=data["agent_id"],
-            name=data["name"],
-            public_key=data["public_key"],
-            key_id=data["key_id"],
-            algorithm=data["algorithm"],
-            capabilities=data["capabilities"],
-            created_at=_parse_timestamp(data["created_at"]),
+            agent_id=require_field(data, "agent_id"),
+            name=require_field(data, "name"),
+            public_key=require_field(data, "public_key"),
+            key_id=require_field(data, "key_id"),
+            algorithm=require_field(data, "algorithm"),
+            capabilities=require_field(data, "capabilities"),
+            created_at=_parse_timestamp(require_field(data, "created_at")),
         )
 
     def issue_token(
@@ -2231,11 +2263,11 @@ class Agent:
         data = _post(f"/agents/{self.agent_id}/sign", body)
 
         response = SignatureResponse(
-            signature=data["signature"],
-            signature_id=data["signature_id"],
-            action_id=data["action_id"],
-            timestamp=data["timestamp"],
-            verification_url=data["verification_url"],
+            signature=require_field(data, "signature"),
+            signature_id=require_field(data, "signature_id"),
+            action_id=require_field(data, "action_id"),
+            timestamp=require_field(data, "timestamp"),
+            verification_url=require_field(data, "verification_url"),
             algorithm=data.get("algorithm"),
             chain_hash=data.get("chain_hash") or data.get("record_hash"),
             rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
@@ -2308,11 +2340,11 @@ class Agent:
             {},
         )
         return SignatureResponse(
-            signature=data["signature"],
-            signature_id=data["signature_id"],
-            action_id=data["action_id"],
-            timestamp=data["timestamp"],
-            verification_url=data["verification_url"],
+            signature=require_field(data, "signature"),
+            signature_id=require_field(data, "signature_id"),
+            action_id=require_field(data, "action_id"),
+            timestamp=require_field(data, "timestamp"),
+            verification_url=require_field(data, "verification_url"),
             algorithm=data.get("algorithm"),
             chain_hash=data.get("chain_hash") or data.get("record_hash"),
             rfc3161_tsa=(data.get("rfc3161_timestamp") or {}).get("tsa"),
@@ -2385,11 +2417,11 @@ class Agent:
             else:
                 results.append(
                     SignatureResponse(
-                        signature=sig["signature"],
-                        signature_id=sig["signature_id"],
-                        action_id=sig["action_id"],
-                        timestamp=sig["timestamp"],
-                        verification_url=sig["verification_url"],
+                        signature=require_field(sig, "signature"),
+                        signature_id=require_field(sig, "signature_id"),
+                        action_id=require_field(sig, "action_id"),
+                        timestamp=require_field(sig, "timestamp"),
+                        verification_url=require_field(sig, "verification_url"),
                         algorithm=sig.get("algorithm"),
                         chain_hash=sig.get("chain_hash") or sig.get("record_hash"),
                         rfc3161_tsa=(sig.get("rfc3161_timestamp") or {}).get("tsa"),
@@ -3266,15 +3298,15 @@ def get_session_signatures(session_id: str) -> list[SignedActionResponse]:
 
     return [
         SignedActionResponse(
-            signature_id=sig["signature_id"],
-            agent_id=sig["agent_id"],
-            action_id=sig["action_id"],
-            action_type=sig["action_type"],
+            signature_id=require_field(sig, "signature_id"),
+            agent_id=require_field(sig, "agent_id"),
+            action_id=require_field(sig, "action_id"),
+            action_type=require_field(sig, "action_type"),
             payload=sig.get("payload"),
-            algorithm=sig["algorithm"],
-            signed_at=_parse_timestamp(sig["signed_at"]),
-            signature_preview=sig["signature_preview"],
-            verification_url=sig["verification_url"],
+            algorithm=require_field(sig, "algorithm"),
+            signed_at=_parse_timestamp(require_field(sig, "signed_at")),
+            signature_preview=require_field(sig, "signature_preview"),
+            verification_url=require_field(sig, "verification_url"),
         )
         for sig in data
     ]
@@ -3367,17 +3399,17 @@ def verify_signature(signature_id: str) -> VerificationResponse:
         else None
     )
     return VerificationResponse(
-        signature_id=data["signature_id"],
-        agent_id=data["agent_id"],
-        agent_name=data["agent_name"],
-        action_id=data["action_id"],
-        action_type=data["action_type"],
+        signature_id=require_field(data, "signature_id"),
+        agent_id=require_field(data, "agent_id"),
+        agent_name=require_field(data, "agent_name"),
+        action_id=require_field(data, "action_id"),
+        action_type=require_field(data, "action_type"),
         payload=data.get("payload"),
-        signature=data["signature"],
-        algorithm=data["algorithm"],
-        signed_at=_parse_timestamp(data["signed_at"]),
-        verified=data["verified"],
-        verification_url=data["verification_url"],
+        signature=require_field(data, "signature"),
+        algorithm=require_field(data, "algorithm"),
+        signed_at=_parse_timestamp(require_field(data, "signed_at")),
+        verified=require_field(data, "verified"),
+        verification_url=require_field(data, "verification_url"),
         verification_detail=detail,
         execution_evidence=execution_evidence,
         type=data.get("type", "signature"),

--- a/python/tests/test_deserializer_guards.py
+++ b/python/tests/test_deserializer_guards.py
@@ -1,0 +1,71 @@
+"""Required-field deserializer guards raise AsqavResponseError, not a
+raw KeyError, when a cloud response omits a field the SDK requires.
+
+Companion to test_verify_response_fields.py, which pins the positive
+case (all fields present). This file pins the negative case: a
+response missing a required field must surface one typed, catchable
+``AsqavResponseError`` naming the field, never a bare ``KeyError`` at
+a random dict index (rule 3.9).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.client import AsqavResponseError, verify_signature
+
+
+def _mock_httpx(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = payload
+    return response
+
+
+def _full_payload() -> dict:
+    """A complete `/verify` response; each test deletes one required key."""
+    return {
+        "signature_id": "sig_test",
+        "agent_id": "agent_test",
+        "agent_name": "test-agent",
+        "action_id": "act_test",
+        "action_type": "x.y",
+        "payload": None,
+        "signature": "ZmFrZQ==",
+        "algorithm": "Ed25519",
+        "signed_at": "2026-05-10T12:00:00+00:00",
+        "verified": True,
+        "verification_url": "https://verify.example/sig_test",
+    }
+
+
+@pytest.mark.parametrize("missing_field", ["action_id", "signature_id"])
+def test_missing_required_field_raises_asqav_response_error(missing_field: str) -> None:
+    """A response missing action_id or signature_id raises
+    AsqavResponseError naming the field, not a raw KeyError."""
+    payload = _full_payload()
+    del payload[missing_field]
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        with pytest.raises(AsqavResponseError, match=missing_field):
+            verify_signature("sig_test")
+
+
+@pytest.mark.parametrize("missing_field", ["action_id", "signature_id"])
+def test_missing_required_field_never_leaks_a_bare_key_error(missing_field: str) -> None:
+    """Regression guard: callers should only ever need to catch
+    AsqavResponseError, never a bare KeyError, on a missing field."""
+    payload = _full_payload()
+    del payload[missing_field]
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        try:
+            verify_signature("sig_test")
+        except KeyError:
+            pytest.fail(f"verify_signature leaked a raw KeyError for '{missing_field}'")
+        except AsqavResponseError:
+            pass

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.6.5",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.6.5",
-      "license": "MIT",
+      "version": "0.8.1",
+      "license": "LicenseRef-Elastic-License-2.0",
       "dependencies": {
         "@noble/post-quantum": "^0.6.1"
       },
@@ -18,6 +18,7 @@
         "@types/node": "^22.0.0",
         "esbuild": "^0.28.1",
         "tsup": "^8.5.0",
+        "tsx": "^4.23.0",
         "typescript": "^5.5.0",
         "vitest": "^4.1.5"
       },
@@ -3005,6 +3006,25 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",
@@ -106,6 +106,7 @@
     "@types/node": "^22.0.0",
     "esbuild": "^0.28.1",
     "tsup": "^8.5.0",
+    "tsx": "^4.23.0",
     "typescript": "^5.5.0",
     "vitest": "^4.1.5"
   },

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -351,14 +351,15 @@ export const RESPONSE_ERROR_DOCS_URL = "https://asqav.com/docs/sdk-errors" as co
  * Centralizes required-field response parsing so a cloud response missing
  * e.g. `signature_id` throws one typed error instead of leaving a
  * TS-typed-as-required field silently `undefined` at runtime. */
-function requireField<T = unknown>(obj: Record<string, unknown>, key: string): T {
-  if (!(key in obj) || obj[key] === undefined) {
+function requireField<T = unknown>(obj: object, key: string): T {
+  const rec = obj as Record<string, unknown>;
+  if (!(key in rec) || rec[key] === undefined) {
     throw new AsqavResponseError(
       `response missing required field '${key}'`,
       RESPONSE_ERROR_DOCS_URL,
     );
   }
-  return obj[key] as T;
+  return rec[key] as T;
 }
 
 // === Public types ===

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -334,6 +334,33 @@ export class APIError extends AsqavError {
   }
 }
 
+/** Thrown when a cloud response omits a field the SDK requires (rule 3.9).
+ * Replaces a silent `undefined` read so a caller gets a typed, catchable
+ * error naming the missing field instead of an unexplained runtime bug. */
+export class AsqavResponseError extends AsqavError {
+  constructor(message: string, docsUrl?: string) {
+    super(message, docsUrl);
+    this.name = "AsqavResponseError";
+  }
+}
+
+/** Docs page anchoring missing-required-field response errors (rule 3.9). */
+export const RESPONSE_ERROR_DOCS_URL = "https://asqav.com/docs/sdk-errors" as const;
+
+/** Return `obj[key]` or throw `AsqavResponseError` if the field is absent.
+ * Centralizes required-field response parsing so a cloud response missing
+ * e.g. `signature_id` throws one typed error instead of leaving a
+ * TS-typed-as-required field silently `undefined` at runtime. */
+function requireField<T = unknown>(obj: Record<string, unknown>, key: string): T {
+  if (!(key in obj) || obj[key] === undefined) {
+    throw new AsqavResponseError(
+      `response missing required field '${key}'`,
+      RESPONSE_ERROR_DOCS_URL,
+    );
+  }
+  return obj[key] as T;
+}
+
 // === Public types ===
 
 export interface InitOptions {
@@ -1864,11 +1891,11 @@ function mapSignWireToResponse(data: SignWireResponse): SignatureResponse {
     return typeof v === "string" ? v : undefined;
   };
   return {
-    signature: data.signature,
-    signatureId: data.signature_id,
-    actionId: data.action_id,
-    timestamp: data.timestamp,
-    verificationUrl: data.verification_url,
+    signature: requireField<string>(data, "signature"),
+    signatureId: requireField<string>(data, "signature_id"),
+    actionId: requireField<string>(data, "action_id"),
+    timestamp: requireField<string>(data, "timestamp"),
+    verificationUrl: requireField<string>(data, "verification_url"),
     algorithm: data.algorithm,
     chainHash: data.chain_hash ?? data.record_hash,
     requiredCoSigners: data.required_co_signers,
@@ -2006,13 +2033,13 @@ export class Agent {
   private sessionId: string | null = null;
 
   private constructor(data: AgentData) {
-    this.agentId = data.agent_id;
-    this.name = data.name;
-    this.publicKey = data.public_key;
-    this.keyId = data.key_id;
-    this.algorithm = data.algorithm;
+    this.agentId = requireField<string>(data, "agent_id");
+    this.name = requireField<string>(data, "name");
+    this.publicKey = requireField<string>(data, "public_key");
+    this.keyId = requireField<string>(data, "key_id");
+    this.algorithm = requireField<string>(data, "algorithm");
     this.capabilities = data.capabilities ?? [];
-    this.createdAt = data.created_at;
+    this.createdAt = requireField<string | number>(data, "created_at");
   }
 
   /** Internal: rebuild an Agent from a server payload. */
@@ -2113,11 +2140,11 @@ export class Agent {
     }>("POST", `/agents/${this.agentId}/countersign/${signatureId}`, {});
 
     return {
-      signature: data.signature,
-      signatureId: data.signature_id,
-      actionId: data.action_id,
-      timestamp: data.timestamp,
-      verificationUrl: data.verification_url,
+      signature: requireField<string>(data, "signature"),
+      signatureId: requireField<string>(data, "signature_id"),
+      actionId: requireField<string>(data, "action_id"),
+      timestamp: requireField<string>(data, "timestamp"),
+      verificationUrl: requireField<string>(data, "verification_url"),
       algorithm: data.algorithm,
       chainHash: data.chain_hash ?? data.record_hash,
       requiredCoSigners: data.required_co_signers,
@@ -2318,16 +2345,16 @@ export async function verifySignature(signatureId: string): Promise<Verification
   }>("GET", `/verify/${signatureId}`);
 
   return {
-    signatureId: data.signature_id,
-    agentId: data.agent_id,
+    signatureId: requireField<string>(data, "signature_id"),
+    agentId: requireField<string>(data, "agent_id"),
     agentName: data.agent_name,
     actionId: data.action_id,
     actionType: data.action_type,
     payload: data.payload,
     signature: data.signature,
-    algorithm: data.algorithm,
-    signedAt: data.signed_at,
-    verified: data.verified,
+    algorithm: requireField<string>(data, "algorithm"),
+    signedAt: requireField<string>(data, "signed_at"),
+    verified: requireField<boolean>(data, "verified"),
     verificationUrl: data.verification_url,
     verificationDetail: data.verification_detail
       ? {
@@ -2401,15 +2428,18 @@ export async function postAppliedAttestation(
     executor_algorithm: options.executorAlgorithm,
     signature_b64: options.signatureB64,
   });
+  const attestation = requireField<typeof data.applied_attestation>(data, "applied_attestation");
   return {
-    signatureId: data.signature_id,
+    signatureId: requireField<string>(data, "signature_id"),
     appliedAttestation: {
-      appliedAt: data.applied_attestation.applied_at,
-      outcome: data.applied_attestation.outcome,
-      errorCode: data.applied_attestation.error_code,
-      executorPubkeyB64: data.applied_attestation.executor_pubkey_b64,
-      executorAlgorithm: data.applied_attestation.executor_algorithm,
-      signatureB64: data.applied_attestation.signature_b64,
+      appliedAt: requireField<string>(attestation, "applied_at"),
+      outcome: requireField<string>(attestation, "outcome"),
+      // error_code's value is nullable by design (null = no error); only
+      // an entirely absent key is the missing-field bug.
+      errorCode: requireField<string | null>(attestation, "error_code"),
+      executorPubkeyB64: requireField<string>(attestation, "executor_pubkey_b64"),
+      executorAlgorithm: requireField<string>(attestation, "executor_algorithm"),
+      signatureB64: requireField<string>(attestation, "signature_b64"),
     },
   };
 }

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.8.0";
+export const SDK_VERSION = "0.8.1";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 

--- a/typescript/tests/deserializer-guards.test.ts
+++ b/typescript/tests/deserializer-guards.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Required-field deserializer guards throw AsqavResponseError, not a
+ * silent `undefined`, when a cloud response omits a field the SDK
+ * requires. Companion to verify-response-fields.test.ts, which pins
+ * the positive case. This file pins the negative case: a sign
+ * response missing action_id or signature_id must throw one typed,
+ * catchable AsqavResponseError naming the field (rule 3.9).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Agent, AsqavResponseError, _resetForTests, init } from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const AGENT_PAYLOAD = {
+  agent_id: "agt_alice",
+  name: "alice",
+  public_key: "pk",
+  key_id: "kid",
+  algorithm: "ml-dsa-65",
+  capabilities: [],
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+function fullSignPayload(): Record<string, unknown> {
+  return {
+    signature: "sig-bytes",
+    signature_id: "sig_1",
+    action_id: "act_1",
+    timestamp: "2026-01-01T00:00:00Z",
+    verification_url: "https://asqav.com/verify/sig_1",
+  };
+}
+
+describe("agent.sign response missing a required field", () => {
+  beforeEach(() => {
+    _resetForTests();
+    init({ apiKey: "sk_test", baseUrl: "https://api.example.test/api/v1" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(["action_id", "signature_id"])(
+    "throws AsqavResponseError naming '%s', not a silent undefined",
+    async (missingField) => {
+      const signPayload = fullSignPayload();
+      delete signPayload[missingField];
+
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(jsonResponse(AGENT_PAYLOAD))
+        .mockResolvedValueOnce(jsonResponse(signPayload));
+
+      const agent = await Agent.create({ name: "alice" });
+
+      let caught: unknown;
+      try {
+        await agent.sign({ actionType: "api:call", context: {} });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(AsqavResponseError);
+      expect((caught as Error).message).toContain(missingField);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

A cloud response missing a required field raises a typed `AsqavResponseError`
naming the field, instead of a raw `KeyError` (Python) or a silently
`undefined` value (TypeScript). Both SDKs route required-field reads through
one shared guard, `require_field()` / `requireField()`.

Guarded call sites: `Agent.create()` / `Agent.get()` (+ async), `Agent.sign()`
/ `Agent.countersign()` (+ batch/session-listing counterparts), and
`verify_signature()` / `verifySignature()`. On the TypeScript side only the
fields that are non-optional per each response interface are guarded, so
`verifySignature()`'s `actionId`/`actionType` (declared optional there) are
intentionally left alone. Version bumped 0.8.0 -> 0.8.1 (patch, per this
repo's pre-1.0 policy) across all 5 version files, and `tsx` was added as a
TS devDependency since the quickstart example already documents `npx tsx
quickstart.ts` (with a matching `package-lock.json` update so `npm ci`
resolves it).

Two release tags following the py-v / ts-v naming convention are prepared
locally for this version and are not pushed.

## Fail-first proof

Reverted `client.py`, `async_client.py`, `index.ts` to origin/main (pre-guard)
and ran the new tests: Python fails at collection (the reverted `client.py`
does not define `AsqavResponseError`, which `asqav/__init__.py` imports);
TypeScript fails both cases because the response silently returns `undefined`
instead of throwing.

Restored the guard code (`git checkout HEAD`) and re-ran: both suites pass.
Full regression run: Python 1278 passed / 1 skipped, TypeScript 581 passed
across 44 files, no regressions.

## Test plan

- [x] New Python tests (`python/tests/test_deserializer_guards.py`) fail
      (ImportError) against reverted pre-guard code, pass against guarded code
- [x] New TypeScript tests (`typescript/tests/deserializer-guards.test.ts`)
      fail (AssertionError, `undefined` where an error was expected) against
      reverted pre-guard code, pass against guarded code
- [x] Full Python suite: 1278 passed, 1 skipped (pre-existing skip)
- [x] Full TypeScript suite: 581 passed, 44 files
- [x] Local release tags present; nothing pushed to the remote for this
      version yet

## Proof of work

Version bump confirmed across all 5 files -
`grep -c 0.8.1 typescript/package.json python/pyproject.toml python/src/asqav/__init__.py typescript/src/userAgent.ts CHANGELOG.md`
```
typescript/package.json:1
python/pyproject.toml:1
python/src/asqav/__init__.py:1
typescript/src/userAgent.ts:1
CHANGELOG.md:1
```

Local tags: `git tag --list 'py-v*' 'ts-v*'` returns 2 matching tags at HEAD.
`git ls-remote --tags origin | grep -c 0.8.1` returns 0, confirming nothing
has been pushed for this version.

Fail-first (reverted to origin/main, pre-guard):
```
Python:
ImportError while importing test module '.../tests/test_deserializer_guards.py'
E   ImportError: cannot import name 'AsqavResponseError' from 'asqav.client'
1 error in 0.24s

TypeScript:
 FAIL  tests/deserializer-guards.test.ts > ... 'action_id' ...
 FAIL  tests/deserializer-guards.test.ts > ... 'signature_id' ...
AssertionError: The instanceof assertion needs a constructor but undefined was given.
Test Files  1 failed (1)
     Tests  2 failed (2)
```

Passing (guard code restored):
```
Python: 4 passed in 0.29s
TypeScript: Test Files  1 passed (1) / Tests  2 passed (2)
```

Full regression: Python `1278 passed, 1 skipped in 15.21s`; TypeScript
`44 files` / `581 tests` passed.

CI: see checks on this PR.
