### PR TITLE
chore(release): bump SDK to 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-07-11
+
+Republish of the 0.8.1 change set from `main`, with no new API. The released
+0.8.1 artifacts were built from a commit behind `main`, so 0.8.2 realigns the
+published packages with what the 0.8.1 notes below describe.
+
+### Fixed
+
+- **Release integrity.** The `asqav` 0.8.1 artifacts on PyPI were built from
+  commit `828bb820`, which predates the public no-key `verify()` convenience
+  wrapper and the fail-clean verification behavior the 0.8.1 notes below
+  describe. 0.8.2 is built from `main` and contains them, so the published
+  package matches its changelog. On npm, `@asqav/sdk` has no 0.8.1 release
+  because that publish run failed at the build step, so the npm package moves
+  from 0.8.0 to 0.8.2 directly. The Python and TypeScript halves realign on
+  0.8.2.
+
 ## [0.8.1] - 2026-07-08
 
 Everything on `main` ships in this patch, so the entries below are consolidated

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.8.1"
+version = "0.8.2"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -161,7 +161,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.8.1";
+export const SDK_VERSION = "0.8.2";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
## What

Bump the SDK from 0.8.1 to 0.8.2 across the five-file version set and add a CHANGELOG entry. No source behavior change.

Files: `typescript/package.json`, `typescript/src/userAgent.ts` (`SDK_VERSION`, which `CLI_VERSION` derives from), `python/pyproject.toml`, `python/src/asqav/__init__.py` (`__version__`), and `CHANGELOG.md`.

## Why

The `asqav` 0.8.1 artifacts on PyPI were built from commit `828bb820`, which is behind `main`. That commit lacks the public no-key `verify()` wrapper and the fail-clean behavior the 0.8.1 changelog describes, so the released package and its changelog drifted apart. 0.8.2 builds from `main` and carries both.

On npm, `@asqav/sdk` has no 0.8.1 release because that publish run failed at the build step, so the npm package moves from 0.8.0 to 0.8.2 directly. The Python and TypeScript halves realign on 0.8.2.

Companion PR #370 adds the missing CI build step, so a break like that failed publish cannot slip through again.

## Proof of work

`npm run build` at the bump commit (b3cb579):

```
DTS dist/index.d.ts   61.66 KB
BUILD EXIT: 0
```

Version-consistency tests:

```
TS  version.test.ts + userAgent.test.ts:  Tests 5 passed (5)  exit 0
Python  test_version_consistency.py:       1 passed            exit 0
```

Registry verified this session: npm `@asqav/sdk` latest 0.8.0 (no 0.8.1), PyPI `asqav` latest 0.8.1. 0.8.2 unpublished on both.

`git diff --stat` vs origin/main:

```
 CHANGELOG.md                 | 17 +++++++++++++++++
 python/pyproject.toml        |  2 +-
 python/src/asqav/__init__.py |  2 +-
 typescript/package.json      |  2 +-
 typescript/src/userAgent.ts  |  2 +-
 5 files changed, 21 insertions(+), 4 deletions(-)
```
