### PR TITLE
feat(extras): add asqav[anthropic] extra + signing tests for openai and anthropic

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -66,6 +66,7 @@ litellm = ["litellm>=1.83.14,!=1.82.7,!=1.82.8"]
 haystack = ["haystack-ai>=2.0.0"]
 openai-agents = ["openai-agents>=0.1.0"]
 openai = ["openai>=1.0.0"]
+anthropic = ["anthropic>=0.18.0"]
 # llama-index-core hard-requires nltk (CVE-2026-54293, no upstream patch as of 2026-06-20).
 # Removed from extras until llama-index-core drops/patches nltk.
 # The integration module (extras/llamaindex.py) stays; users can install llama-index-core

--- a/python/src/asqav/extras/anthropic.py
+++ b/python/src/asqav/extras/anthropic.py
@@ -1,0 +1,83 @@
+"""Anthropic SDK integration for asqav.
+
+Install: pip install asqav[anthropic]
+
+Wraps anthropic.Anthropic so every messages.create call produces a
+signed asqav receipt automatically.
+
+Usage::
+
+    from asqav.extras.anthropic import AsqavAnthropic
+    client = AsqavAnthropic(
+        anthropic_api_key="sk-ant-...",
+        asqav_api_key="sk_live_...",
+        agent_name="my-claude-agent",
+    )
+    response = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    print(response.content[0].text)
+    print(response._asqav_receipt.verification_url)
+"""
+from __future__ import annotations
+import logging
+from typing import Any
+import asqav
+
+logger = logging.getLogger("asqav.extras.anthropic")
+
+
+class _SignedMessages:
+    def __init__(self, real_messages: Any, agent: Any) -> None:
+        self._real = real_messages
+        self._agent = agent
+
+    def create(self, **kwargs: Any) -> Any:
+        model = kwargs.get("model", "unknown")
+        response = self._real.create(**kwargs)
+        try:
+            context: dict[str, Any] = {
+                "model": getattr(response, "model", model),
+                "anthropic_id": getattr(response, "id", None),
+                "action_type": f"anthropic:chat:{model}",
+            }
+            usage = getattr(response, "usage", None)
+            if usage:
+                context["input_tokens"] = getattr(usage, "input_tokens", None)
+                context["output_tokens"] = getattr(usage, "output_tokens", None)
+            sig = self._agent.sign(action_type=context["action_type"], context=context)
+            response._asqav_receipt = sig
+        except Exception:
+            logger.debug("asqav sign failed (fail-soft)", exc_info=True)
+        return response
+
+
+class _SignedClient:
+    def __init__(self, real_client: Any, agent: Any) -> None:
+        self._real = real_client
+        self.messages = _SignedMessages(real_client.messages, agent)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+class AsqavAnthropic:
+    """Drop-in replacement for anthropic.Anthropic that signs every call."""
+
+    def __init__(
+        self,
+        anthropic_api_key: str | None = None,
+        asqav_api_key: str | None = None,
+        agent_name: str = "anthropic-agent",
+        **kwargs: Any,
+    ) -> None:
+        from anthropic import Anthropic
+        self._client = Anthropic(api_key=anthropic_api_key, **kwargs)
+        asqav.init(asqav_api_key)
+        self._agent = asqav.Agent.create(name=agent_name)
+        self._wrapped = _SignedClient(self._client, self._agent)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)

--- a/python/src/asqav/extras/anthropic.py
+++ b/python/src/asqav/extras/anthropic.py
@@ -22,8 +22,10 @@ Usage::
     print(response._asqav_receipt.verification_url)
 """
 from __future__ import annotations
+
 import logging
 from typing import Any
+
 import asqav
 
 logger = logging.getLogger("asqav.extras.anthropic")

--- a/python/src/asqav/extras/anthropic.py
+++ b/python/src/asqav/extras/anthropic.py
@@ -21,6 +21,7 @@ Usage::
     print(response.content[0].text)
     print(response._asqav_receipt.verification_url)
 """
+
 from __future__ import annotations
 
 import logging
@@ -76,6 +77,7 @@ class AsqavAnthropic:
         **kwargs: Any,
     ) -> None:
         from anthropic import Anthropic
+
         self._client = Anthropic(api_key=anthropic_api_key, **kwargs)
         asqav.init(asqav_api_key)
         self._agent = asqav.Agent.create(name=agent_name)

--- a/python/src/asqav/extras/openai.py
+++ b/python/src/asqav/extras/openai.py
@@ -3,8 +3,8 @@
 Install: pip install asqav[openai]
 
 Wraps ``openai.OpenAI`` so every ``chat.completions.create`` call produces a
-signed asqav receipt automatically. The OpenAI response is returned unchanged;
-the receipt metadata is attached as ``response._asqav_receipt``.
+signed asqav receipt automatically. The OpenAI response is returned unchanged.
+The receipt metadata is attached as ``response._asqav_receipt``.
 
 Usage::
 

--- a/python/tests/test_openai_anthropic_extras.py
+++ b/python/tests/test_openai_anthropic_extras.py
@@ -1,0 +1,287 @@
+"""Tests for the asqav[openai] and asqav[anthropic] extras.
+
+Each extra wraps the vendor SDK so every chat call produces a signed asqav
+receipt attached as ``response._asqav_receipt``. The vendor SDKs are mocked
+via ``sys.modules`` so these tests run without openai or anthropic installed
+and without any network access. Signing is fail-soft by design (matching the
+rest of the extras: signing records governance, it does not enforce it), so a
+sign failure must never block the underlying LLM call.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav  # noqa: E402
+from asqav.extras.anthropic import AsqavAnthropic  # noqa: E402
+from asqav.extras.openai import AsqavOpenAI  # noqa: E402
+
+
+class _FakeResponse:
+    """Stand-in for a vendor response that allows attribute assignment."""
+
+    def __init__(self, model: str, response_id: str, usage) -> None:
+        self.model = model
+        self.id = response_id
+        self.usage = usage
+
+
+def _receipt() -> SimpleNamespace:
+    return SimpleNamespace(
+        signature_id="sig_123",
+        verification_url="https://asqav.com/verify/sig_123",
+    )
+
+
+def _patch_asqav(monkeypatch, agent: MagicMock) -> MagicMock:
+    """Stub asqav.init and asqav.Agent.create so no network call happens."""
+    init_mock = MagicMock()
+    monkeypatch.setattr(asqav, "init", init_mock)
+    create_mock = MagicMock(return_value=agent)
+    monkeypatch.setattr(asqav.Agent, "create", create_mock)
+    return init_mock
+
+
+def _install_fake_openai(monkeypatch, response: _FakeResponse):
+    """Inject a fake openai module whose client returns ``response``."""
+    completions = MagicMock()
+    completions.create.return_value = response
+    client_instance = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    fake_module = ModuleType("openai")
+    openai_cls = MagicMock(return_value=client_instance)
+    fake_module.OpenAI = openai_cls
+    monkeypatch.setitem(sys.modules, "openai", fake_module)
+    return openai_cls, completions
+
+
+def _install_fake_anthropic(monkeypatch, response: _FakeResponse):
+    """Inject a fake anthropic module whose client returns ``response``."""
+    messages = MagicMock()
+    messages.create.return_value = response
+    client_instance = SimpleNamespace(messages=messages)
+    fake_module = ModuleType("anthropic")
+    anthropic_cls = MagicMock(return_value=client_instance)
+    fake_module.Anthropic = anthropic_cls
+    monkeypatch.setitem(sys.modules, "anthropic", fake_module)
+    return anthropic_cls, messages
+
+
+# -- OpenAI extra --
+
+
+def test_openai_signs_receipt_and_attaches_it(monkeypatch):
+    response = _FakeResponse(
+        "gpt-4o",
+        "chatcmpl-1",
+        SimpleNamespace(prompt_tokens=3, completion_tokens=5, total_tokens=8),
+    )
+    _, completions = _install_fake_openai(monkeypatch, response)
+    agent = MagicMock()
+    receipt = _receipt()
+    agent.sign.return_value = receipt
+    init_mock = _patch_asqav(monkeypatch, agent)
+
+    client = AsqavOpenAI(
+        openai_api_key="sk-openai-secret",
+        asqav_api_key="sk_live_asqav",
+        agent_name="my-openai-agent",
+    )
+    out = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hi"}],
+    )
+
+    assert out is response
+    completions.create.assert_called_once()
+    init_mock.assert_called_once_with("sk_live_asqav")
+
+    agent.sign.assert_called_once()
+    kwargs = agent.sign.call_args.kwargs
+    assert kwargs["action_type"] == "openai:chat:gpt-4o"
+    context = kwargs["context"]
+    assert context["model"] == "gpt-4o"
+    assert context["openai_id"] == "chatcmpl-1"
+    assert context["prompt_tokens"] == 3
+    assert context["completion_tokens"] == 5
+    assert context["total_tokens"] == 8
+
+    assert response._asqav_receipt is receipt
+
+
+def test_openai_fail_soft_does_not_block_call(monkeypatch):
+    response = _FakeResponse("gpt-4o", "chatcmpl-2", None)
+    _, completions = _install_fake_openai(monkeypatch, response)
+    agent = MagicMock()
+    agent.sign.side_effect = RuntimeError("signing backend down")
+    _patch_asqav(monkeypatch, agent)
+
+    client = AsqavOpenAI(openai_api_key="sk-x", asqav_api_key="sk_live_y")
+    out = client.chat.completions.create(model="gpt-4o", messages=[])
+
+    assert out is response
+    completions.create.assert_called_once()
+    agent.sign.assert_called_once()
+    assert not hasattr(response, "_asqav_receipt")
+
+
+def test_openai_real_llm_error_propagates(monkeypatch):
+    response = _FakeResponse("gpt-4o", "chatcmpl-3", None)
+    _, completions = _install_fake_openai(monkeypatch, response)
+    completions.create.side_effect = ValueError("upstream api down")
+    agent = MagicMock()
+    _patch_asqav(monkeypatch, agent)
+
+    client = AsqavOpenAI(openai_api_key="sk-x", asqav_api_key="sk_live_y")
+    with pytest.raises(ValueError, match="upstream api down"):
+        client.chat.completions.create(model="gpt-4o", messages=[])
+
+    agent.sign.assert_not_called()
+
+
+def test_openai_context_leaks_no_secrets_or_content(monkeypatch):
+    response = _FakeResponse("gpt-4o", "chatcmpl-4", None)
+    _install_fake_openai(monkeypatch, response)
+    agent = MagicMock()
+    agent.sign.return_value = _receipt()
+    _patch_asqav(monkeypatch, agent)
+
+    client = AsqavOpenAI(
+        openai_api_key="sk-openai-secret",
+        asqav_api_key="sk_live_asqav",
+    )
+    client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "super secret prompt text"}],
+    )
+
+    context = agent.sign.call_args.kwargs["context"]
+    rendered = repr(context)
+    assert "sk-openai-secret" not in rendered
+    assert "sk_live_asqav" not in rendered
+    assert "super secret prompt text" not in rendered
+    assert "messages" not in context
+
+
+# -- Anthropic extra --
+
+
+def test_anthropic_signs_receipt_and_attaches_it(monkeypatch):
+    response = _FakeResponse(
+        "claude-sonnet-4-20250514",
+        "msg_1",
+        SimpleNamespace(input_tokens=4, output_tokens=9),
+    )
+    _, messages = _install_fake_anthropic(monkeypatch, response)
+    agent = MagicMock()
+    receipt = _receipt()
+    agent.sign.return_value = receipt
+    init_mock = _patch_asqav(monkeypatch, agent)
+
+    client = AsqavAnthropic(
+        anthropic_api_key="sk-ant-secret",
+        asqav_api_key="sk_live_asqav",
+        agent_name="my-claude-agent",
+    )
+    out = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hi"}],
+    )
+
+    assert out is response
+    messages.create.assert_called_once()
+    init_mock.assert_called_once_with("sk_live_asqav")
+
+    agent.sign.assert_called_once()
+    kwargs = agent.sign.call_args.kwargs
+    assert kwargs["action_type"] == "anthropic:chat:claude-sonnet-4-20250514"
+    context = kwargs["context"]
+    assert context["model"] == "claude-sonnet-4-20250514"
+    assert context["anthropic_id"] == "msg_1"
+    assert context["input_tokens"] == 4
+    assert context["output_tokens"] == 9
+
+    assert response._asqav_receipt is receipt
+
+
+def test_anthropic_fail_soft_does_not_block_call(monkeypatch):
+    response = _FakeResponse("claude-sonnet-4-20250514", "msg_2", None)
+    _, messages = _install_fake_anthropic(monkeypatch, response)
+    agent = MagicMock()
+    agent.sign.side_effect = RuntimeError("signing backend down")
+    _patch_asqav(monkeypatch, agent)
+
+    client = AsqavAnthropic(anthropic_api_key="sk-ant-x", asqav_api_key="sk_live_y")
+    out = client.messages.create(model="claude-sonnet-4-20250514", max_tokens=16)
+
+    assert out is response
+    messages.create.assert_called_once()
+    agent.sign.assert_called_once()
+    assert not hasattr(response, "_asqav_receipt")
+
+
+def test_anthropic_real_llm_error_propagates(monkeypatch):
+    response = _FakeResponse("claude-sonnet-4-20250514", "msg_3", None)
+    _, messages = _install_fake_anthropic(monkeypatch, response)
+    messages.create.side_effect = ValueError("upstream api down")
+    agent = MagicMock()
+    _patch_asqav(monkeypatch, agent)
+
+    client = AsqavAnthropic(anthropic_api_key="sk-ant-x", asqav_api_key="sk_live_y")
+    with pytest.raises(ValueError, match="upstream api down"):
+        client.messages.create(model="claude-sonnet-4-20250514", max_tokens=16)
+
+    agent.sign.assert_not_called()
+
+
+def test_anthropic_context_leaks_no_secrets_or_content(monkeypatch):
+    response = _FakeResponse("claude-sonnet-4-20250514", "msg_4", None)
+    _install_fake_anthropic(monkeypatch, response)
+    agent = MagicMock()
+    agent.sign.return_value = _receipt()
+    _patch_asqav(monkeypatch, agent)
+
+    client = AsqavAnthropic(
+        anthropic_api_key="sk-ant-secret",
+        asqav_api_key="sk_live_asqav",
+    )
+    client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=16,
+        messages=[{"role": "user", "content": "super secret prompt text"}],
+    )
+
+    context = agent.sign.call_args.kwargs["context"]
+    rendered = repr(context)
+    assert "sk-ant-secret" not in rendered
+    assert "sk_live_asqav" not in rendered
+    assert "super secret prompt text" not in rendered
+    assert "messages" not in context
+
+
+# -- Packaging --
+
+
+def test_pyproject_defines_openai_and_anthropic_extras():
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    with open(pyproject_path, "rb") as fh:
+        data = tomllib.load(fh)
+
+    opt_deps = data["project"]["optional-dependencies"]
+    assert "openai" in opt_deps
+    assert "anthropic" in opt_deps
+    assert any(dep.startswith("openai") for dep in opt_deps["openai"])
+    assert any(dep.startswith("anthropic") for dep in opt_deps["anthropic"])


### PR DESCRIPTION
## What this PR delivers (after rebase onto main)

The openai extra and the README free-tier change (5K to 25K) already landed on
main via #381. Rebasing onto main dropped those hunks (git reported "patch
contents already upstream"), so this PR holds the remaining work:

- New `asqav[anthropic]` extra (`python/src/asqav/extras/anthropic.py`): wraps
  `anthropic.Anthropic` so every `messages.create` call signs an asqav receipt
  and attaches it as `response._asqav_receipt`. Mirrors the openai extra.
- `pyproject.toml`: the `anthropic = ["anthropic>=0.18.0"]` extra wiring.
- Tests for both the openai and anthropic extras (mocked vendor SDKs).
- A forbidden-token fix: dropped a prose semicolon in the openai extra docstring.

## Audit findings

- Correctness: both extras call the real vendor `create` outside the try block
  (real LLM errors propagate), then sign and attach the receipt inside it.
- Fail-soft: a signing failure logs and returns the response without a receipt.
  This matches the rest of the extras (`_base.py` fail-open, litellm fail-soft).
  asqav signing records governance. It does not enforce or block the LLM call.
- No secret leakage: the signed context holds the model, the vendor response id,
  and token usage only. API keys and prompt/response content stay out of it.
- README 25K claim: verified accurate. The backend free tier defaults to 25000
  signatures/month (`asqav_cloud/api/tier_config.py`, env-tunable) and the
  pricing page lists 25K. No overclaiming.

## Verification

- `cd python && PYTHONPATH=src python -m pytest tests -q`: 1498 passed, 2 skipped
  (1489 baseline plus 9 new extra tests).
- `ruff check python/src`: clean. `ruff format`: clean.
