### PR TITLE
chore: shorten verbose code comments to terse one-liners

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1939,9 +1939,7 @@ class Agent:
                 validate_context_schema(context, context_schema)
             context = normalize_context(context)
 
-        # Pluggable detector gate (criterion 331).
-        # Runs after schema normalize so detectors see the final context.
-        # Fail-closed by default; raises DetectorBlockedError when denied.
+        # Pluggable detector gate (criterion 331), fail-closed; runs after normalize.
         from ._detectors import run_detectors
 
         _detector_records = run_detectors(action_type, context)
@@ -3104,9 +3102,7 @@ def get_agent() -> Agent:
     """
     global _global_agent
     if _global_agent is None:
-        # Serialise auto-creation: without the lock, two threads hitting
-        # their first decorated call can race Agent.create and register
-        # duplicate agents, splitting the receipt chain across them.
+        # Serialise auto-creation: racing first calls would register duplicate agents.
         with _global_agent_lock:
             if _global_agent is None:
                 name = _auto_generate_name()

--- a/python/src/asqav/extras/_base.py
+++ b/python/src/asqav/extras/_base.py
@@ -48,10 +48,7 @@ class AsqavAdapter:
         if _client._api_key is None and api_key is None:
             raise AsqavError("Call asqav.init() first")
 
-        # The documented per-adapter override: an explicit key (re)initialises
-        # the client so Agent.create/get below actually authenticate with it.
-        # Without this, an adapter constructed with only api_key= passes the
-        # guard above yet fails on its first request.
+        # Explicit key re-inits the client so Agent calls authenticate with it.
         if api_key is not None and api_key != _client._api_key:
             _client.init(api_key)
 

--- a/python/src/asqav/extras/langchain.py
+++ b/python/src/asqav/extras/langchain.py
@@ -173,8 +173,7 @@ class AsqavCallbackHandler(BaseCallbackHandler, AsqavAdapter):  # type: ignore[m
 
 # -- Default-on entrypoint -----------------------------------------------------
 
-# LangChain auto-attaches a handler to every run when its ContextVar is set and
-# the paired configure hook is registered (langchain_core _configure loop).
+# LangChain auto-attaches the handler once its ContextVar is set and the hook is registered.
 _ASQAV_LC_HANDLER: ContextVar[AsqavCallbackHandler | None] = ContextVar(
     "asqav_langchain_handler", default=None
 )

--- a/python/src/asqav/extras/litellm.py
+++ b/python/src/asqav/extras/litellm.py
@@ -42,10 +42,7 @@ except ImportError as err:
     ) from err
 
 try:
-    # Optional at import time: the CustomLogger base may not be present in
-    # every litellm build. AsqavSigningLogger is duck-typed by litellm's
-    # callback dispatch, so falling back to object keeps the module importable
-    # (and AsqavGuardrail usable) when the base is unavailable.
+    # Optional base: litellm duck-types the logger, so fall back to object.
     from litellm.integrations.custom_logger import CustomLogger
 except ImportError:
     CustomLogger = object  # type: ignore[assignment,misc]
@@ -309,9 +306,7 @@ class AsqavSigningLogger(CustomLogger):
         self._lock = threading.Lock()
         self._warned = False
 
-        # Key resolution mirrors AsqavAdapter (_base.py): explicit api_key,
-        # then ASQAV_API_KEY env, then the key asqav.init() set on the client.
-        # The init() fallback keeps the documented quickstart actually signing.
+        # Key resolution mirrors AsqavAdapter: explicit key, then env, then init() key.
         resolved_key = (
             api_key or os.environ.get("ASQAV_API_KEY") or _client._api_key
         )

--- a/python/src/asqav/local.py
+++ b/python/src/asqav/local.py
@@ -46,9 +46,7 @@ class LocalQueue:
             "status": "pending",
         }
 
-        # Write-then-rename so a crash mid-write never leaves a truncated
-        # .json item that list_pending() would silently skip forever.
-        # The .tmp suffix keeps half-written files out of the *.json glob.
+        # Write-then-rename: a crash never leaves a truncated .json list_pending skips.
         filepath = self.queue_dir / f"{item_id}.json"
         tmp_path = self.queue_dir / f"{item_id}.json.tmp"
         tmp_path.write_text(json.dumps(payload, indent=2))

--- a/python/src/asqav/verifier/oracle/adapters/acta.py
+++ b/python/src/asqav/verifier/oracle/adapters/acta.py
@@ -121,9 +121,8 @@ class ActaAdapter(FormatAdapter):
             return "FAIL", "ACTA receipt needs object payload and signature"
         missing = [f for f in ("issued_at",) if f not in payload]
         missing += [f"signature.{f}" for f in ("alg", "kid", "sig") if f not in sig]
-        # Rev-02 asqav profile: `type` marks the profile; when present, `type` and
-        # `issuer_id` are REQUIRED too. Upstream A2A receipts carry neither and stay
-        # relaxed (documented deviation - they are not rev-02 receipts).
+        # Rev-02 asqav profile: with `type` present, `issuer_id` is required too.
+        # Upstream A2A receipts carry neither and stay relaxed (not rev-02).
         if "type" in payload:
             if not isinstance(payload["type"], str) or not payload["type"]:
                 return "FAIL", "type must be a non-empty namespaced string"

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -685,9 +685,8 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
         eff_status, eff_kid = status, kid
         eff_issuer = resolve_key_issuer(jwks, kid)
         eff_revoked_at = resolve_revoked_at(jwks, kid)
-        # Cloud receipts set kid to the issuer id but sign with the agent's own
-        # key, so fall back to the agent key. agent_id is attacker-controlled, so
-        # bind it: only a key whose issuer_id equals the claimed one is trusted.
+        # Cloud receipts sign with the agent key though kid is the issuer id; fall back.
+        # agent_id is attacker-controlled, so trust only a key whose issuer_id matches.
         if sig_res[0] != "PASS":
             agent_id = payload.get("agent_id") or envelope.get("agent_id")
             pk_a, status_a, alg_a, kid_a, issuer_a = resolve_key_by_agent_id(

--- a/typescript/src/algorithms.ts
+++ b/typescript/src/algorithms.ts
@@ -1,15 +1,8 @@
 // Algorithm agility for receipt signing.
 
-// SUPPORTED_ALGORITHMS is the client-side validation set (all five:
-// ml-dsa-65 default, ml-dsa-44, ml-dsa-87, ed25519, es256), so Agent.create
-// passes any of the five past local validation.
-
-// The cloud signs server-side only with ml-dsa-{44,65,87}. ed25519/es256
-// clear local validation but the cloud returns HTTP 400 on Agent.create
-// (see index.ts create comment + both READMEs).
-
-// ed25519/es256 are for LOCAL keypair generation and local sign/verify via
-// the node:crypto helpers below (LOCAL_SIGNING_ALGORITHMS), not cloud signing.
+// SUPPORTED_ALGORITHMS is the client-side validation set (all five). The cloud
+// signs only with ml-dsa-{44,65,87}; ed25519/es256 pass local validation but
+// the cloud returns HTTP 400. Those two are for local sign/verify only.
 
 import {
   createPrivateKey,
@@ -87,9 +80,8 @@ export function generateKeypair(algorithm: LocalSigningAlgorithm): LocalKeypair 
   throw new Error(`Unsupported local algorithm: ${exhaustive as string}`);
 }
 
-// Sign canonical bytes with a locally-generated keypair, raw signature as
-// base64. es256 emits IEEE P1363 (raw r||s) to match the cloud verifier.
-// Node defaults ECDSA to DER, so we convert.
+// Sign canonical bytes with a local keypair. es256 emits IEEE P1363 (raw r||s)
+// to match the cloud verifier; Node defaults ECDSA to DER, so we convert.
 export function signMessage(
   algorithm: LocalSigningAlgorithm,
   privateKeyPkcs8B64: string,

--- a/typescript/src/extras/langchain.ts
+++ b/typescript/src/extras/langchain.ts
@@ -229,9 +229,8 @@ async function loadContext(): Promise<LangchainContextModule> {
 const ASQAV_LC_CONTEXT_VAR = "asqav_langchain_handler";
 let hookRegistered = false;
 
-// Turn on default-on Asqav governance for LangChain.js. Registers a configure
-// hook once and binds the handler to a context variable so every run signs
-// automatically. Signing stays fail-open. Returns the handler.
+// Enable default-on governance: register a configure hook once and bind the
+// handler to a context variable so every run signs (fail-open). Returns it.
 export async function enableLangchainGovernance(
   opts: AsqavCallbackHandlerOptions,
 ): Promise<AsqavCallbackHandler & BaseCallbackHandlerLike> {

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -203,11 +203,9 @@ export function checkOrgBinding(
 const REVOKED_KEY_STATUSES = new Set(["revoked", "suspended", "compromised"]);
 
 // Gate on the key's JWKS status (mirrors `check_key_status`).
-// With revoked_at and a trusted anchor, receipts signed before revocation PASS.
-// Without revoked_at, any revoked-status key FAILs the axis.
-// Without an anchor, a pre-revocation issued_at is self-attested and cannot be
-// trusted: a holder of the compromised key can backdate. Downgrade to SKIPPED so
-// the verdict is INCOMPLETE, never a hiding PASS.
+// With revoked_at and a trusted anchor, pre-revocation receipts PASS; without
+// revoked_at, any revoked-status key FAILs. Without an anchor, issued_at is
+// self-attested (a compromised-key holder can backdate), so downgrade to SKIPPED.
 export function checkKeyStatus(
   status: string | null,
   issuedAt: string,


### PR DESCRIPTION
Condense multi-line narration/WHY comment blocks in python/src and typescript/src to 1-2 terse lines (each <=100 chars). Comment-only: no code, names, strings, types, or behavior changed. License headers and public API docstrings left untouched.

Verify: ruff check passed, python ast parse passed. tsc not installed (no node_modules); TS edits confirmed comment-only via diff inspection.

Generated with Qwen Code (1-shotted by Qwen-Coder)