### PR TITLE
ci: build the typescript package in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
         working-directory: typescript
       - run: npm test
         working-directory: typescript
+      # Run the release build in CI so a green run guarantees
+      # npm run build (dts included) compiles. Publish runs the same command.
+      - run: npm run build
+        working-directory: typescript
 
   verifier:
     needs: changes


### PR DESCRIPTION
## What

Add `npm run build` to the CI typescript job, right after `npm test`. This is the same command the publish workflow runs, declaration (dts) output included.

## Why

The publish job compiles the package with `npm run build`, while the CI typescript job runs only lint and test. A type error that breaks the dts build slips past CI and first shows up at publish time, failing the release instead of the pull request. The failed publish run (29149579961) is exactly that shape: it built a stale tag commit (828bb82) where `npm run build` errored with eleven TS2345 errors, and CI never caught it.

Adding the build step in CI closes the gap. A green CI run now guarantees the release build compiles. origin/main already builds green, so this PR is green from the start. The gate pays off on any future change that would break the dts build.

## Scope

One workflow file, four inserted lines. No source or version change.

## Proof of work

`git diff --stat` vs origin/main:

```
 .github/workflows/ci.yml | 4 ++++
 1 file changed, 4 insertions(+)
```

Registry state verified this session: npm `@asqav/sdk` latest 0.8.0, PyPI `asqav` latest 0.8.1.

CI on this PR runs the new `npm run build` step in the typescript job. See the Checks tab for the green run.
