### PR TITLE
chore(comments): compress remaining multi-line comment blocks

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -470,8 +470,7 @@ class SignatureResponse:
     incident_class: str | list[str] | None = None
     reason: str | None = None
     previous_receipt_hash: str | None = None
-    # Spec `decision` token (allow | deny | rate_limit). None on
-    # non-compliance receipts.
+    # Spec `decision` token (allow | deny | rate_limit). None on non-compliance receipts.
     decision: str | None = None
     # Three-key Compliance Receipts envelope (payload + anchors); None on non-compliance.
     payload: dict[str, Any] | None = None

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -202,10 +202,9 @@ export function checkOrgBinding(
 // Mirrors Python REVOKED_KEY_STATUSES; receipts from these keys must not PASS offline.
 const REVOKED_KEY_STATUSES = new Set(["revoked", "suspended", "compromised"]);
 
-// Gate on the key's JWKS status (mirrors `check_key_status`).
-// With revoked_at and a trusted anchor, pre-revocation receipts PASS; without
-// revoked_at, any revoked-status key FAILs. Without an anchor, issued_at is
-// self-attested (a compromised-key holder can backdate), so downgrade to SKIPPED.
+// Gate on the key's JWKS status (mirrors `check_key_status`). With revoked_at and a trusted
+// anchor, pre-revocation receipts PASS, and without revoked_at any revoked-status key FAILs.
+// Without an anchor, issued_at is self-attested (backdateable), so downgrade to SKIPPED.
 export function checkKeyStatus(
   status: string | null,
   issuedAt: string,


### PR DESCRIPTION
Comment-only sweep over python/src and typescript/src.

- Merge one clean two-line block to a single line (client.py).
- Compress the four-line JWKS status block to three (vrShim.ts).
- 2 files, +4/-6 (net -2 lines).

The SDK was already compressed by #387, so few multi-line blocks remain.
The rest are dense two-line why-comments or license headers, left intact.

Verification:
- Comment-only proof: every changed line is a # or // comment or blank (0 code lines).
- No added comment line over 100 chars, no em dash, no prose semicolon, no forbidden token.
- ruff check python/src: All checks passed.