### PR TITLE
ci: run npm run build in the typescript job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
         working-directory: typescript
       - run: npm test
         working-directory: typescript
+      # Run the release build in CI so a green run guarantees
+      # npm run build (dts included) compiles. Publish runs the same command.
+      - run: npm run build
+        working-directory: typescript
 
   verifier:
     needs: changes


### PR DESCRIPTION
## What

Add `npm run build` to the typescript CI job, right after `npm test`. That is the exact command the publish workflow runs, `.d.ts` output included.

## Why

The publish job compiles the package with `npm run build`. The CI typescript job ran lint and test but not that build, so a type error that breaks the declaration build slips past CI and first shows up at publish time, failing the release rather than the pull request.

The failed publish run 29149579961 is that shape. It built a stale tag commit where `npm run build` errored on the type check, and CI had no build step to catch it. Adding the build here closes the gap. origin/main already builds green, so this PR is green from the start, and the gate pays off on any future change that would break the declaration build.

## Scope

One workflow file, four inserted lines. No source or version change.

## Proof of work

`git diff --stat origin/main`

```
 .github/workflows/ci.yml | 4 ++++
 1 file changed, 4 insertions(+)
```

`secret-scan.js --worktree <ci>` -> `SCANNER: gitleaks - clean` (exit 0)

Registry state verified this session: npm `@asqav/sdk` latest 0.8.0, PyPI `asqav` latest 0.8.1. Commit `7366266`. CI runs the new build step on this PR head, result in the Checks tab.
