### PR TITLE
docs: align README license sections with the LICENSE file

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -531,4 +531,4 @@ See <https://asqav.com/docs> for the live feature set.
 
 ## License
 
-MIT. Get an API key at [asqav.com](https://asqav.com).
+Elastic License 2.0. Get an API key at [asqav.com](https://asqav.com).

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -543,4 +543,4 @@ See <https://asqav.com/docs> for the live feature set.
 
 ## License
 
-MIT. Get an API key at [asqav.com](https://asqav.com).
+Elastic License 2.0. Get an API key at [asqav.com](https://asqav.com).


### PR DESCRIPTION
The License section at the end of both SDK READMEs says MIT while the LICENSE file and the root README badge carry Elastic License 2.0. This aligns the two lines so the packaged READMEs match the manifests. Two-line diff, docs only.