### PR TITLE
fix(verifier): offline verify must not treat anchor presence as trusted timing

### DIFF
--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -178,9 +178,9 @@ class AsqavNativeAdapter(FormatAdapter):
         else:
             issued_at = _payload(doc).get("issued_at", "")
         revoked_at = _vr.resolve_revoked_at(jwks, kid)
-        _env = _vr.normalise_envelope(doc)
-        _has_anchor = bool(_env.get("anchors"))
-        res, note = _vr.check_key_status(status, issued_at, revoked_at, _has_anchor)
+        # Offline anchor presence is unverifiable (anchors are unsigned); pass
+        # False so a forged anchor never rides a revoked key to PASS.
+        res, note = _vr.check_key_status(status, issued_at, revoked_at, False)
         return [("key_status", res, note)]
 
     def attestation(self, doc: dict) -> dict[str, Any]:

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -343,13 +343,14 @@ def check_key_status(status, issued_at: str, revoked_at=None, has_trusted_anchor
 
     When the JWKS carries a precise revoked_at, prefer the at-or-before-issuance
     check so a receipt signed BEFORE revocation still PASSes (historical verify).
-    The JWKS today publishes status only, so without revoked_at any revoked key
-    fails the axis.
+    Without a revoked_at the axis cannot place issuance, so any revoked key fails.
 
-    Without a trusted time anchor the signed issued_at is self-attested: a holder
-    of the compromised key can backdate. Downgrade that exact case to SKIPPED so
-    the verdict is INCOMPLETE, never a hiding PASS. Default False so callers that
-    ignore the parameter never hide behind a self-attested timestamp.
+    has_trusted_anchor must be an anchor the caller CRYPTOGRAPHICALLY verified as
+    pre-revocation timing; mere presence is not enough (anchors are unsigned and
+    attacker-addable). Without one the self-attested issued_at is backdateable, so
+    that case downgrades to SKIPPED (INCOMPLETE), never a hiding PASS. The offline
+    verifier cannot do that walk and passes False; default False so a caller that
+    ignores the parameter never hides behind a bare timestamp.
     """
     s = (status or "").lower()
     if s not in REVOKED_KEY_STATUSES:
@@ -531,9 +532,10 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
     else:
         results.append(("issuer_key", "PASS", f"resolved kid {kid} (status={status})"))
         revoked_at = resolve_revoked_at(jwks, kid)
-        _has_anchor = bool(envelope.get("anchors"))
+        # Offline anchor presence is unverifiable (anchors are unsigned); pass
+        # False so a forged anchor never rides a revoked key to PASS.
         results.append(
-            ("key_status", *check_key_status(status, payload.get("issued_at", ""), revoked_at, _has_anchor))
+            ("key_status", *check_key_status(status, payload.get("issued_at", ""), revoked_at, False))
         )
         _raw_sig = sig_obj.get("sig", "")
         sig = _b64decode(_raw_sig) if isinstance(_raw_sig, str) else b""
@@ -684,9 +686,10 @@ def run_structured(
             }
         )
         revoked_at = resolve_revoked_at(jwks, kid)
-        _has_anchor = bool(envelope.get("anchors"))
+        # Offline anchor presence is not trusted timing; pass False so a forged
+        # anchor never upgrades a revoked key to PASS (hosted /verify does).
         ks_r, ks_n = check_key_status(
-            status, payload.get("issued_at", ""), revoked_at, _has_anchor
+            status, payload.get("issued_at", ""), revoked_at, False
         )
         axes.append({"name": "key_status", "result": ks_r, "note": ks_n})
         _raw_sig = sig_obj.get("sig", "")

--- a/python/tests/test_verify_receipt_revoked_key.py
+++ b/python/tests/test_verify_receipt_revoked_key.py
@@ -1,11 +1,14 @@
 """Offline verifier gates the verdict on the signing key's revocation status.
 
 A receipt signed by a key the JWKS marks revoked must not PASS offline, matching
-the hosted /verify. The public JWKS publishes status today (no revoked_at), so a
-revoked key fails the key_status axis and the verdict is FAIL, not PASS.
+the hosted /verify. Offline the verifier cannot verify a timestamp anchor, so a
+revoked key never rides a forgeable anchor to PASS: the key_status axis is FAIL or
+SKIPPED and the verdict is never PASS.
 """
 
 from __future__ import annotations
+
+import pytest
 
 from asqav.verifier import verify_receipt as v
 from asqav.verifier.oracle.adapters.asqav_native import AsqavNativeAdapter
@@ -154,8 +157,8 @@ def test_run_structured_revoked_at_after_issuance_skipped_without_anchor():
     assert result["verdict"] != "PASS"
 
 
-def test_run_structured_revoked_at_after_issuance_passes_with_anchor():
-    """With a trusted anchor, pre-revocation receipts still PASS."""
+def test_run_structured_forged_anchor_stays_skipped_offline():
+    """Offline a present anchor is not trusted, so key_status stays SKIPPED."""
     envelope = {
         "payload": _payload(),
         "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
@@ -165,7 +168,48 @@ def test_run_structured_revoked_at_after_issuance_passes_with_anchor():
         envelope, _jwks("revoked", revoked_at="2026-07-01T00:00:00Z"), None
     )
     ks = next(a for a in result["axes"] if a["name"] == "key_status")
-    assert ks["result"] == "PASS"
+    assert ks["result"] == "SKIPPED"
+    assert "anchor" in ks["note"].lower()
+
+
+def test_run_structured_forged_anchor_does_not_upgrade_revoked_key():
+    """A forgeable anchor must not upgrade a revoked key to PASS offline.
+    Anchors sit outside the signed payload and are only shape-checked, so a
+    revoked-key holder can append one; offline it is not trustworthy timing."""
+    envelope = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [{"type": "rfc3161", "value": "dGVzdA=="}],  # base64('test'), not a token
+    }
+    result = v.run_structured(
+        envelope, _jwks("revoked", revoked_at="2026-07-01T00:00:00Z"), None
+    )
+    ks = next(a for a in result["axes"] if a["name"] == "key_status")
+    assert ks["result"] == "SKIPPED", f"forged anchor upgraded key_status to {ks['result']!r}"
+    assert result["verdict"] != "PASS"
+
+
+def test_offline_forged_anchor_revoked_key_verdict_not_pass():
+    """End-to-end: a revoked key cannot mint a PASS by appending a forged anchor.
+    A real ML-DSA-65 signature over a backdated payload verifies (the holder keeps
+    the key), but the forged anchor must not upgrade it, so verdict is INCOMPLETE."""
+    import base64
+
+    pytest.importorskip("dilithium_py")
+    from dilithium_py.ml_dsa import ML_DSA_65
+
+    pk, sk = ML_DSA_65.keygen()
+    payload = _payload()  # issued_at precedes the revoked_at below
+    sig = base64.b64encode(ML_DSA_65.sign(sk, v.canonical_json(payload))).decode()
+    jwks = _jwks("revoked", revoked_at="2026-07-11T14:57:49Z")
+    jwks["keys"][0]["public_key"] = base64.b64encode(pk).decode()
+    envelope = {
+        "payload": payload,
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": sig},
+        "anchors": [{"type": "rfc3161", "value": "dGVzdA=="}],
+    }
+    result = v.run_structured(envelope, jwks, None)
+    assert result["verdict"] == "INCOMPLETE", f"revoked key produced verdict {result['verdict']!r}"
 
 
 # --- oracle adapter path ---
@@ -192,3 +236,15 @@ def test_oracle_active_key_axis_passes():
     ad = AsqavNativeAdapter()
     axes = ad.extra_axes(doc, _jwks("active"))
     assert axes[0][1] == "PASS"
+
+
+def test_oracle_forged_anchor_revoked_key_axis_skipped():
+    """The adapter must not let a forged anchor upgrade a revoked key's axis."""
+    doc = {
+        "payload": _payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
+        "anchors": [{"type": "rfc3161", "value": "dGVzdA=="}],
+    }
+    ad = AsqavNativeAdapter()
+    axes = ad.extra_axes(doc, _jwks("revoked", revoked_at="2026-07-01T00:00:00Z"))
+    assert axes[0][1] == "SKIPPED", f"forged anchor upgraded axis to {axes[0][1]!r}"

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -193,9 +193,9 @@ export class AsqavNativeAdapter extends FormatAdapter {
       ? String(doc.server_timestamp ?? "")
       : String(payloadOf(doc).issued_at ?? "");
     const revokedAt = resolveRevokedAt(jwks, kid);
-    const env = normaliseEnvelope(doc);
-    const anchors = Array.isArray(env.anchors) ? (env.anchors as unknown[]) : [];
-    const [res, note] = checkKeyStatus(status, issuedAt, revokedAt, anchors.length > 0);
+    // Offline anchor presence is unverifiable (anchors unsigned); pass false
+    // so a forged anchor never rides a revoked key to PASS.
+    const [res, note] = checkKeyStatus(status, issuedAt, revokedAt, false);
     return [["key_status", res, note]];
   }
 

--- a/typescript/tests/offline-verify.test.ts
+++ b/typescript/tests/offline-verify.test.ts
@@ -187,20 +187,21 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     expect(keyAxis?.note).toMatch(/no anchor/i);
   });
 
-  it("revoked key with revoked_at AFTER issuance PASSes WITH a trusted anchor (c386)", () => {
+  it("forged anchor does not upgrade a revoked key offline (revocation-bypass guard)", () => {
     const receipt = loadJson(REVOKED_DIR, "receipt.json");
     const revokedJwks = loadJson(REVOKED_DIR, "jwks.json");
     const futureJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
     ((futureJwks.keys as Array<Record<string, unknown>>)[0]).revoked_at = "2026-12-01T00:00:00+00:00";
-    // Attach a TSA anchor. Anchors are NOT part of the signed payload, so the
-    // original signature still validates and the timing is now corroborated.
+    // Anchors sit outside the signed payload and are only shape-checked, so a
+    // revoked-key holder can append one. Offline it is not verifiable timing.
     const anchored = JSON.parse(JSON.stringify(receipt)) as Record<string, unknown>;
     anchored.anchors = [{ type: "rfc3161", value: "dGVzdC10c3ItY29va2ll", tsa_url: "https://tsa.example/timestamp" }];
     const result = verifyReceiptOffline(anchored, futureJwks);
-    expect(result.verdict).toBe("PASS");
+    expect(result.verdict).not.toBe("PASS");
+    expect(result.verdict).toBe("INCOMPLETE");
     const keyAxis = result.axes.find((a) => a.axis === "key_status");
-    expect(keyAxis?.result).toBe("PASS");
-    expect(keyAxis?.note).toMatch(/after issuance/i);
+    expect(keyAxis?.result).toBe("SKIPPED");
+    expect(keyAxis?.note).toMatch(/no anchor|self-attested/i);
   });
 
   it("c386: compromised-key backdated receipt, offline, no anchor, must NOT PASS", () => {


### PR DESCRIPTION
## Summary

The standalone offline receipt verifier gated the key-status axis on mere anchor
presence (`has_trusted_anchor = bool(envelope.get("anchors"))` in Python, and
`anchors.length > 0` in TS). Anchors sit outside the signed payload and are only
base64-shape-checked, so their presence is not proof that a receipt predates a
key's revocation. A revoked-key receipt with a self-attested, backdated
`issued_at` plus a shape-only anchor could move `key_status` from SKIPPED to
PASS, so the offline tool emitted a PASS verdict for a revoked-key receipt.

The offline verifier does not do the timestamp certificate-chain walk that proves
pre-revocation timing (module docstring: needs server state or ASN.1; use the
hosted verify). It therefore cannot establish a trusted anchor, so all four
offline callers now pass `has_trusted_anchor=False`:

- `verify_receipt.run`
- `verify_receipt.run_structured`
- oracle `asqav_native` adapter (Python)
- `asqavNative` adapter (TypeScript)

A revoked-key receipt with a backdated `issued_at` stays SKIPPED offline (verdict
INCOMPLETE); the hosted verify remains the surface that establishes pre-revocation
timing and can PASS a genuine historical receipt.

## Why it matters

The offline verifier is the verify-it-yourself trust anchor for the product. A
holder of a revoked signing key (a key revoked because it was compromised, or an
offboarded agent's key) must not be able to produce a receipt the offline tool
reports as PASS. This closes that gap while keeping the honest historical path on
the hosted verify. The `check_key_status` primitive is unchanged; its unit
contract (a genuinely trusted anchor PASSes) still holds for the hosted caller.

## Tests

Fail-first regression tests (Python + TS) assert a shape-only anchor does not
upgrade a revoked key: `key_status` stays SKIPPED and the verdict is not PASS.
Each fails on the base commit and passes on this branch. An end-to-end Python
test signs a backdated payload with a real ML-DSA-65 keypair and asserts the
shape-only-anchor receipt verifies as INCOMPLETE.

## Proof of work

Fail-first, base commit (tests expect SKIPPED, unpatched code returns PASS):

```
$ pytest tests/test_verify_receipt_revoked_key.py -k forged_anchor
E       assert 'PASS' == 'SKIPPED'
FAILED ... test_run_structured_forged_anchor_stays_skipped_offline
FAILED ... test_run_structured_forged_anchor_does_not_upgrade_revoked_key
FAILED ... test_offline_forged_anchor_revoked_key_verdict_not_pass
FAILED ... test_oracle_forged_anchor_revoked_key_axis_skipped
4 failed, 12 deselected

$ vitest run tests/offline-verify.test.ts -t "forged anchor does not upgrade"
AssertionError: expected 'PASS' not to be 'PASS'
1 failed | 25 skipped (26)
```

After the change:

```
$ pytest tests/test_verify_receipt_revoked_key.py
16 passed

$ vitest run          # full TS suite
Test Files  45 passed (45)
     Tests  587 passed (587)

$ tsc --noEmit        # exit 0
$ ruff check src/asqav/verifier/...   # All checks passed!
```

Diff: 5 files, +88 / -28.
