### PR TITLE
Complete the SDK fail-clean surface: crash shapes, anchors, CLI, TS parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-08
+
+Everything on `main` ships in this patch, so the entries below are consolidated
+here from the working set. The date refreshes at publish.
+
 ### Added
 
 - **Default-on LangChain governance (Python + TypeScript).**
@@ -26,6 +31,17 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   8785 canonical payload, the value a successor carries as `previousReceiptHash`)
   so the chain link is reproducible offline. The flagship README "Verifying a
   receipt" example now runs as written.
+- Added `tsx` as a TypeScript devDependency. It is the runner the
+  quickstart example already documents (`npx tsx quickstart.ts`).
+
+### Changed
+
+- Relicensed asqav-sdk from MIT to Elastic License 2.0 (ELv2) for versions
+  released after 0.8.0. ELv2 permits free use and modification but restricts
+  offering the SDK as a hosted or managed service to third parties.
+  Version 0.8.0 and all versions published before it remain MIT-licensed
+  irrevocably. The conformance test vectors in `conformance/` remain
+  Apache-2.0 licensed.
 
 ### Removed
 
@@ -38,35 +54,6 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   touch the `protectmcp:*` receipt vocabulary or the `mcp_proxy`
   capture-topology token, which stay as part of the wire contract.
 
-### Changed
-
-- Relicensed asqav-sdk from MIT to Elastic License 2.0 (ELv2) for versions
-  released after 0.8.0. ELv2 permits free use and modification but restricts
-  offering the SDK as a hosted or managed service to third parties.
-  Version 0.8.0 and all versions published before it remain MIT-licensed
-  irrevocably. The conformance test vectors in `conformance/` remain
-  Apache-2.0 licensed.
-
-### Fixed
-
-- The standalone receipt verifier (`python -m asqav.verifier.verify_receipt`)
-  now fails clean on missing, empty, or non-object input: it prints one readable
-  line and exits nonzero instead of leaking a urllib/json traceback, and it reads
-  a receipt from stdin via `--receipt -`. The verifier README worked example
-  points at the live public fixture `sig_example_regulator_cold_verify_2026`
-  (the previous example id returned 404).
-
-### Security
-
-- Offline receipt verification blocks backdating on revoked keys. A revoked
-  key with a `revoked_at` timestamp returns INCOMPLETE instead of PASS for
-  any receipt whose self-attested `issued_at` predates the revocation, unless
-  a trusted time anchor corroborates the timing. An attacker holding the
-  compromised key cannot re-sign with a backdated timestamp and read PASS
-  offline. (#362)
-
-## [0.8.1] - 2026-07-08
-
 ### Fixed
 
 - Required-field deserializer guards (Python + TypeScript). `Agent.sign()`,
@@ -76,11 +63,32 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   the cloud response omits a required field, instead of a raw `KeyError`
   (Python) or a silently `undefined` value (TypeScript). Both languages
   route through one shared guard, `require_field()` / `requireField()`.
+- The standalone receipt verifier (`python -m asqav.verifier.verify_receipt`)
+  now fails clean on missing, empty, or non-object input: it prints one readable
+  line and exits nonzero instead of leaking a urllib/json traceback, and it reads
+  a receipt from stdin via `--receipt -`. The verifier README worked example
+  points at the live public fixture `sig_example_regulator_cold_verify_2026`.
+- The standalone verifier and the offline `verify_receipt_offline` API now fail
+  clean on every remaining malformed-input shape: a NaN/Infinity receipt, a
+  non-object `signature` block, a malformed or `public_key`-less JWKS, a
+  non-string `sig`, a binary / non-UTF8 `--receipt` file, and a falsy non-list
+  `anchors` value (`{}`, `""`, `0`). Each prints one readable line with the
+  input-error exit code, and the offline API returns INCOMPLETE rather than
+  raising on a malformed JWKS.
+- The `asqav verify` CLI reports a connection or timeout failure as one readable
+  line and a nonzero exit, instead of a raw httpx traceback.
+- The public no-key `verify()` (TypeScript) targets the base URL configured via
+  `init()` and reads `ASQAV_API_URL` when no key is set, so it honors a custom
+  endpoint the same way the Python half does.
 
-### Added
+### Security
 
-- Added `tsx` as a TypeScript devDependency. It is the runner the
-  quickstart example already documents (`npx tsx quickstart.ts`).
+- Offline receipt verification blocks backdating on revoked keys. A revoked
+  key with a `revoked_at` timestamp returns INCOMPLETE instead of PASS for
+  any receipt whose self-attested `issued_at` predates the revocation, unless
+  a trusted time anchor corroborates the timing. An attacker holding the
+  compromised key cannot re-sign with a backdated timestamp and read PASS
+  offline. (#362)
 
 ## [0.8.0] - 2026-07-03
 

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -120,6 +120,9 @@ def verify(
     when the cloud emitted them.
     """
     import json as json_mod
+    import urllib.error
+
+    import httpx
 
     from asqav import APIError, verify_signature
 
@@ -130,6 +133,10 @@ def verify(
             print(f"Signature not found: {signature_id}")
             raise typer.Exit(code=1) from exc
         print(f"Error: {exc}")
+        raise typer.Exit(code=1) from exc
+    except (httpx.RequestError, urllib.error.URLError) as exc:
+        # Connection refused / DNS / timeout: one readable line, not a raw traceback.
+        print(f"Error: could not reach the Asqav API ({exc})")
         raise typer.Exit(code=1) from exc
 
     if output == "json":

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -103,6 +103,17 @@ def canonical_json(obj) -> bytes:
     ).encode("utf-8")
 
 
+def _describe_value(value) -> str:
+    """Short, safe description of a value's actual shape for an error message."""
+    if value is None:
+        return "null"
+    if isinstance(value, (bool, int, float, str)):
+        return f"{type(value).__name__} {value!r}"
+    if isinstance(value, list):
+        return f"list ({len(value)} item{'s' if len(value) != 1 else ''})"
+    return type(value).__name__
+
+
 def envelope_minus_anchors_jcs(env: dict) -> bytes:
     """JCS bytes of the envelope with ``anchors`` removed (the anchored bytes)."""
     e = dict(env)
@@ -116,13 +127,20 @@ def _contains_non_finite(obj) -> bool:
     ``canonical_json`` rejects those (allow_nan=False) and the server never
     emits one, so a receipt carrying one is reported as a readable input error
     rather than leaking the json ValueError from a canonicalisation call.
+
+    Iterative (explicit stack, no recursion): an arbitrarily deep receipt
+    must not blow the interpreter's recursion limit here.
     """
-    if isinstance(obj, float):
-        return not math.isfinite(obj)
-    if isinstance(obj, dict):
-        return any(_contains_non_finite(v) for v in obj.values())
-    if isinstance(obj, list):
-        return any(_contains_non_finite(v) for v in obj)
+    stack = [obj]
+    while stack:
+        cur = stack.pop()
+        if isinstance(cur, float):
+            if not math.isfinite(cur):
+                return True
+        elif isinstance(cur, dict):
+            stack.extend(cur.values())
+        elif isinstance(cur, list):
+            stack.extend(cur)
     return False
 
 
@@ -146,6 +164,10 @@ def _parse_object(text: str, source: str) -> dict:
         value = json.loads(text)
     except json.JSONDecodeError as exc:
         raise VerifierInputError(f"{source}: not valid JSON ({exc})") from exc
+    except RecursionError as exc:
+        # Some json decoder flavors (a pure-Python fallback) recurse per nesting
+        # level; a too-deep input is an input error, never a raw crash.
+        raise VerifierInputError(f"{source}: too deeply nested to parse ({exc})") from exc
     if not isinstance(value, dict):
         raise VerifierInputError(
             f"{source}: expected a JSON object, got {type(value).__name__}"
@@ -425,10 +447,10 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
         # redacted receipts). Nothing to verify; say so instead of crashing.
         print("Asqav receipt verification")
         print(
-            "  [FAIL] payload      receipt payload not available from this "
-            "surface (the server returned payload: null). Verify with a saved "
-            "receipt instead: --receipt FILE from your Audit Pack or SDK "
-            "capture."
+            f"  [FAIL] payload      receipt payload not available from this "
+            f"surface (got {_describe_value(payload)} instead of an object). "
+            f"Verify with a saved receipt instead: --receipt FILE from your "
+            f"Audit Pack or SDK capture."
         )
         print("\n  => INCOMPLETE (no payload to verify; never a PASS)")
         return 2
@@ -543,8 +565,8 @@ def run_structured(
                     "result": "FAIL",
                     "note": (
                         "receipt payload not available from this surface "
-                        "(the server returned payload: null). Verify with a saved "
-                        "receipt instead."
+                        f"(got {_describe_value(payload)} instead of an object). "
+                        "Verify with a saved receipt instead."
                     ),
                 }
             ],

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -35,6 +35,7 @@ import argparse
 import base64
 import hashlib
 import json
+import math
 import sys
 import urllib.error
 import urllib.request
@@ -107,6 +108,22 @@ def envelope_minus_anchors_jcs(env: dict) -> bytes:
     e = dict(env)
     e.pop("anchors", None)
     return canonical_json(e)
+
+
+def _contains_non_finite(obj) -> bool:
+    """True if any float inside ``obj`` is NaN or Infinity.
+
+    ``canonical_json`` rejects those (allow_nan=False) and the server never
+    emits one, so a receipt carrying one is reported as a readable input error
+    rather than leaking the json ValueError from a canonicalisation call.
+    """
+    if isinstance(obj, float):
+        return not math.isfinite(obj)
+    if isinstance(obj, dict):
+        return any(_contains_non_finite(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_contains_non_finite(v) for v in obj)
+    return False
 
 
 class VerifierInputError(Exception):
@@ -219,7 +236,9 @@ def normalise_envelope(raw: dict) -> dict:
     return {
         "payload": payload,
         "signature": sig_obj,
-        "anchors": raw.get("anchors") or [],
+        # Preserve the raw anchors value (even a malformed {} / "" / 0) so
+        # check_anchors sees it and can FAIL it, rather than laundering to [].
+        "anchors": raw.get("anchors"),
     }
 
 
@@ -227,11 +246,21 @@ def resolve_key(jwks: dict, kid: str):
     """Return (public_key_bytes, status, alg) for the receipt's signature.kid.
 
     The public jwks directory lists each key under both its bare issuer id and
-    its crypto key id; match either so the bare-kid wire form resolves.
+    its crypto key id; match either so the bare-kid wire form resolves. A
+    non-list ``keys``, a non-dict entry, or a matched key with no usable
+    ``public_key`` is a resolution failure (returns None), never a crash.
     """
-    for k in jwks.get("keys", []):
+    keys = jwks.get("keys") if isinstance(jwks, dict) else None
+    if not isinstance(keys, list):
+        return None, None, None
+    for k in keys:
+        if not isinstance(k, dict):
+            continue
         if kid and kid in (k.get("issuer_id"), k.get("kid")):
-            return _b64decode(k["public_key"]), k.get("status"), k.get("alg")
+            pub = k.get("public_key")
+            if not isinstance(pub, str):
+                continue
+            return _b64decode(pub), k.get("status"), k.get("alg")
     return None, None, None
 
 
@@ -239,9 +268,15 @@ def resolve_revoked_at(jwks: dict, kid: str):
     """Return the JWKS revoked_at for kid if published, else None.
 
     Optional field: the public JWKS publishes status today but not the
-    timestamp, so the key-status axis falls back to a bare status gate.
+    timestamp, so the key-status axis falls back to a bare status gate. Shares
+    resolve_key's defensive shape so a malformed JWKS never crashes a direct call.
     """
-    for k in jwks.get("keys", []):
+    keys = jwks.get("keys") if isinstance(jwks, dict) else None
+    if not isinstance(keys, list):
+        return None
+    for k in keys:
+        if not isinstance(k, dict):
+            continue
         if kid and kid in (k.get("issuer_id"), k.get("kid")):
             return k.get("revoked_at")
     return None
@@ -338,11 +373,15 @@ def check_chain(payload: dict, predecessor_payload: dict | None):
 
 
 def check_anchors(envelope: dict):
-    anchors = envelope.get("anchors") or []
-    if not anchors:
+    anchors = envelope.get("anchors")
+    # Absent/null is a legitimate no-anchors receipt (SKIPPED); a present
+    # non-list value ({} / "" / 0) is malformed and FAILs, never laundered to [].
+    if anchors is None:
         return "SKIPPED", "no anchors on this receipt"
     if not isinstance(anchors, list):
         return "FAIL", f"anchors field is not a list (got {type(anchors).__name__})"
+    if not anchors:
+        return "SKIPPED", "no anchors on this receipt"
     bound = hashlib.sha256(envelope_minus_anchors_jcs(envelope)).hexdigest()
     lines = [f"anchors bind envelope digest sha256:{bound[:16]}.."]
     all_ok = True
@@ -393,6 +432,14 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
         )
         print("\n  => INCOMPLETE (no payload to verify; never a PASS)")
         return 2
+    if _contains_non_finite(envelope) or _contains_non_finite(predecessor_payload):
+        print("Asqav receipt verification")
+        print(
+            "  [FAIL] input       receipt carries a non-finite number "
+            "(NaN/Infinity); it cannot be canonicalised"
+        )
+        print("\n  => INCOMPLETE (receipt not canonicalisable; never a PASS)")
+        return 2
     sig_obj = envelope.get("signature", {})
     if isinstance(sig_obj, str):  # flat-string signature, derive the object
         sig_obj = {
@@ -400,6 +447,10 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
             "kid": payload.get("issuer_id", ""),
             "sig": sig_obj,
         }
+    elif not isinstance(sig_obj, dict):
+        # A non-object signature (list, number, ...) carries no kid/sig; key
+        # resolution then FAILs cleanly instead of .get on a non-dict.
+        sig_obj = {}
     kid = sig_obj.get("kid", "")
     alg = sig_obj.get("alg", "ML-DSA-65")
     msg = canonical_json(payload)
@@ -418,7 +469,8 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
         results.append(
             ("key_status", *check_key_status(status, payload.get("issued_at", ""), revoked_at, _has_anchor))
         )
-        sig = _b64decode(sig_obj.get("sig", ""))
+        _raw_sig = sig_obj.get("sig", "")
+        sig = _b64decode(_raw_sig) if isinstance(_raw_sig, str) else b""
         results.append(("signature", *verify_signature(pk, msg, sig, alg or jwks_alg)))
 
     results.append(("chain", *check_chain(payload, predecessor_payload)))
@@ -499,6 +551,19 @@ def run_structured(
             "canonical_sha256": None,
             "kid": None,
         }
+    if _contains_non_finite(envelope) or _contains_non_finite(predecessor_payload):
+        return {
+            "verdict": "INCOMPLETE",
+            "axes": [
+                {
+                    "name": "input",
+                    "result": "FAIL",
+                    "note": "receipt carries a non-finite number (NaN/Infinity); it cannot be canonicalised",
+                }
+            ],
+            "canonical_sha256": None,
+            "kid": None,
+        }
 
     sig_obj = envelope.get("signature", {})
     if isinstance(sig_obj, str):
@@ -507,6 +572,8 @@ def run_structured(
             "kid": payload.get("issuer_id", ""),
             "sig": sig_obj,
         }
+    elif not isinstance(sig_obj, dict):
+        sig_obj = {}  # non-object signature: no usable kid/sig, key resolution FAILs cleanly
     kid = sig_obj.get("kid", "")
     alg = sig_obj.get("alg", "ML-DSA-65")
     msg = canonical_json(payload)
@@ -550,7 +617,8 @@ def run_structured(
             status, payload.get("issued_at", ""), revoked_at, _has_anchor
         )
         axes.append({"name": "key_status", "result": ks_r, "note": ks_n})
-        sig_bytes = _b64decode(sig_obj.get("sig", ""))
+        _raw_sig = sig_obj.get("sig", "")
+        sig_bytes = _b64decode(_raw_sig) if isinstance(_raw_sig, str) else b""
         sig_r, sig_n = verify_signature(pk, msg, sig_bytes, alg or jwks_alg)
         axes.append({"name": "signature", "result": sig_r, "note": sig_n})
 
@@ -584,10 +652,12 @@ def _load(path: str) -> dict:
     if path == "-":
         return _parse_object(sys.stdin.read(), "stdin")
     try:
-        with open(path) as fh:
+        with open(path, encoding="utf-8") as fh:
             text = fh.read()
     except OSError as exc:
         raise VerifierInputError(f"{path}: {exc.strerror or exc}") from exc
+    except UnicodeDecodeError as exc:
+        raise VerifierInputError(f"{path}: not valid UTF-8 text ({exc})") from exc
     return _parse_object(text, path)
 
 

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -88,6 +88,11 @@ ALLOWED_TYPES = {
 }
 
 
+#: Nesting depth above which a receipt is malformed input, not a crash; the
+#: stdlib json encoder recurses per level and crashes past ~1000 on Python <= 3.12.
+MAX_NESTING_DEPTH = 200
+
+
 def canonical_json(obj) -> bytes:
     """JCS canonical bytes - byte-identical to the server's canonical_json.
 
@@ -104,11 +109,15 @@ def canonical_json(obj) -> bytes:
 
 
 def _describe_value(value) -> str:
-    """Short, safe description of a value's actual shape for an error message."""
+    """Short, safe description of a value's actual shape for an error message.
+
+    Truncated so a huge string payload cannot blow up the error line itself.
+    """
     if value is None:
         return "null"
     if isinstance(value, (bool, int, float, str)):
-        return f"{type(value).__name__} {value!r}"
+        text = f"{type(value).__name__} {value!r}"
+        return text if len(text) <= 80 else text[:77] + "..."
     if isinstance(value, list):
         return f"list ({len(value)} item{'s' if len(value) != 1 else ''})"
     return type(value).__name__
@@ -121,27 +130,45 @@ def envelope_minus_anchors_jcs(env: dict) -> bytes:
     return canonical_json(e)
 
 
+def _scan_shape(obj, max_depth: int | None = None) -> str | None:
+    """Iteratively walk ``obj``; returns "non_finite", "too_deep", or None (ok).
+
+    Explicit stack, no recursion: depth alone cannot crash this walk. With
+    ``max_depth`` set, nesting past it stops the walk and reports "too_deep"
+    before the caller can hand the structure to the recursive stdlib json
+    encoder (canonical_json), which crashes past ~1000 levels on Python's C
+    encoder for versions <= 3.12.
+    """
+    stack = [(obj, 0)]
+    while stack:
+        cur, depth = stack.pop()
+        if max_depth is not None and depth > max_depth:
+            return "too_deep"
+        if isinstance(cur, float):
+            if not math.isfinite(cur):
+                return "non_finite"
+        elif isinstance(cur, dict):
+            stack.extend((v, depth + 1) for v in cur.values())
+        elif isinstance(cur, list):
+            stack.extend((v, depth + 1) for v in cur)
+    return None
+
+
 def _contains_non_finite(obj) -> bool:
     """True if any float inside ``obj`` is NaN or Infinity.
 
     ``canonical_json`` rejects those (allow_nan=False) and the server never
     emits one, so a receipt carrying one is reported as a readable input error
     rather than leaking the json ValueError from a canonicalisation call.
-
-    Iterative (explicit stack, no recursion): an arbitrarily deep receipt
-    must not blow the interpreter's recursion limit here.
     """
-    stack = [obj]
-    while stack:
-        cur = stack.pop()
-        if isinstance(cur, float):
-            if not math.isfinite(cur):
-                return True
-        elif isinstance(cur, dict):
-            stack.extend(cur.values())
-        elif isinstance(cur, list):
-            stack.extend(cur)
-    return False
+    return _scan_shape(obj) == "non_finite"
+
+
+#: Shape-check outcome -> the readable message run()/run_structured() print.
+_SHAPE_MESSAGES = {
+    "non_finite": "receipt carries a non-finite number (NaN/Infinity); it cannot be canonicalised",
+    "too_deep": f"receipt nesting exceeds the supported depth (> {MAX_NESTING_DEPTH} levels)",
+}
 
 
 class VerifierInputError(Exception):
@@ -388,7 +415,12 @@ def check_chain(payload: dict, predecessor_payload: dict | None):
         return "PASS", "first receipt on chain (all-zero seed)"
     if predecessor_payload is None:
         return "SKIPPED", "no predecessor supplied (pass --predecessor to check)"
-    actual = hashlib.sha256(canonical_json(predecessor_payload)).hexdigest()
+    try:
+        actual = hashlib.sha256(canonical_json(predecessor_payload)).hexdigest()
+    except RecursionError:
+        # Defense in depth: the caller's depth-cap gate should already have
+        # rejected this; this stops a bypassing call from crashing here too.
+        return "FAIL", "predecessor payload too deeply nested to canonicalise"
     if actual == prev:
         return "PASS", "chain link rederives from predecessor"
     return "FAIL", f"chain break: expected {str(prev)[:16]}.. got {actual[:16]}.."
@@ -404,7 +436,11 @@ def check_anchors(envelope: dict):
         return "FAIL", f"anchors field is not a list (got {type(anchors).__name__})"
     if not anchors:
         return "SKIPPED", "no anchors on this receipt"
-    bound = hashlib.sha256(envelope_minus_anchors_jcs(envelope)).hexdigest()
+    try:
+        bound = hashlib.sha256(envelope_minus_anchors_jcs(envelope)).hexdigest()
+    except RecursionError:
+        # Defense in depth, same rationale as check_chain's guard above.
+        return "FAIL", "envelope too deeply nested to canonicalise for anchor binding"
     lines = [f"anchors bind envelope digest sha256:{bound[:16]}.."]
     all_ok = True
     for a in anchors:
@@ -454,12 +490,12 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
         )
         print("\n  => INCOMPLETE (no payload to verify; never a PASS)")
         return 2
-    if _contains_non_finite(envelope) or _contains_non_finite(predecessor_payload):
+    shape = _scan_shape(envelope, max_depth=MAX_NESTING_DEPTH)
+    if shape is None:
+        shape = _scan_shape(predecessor_payload, max_depth=MAX_NESTING_DEPTH)
+    if shape is not None:
         print("Asqav receipt verification")
-        print(
-            "  [FAIL] input       receipt carries a non-finite number "
-            "(NaN/Infinity); it cannot be canonicalised"
-        )
+        print(f"  [FAIL] input       {_SHAPE_MESSAGES[shape]}")
         print("\n  => INCOMPLETE (receipt not canonicalisable; never a PASS)")
         return 2
     sig_obj = envelope.get("signature", {})
@@ -475,7 +511,15 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
         sig_obj = {}
     kid = sig_obj.get("kid", "")
     alg = sig_obj.get("alg", "ML-DSA-65")
-    msg = canonical_json(payload)
+    try:
+        msg = canonical_json(payload)
+    except RecursionError:
+        # Defense in depth: the shape gate above should already have caught
+        # this; this stops a bypassing caller from crashing here too.
+        print("Asqav receipt verification")
+        print(f"  [FAIL] input       {_SHAPE_MESSAGES['too_deep']}")
+        print("\n  => INCOMPLETE (receipt not canonicalisable; never a PASS)")
+        return 2
 
     results = []
     results.append(("structure", *check_structure(payload)))
@@ -573,16 +617,13 @@ def run_structured(
             "canonical_sha256": None,
             "kid": None,
         }
-    if _contains_non_finite(envelope) or _contains_non_finite(predecessor_payload):
+    shape = _scan_shape(envelope, max_depth=MAX_NESTING_DEPTH)
+    if shape is None:
+        shape = _scan_shape(predecessor_payload, max_depth=MAX_NESTING_DEPTH)
+    if shape is not None:
         return {
             "verdict": "INCOMPLETE",
-            "axes": [
-                {
-                    "name": "input",
-                    "result": "FAIL",
-                    "note": "receipt carries a non-finite number (NaN/Infinity); it cannot be canonicalised",
-                }
-            ],
+            "axes": [{"name": "input", "result": "FAIL", "note": _SHAPE_MESSAGES[shape]}],
             "canonical_sha256": None,
             "kid": None,
         }
@@ -598,7 +639,16 @@ def run_structured(
         sig_obj = {}  # non-object signature: no usable kid/sig, key resolution FAILs cleanly
     kid = sig_obj.get("kid", "")
     alg = sig_obj.get("alg", "ML-DSA-65")
-    msg = canonical_json(payload)
+    try:
+        msg = canonical_json(payload)
+    except RecursionError:
+        # Defense in depth; the shape gate above should already have caught this.
+        return {
+            "verdict": "INCOMPLETE",
+            "axes": [{"name": "input", "result": "FAIL", "note": _SHAPE_MESSAGES["too_deep"]}],
+            "canonical_sha256": None,
+            "kid": None,
+        }
 
     axes: list[dict] = []
     axes.append(

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -76,6 +76,18 @@ def test_verify_not_found(mock_verify: MagicMock) -> None:
     assert "not found" in result.output.lower()
 
 
+@patch("asqav.verify_signature")
+def test_verify_network_failure_readable(mock_verify: MagicMock) -> None:
+    """A transport failure prints one readable line and exits nonzero, never a
+    raw httpx traceback (the command caught only APIError before)."""
+    import httpx
+
+    mock_verify.side_effect = httpx.ConnectError("Connection refused")
+    result = runner.invoke(app, ["verify", "sig_x"])
+    assert result.exit_code == 1
+    assert "could not reach" in result.output.lower()
+
+
 # === sign command (IETF Compliance Receipts profile) ===
 
 

--- a/python/tests/test_offline_verify.py
+++ b/python/tests/test_offline_verify.py
@@ -304,3 +304,31 @@ def test_run_structured_directly():
     assert result["verdict"] in ("PASS", "INCOMPLETE")
     assert isinstance(result["axes"], list)
     assert result["canonical_sha256"] is not None
+
+
+# criterion 446: a malformed JWKS must not crash the public offline API. Each
+# reached verify_receipt.resolve_key via asqav_native.py and raised before the guard.
+
+
+def test_offline_api_missing_public_key_no_crash():
+    """A JWK with a matching kid but no public_key field resolves as a failure,
+    not a KeyError out of the public API."""
+    receipt = _load(PASS_VECTOR / "receipt.json")
+    kid = receipt["signature"]["kid"]
+    jwks = {"keys": [{"kid": kid, "kty": "OKP", "crv": "Ed25519", "x": "abc"}]}
+    result = asqav.verify_receipt_offline(receipt, jwks)
+    assert result["verdict"] in ("FAIL", "INCOMPLETE")
+    sig_axis = next(a for a in result["axes"] if a["name"] == "signature")
+    assert sig_axis["result"] in ("FAIL", "SKIPPED")
+
+
+def test_offline_api_keys_is_string_no_crash():
+    receipt = _load(PASS_VECTOR / "receipt.json")
+    result = asqav.verify_receipt_offline(receipt, {"keys": "abc"})
+    assert isinstance(result["verdict"], str)
+
+
+def test_offline_api_keys_is_list_of_ints_no_crash():
+    receipt = _load(PASS_VECTOR / "receipt.json")
+    result = asqav.verify_receipt_offline(receipt, {"keys": [123]})
+    assert isinstance(result["verdict"], str)

--- a/python/tests/test_verify_receipt_failclean.py
+++ b/python/tests/test_verify_receipt_failclean.py
@@ -306,17 +306,41 @@ def test_contains_non_finite_survives_very_deep_nesting() -> None:
     assert vr._contains_non_finite(_deep_dict(4000)) is False
 
 
+def test_scan_shape_flags_too_deep() -> None:
+    # The depth-capped walk must reject nesting past MAX_NESTING_DEPTH before
+    # any caller can hand the structure to the recursive json encoder.
+    deep = _deep_dict(vr.MAX_NESTING_DEPTH + 50)
+    assert vr._scan_shape(deep, max_depth=vr.MAX_NESTING_DEPTH) == "too_deep"
+
+
+def test_scan_shape_ok_under_the_cap() -> None:
+    shallow = _deep_dict(vr.MAX_NESTING_DEPTH - 50)
+    assert vr._scan_shape(shallow, max_depth=vr.MAX_NESTING_DEPTH) is None
+
+
 def test_run_deep_nesting_no_recursion_error(capsys) -> None:
-    # End-to-end: a deeply nested receipt must reach a verdict, never crash.
+    # Version-independent: rejected as malformed input before canonical_json
+    # (json.dumps) ever sees it, so no dependence on the encoder's own limits.
     env = {"payload": {"a": _deep_dict(1500)}, "signature": _sig(), "anchors": []}
     code = vr.run(env, {"keys": []}, None)
-    assert code in (1, 2)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "nesting exceeds" in out
 
 
 def test_run_structured_deep_nesting_no_recursion_error() -> None:
     env = {"payload": {"a": _deep_dict(1500)}, "signature": _sig(), "anchors": []}
     out = vr.run_structured(env, {"keys": []})
-    assert out["verdict"] in ("FAIL", "INCOMPLETE")
+    assert out["verdict"] == "INCOMPLETE"
+    assert "nesting exceeds" in out["axes"][0]["note"]
+
+
+def test_run_deep_predecessor_no_recursion_error() -> None:
+    # The predecessor argument is a separate object from envelope; it must be
+    # depth-checked too, since check_chain canonicalises it independently.
+    env = {"payload": _payload(), "signature": _sig(), "anchors": []}
+    code = vr.run(env, {"keys": []}, {"a": _deep_dict(1500)})
+    assert code == 2
 
 
 def test_parse_object_recursion_error_becomes_input_error(monkeypatch) -> None:
@@ -328,6 +352,28 @@ def test_parse_object_recursion_error_becomes_input_error(monkeypatch) -> None:
     monkeypatch.setattr(vr.json, "loads", _boom)
     with pytest.raises(vr.VerifierInputError):
         vr._parse_object('{"a": 1}', "stdin")
+
+
+def test_canonical_json_recursion_error_becomes_incomplete(monkeypatch, capsys) -> None:
+    # Defense-in-depth: even if canonical_json itself raises RecursionError
+    # (a bypassed or future call path), run() must still report cleanly.
+    def _boom(*a, **kw):
+        raise RecursionError("maximum recursion depth exceeded while encoding a JSON object")
+
+    monkeypatch.setattr(vr.json, "dumps", _boom)
+    env = {"payload": _payload(), "signature": _sig(), "anchors": []}
+    code = vr.run(env, {"keys": []}, None)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "nesting exceeds" in out
+
+
+def test_describe_value_truncates_huge_string() -> None:
+    # A multi-megabyte string payload must not blow up the error line itself.
+    huge = "x" * (2 * 1024 * 1024)
+    text = vr._describe_value(huge)
+    assert len(text) <= 85
+    assert "..." in text
 
 
 # === advisory: the payload-not-an-object message names the actual type ===

--- a/python/tests/test_verify_receipt_failclean.py
+++ b/python/tests/test_verify_receipt_failclean.py
@@ -283,3 +283,74 @@ def test_end_to_end_reconstruct_path_falsy_anchors(tmp_path, monkeypatch, capsys
     vr.main()
     out = capsys.readouterr().out
     assert "[FAIL] anchors" in out
+
+
+# === regression: _contains_non_finite must not blow the recursion limit ===
+
+
+def _deep_dict(depth: int) -> dict:
+    d: dict = {"a": 1.0}
+    for _ in range(depth):
+        d = {"a": d}
+    return d
+
+
+def test_contains_non_finite_survives_deep_nesting() -> None:
+    # A ~1500-deep payload used to raise RecursionError out of the (recursive)
+    # guard itself; the iterative walk must return a plain bool instead.
+    deep = _deep_dict(1500)
+    assert vr._contains_non_finite(deep) is False
+
+
+def test_contains_non_finite_survives_very_deep_nesting() -> None:
+    assert vr._contains_non_finite(_deep_dict(4000)) is False
+
+
+def test_run_deep_nesting_no_recursion_error(capsys) -> None:
+    # End-to-end: a deeply nested receipt must reach a verdict, never crash.
+    env = {"payload": {"a": _deep_dict(1500)}, "signature": _sig(), "anchors": []}
+    code = vr.run(env, {"keys": []}, None)
+    assert code in (1, 2)
+
+
+def test_run_structured_deep_nesting_no_recursion_error() -> None:
+    env = {"payload": {"a": _deep_dict(1500)}, "signature": _sig(), "anchors": []}
+    out = vr.run_structured(env, {"keys": []})
+    assert out["verdict"] in ("FAIL", "INCOMPLETE")
+
+
+def test_parse_object_recursion_error_becomes_input_error(monkeypatch) -> None:
+    # Defense-in-depth: json.loads itself raising RecursionError (a pure-Python
+    # decoder fallback) must surface as VerifierInputError, not crash the CLI.
+    def _boom(text):
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(vr.json, "loads", _boom)
+    with pytest.raises(vr.VerifierInputError):
+        vr._parse_object('{"a": 1}', "stdin")
+
+
+# === advisory: the payload-not-an-object message names the actual type ===
+
+
+def test_run_payload_int_names_actual_type(capsys) -> None:
+    code = vr.run({"payload": 42, "signature": "x"}, {"keys": []}, None)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "int" in out
+    assert "42" in out
+
+
+def test_run_payload_string_names_actual_type(capsys) -> None:
+    code = vr.run({"payload": "hello", "signature": "x"}, {"keys": []}, None)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "str" in out
+    assert "hello" in out
+
+
+def test_run_structured_payload_list_names_actual_type() -> None:
+    out = vr.run_structured({"payload": [1, 2, 3], "signature": "x"}, {"keys": []})
+    assert out["verdict"] == "INCOMPLETE"
+    note = out["axes"][0]["note"]
+    assert "list" in note

--- a/python/tests/test_verify_receipt_failclean.py
+++ b/python/tests/test_verify_receipt_failclean.py
@@ -93,3 +93,193 @@ def test_run_structured_handles_malformed_anchor_entries() -> None:
     envelope = {"payload": {"type": "x"}, "anchors": ["x"]}
     out = vr.run_structured(envelope, {"keys": []})
     assert out["verdict"] in ("FAIL", "INCOMPLETE")
+
+
+# === criterion 446: complete the fail-clean surface ===
+
+# S1: NaN / Infinity inside the receipt (canonical_json rejects them, allow_nan=False)
+
+
+def _payload() -> dict:
+    return {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-05-04T09:14:22.000000Z",
+        "issuer_id": "kid-x",
+        "action_ref": "sha256:" + "8" * 64,
+        "payload_digest": {"hash": "8" * 64, "size": 512},
+        "policy_digest": "sha256:" + "3" * 64,
+        "previousReceiptHash": "0" * 64,
+        "decision": "observation",
+    }
+
+
+def _sig() -> dict:
+    return {"alg": "ML-DSA-65", "kid": "kid-x", "sig": "AAAA"}
+
+
+def test_run_nan_in_payload_fails_clean(capsys) -> None:
+    # A non-finite float in the payload must not raise ValueError out of run().
+    env = {"payload": {**_payload(), "score": float("nan")}, "signature": _sig(), "anchors": []}
+    code = vr.run(env, {"keys": []}, None)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "non-finite" in out.lower()
+    assert "PASS" not in out.replace("never a PASS", "")
+
+
+def test_run_infinity_in_payload_fails_clean(capsys) -> None:
+    env = {"payload": {**_payload(), "score": float("inf")}, "signature": _sig(), "anchors": []}
+    code = vr.run(env, {"keys": []}, None)
+    assert code == 2
+
+
+def test_run_structured_nan_fails_clean() -> None:
+    env = {"payload": {**_payload(), "score": float("nan")}, "signature": _sig(), "anchors": []}
+    out = vr.run_structured(env, {"keys": []})
+    assert out["verdict"] == "INCOMPLETE"
+
+
+# S2: non-dict "signature" on a flat receipt (no payload wrapper) -> kid = sig_obj.get(...)
+
+
+def test_run_non_dict_signature_fails_clean(capsys) -> None:
+    env = {**_payload(), "signature": [1, 2, 3]}
+    code = vr.run(env, {"keys": []}, None)
+    assert code != 0  # never a PASS, never an AttributeError
+
+
+def test_run_structured_non_dict_signature_fails_clean() -> None:
+    env = {**_payload(), "signature": [1, 2, 3]}
+    out = vr.run_structured(env, {"keys": []})
+    assert out["verdict"] in ("FAIL", "INCOMPLETE")
+
+
+# S3: malformed JWKS "keys" (string / list of non-dicts) -> resolve_key must not crash
+
+
+def test_resolve_key_keys_is_string() -> None:
+    assert vr.resolve_key({"keys": "abc"}, "kid-x") == (None, None, None)
+
+
+def test_resolve_key_keys_is_list_of_ints() -> None:
+    assert vr.resolve_key({"keys": [123]}, "kid-x") == (None, None, None)
+
+
+def test_resolve_revoked_at_malformed_keys_no_crash() -> None:
+    # The revoked_at helper shares the loop shape; guard it too so a direct call is safe.
+    assert vr.resolve_revoked_at({"keys": "abc"}, "kid-x") is None
+    assert vr.resolve_revoked_at({"keys": [123]}, "kid-x") is None
+
+
+# S4: a JWK whose matching key lacks "public_key" -> resolution failure, not KeyError
+
+
+def test_resolve_key_missing_public_key_no_crash() -> None:
+    jwks = {"keys": [{"kid": "kid-x", "kty": "OKP", "crv": "Ed25519", "x": "abc"}]}
+    assert vr.resolve_key(jwks, "kid-x") == (None, None, None)
+
+
+# S5: non-string "sig" with a resolvable kid -> _b64decode must not hit .replace on a non-str
+
+
+def _resolvable_jwks() -> dict:
+    return {"keys": [{"kid": "kid-x", "public_key": "AAAA", "alg": "ML-DSA-65", "status": "active"}]}
+
+
+def test_run_non_string_sig_fails_clean(capsys) -> None:
+    env = {"payload": _payload(), "signature": {"alg": "ML-DSA-65", "kid": "kid-x", "sig": 123}, "anchors": []}
+    code = vr.run(env, _resolvable_jwks(), None)
+    out = capsys.readouterr().out
+    assert code != 0
+    assert "[  ok] issuer_key" in out  # the kid DID resolve; only the sig bytes are bad
+
+
+def test_run_structured_non_string_sig_fails_clean() -> None:
+    env = {"payload": _payload(), "signature": {"alg": "ML-DSA-65", "kid": "kid-x", "sig": 123}, "anchors": []}
+    out = vr.run_structured(env, _resolvable_jwks())
+    assert out["verdict"] in ("FAIL", "INCOMPLETE")
+
+
+# S6: binary / non-UTF8 --receipt file -> VerifierInputError, not a raw UnicodeDecodeError
+
+
+def test_load_binary_file_raises_input_error(tmp_path) -> None:
+    p = tmp_path / "binary.receipt"
+    p.write_bytes(b"\xff\xfe\x00\x01\x80\x81receipt")
+    with pytest.raises(vr.VerifierInputError):
+        vr._load(str(p))
+
+
+# Falsy-anchors laundering: {} / "" / 0 are malformed, not "no anchors"
+
+
+def test_check_anchors_empty_dict_is_malformed() -> None:
+    result, _ = vr.check_anchors({"anchors": {}})
+    assert result == "FAIL"
+
+
+def test_check_anchors_empty_string_is_malformed() -> None:
+    result, _ = vr.check_anchors({"anchors": ""})
+    assert result == "FAIL"
+
+
+def test_check_anchors_zero_is_malformed() -> None:
+    result, _ = vr.check_anchors({"anchors": 0})
+    assert result == "FAIL"
+
+
+def test_check_anchors_absent_is_skipped() -> None:
+    assert vr.check_anchors({})[0] == "SKIPPED"
+
+
+def test_check_anchors_null_is_skipped() -> None:
+    assert vr.check_anchors({"anchors": None})[0] == "SKIPPED"
+
+
+def test_check_anchors_empty_list_is_skipped() -> None:
+    assert vr.check_anchors({"anchors": []})[0] == "SKIPPED"
+
+
+def test_normalise_envelope_preserves_falsy_anchors() -> None:
+    # The reconstruct path must hand the malformed anchors value to check_anchors,
+    # not launder it to [] before the guard runs.
+    env = vr.normalise_envelope({"payload": _payload(), "anchors": {}})
+    assert env["anchors"] == {}
+
+
+def _write_receipt(tmp_path, anchors) -> tuple[str, str]:
+    import json
+
+    rp = tmp_path / "receipt.json"
+    jp = tmp_path / "jwks.json"
+    rp.write_text(json.dumps({"payload": _payload(), "signature": _sig(), "anchors": anchors}))
+    jp.write_text('{"keys": []}')
+    return str(rp), str(jp)
+
+
+@pytest.mark.parametrize("anchors", [{}, "", 0])
+def test_end_to_end_falsy_anchors_fail_malformed(tmp_path, monkeypatch, capsys, anchors) -> None:
+    # The contract's end-to-end proof: a --receipt file with a falsy non-list
+    # anchors value must reach check_anchors as malformed, through the whole tool.
+    rp, jp = _write_receipt(tmp_path, anchors)
+    monkeypatch.setattr(sys, "argv", ["verify_receipt.py", "--receipt", rp, "--jwks", jp, "--offline"])
+    vr.main()
+    out = capsys.readouterr().out
+    assert "[FAIL] anchors" in out
+    assert "not a list" in out
+
+
+def test_end_to_end_reconstruct_path_falsy_anchors(tmp_path, monkeypatch, capsys) -> None:
+    # No signature dict -> normalise_envelope reconstruct path -> proves the :222 fix.
+    import json
+
+    rp = tmp_path / "receipt.json"
+    jp = tmp_path / "jwks.json"
+    rp.write_text(json.dumps({"payload": _payload(), "anchors": {}}))
+    jp.write_text('{"keys": []}')
+    monkeypatch.setattr(
+        sys, "argv", ["verify_receipt.py", "--receipt", str(rp), "--jwks", str(jp), "--offline"]
+    )
+    vr.main()
+    out = capsys.readouterr().out
+    assert "[FAIL] anchors" in out

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -294,7 +294,9 @@ interface Config {
 
 const config: Config = {
   apiKey: null,
-  baseUrl: DEFAULT_BASE_URL,
+  // Seed the base URL from ASQAV_API_URL, matching the Python half's module-level
+  // _api_base, so keyless verify() honors the env without an init() call.
+  baseUrl: process.env.ASQAV_API_URL ?? DEFAULT_BASE_URL,
   mode: "full-payload",
   orgSalt: null,
 };
@@ -2414,7 +2416,7 @@ export async function verify(signatureId: string): Promise<{
   verificationUrl?: string;
   chainHash: string | null;
 }> {
-  const url = `${DEFAULT_BASE_URL}/verify/${signatureId}`;
+  const url = `${config.baseUrl.replace(/\/+$/, "")}/verify/${signatureId}`;
   const response = await fetch(url, {
     headers: { Accept: "application/json", ...userAgentHeaders() },
   });
@@ -2641,7 +2643,7 @@ export function verifyReceiptOffline(
 /** @internal - reset module state. Used in tests. */
 export function _resetForTests(): void {
   config.apiKey = null;
-  config.baseUrl = DEFAULT_BASE_URL;
+  config.baseUrl = process.env.ASQAV_API_URL ?? DEFAULT_BASE_URL;
   config.mode = "full-payload";
   config.orgSalt = null;
 }

--- a/typescript/tests/verify-public.test.ts
+++ b/typescript/tests/verify-public.test.ts
@@ -3,7 +3,7 @@
 import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { canonicalJson, verify } from "../src/index.js";
+import { _resetForTests, canonicalJson, init, verify } from "../src/index.js";
 
 const PAYLOAD = {
   type: "protectmcp:decision",
@@ -31,7 +31,11 @@ function mockFetch(status: number, body: unknown) {
   });
 }
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  _resetForTests();
+});
 
 describe("verify (public, no key)", () => {
   it("returns a plain object with verified / agentId / verificationUrl", async () => {
@@ -63,5 +67,28 @@ describe("verify (public, no key)", () => {
   it("throws on a 404 (unknown signature id)", async () => {
     vi.stubGlobal("fetch", mockFetch(404, { detail: "Signature not found" }));
     await expect(verify("sig_missing")).rejects.toThrow();
+  });
+});
+
+describe("verify (public) base URL resolution", () => {
+  it("targets the baseUrl configured through init(), not the hardcoded default", async () => {
+    const fetchMock = mockFetch(200, cloudResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    // init() throws without an apiKey, so pass a dummy one to redirect keyless verify.
+    init({ apiKey: "dummy_key", baseUrl: "https://custom.example/api/v1" });
+    await verify("sig_test_dict");
+    const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+    expect(calledUrl).toBe("https://custom.example/api/v1/verify/sig_test_dict");
+  });
+
+  it("honors ASQAV_API_URL keylessly, matching the Python half", async () => {
+    vi.stubEnv("ASQAV_API_URL", "https://envbase.example/api/v1");
+    vi.resetModules();
+    const mod = await import("../src/index.js");
+    const fetchMock = mockFetch(200, cloudResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    await mod.verify("sig_test_dict");
+    const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+    expect(calledUrl).toBe("https://envbase.example/api/v1/verify/sig_test_dict");
   });
 });


### PR DESCRIPTION
Completes the fail-clean surface across the standalone verifier, the public
offline API, the CLI, and TypeScript verify() parity.

## What changed

**Crash shapes in verify_receipt.py.** Six malformed-input shapes now print
one readable line with the input-error exit code instead of raising:
NaN/Infinity inside the receipt, a non-dict `signature` block, a malformed
JWKS (`keys` as a string or a list of non-dicts), a JWKS key that matches
the kid but carries no `public_key` (treated as a resolution failure, so it
stays crash-free), a non-string `sig` with a resolvable kid, and a binary /
non-UTF8 `--receipt` file. The same public_key-less and malformed-keys JWKS
shapes reach `asqav.verify_receipt_offline` through the oracle adapter; that
public API returns a structured INCOMPLETE result instead of raising.

**Falsy-anchors laundering.** `anchors: {}`, `""`, and `0` collapsed to a
"no anchors" skip both on the direct check and on the hosted-response
reconstruct path. `normalise_envelope` now preserves the raw value and
`check_anchors` gates on "is it a list" ahead of the emptiness check, so a
malformed `anchors` field fails as malformed end-to-end through the tool.

**CLI network failure.** `asqav verify <id>` only caught `APIError`, so a
connection or timeout failure surfaced as a raw httpx traceback. It now
also catches `httpx.RequestError` / `urllib.error.URLError` and prints one
readable line with a nonzero exit.

**TypeScript verify() base URL parity.** The top-level `verify()` hardcoded
the default base URL; it now routes through the configured `baseUrl`, same
as `verifySignature()`. Decision on keyless env parity: TypeScript gets full
parity, not config-only — `config.baseUrl` seeds from `ASQAV_API_URL` at
module load, mirroring the Python client's module-level base-URL resolution,
so a keyless `verify()` call honors the env var in both languages.

**CHANGELOG.** Folded every `[Unreleased]` entry into the dated pending-patch
section, since the next tag cut from main ships everything staged there. The
`[Unreleased]` header is left as an empty placeholder.

Every fix carries a fail-first test (shown red on the pre-fix tree, green
after the change).

## Proof of work

VERIFY-WITH (crash-shape probes, each with before/after, plus the network probe):

```
S1 NaN:    before ValueError from canonical_json                -> after "[FAIL] input ... non-finite" exit 2
S2 sig:    before AttributeError 'list' object has no 'get'      -> after "[FAIL] issuer_key" verdict FAIL exit 1
S3 jwks:   before AttributeError 'str'/'int' object has no 'get' -> after "[FAIL] issuer_key" verdict FAIL exit 1
S4 jwks:   before KeyError 'public_key'                          -> after "[FAIL] issuer_key" verdict FAIL exit 1
S5 sig:    before AttributeError 'int' object has no 'replace'   -> after issuer_key ok, "[FAIL] signature" exit 1
S6 file:   before UnicodeDecodeError                             -> after "not valid UTF-8 text" exit 2
anchors:   before "[skip] anchors no anchors" (all 4 falsy vals) -> after "[FAIL] anchors ... not a list"
offline API (public_key-less + malformed-keys JWKS): before KeyError/AttributeError -> after verdict INCOMPLETE, exit 0
CLI network (ASQAV_API_URL to a dead port): before a 260-line httpx traceback -> after "Error: could not reach the Asqav API" exit 1
```

Full suites in the worktree:

```
cd python && PYTHONPATH=src pytest -q
1323 passed in 15.32s

cd typescript && npx vitest run
Test Files  45 passed (45)
     Tests  587 passed (587)
```

TS parity tests (fail-first confirmed): stashed the `index.ts` change, re-ran
`vitest run tests/verify-public.test.ts -t "base URL resolution"` — 2 failed
(hardcoded default). Restored the change, all 6 pass.

CI-equivalent gates: `ruff check python/src` clean, `tsc --noEmit` clean,
`npm run build` (tsup) clean.

Diff stat: 8 files changed, 388 insertions(+), 44 deletions(-).

CI on this branch: pending at push time (not waited on; snapshot below).
