### PR TITLE
release: SDK 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-07-20
+
+Patch release with a verifier correctness fix and a docs alignment.
+
+### Fixed
+
+- **Offline verify must not treat anchor presence as trusted timing.** The
+  neutral verifier client returned an `anchored` verdict when an anchor was
+  present on the receipt, even if the anchor was not independently verified.
+  The client reports anchor presence as metadata only, and the verdict
+  reflects the cryptographic verification state alone. (#376)
+
+### Changed
+
+- Aligned the README license sections with the actual LICENSE file (ELv2 for
+  the SDK code, Apache-2.0 for the conformance vectors). (#374)
+
 ## [0.8.2] - 2026-07-11
 
 Release-hygiene patch that re-ships the 0.8.1 feature set from `main`. The `asqav`

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.8.2"
+version = "0.8.3"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -161,7 +161,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.8.2";
+export const SDK_VERSION = "0.8.3";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Version bump 0.8.2 -> 0.8.3 (PATCH per the SDK version-bump-defaults-to-PATCH lesson).

## What changed since 0.8.2

- #376: fix(verifier): offline verify must not treat anchor presence as trusted timing
- #374: docs: align README license sections with the LICENSE file

## Version files bumped

- python/pyproject.toml
- python/src/asqav/__init__.py
- typescript/package.json
- typescript/src/userAgent.ts
- CHANGELOG.md

The py- and ts- 0.8.3 release tags will be pushed after ci-ok merge to trigger publish.yml.