### PR TITLE
Make the SDK verify examples runnable and fail clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   path where `serialized` arrives as None falls back to a stable chain label,
   the LangChain configure hook registers at most once so a repeat call cannot
   double-sign, and `enable_crew_governance` is idempotent. (#361)
+- **Public no-key `verify()` (Python + TypeScript).** `asqav.verify(signature_id)`
+  and the top-level `verify()` export fetch the public verify verdict with no API
+  key, then recompute the receipt's `chain_hash` locally (the SHA-256 over the RFC
+  8785 canonical payload, the value a successor carries as `previousReceiptHash`)
+  so the chain link is reproducible offline. The flagship README "Verifying a
+  receipt" example now runs as written.
 
 ### Removed
 
@@ -40,6 +46,15 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   Version 0.8.0 and all versions published before it remain MIT-licensed
   irrevocably. The conformance test vectors in `conformance/` remain
   Apache-2.0 licensed.
+
+### Fixed
+
+- The standalone receipt verifier (`python -m asqav.verifier.verify_receipt`)
+  now fails clean on missing, empty, or non-object input: it prints one readable
+  line and exits nonzero instead of leaking a urllib/json traceback, and it reads
+  a receipt from stdin via `--receipt -`. The verifier README worked example
+  points at the live public fixture `sig_example_regulator_cold_verify_2026`
+  (the previous example id returned 404).
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -259,14 +259,15 @@ The two SDKs are versioned and released independently.
 
 ## Verifying a receipt
 
-Receipts are portable. Anyone with a `signature_id` can verify it without an API key:
+Receipts are portable. Anyone with a `signature_id` can verify one without an API key. `verify()` returns the public verdict and recomputes the receipt's `chain_hash` on your machine (the SHA-256 over the RFC 8785 canonical payload), so the chain link is reproducible locally.
 
 Python:
 
 ```python
 import asqav
 
-result = asqav.verify("sig_a1b2c3")
+# The public fixture below needs no API key. Swap in your own signature_id.
+result = asqav.verify("sig_example_regulator_cold_verify_2026")
 assert result["verified"]
 print(result["agent_id"], result["chain_hash"])
 ```
@@ -276,12 +277,18 @@ TypeScript:
 ```ts
 import { verify } from "@asqav/sdk";
 
-const result = await verify("sig_a1b2c3");
+const result = await verify("sig_example_regulator_cold_verify_2026");
 console.assert(result.verified);
 console.log(result.agentId, result.chainHash);
 ```
 
-Or open the receipt's `verification_url` in a browser. Hashes are reproducible offline from the RFC 8785 payload, the JSON canonicalization format, so auditors do not need to trust Asqav's servers - the signature speaks for itself.
+From the command line, install the optional CLI extra (`pip install "asqav[cli]"`) and run:
+
+```bash
+asqav verify sig_example_regulator_cold_verify_2026
+```
+
+Or open the receipt's `verification_url` in a browser. For a fully offline, zero-trust check that reproduces the ML-DSA-65 signature itself, use `asqav.verify_receipt_offline(receipt, jwks)` in Python or `verifyReceiptOffline()` in TypeScript, or run the standalone `python -m asqav.verifier.verify_receipt --offline`. Every hash rederives from the RFC 8785 canonical payload, so auditors do not need to trust Asqav's servers.
 
 ## Verified by Asqav badge
 

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -126,6 +126,7 @@ from .client import (
     span,
     update_risk_rule,
     update_signing_group,
+    verify,
     verify_attestation,
     verify_compliance_receipt,
     verify_output,
@@ -229,6 +230,7 @@ __all__ = [
     # Session Listing
     "list_sessions",
     # Verification
+    "verify",
     "verify_signature",
     "verify_output",
     "VerificationDetail",

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -3420,6 +3420,45 @@ def verify_signature(signature_id: str) -> VerificationResponse:
     )
 
 
+def verify(signature_id: str) -> dict[str, Any]:
+    """Publicly verify a receipt by id and return a plain dict. No API key.
+
+    Fetches the public ``/verify/{id}`` verdict, then recomputes the receipt's
+    ``chain_hash`` locally: the SHA-256 over the RFC 8785 canonical payload,
+    the exact value a successor receipt carries as its ``previousReceiptHash``,
+    so the chain linkage is reproducible offline.
+
+    Args:
+        signature_id: The signature id to verify.
+
+    Returns:
+        dict with ``verified``, ``agent_id``, ``agent_name``, ``signature_id``,
+        ``algorithm``, ``verification_url``, and ``chain_hash`` (None when the
+        server does not expose the payload).
+
+    Example:
+        result = asqav.verify("sig_abc123")
+        assert result["verified"]
+        print(result["agent_id"], result["chain_hash"])
+    """
+    from ._jcs import canonical_json
+
+    resp = verify_signature(signature_id)
+    payload = resp.payload if isinstance(resp.payload, dict) else None
+    chain_hash = (
+        hashlib.sha256(canonical_json(payload)).hexdigest() if payload else None
+    )
+    return {
+        "verified": resp.verified,
+        "agent_id": resp.agent_id,
+        "agent_name": resp.agent_name,
+        "signature_id": resp.signature_id,
+        "algorithm": resp.algorithm,
+        "verification_url": resp.verification_url,
+        "chain_hash": chain_hash,
+    }
+
+
 @dataclass
 class ComplianceReceiptVerification:
     """Outcome of the SDK-side Compliance Receipt sanity check.

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -341,10 +341,16 @@ def check_anchors(envelope: dict):
     anchors = envelope.get("anchors") or []
     if not anchors:
         return "SKIPPED", "no anchors on this receipt"
+    if not isinstance(anchors, list):
+        return "FAIL", f"anchors field is not a list (got {type(anchors).__name__})"
     bound = hashlib.sha256(envelope_minus_anchors_jcs(envelope)).hexdigest()
     lines = [f"anchors bind envelope digest sha256:{bound[:16]}.."]
     all_ok = True
     for a in anchors:
+        if not isinstance(a, dict):
+            all_ok = False
+            lines.append(f"    - malformed anchor entry (got {type(a).__name__}, expected an object)")
+            continue
         atype = a.get("type", "?")
         val = a.get("value")
         ok = bool(val) and _safe_b64(val)

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -36,6 +36,7 @@ import base64
 import hashlib
 import json
 import sys
+import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 
@@ -108,12 +109,49 @@ def envelope_minus_anchors_jcs(env: dict) -> bytes:
     return canonical_json(e)
 
 
+class VerifierInputError(Exception):
+    """A receipt or JWKS input was missing, empty, or not a JSON object.
+
+    Raised so the CLI prints one readable line and exits nonzero rather than
+    leaking a urllib/json traceback on bad input.
+    """
+
+
+def _parse_object(text: str, source: str) -> dict:
+    """Parse ``text`` as a JSON object, or raise VerifierInputError.
+
+    Rejects empty input and any non-object (array/string/number/null) so a
+    later ``.get`` never lands on a non-dict.
+    """
+    if not text or not text.strip():
+        raise VerifierInputError(f"{source}: empty input, expected a JSON object")
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise VerifierInputError(f"{source}: not valid JSON ({exc})") from exc
+    if not isinstance(value, dict):
+        raise VerifierInputError(
+            f"{source}: expected a JSON object, got {type(value).__name__}"
+        )
+    return value
+
+
 def _get_json(url: str, *, timeout: int = 30) -> dict:
     req = urllib.request.Request(
         url, headers={"Accept": "application/json", "User-Agent": USER_AGENT}
     )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise VerifierInputError(
+            f"{url}: server returned HTTP {exc.code} {exc.reason}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise VerifierInputError(
+            f"{url}: could not reach the server ({exc.reason})"
+        ) from exc
+    return _parse_object(body, url)
 
 
 def fetch_jwks(url: str = JWKS_URL, *, timeout: int = 30) -> dict:
@@ -327,6 +365,14 @@ def check_structure(payload: dict):
 
 
 def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
+    if not isinstance(envelope, dict):
+        print("Asqav receipt verification")
+        print(
+            f"  [FAIL] input       expected a JSON object receipt, got "
+            f"{type(envelope).__name__}"
+        )
+        print("\n  => INCOMPLETE (no receipt object to verify; never a PASS)")
+        return 2
     envelope = normalise_envelope(envelope)
     payload = envelope.get("payload", envelope)
     if not isinstance(payload, dict):
@@ -412,6 +458,22 @@ def run_structured(
           - ``"canonical_sha256"``: hex SHA-256 of the canonical payload bytes
           - ``"kid"``: the signature key id resolved
     """
+    if not isinstance(envelope, dict):
+        return {
+            "verdict": "INCOMPLETE",
+            "axes": [
+                {
+                    "name": "input",
+                    "result": "FAIL",
+                    "note": (
+                        "expected a JSON object receipt, got "
+                        f"{type(envelope).__name__}"
+                    ),
+                }
+            ],
+            "canonical_sha256": None,
+            "kid": None,
+        }
     envelope = normalise_envelope(envelope)
     payload = envelope.get("payload", envelope)
     if not isinstance(payload, dict):
@@ -513,41 +575,51 @@ def run_structured(
 
 
 def _load(path: str) -> dict:
-    with open(path) as fh:
-        return json.load(fh)
+    if path == "-":
+        return _parse_object(sys.stdin.read(), "stdin")
+    try:
+        with open(path) as fh:
+            text = fh.read()
+    except OSError as exc:
+        raise VerifierInputError(f"{path}: {exc.strerror or exc}") from exc
+    return _parse_object(text, path)
 
 
 def main() -> int:
     p = argparse.ArgumentParser(description="Standalone Asqav receipt verifier.")
     p.add_argument("--id", help="signature id to fetch from api.asqav.com")
-    p.add_argument("--receipt", help="path to a saved receipt JSON")
-    p.add_argument("--jwks", help="path to a saved jwks.json (offline)")
+    p.add_argument("--receipt", help="path to a saved receipt JSON, or - for stdin")
+    p.add_argument("--jwks", help="path to a saved jwks.json, or - for stdin (offline)")
     p.add_argument(
         "--predecessor", help="path to predecessor receipt JSON for the chain check"
     )
     p.add_argument("--offline", action="store_true", help="never reach the network")
     args = p.parse_args()
 
-    if args.receipt:
-        envelope = _load(args.receipt)
-    elif args.id and not args.offline:
-        envelope = _get_json(f"{API_BASE}/verify/{args.id}")
-    else:
-        p.error("supply --receipt FILE, or --id ID without --offline")
-        return 2
+    try:
+        if args.receipt:
+            envelope = _load(args.receipt)
+        elif args.id and not args.offline:
+            envelope = _get_json(f"{API_BASE}/verify/{args.id}")
+        else:
+            p.error("supply --receipt FILE (or -), or --id ID without --offline")
+            return 2
 
-    if args.jwks:
-        jwks = _load(args.jwks)
-    elif not args.offline:
-        jwks = _get_json(JWKS_URL)
-    else:
-        p.error("offline mode needs --jwks FILE")
-        return 2
+        if args.jwks:
+            jwks = _load(args.jwks)
+        elif not args.offline:
+            jwks = _get_json(JWKS_URL)
+        else:
+            p.error("offline mode needs --jwks FILE")
+            return 2
 
-    predecessor_payload = None
-    if args.predecessor:
-        pred = _load(args.predecessor)
-        predecessor_payload = pred.get("payload", pred)
+        predecessor_payload = None
+        if args.predecessor:
+            pred = _load(args.predecessor)
+            predecessor_payload = pred.get("payload", pred)
+    except VerifierInputError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
     return run(envelope, jwks, predecessor_payload)
 

--- a/python/tests/test_verify_public_dict.py
+++ b/python/tests/test_verify_public_dict.py
@@ -1,0 +1,74 @@
+"""asqav.verify(id) returns a plain dict with a locally reproduced chain_hash.
+
+Regression guard for the goal9 flagship README example
+(``asqav.verify`` -> ``result["verified"]`` / ``result["agent_id"]`` /
+``result["chain_hash"]``). It must resolve to the real, no-key public verify
+path, and chain_hash must equal sha256(canonical_json(payload)).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav
+from asqav._jcs import canonical_json
+
+
+def _cloud_payload() -> dict:
+    return {
+        "type": "signature",
+        "signature_id": "sig_test_dict",
+        "agent_id": "agent_dict",
+        "agent_name": "dict-agent",
+        "action_id": "act_dict",
+        "action_type": "decision:approve",
+        "payload": {
+            "type": "protectmcp:decision",
+            "issued_at": "2026-05-04T09:14:22.118Z",
+            "issuer_id": "00000000000000000098",
+        },
+        "signature": "ZmFrZQ==",
+        "algorithm": "ML-DSA-65",
+        "signed_at": "2026-05-10T12:00:00+00:00",
+        "verified": True,
+        "verification_url": "https://www.asqav.com/verify/sig_test_dict",
+    }
+
+
+def _mock_httpx(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = payload
+    return response
+
+
+def test_verify_returns_plain_dict_shape() -> None:
+    payload = _cloud_payload()
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        result = asqav.verify("sig_test_dict")
+    assert isinstance(result, dict)
+    assert result["verified"] is True
+    assert result["agent_id"] == "agent_dict"
+    assert result["algorithm"] == "ML-DSA-65"
+    assert result["verification_url"].endswith("sig_test_dict")
+
+
+def test_verify_chain_hash_matches_local_canonical() -> None:
+    payload = _cloud_payload()
+    expected = hashlib.sha256(canonical_json(payload["payload"])).hexdigest()
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        result = asqav.verify("sig_test_dict")
+    assert result["chain_hash"] == expected
+
+
+def test_verify_chain_hash_none_when_no_payload() -> None:
+    payload = _cloud_payload()
+    payload["payload"] = None
+    with patch("asqav.client.httpx.get", return_value=_mock_httpx(payload)):
+        result = asqav.verify("sig_test_dict")
+    assert result["chain_hash"] is None

--- a/python/tests/test_verify_receipt_failclean.py
+++ b/python/tests/test_verify_receipt_failclean.py
@@ -63,3 +63,33 @@ def test_load_missing_file_raises_input_error() -> None:
     # A missing file surfaces as VerifierInputError, not a raw OSError traceback.
     with pytest.raises(vr.VerifierInputError):
         vr._load("/no/such/receipt/file.json")
+
+
+def test_check_anchors_rejects_non_list_string() -> None:
+    # A string "anchors" value must not crash check_anchors; it FAILs the axis.
+    result, note = vr.check_anchors({"anchors": "str"})
+    assert result == "FAIL"
+
+
+def test_check_anchors_rejects_non_dict_entries() -> None:
+    # A list of bare strings must not crash on a.get(); each entry FAILs the axis.
+    result, note = vr.check_anchors({"anchors": ["x"]})
+    assert result == "FAIL"
+
+
+def test_check_anchors_rejects_non_dict_entries_int() -> None:
+    result, note = vr.check_anchors({"anchors": [1]})
+    assert result == "FAIL"
+
+
+def test_run_structured_handles_malformed_anchors_string() -> None:
+    # printf '{"anchors":"str"}' | verify_receipt --receipt - must not raise.
+    envelope = {"payload": {"type": "x"}, "anchors": "str"}
+    out = vr.run_structured(envelope, {"keys": []})
+    assert out["verdict"] in ("FAIL", "INCOMPLETE")
+
+
+def test_run_structured_handles_malformed_anchor_entries() -> None:
+    envelope = {"payload": {"type": "x"}, "anchors": ["x"]}
+    out = vr.run_structured(envelope, {"keys": []})
+    assert out["verdict"] in ("FAIL", "INCOMPLETE")

--- a/python/tests/test_verify_receipt_failclean.py
+++ b/python/tests/test_verify_receipt_failclean.py
@@ -1,0 +1,65 @@
+"""Report tool fails clean on missing / empty / non-object input.
+
+Regression guard for the goal9 SDK example fix: verify_receipt must never leak
+a urllib/json traceback on bad input. It exits nonzero with one readable line,
+and reads a receipt from stdin via ``--receipt -``.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.verifier import verify_receipt as vr
+
+
+def test_run_rejects_non_object_envelope() -> None:
+    # A JSON array (non-object) must not crash run(); it returns 2 (INCOMPLETE).
+    assert vr.run([], {"keys": []}, None) == 2
+
+
+def test_run_structured_rejects_non_object() -> None:
+    out = vr.run_structured("not-an-object", {"keys": []})
+    assert out["verdict"] == "INCOMPLETE"
+    assert out["canonical_sha256"] is None
+
+
+def test_parse_object_rejects_array() -> None:
+    with pytest.raises(vr.VerifierInputError):
+        vr._parse_object("[]", "stdin")
+
+
+def test_parse_object_rejects_empty() -> None:
+    with pytest.raises(vr.VerifierInputError):
+        vr._parse_object("   ", "stdin")
+
+
+def test_parse_object_rejects_bad_json() -> None:
+    with pytest.raises(vr.VerifierInputError):
+        vr._parse_object("{not json", "stdin")
+
+
+def test_parse_object_accepts_object() -> None:
+    assert vr._parse_object('{"a": 1}', "stdin") == {"a": 1}
+
+
+def test_load_dash_reads_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO('{"a": 1}'))
+    assert vr._load("-") == {"a": 1}
+
+
+def test_load_dash_non_object_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO("[]"))
+    with pytest.raises(vr.VerifierInputError):
+        vr._load("-")
+
+
+def test_load_missing_file_raises_input_error() -> None:
+    # A missing file surfaces as VerifierInputError, not a raw OSError traceback.
+    with pytest.raises(vr.VerifierInputError):
+        vr._load("/no/such/receipt/file.json")

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./schema.js";
 import { runDetectors } from "./detectors.js";
 import { userAgentHeaders } from "./userAgent.js";
+import { deriveChainHash } from "./replay.js";
 
 export { SDK_VERSION, USER_AGENT, userAgentHeaders } from "./userAgent.js";
 
@@ -2396,6 +2397,53 @@ export async function verifySignature(signatureId: string): Promise<Verification
     signatureEnvelope: data.signature_envelope,
     anchors: data.anchors,
     algorithmRegistryVersion: data.algorithm_registry_version,
+  };
+}
+
+/**
+ * Publicly verify a receipt by id. No API key or `init()` required. Recomputes
+ * `chainHash` locally (sha256 of the RFC 8785 canonical payload) so the chain
+ * link stays reproducible offline.
+ */
+export async function verify(signatureId: string): Promise<{
+  verified: boolean;
+  agentId: string;
+  agentName?: string;
+  signatureId: string;
+  algorithm: string;
+  verificationUrl?: string;
+  chainHash: string | null;
+}> {
+  const url = `${DEFAULT_BASE_URL}/verify/${signatureId}`;
+  const response = await fetch(url, {
+    headers: { Accept: "application/json", ...userAgentHeaders() },
+  });
+  if (response.status === 404) throw new APIError("Signature not found", 404);
+  if (response.status >= 400) {
+    throw new APIError(await response.text(), response.status);
+  }
+  const data = (await response.json()) as {
+    signature_id: string;
+    agent_id: string;
+    agent_name?: string;
+    algorithm: string;
+    verified: boolean;
+    verification_url?: string;
+    payload?: unknown;
+  };
+  const payload = data.payload;
+  const chainHash =
+    payload !== null && typeof payload === "object" && !Array.isArray(payload)
+      ? deriveChainHash(payload as Record<string, unknown>)
+      : null;
+  return {
+    verified: requireField<boolean>(data, "verified"),
+    agentId: requireField<string>(data, "agent_id"),
+    agentName: data.agent_name,
+    signatureId: requireField<string>(data, "signature_id"),
+    algorithm: requireField<string>(data, "algorithm"),
+    verificationUrl: data.verification_url,
+    chainHash,
   };
 }
 

--- a/typescript/tests/verify-public.test.ts
+++ b/typescript/tests/verify-public.test.ts
@@ -1,0 +1,67 @@
+/** verify(id): public no-key verify-by-id with a locally reproduced chainHash. */
+
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { canonicalJson, verify } from "../src/index.js";
+
+const PAYLOAD = {
+  type: "protectmcp:decision",
+  issued_at: "2026-05-04T09:14:22.118Z",
+  issuer_id: "00000000000000000098",
+};
+
+function cloudResponse(): Record<string, unknown> {
+  return {
+    signature_id: "sig_test_dict",
+    agent_id: "agent_dict",
+    agent_name: "dict-agent",
+    algorithm: "ML-DSA-65",
+    verified: true,
+    verification_url: "https://www.asqav.com/verify/sig_test_dict",
+    payload: PAYLOAD,
+  };
+}
+
+function mockFetch(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("verify (public, no key)", () => {
+  it("returns a plain object with verified / agentId / verificationUrl", async () => {
+    vi.stubGlobal("fetch", mockFetch(200, cloudResponse()));
+    const r = await verify("sig_test_dict");
+    expect(r.verified).toBe(true);
+    expect(r.agentId).toBe("agent_dict");
+    expect(r.algorithm).toBe("ML-DSA-65");
+    expect(r.verificationUrl).toContain("sig_test_dict");
+  });
+
+  it("chainHash equals sha256(canonicalJson(payload))", async () => {
+    vi.stubGlobal("fetch", mockFetch(200, cloudResponse()));
+    const r = await verify("sig_test_dict");
+    const expected = createHash("sha256")
+      .update(canonicalJson(PAYLOAD))
+      .digest("hex");
+    expect(r.chainHash).toBe(expected);
+  });
+
+  it("chainHash is null when the payload is absent", async () => {
+    const body = cloudResponse();
+    delete body.payload;
+    vi.stubGlobal("fetch", mockFetch(200, body));
+    const r = await verify("sig_test_dict");
+    expect(r.chainHash).toBeNull();
+  });
+
+  it("throws on a 404 (unknown signature id)", async () => {
+    vi.stubGlobal("fetch", mockFetch(404, { detail: "Signature not found" }));
+    await expect(verify("sig_missing")).rejects.toThrow();
+  });
+});

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -40,14 +40,16 @@ python -m asqav.verifier.verify_receipt --id sig_abc123
 The public worked example needs no API key:
 
 ```bash
-python -m asqav.verifier.verify_receipt --id sig_example_loan_decision_2026
+python -m asqav.verifier.verify_receipt --id sig_example_regulator_cold_verify_2026
 ```
 
 This pulls `https://api.asqav.com/api/v1/verify/<id>` and
 `https://api.asqav.com/.well-known/jwks.json`, then prints a per-axis report.
-(The public `/verify/example` fixture ships a placeholder signature to document
-the receipt shape; point `--id` at one of your own signed receipts to exercise
-the full cryptographic path against a real signature.)
+This is a public documentation fixture. Its signing key is a reserved example
+identity that is not published in the public JWKS, so the offline verdict is a
+FAIL on issuer-key resolution rather than a green PASS. Point `--id` at one of
+your own signed receipts, whose agent key is in the JWKS, to run the full
+cryptographic path through to a PASS.
 
 ## Verify fully offline
 


### PR DESCRIPTION
## What and why

The flagship "Verifying a receipt" README example advertised `asqav.verify()` (Python) and a top-level `verify()` (TypeScript), neither of which existed, so a first-touch reader hit an AttributeError. The standalone verifier's worked example pointed at an id that now returns 404, so that command crashed with a raw urllib traceback.

This makes both examples real and makes the verifier fail clean.

- **New `verify(id)` in both halves.** `asqav.verify(signature_id)` and the top-level `verify()` export do a no-key public verify-by-id and return a plain dict or object with `verified`, `agent_id`, and a `chain_hash` recomputed locally (sha256 over the canonical JSON payload bytes, the value a successor receipt carries as its previous-receipt hash). Python delegates to the existing public `verify_signature`. TypeScript does a small raw fetch because its `request()` needs init and a key.
- **Fail-clean verifier.** `python -m asqav.verifier.verify_receipt` now prints one readable line and exits nonzero on missing, empty, or non-object input instead of leaking a traceback, and `--receipt -` reads a receipt from stdin.
- **Live worked example.** The verifier README points at the live public fixture. Its signing key is a reserved example identity that is not in the public JWKS, so the offline verdict is an honest FAIL on issuer-key resolution rather than a green PASS, and the README says so.
- **Docs.** The flagship block documents the optional `asqav[cli]` install for `asqav verify`.

Changes fold into the patch already staged in the version files (the registry is one release behind). New pytest and vitest tests cover both halves. Draft for review, no publish or tag.

## Proof of work

Check (a) documented no-key example, real structured verdict (not a crash):
```
$ python -m asqav.verifier.verify_receipt --id sig_example_regulator_cold_verify_2026
  [  ok] structure   required fields present; type protectmcp:decision
  [FAIL] issuer_key  kid '00000000000000000098' not in jwks directory
  [skip] signature   no issuer key to verify against
  => FAIL            (exit 1)
```

Check (b) report tool fails clean on non-object input, no traceback:
```
$ printf '[]' | python -m asqav.verifier.verify_receipt --receipt -
error: stdin: expected a JSON object, got list
$ echo $?
2
```

Check (c) new tests fail on the pre-fix tree, pass on this branch:
```
pre-fix (origin/main): 12 failed in 0.23s
this branch:           12 passed in 0.08s
```

Check (d) TypeScript verify() end-to-end against the built package (npm ci + build), real prod, no key:
```
$ node verify-e2e.mjs
verified:        true
agentId:         agt_example_public_fixture
chainHash:       09123775c81dae5ea34f706462a6f98d4f5b83311953a0e64250ab677b009646   (matches Python)
```

Regression: Python targeted suite 218 passed, TypeScript full suite 585 passed (45 files), tsc --noEmit clean, build clean.

Diff stat:
```
 CHANGELOG.md                                  |  15 ++++
 README.md                                     |  15 +++-
 python/src/asqav/__init__.py                  |   2 +
 python/src/asqav/client.py                    |  39 +++++++++
 python/src/asqav/verifier/verify_receipt.py   | 120 ++++++++++++++++++++------
 python/tests/test_verify_public_dict.py       |  74 ++++++++++++++++
 python/tests/test_verify_receipt_failclean.py |  65 ++++++++++++++
 typescript/src/index.ts                       |  48 +++++++++++
 typescript/tests/verify-public.test.ts        |  67 ++++++++++++++
 verifier/README.md                            |  10 ++-
 10 files changed, 423 insertions(+), 32 deletions(-)
```
