### PR TITLE
fix(oracle): cap receipt nesting depth in the neutral verifier

### DIFF
--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -90,6 +90,30 @@ def _chain_axis(
     return AxisResult("chain", crypto.FAIL, f"chain break: expected {exp}.. got {actual[:16]}..")
 
 
+#: Max nesting the recursive JCS encoder tolerates, mirrors the standalone verifier cap.
+MAX_NESTING_DEPTH = 200
+
+_TOO_DEEP_NOTE = f"receipt nesting exceeds the supported depth (> {MAX_NESTING_DEPTH} levels)"
+
+
+def _exceeds_depth(obj: Any, max_depth: int) -> bool:
+    """True when ``obj`` nests deeper than ``max_depth``, walked with an explicit stack.
+
+    No recursion here, so the check itself never overflows before it can cap a
+    receipt the JCS canonicaliser (signing_input, chain recompute) would crash on.
+    """
+    stack: list[tuple[Any, int]] = [(obj, 0)]
+    while stack:
+        cur, depth = stack.pop()
+        if depth > max_depth:
+            return True
+        if isinstance(cur, dict):
+            stack.extend((v, depth + 1) for v in cur.values())
+        elif isinstance(cur, list):
+            stack.extend((v, depth + 1) for v in cur)
+    return False
+
+
 def verify(
     doc: dict,
     adapters: list[FormatAdapter],
@@ -103,6 +127,16 @@ def verify(
             fmt="unknown",
             axes=[AxisResult("structure", crypto.FAIL, "no adapter recognises this receipt")],
             verdict="FAIL",
+        )
+    # An over-nested receipt would crash the recursive JCS encoder. Cap it here and
+    # report INCOMPLETE, never a PASS, matching the standalone verifier shape gate.
+    if _exceeds_depth(doc, MAX_NESTING_DEPTH) or (
+        predecessor is not None and _exceeds_depth(predecessor, MAX_NESTING_DEPTH)
+    ):
+        return VerifyResult(
+            fmt=ad.name,
+            axes=[AxisResult("structure", crypto.FAIL, _TOO_DEEP_NOTE)],
+            verdict="INCOMPLETE",
         )
 
     axes = [

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -933,3 +933,64 @@ def test_oracle_verify_nonobject_doc_fails_clean() -> None:
     for bad_doc in (None, "a string", 123, [1, 2]):
         res = verify(bad_doc, ADAPTERS)
         assert res.verdict == "FAIL"
+
+
+# A did:web signer resolved from an injected map, so the signature axis reaches the
+# JCS canonicaliser without a high-entropy did:key literal in the fixture.
+_ISSUER_DID = "did:web:asqav.example"
+_SIGNER = {_ISSUER_DID + "#key-1": "00" * 32}
+
+
+def _nested(depth: int) -> object:
+    """A dict nested ``depth`` levels deep, built iteratively so the fixture never overflows."""
+    node: object = 1
+    for _ in range(depth):
+        node = {"a": node}
+    return node
+
+
+def _deep_agentreceipt(depth: int, *, genesis: bool = True) -> dict:
+    """A well-formed agentreceipts envelope whose credentialSubject nests ``depth`` deep."""
+    return {
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
+        "id": "urn:uuid:00000000-0000-0000-0000-000000000000",
+        "type": ["VerifiableCredential", "AgentReceipt"],
+        "version": "1.0",
+        "issuer": {"id": _ISSUER_DID},
+        "issuanceDate": "2026-01-01T00:00:00Z",
+        "credentialSubject": {
+            "chain": {"previous_receipt_hash": None if genesis else "sha256:" + "a" * 64},
+            "data": _nested(depth),
+        },
+        "proof": {
+            "type": "Ed25519Signature2020",
+            "verificationMethod": _ISSUER_DID + "#key-1",
+            "proofValue": "uAAAA",
+        },
+    }
+
+
+def test_oracle_over_nested_receipt_is_incomplete_not_recursionerror() -> None:
+    """A receipt nested past the cap returns INCOMPLETE, never an unhandled RecursionError.
+
+    The signer resolves so the signature axis reaches the recursive JCS
+    canonicaliser, which overflows the stack without the depth gate in verify().
+    """
+    res = verify(_deep_agentreceipt(3000), ADAPTERS, key_provider=_SIGNER)
+    assert res.verdict == "INCOMPLETE"
+    assert res.fmt == "agentreceipts"
+    assert "depth" in (res.axis("structure").note or "")
+
+
+def test_oracle_over_nested_predecessor_is_incomplete_not_recursionerror() -> None:
+    """A deeply nested predecessor is capped on the chain axis, never a RecursionError."""
+    doc = _deep_agentreceipt(1, genesis=False)
+    res = verify(doc, ADAPTERS, key_provider=_SIGNER, predecessor=_deep_agentreceipt(3000))
+    assert res.verdict == "INCOMPLETE"
+    assert "depth" in (res.axis("structure").note or "")
+
+
+def test_oracle_receipt_within_depth_is_not_flagged_too_deep() -> None:
+    """A receipt nested under the cap verifies normally and is not reported too-deep."""
+    res = verify(_deep_agentreceipt(50), ADAPTERS, key_provider=_SIGNER)
+    assert "depth" not in (res.axis("structure").note or "")


### PR DESCRIPTION
## What

`oracle.verify()` had no bound on how deeply a receipt could nest. When the signer resolves (a did:key or an injected key), the signature and chain axes hand the receipt to the recursive JCS canonicaliser, so a deeply nested payload ran the stack past its limit and raised an unhandled `RecursionError` instead of returning a verdict.

The fix adds an iterative depth check at the top of `verify()`, capped at 200 levels to match the standalone verifier's `_scan_shape`. A receipt or predecessor past the cap now reads as `INCOMPLETE` with a structure-axis note. Real receipts are a few levels deep, so nothing legitimate changes.

## Why

The oracle is the public neutral verifier and reads bytes it does not control. Input that crashes it rather than returning a verdict is a denial-of-service surface. The standalone verifier already caps depth, and the oracle now does the same.

## Tests

Three regression tests in `test_oracle.py`: an over-nested receipt, an over-nested predecessor, and a receipt under the cap that must still verify normally. pytest gets wedged rendering a `RecursionError` from a deep structure, so the pre/post proof runs the same three functions as plain calls.

## Proof of work

Same three test functions, pre-fix (origin/main `core.py`) vs post-fix:

```
########## POST-FIX ##########
PASS  test_oracle_over_nested_receipt_is_incomplete_not_recursionerror
PASS  test_oracle_over_nested_predecessor_is_incomplete_not_recursionerror
PASS  test_oracle_receipt_within_depth_is_not_flagged_too_deep
POST-FIX EXIT: 0
########## PRE-FIX (origin/main core.py) ##########
FAIL  test_oracle_over_nested_receipt_is_incomplete_not_recursionerror: unhandled RecursionError
FAIL  test_oracle_over_nested_predecessor_is_incomplete_not_recursionerror: unhandled RecursionError
PASS  test_oracle_receipt_within_depth_is_not_flagged_too_deep
PRE-FIX EXIT: 1
```

Full oracle suite post-fix:

```
74 passed in 2.12s
```

`ruff check src`: All checks passed. Diff: 2 files, +95.

Draft, not for merge.
