### PR TITLE
docs(sdk): describe the org_salt model as it actually works

### DIFF
--- a/python/src/asqav/canonicalize.py
+++ b/python/src/asqav/canonicalize.py
@@ -80,7 +80,9 @@ def hash_action(
     salt: bytes | None = None,
 ) -> str:
     """Return ``"sha256:<hex>"`` of canonicalized ``{action_type, context}``; with
-    ``salt`` set, uses HMAC-SHA-256 (per-org keyed hash) instead of plain SHA-256.
+    ``salt`` set, uses HMAC-SHA-256 keyed by that caller-held salt instead of plain
+    SHA-256. The prefix reads ``sha256`` either way, so a verifier that recomputes
+    per ``docs/fingerprint-spec.md`` cannot tell a salted digest from a plain one.
     """
     canonical = canonicalize_action(action_type, context)
     if salt is not None:

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -2850,9 +2850,14 @@ def init(
             ``hash-only`` for the Asqav cloud (``*.asqav.com``) and
             ``full-payload`` for self-hosted deployments. The
             ``ASQAV_MODE`` env var is consulted when ``mode="auto"``.
-        org_salt: Optional 32-byte per-organization salt. When set, the
-            SDK uses HMAC-SHA-256 instead of plain SHA-256 for hash-only
-            requests. Fetch yours from the Asqav dashboard.
+        org_salt: Optional 32-byte salt that you generate and hold. When
+            set, hash-only requests use HMAC-SHA-256 keyed by it instead
+            of plain SHA-256. Asqav never receives it and cannot recover
+            it for you. Leave it unset and the digest is an unsalted
+            SHA-256, which can be guessed for a predictable context.
+            Salted digests still travel labelled ``sha256``, so a third
+            party recomputing per ``docs/fingerprint-spec.md`` sees a
+            mismatch even though the signature verifies.
 
     Raises:
         AuthenticationError: If no API key is provided.
@@ -2924,7 +2929,9 @@ def govern(
         capabilities: Capability strings for the new agent.
         base_url: Override API base URL (for testing).
         mode: Wire mode - "auto" (default), "hash-only", or "full-payload".
-        org_salt: Optional 32-byte HMAC salt for hash-only mode.
+        org_salt: Optional 32-byte HMAC salt for hash-only mode, generated
+            and held by you. Unset means an unsalted SHA-256 digest. See
+            init() for the full caveats.
 
     Returns:
         A ready-to-use Agent instance.

--- a/typescript/src/canonicalize.ts
+++ b/typescript/src/canonicalize.ts
@@ -175,7 +175,9 @@ export function canonicalizeToolArgs(args: unknown): Uint8Array {
 
 /**
  * Self-describing hash for an action: `sha256:<hex>`.
- * With `salt` set, uses HMAC-SHA-256.
+ * With `salt` set, uses HMAC-SHA-256 keyed by that caller-held salt. The prefix
+ * reads `sha256` either way, so a verifier recomputing per the fingerprint spec
+ * cannot tell a salted digest from a plain one.
  */
 export async function hashAction(
   actionType: string,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -378,8 +378,13 @@ export interface InitOptions {
    */
   mode?: "auto" | "hash-only" | "full-payload";
   /**
-   * Optional 32-byte per-organization salt. When set, hash-only mode
-   * uses HMAC-SHA-256 instead of plain SHA-256.
+   * Optional 32-byte salt that you generate and hold. When set, hash-only
+   * mode uses HMAC-SHA-256 keyed by it instead of plain SHA-256. Asqav
+   * never receives it and cannot recover it for you. Unset means an
+   * unsalted SHA-256 digest, which can be guessed for a predictable
+   * context. Salted digests still travel labelled `sha256`, so a third
+   * party recomputing per `docs/fingerprint-spec.md` sees a mismatch even
+   * though the signature verifies.
    */
   orgSalt?: Uint8Array;
 }
@@ -1024,7 +1029,10 @@ export interface GovernOptions {
   baseUrl?: string;
   /** Wire mode - "auto" (default), "hash-only", or "full-payload". */
   mode?: "auto" | "hash-only" | "full-payload";
-  /** Optional 32-byte HMAC salt for hash-only mode. */
+  /**
+   * Optional 32-byte HMAC salt for hash-only mode, generated and held by
+   * you. Unset means an unsalted SHA-256 digest. See InitOptions.orgSalt.
+   */
   orgSalt?: Uint8Array;
 }
 


### PR DESCRIPTION
The `init()` docstring told users to fetch an org salt from the Asqav dashboard. No such surface exists. A grep for `org_salt|orgsalt|hmac_salt` across the backend's `src/`, `website/`, and `docs/` returns nothing, so nothing issues a salt and nothing receives one. A user following that sentence had nowhere to go.

The salt is generated and held by the caller. Asqav never sees it and cannot recover it.

## What changed

Docstrings only. No behaviour, no wire format, no signing code.

| File | Correction |
|---|---|
| `python/src/asqav/client.py` `init()` | drops "Fetch yours from the Asqav dashboard"; states the salt is caller-generated, that unset means an unsalted SHA-256, and that a salted digest still travels labelled `sha256` |
| `python/src/asqav/client.py` `govern()` | adds that the salt is caller-generated and that unset means an unsalted SHA-256 |
| `typescript/src/index.ts` `InitOptions.orgSalt` | "per-organization salt" becomes a caller-held salt, with the unsalted default and the label caveat |
| `typescript/src/index.ts` second `orgSalt` | same, pointing at `InitOptions.orgSalt` for the detail |
| both `canonicalize` helpers | "(per-org keyed hash)" becomes a caller-held salt, and both note the prefix reads `sha256` either way |

The label caveat matters because it is the surprising part: `hashAction` returns `sha256:<hex>` whether or not a salt was applied, so a verifier recomputing per the fingerprint spec cannot tell the two apart and will report a mismatch on a receipt whose signature is perfectly valid.

## Proof of work

The claim about the shared label is verified by the SDK's own test, which asserts both branches produce a `sha256:` prefix:

```
$ python3 -m pytest tests/test_client_hash_mode.py -q
PYTEST_EXIT=0
............                                                             [100%]
12 passed in 0.26s
```

```
$ ./node_modules/.bin/tsc --noEmit -p tsconfig.json
TSC_EXIT=0
(no output)

$ python3 -m py_compile python/src/asqav/client.py python/src/asqav/canonicalize.py
PYCOMPILE_EXIT=0

$ node secret-scan.js --worktree .
SDK_SECRET_EXIT=0
SCANNER: gitleaks - clean
```

Whole-repo sweep for the stale claim, exit code captured directly:

```
$ git ls-files -z | xargs -0 grep -niE "Fetch yours from the Asqav dashboard|per-organization salt|per-org keyed hash"
SDK_RESIDUE_EXIT=1
```

Exit 1 means no matches.

Rebased onto main, which has since taken #383 and #384.

Diff stat:

```
 python/src/asqav/canonicalize.py |  4 +++-
 python/src/asqav/client.py       | 15 +++++++++++----
 typescript/src/canonicalize.ts   |  4 +++-
 typescript/src/index.ts          | 14 +++++++++++---
 4 files changed, 28 insertions(+), 9 deletions(-)
```

Paired with the backend change that corrects the same claim on the public pages.
