### PR TITLE
feat(sdk): caller-held commitment helper and offline attestation verification (criterion 281)

### DIFF
--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -38,6 +38,14 @@ from ._detectors import (
 from ._jcs import canonical_json
 from ._schema import normalize_context, validate_context_schema
 from .async_client import AsyncAgent
+from .attestation import (
+    ATTESTATION_STATEMENT_SCHEMA,
+    VERDICT_VERIFIED_NOT_REDERIVABLE,
+    compute_statement_hash,
+    reconstruct_signed_message,
+    verify_attestation_offline,
+    verify_merkle_inclusion,
+)
 from .canonicalize import canonicalize, canonicalize_tool_args, hash_action
 from .client import (
     CAPTURE_TOPOLOGY_NAMESPACE,
@@ -132,6 +140,7 @@ from .client import (
     verify_output,
     verify_signature,
 )
+from .commitment import commit, new_opening
 from .compliance import ComplianceBundle, export_bundle, fetch_audit_pack
 from .counterparty import (
     ACKNOWLEDGMENT_RECEIPT_TYPE,
@@ -340,6 +349,15 @@ __all__ = [
     # Offline / air-gapped verification helpers
     "fetch_jwks",
     "verify_receipt_offline",
+    # Opaque-claim attestation commitments and offline verification (criterion 281)
+    "new_opening",
+    "commit",
+    "compute_statement_hash",
+    "reconstruct_signed_message",
+    "verify_attestation_offline",
+    "verify_merkle_inclusion",
+    "ATTESTATION_STATEMENT_SCHEMA",
+    "VERDICT_VERIFIED_NOT_REDERIVABLE",
     # Structured receipts (criterion 328)
     "validate_context_schema",
     "normalize_context",

--- a/python/src/asqav/attestation.py
+++ b/python/src/asqav/attestation.py
@@ -1,0 +1,328 @@
+"""Offline verification for opaque-claim attestation receipts.
+
+Mirrors the statement-hash canonicalization the asqav cloud pins for
+POST /attestations, so a caller holding the ORIGINAL claim can re-derive
+the statement hash a receipt commits to, check asqav's signature over the
+signed message, and check the inclusion proof against a signed tree head.
+
+The verdict is deliberately distinct from a plain pass. The receipt's
+commitment is an HMAC sealed with a key only the holder has, so a verifier
+can confirm the commitment was hashed and signed but can never re-derive it
+from the claim. A good receipt therefore yields a "verified, commitment not
+re-derivable" outcome, never a plain PASS.
+
+The statement-hash and signed-message shapes mirror the cloud route
+src/asqav_cloud/api/routes/attestations.py byte for byte. The Merkle helpers
+mirror src/asqav_cloud/core/merkle.py (certificate-transparency 6962-style).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from collections.abc import Callable
+from typing import Any
+
+from ._jcs import canonical_json
+
+__all__ = [
+    "ATTESTATION_STATEMENT_SCHEMA",
+    "VERDICT_VERIFIED_NOT_REDERIVABLE",
+    "compute_statement_hash",
+    "reconstruct_signed_message",
+    "merkle_leaf_hash",
+    "merkle_node_hash",
+    "merkle_root",
+    "merkle_inclusion_proof",
+    "verify_merkle_inclusion",
+    "verify_attestation_offline",
+]
+
+# Pinned by the cloud route. A change here silently breaks every verification.
+ATTESTATION_STATEMENT_SCHEMA = "asqav.attestation/1"
+DEFAULT_COMMITMENT_ALG = "HMAC-SHA256"
+
+#: Distinct outcome for a good attestation receipt. Never a plain PASS.
+VERDICT_VERIFIED_NOT_REDERIVABLE = "VERIFIED_COMMITMENT_NOT_REDERIVABLE"
+VERDICT_FAIL = "FAIL"
+VERDICT_INCOMPLETE = "INCOMPLETE"
+
+_AXIS_PASS = "PASS"
+_AXIS_FAIL = "FAIL"
+_AXIS_SKIP = "SKIP"
+_AXIS_NOT_REDERIVABLE = "NOT_REDERIVABLE"
+
+# Merkle domain separation, mirroring the cloud (6962-style second-preimage guard).
+_LEAF_PREFIX = b"\x00"
+_NODE_PREFIX = b"\x01"
+
+
+def compute_statement_hash(
+    claim: dict[str, Any],
+    commitment: str,
+    key_id: str,
+    timestamp: str,
+    commitment_alg: str = DEFAULT_COMMITMENT_ALG,
+) -> str:
+    """Re-derive the receipt's statementHash from the ORIGINAL claim.
+
+    Byte-for-byte mirror of the cloud's statement payload canonicalization.
+    Returns the self-describing ``sha256:<hex>`` form.
+    """
+    statement_payload = {
+        "v": 1,
+        "type": ATTESTATION_STATEMENT_SCHEMA,
+        "claim": claim,
+        "commitment": commitment,
+        "commitmentAlg": commitment_alg,
+        "keyId": key_id,
+        "timestamp": timestamp,
+    }
+    return "sha256:" + hashlib.sha256(canonical_json(statement_payload)).hexdigest()
+
+
+def reconstruct_signed_message(
+    *,
+    statement_hash: str,
+    commitment: str,
+    commitment_alg: str,
+    key_id: str,
+    claim_type: str,
+    server_timestamp: str,
+    action_id: str,
+    agent_id: str,
+    org_id: str,
+) -> bytes:
+    """Return the canonical signed-message bytes the cloud agent signed.
+
+    Byte-for-byte mirror of the cloud's message payload. A caller rebuilds
+    this from the receipt plus its own action_id/agent_id/org_id records and
+    verifies the receipt signature over these exact bytes.
+    """
+    message_payload = {
+        "v": 1,
+        "mode": "attestation",
+        "statement_hash": statement_hash,
+        "commitment": commitment,
+        "commitment_alg": commitment_alg,
+        "key_id": key_id,
+        "claim_type": claim_type,
+        "server_timestamp": server_timestamp,
+        "action_id": action_id,
+        "agent_id": agent_id,
+        "org_id": org_id,
+    }
+    return canonical_json(message_payload)
+
+
+# === Pure Merkle helpers (certificate-transparency 6962-style) ===
+
+
+def merkle_leaf_hash(entry: bytes) -> bytes:
+    """SHA256(0x00 || entry). Mirrors the cloud's leaf domain separation."""
+    return hashlib.sha256(_LEAF_PREFIX + entry).digest()
+
+
+def merkle_node_hash(left: bytes, right: bytes) -> bytes:
+    """SHA256(0x01 || left || right). Mirrors the cloud's internal node hash."""
+    return hashlib.sha256(_NODE_PREFIX + left + right).digest()
+
+
+def _largest_power_of_two_below(n: int) -> int:
+    """Largest power of two strictly less than n (n > 1). The 6962 split point."""
+    k = 1
+    while k << 1 < n:
+        k <<= 1
+    return k
+
+
+def merkle_root(leaves: list[bytes]) -> bytes:
+    """Merkle tree hash over already-hashed leaves. Empty tree hashes SHA256(b"")."""
+    n = len(leaves)
+    if n == 0:
+        return hashlib.sha256(b"").digest()
+    if n == 1:
+        return leaves[0]
+    k = _largest_power_of_two_below(n)
+    return merkle_node_hash(merkle_root(leaves[:k]), merkle_root(leaves[k:]))
+
+
+def merkle_inclusion_proof(leaves: list[bytes], index: int) -> list[bytes]:
+    """Audit path (sibling hashes, leaf-up) for the leaf at ``index``."""
+    n = len(leaves)
+    if index < 0 or index >= n:
+        raise IndexError(f"index {index} out of range for tree size {n}")
+    if n == 1:
+        return []
+    k = _largest_power_of_two_below(n)
+    if index < k:
+        return merkle_inclusion_proof(leaves[:k], index) + [merkle_root(leaves[k:])]
+    return merkle_inclusion_proof(leaves[k:], index - k) + [merkle_root(leaves[:k])]
+
+
+def verify_merkle_inclusion(
+    leaf: bytes,
+    index: int,
+    tree_size: int,
+    proof: list[bytes],
+    root: bytes,
+) -> bool:
+    """Verify an inclusion proof offline (6962 algorithm). False on any mismatch."""
+    if index < 0 or index >= tree_size or tree_size <= 0:
+        return False
+    if tree_size == 1:
+        return len(proof) == 0 and hmac.compare_digest(leaf, root)
+
+    fn, sn = index, tree_size - 1
+    r = leaf
+    for sibling in proof:
+        if sn == 0:
+            return False
+        if (fn & 1) or fn == sn:
+            r = merkle_node_hash(sibling, r)
+            if not (fn & 1):
+                while fn != 0 and not (fn & 1):
+                    fn >>= 1
+                    sn >>= 1
+        else:
+            r = merkle_node_hash(r, sibling)
+        fn >>= 1
+        sn >>= 1
+    return sn == 0 and hmac.compare_digest(r, root)
+
+
+# === Offline attestation verification ===
+
+
+def _axis(name: str, result: str, note: str) -> dict[str, str]:
+    return {"name": name, "result": result, "note": note}
+
+
+def verify_attestation_offline(
+    claim: dict[str, Any],
+    receipt: dict[str, Any],
+    *,
+    signed_message: bytes | None = None,
+    verify_signature: Callable[[bytes, bytes], bool] | None = None,
+    signed_tree_head: bytes | None = None,
+    commitment_alg: str = DEFAULT_COMMITMENT_ALG,
+) -> dict[str, Any]:
+    """Verify an attestation receipt offline from the ORIGINAL claim.
+
+    Recomputes statementHash with the cloud's exact canonicalization, checks
+    asqav's signature over the signed message, and checks the inclusion proof
+    against a supplied signed tree head. The commitment is an HMAC sealed with
+    a holder-only key, so it can never be re-derived here. A good receipt
+    yields VERDICT_VERIFIED_NOT_REDERIVABLE, never a plain PASS.
+
+    Args:
+        claim: The original claim dict the caller submitted.
+        receipt: The receipt dict (camelCase wire keys: statementHash,
+            commitment, keyId, timestamp, signature, inclusionProof).
+        signed_message: The canonical signed-message bytes (rebuild with
+            reconstruct_signed_message). Optional, signature axis SKIPs without it.
+        verify_signature: Callable(message, signature) -> bool for the agent key.
+            Optional, signature axis SKIPs without it.
+        signed_tree_head: The Merkle root the inclusion proof is checked against.
+            Optional, inclusion axis SKIPs without it or without a proof.
+        commitment_alg: Commitment algorithm id. Defaults to HMAC-SHA256.
+
+    Returns:
+        dict with ``verdict`` (VERIFIED_COMMITMENT_NOT_REDERIVABLE | FAIL |
+        INCOMPLETE), ``axes`` (per-axis name/result/note), and ``statementHash``
+        (the recomputed value).
+    """
+    axes: list[dict[str, str]] = []
+
+    recomputed = compute_statement_hash(
+        claim,
+        receipt.get("commitment", ""),
+        receipt.get("keyId", ""),
+        receipt.get("timestamp", ""),
+        commitment_alg,
+    )
+    receipt_hash = receipt.get("statementHash", "")
+    if recomputed == receipt_hash:
+        axes.append(_axis("statement_hash", _AXIS_PASS, "recomputed from the original claim"))
+    else:
+        axes.append(_axis("statement_hash", _AXIS_FAIL, "claim does not match the receipt hash"))
+
+    # Signature axis: verify over the exact signed message and bind it to the claim.
+    if signed_message is None or verify_signature is None:
+        axes.append(_axis("signature", _AXIS_SKIP, "no signed message or verifier supplied"))
+    else:
+        sig_result, sig_note = _check_signature(
+            signed_message, receipt, recomputed, verify_signature
+        )
+        axes.append(_axis("signature", sig_result, sig_note))
+
+    # Inclusion axis: check the proof against the supplied signed tree head.
+    proof = receipt.get("inclusionProof")
+    if signed_tree_head is None or proof is None:
+        axes.append(_axis("inclusion", _AXIS_SKIP, "no signed tree head or proof supplied"))
+    else:
+        incl_ok = verify_merkle_inclusion(
+            bytes.fromhex(proof["leafHash"]),
+            int(proof["leafIndex"]),
+            int(proof["treeSize"]),
+            [bytes.fromhex(h) for h in proof["auditPath"]],
+            signed_tree_head,
+        )
+        if incl_ok:
+            axes.append(_axis("inclusion", _AXIS_PASS, "proof verifies against the tree head"))
+        else:
+            axes.append(_axis("inclusion", _AXIS_FAIL, "proof does not match the tree head"))
+
+    # Commitment axis: the holder key is required and absent, so this is structural.
+    axes.append(
+        _axis(
+            "commitment",
+            _AXIS_NOT_REDERIVABLE,
+            "HMAC needs the holder key, which the verifier never has",
+        )
+    )
+
+    return {
+        "verdict": _verdict(axes),
+        "axes": axes,
+        "statementHash": recomputed,
+    }
+
+
+def _check_signature(
+    signed_message: bytes,
+    receipt: dict[str, Any],
+    recomputed_hash: str,
+    verify_signature: Callable[[bytes, bytes], bool],
+) -> tuple[str, str]:
+    """Verify the receipt signature over the signed message and bind it to the claim."""
+    try:
+        message_obj = json.loads(signed_message)
+    except (ValueError, TypeError):
+        return _AXIS_FAIL, "signed message is not valid canonical JSON"
+    if message_obj.get("statement_hash") != recomputed_hash:
+        return _AXIS_FAIL, "signed message does not bind to the original claim"
+    try:
+        signature = base64.b64decode(receipt.get("signature", ""))
+    except (ValueError, TypeError):
+        return _AXIS_FAIL, "receipt signature is not valid base64"
+    if verify_signature(signed_message, signature):
+        return _AXIS_PASS, "signature verifies over the signed message"
+    return _AXIS_FAIL, "signature does not verify over the signed message"
+
+
+def _verdict(axes: list[dict[str, str]]) -> str:
+    """Map per-axis results to a verdict. A good receipt is never a plain PASS."""
+    results = {a["name"]: a["result"] for a in axes}
+    if any(r == _AXIS_FAIL for r in results.values()):
+        return VERDICT_FAIL
+    checked = (
+        results.get("statement_hash") == _AXIS_PASS
+        and results.get("signature") == _AXIS_PASS
+        and results.get("inclusion") == _AXIS_PASS
+    )
+    if checked:
+        return VERDICT_VERIFIED_NOT_REDERIVABLE
+    return VERDICT_INCOMPLETE

--- a/python/src/asqav/commitment.py
+++ b/python/src/asqav/commitment.py
@@ -1,0 +1,52 @@
+"""Caller-held keyed commitments for opaque-claim attestations.
+
+Builds a randomised keyed commitment locally so a caller can seal a claim
+before submitting it to asqav's /attestations route. The commitment is an
+HMAC the caller seals with a key only they hold, so asqav can never open it.
+
+The keyed framing (opening, label, version, data) follows the IETF KeyTrans
+protocol draft: https://datatracker.ietf.org/doc/draft-ietf-keytrans-protocol/
+
+SECURITY: the key is generated and held by the CALLER. This module never
+sends, logs, persists, or default-generates key material. Key bytes only
+ever live in the caller's memory for the lifetime of the HMAC call.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+
+__all__ = ["new_opening", "commit"]
+
+_OPENING_BYTES = 16
+
+
+def new_opening() -> bytes:
+    """Return 16 fresh random bytes for use as a commitment opening.
+
+    The opening is caller entropy that makes each commitment unlinkable.
+    It is generated locally with the OS CSPRNG and never leaves the caller.
+    """
+    return secrets.token_bytes(_OPENING_BYTES)
+
+
+def commit(
+    key: bytes,
+    opening: bytes,
+    label: str,
+    version: int,
+    data: bytes,
+) -> str:
+    """Return lowercase hex of HMAC-SHA256 over the framed commitment input.
+
+    The MAC input is ``opening || label || version || data`` with the label
+    UTF-8 encoded and the version as a 4-byte big-endian integer, the keyed
+    framing from the IETF KeyTrans draft. The caller supplies ``key``. This
+    function never generates, stores, logs, or transmits the key.
+    """
+    # Key material is caller-owned. It is read here and nowhere else, and it
+    # never leaves the caller's process. Do not add a default or a fallback.
+    framed = opening + label.encode("utf-8") + version.to_bytes(4, "big") + data
+    return hmac.new(key, framed, hashlib.sha256).hexdigest()

--- a/python/tests/test_attestation_offline.py
+++ b/python/tests/test_attestation_offline.py
@@ -1,0 +1,228 @@
+"""Anti-vacuous tests for offline attestation verification (criterion 281).
+
+Prove the SDK re-derives the cloud's statementHash byte for byte from the
+original claim, that a tampered claim or receipt fails, and that a good
+receipt yields the distinct "verified, commitment not re-derivable" outcome
+rather than a plain PASS.
+
+The golden statementHash below was captured from the cloud route's merged
+canonicalization (src/asqav_cloud/api/routes/attestations.py), not a live call.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.attestation import (
+    VERDICT_FAIL,
+    VERDICT_VERIFIED_NOT_REDERIVABLE,
+    compute_statement_hash,
+    merkle_inclusion_proof,
+    merkle_leaf_hash,
+    merkle_root,
+    reconstruct_signed_message,
+    verify_attestation_offline,
+)
+
+# Fixture captured from the cloud's merged canonicalization (no live call).
+_CLAIM = {
+    "type": "vendor.risk_assessment/1",
+    "subject": "agt-swarm-9f2c",
+    "assertions": {"score": "risk-0.93"},
+}
+_COMMITMENT = "ab" * 32
+_KEY_ID = "caller-key-1"
+_TIMESTAMP = "2026-07-26T12:00:00Z"
+_GOLDEN_HASH = "sha256:ffdf04a90b96ede30294d6f4622bf8946fb03e4f2500a201a4e05030886199a0"
+
+_ACTION_ID = "act_test"
+_AGENT_ID = "agt_test"
+_ORG_ID = "org_test"
+
+
+def _ed25519_signer():
+    """Return (sign(message) -> bytes, verify(message, sig) -> bool) for a fresh key."""
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    private = ed25519.Ed25519PrivateKey.generate()
+    public = private.public_key()
+
+    def verify(message: bytes, signature: bytes) -> bool:
+        try:
+            public.verify(signature, message)
+            return True
+        except InvalidSignature:
+            return False
+
+    return private.sign, verify
+
+
+def _signed_message(claim: dict = _CLAIM) -> bytes:
+    statement_hash = compute_statement_hash(claim, _COMMITMENT, _KEY_ID, _TIMESTAMP)
+    return reconstruct_signed_message(
+        statement_hash=statement_hash,
+        commitment=_COMMITMENT,
+        commitment_alg="HMAC-SHA256",
+        key_id=_KEY_ID,
+        claim_type=claim["type"],
+        server_timestamp=_TIMESTAMP,
+        action_id=_ACTION_ID,
+        agent_id=_AGENT_ID,
+        org_id=_ORG_ID,
+    )
+
+
+def _tree_head_and_proof(index: int = 2, size: int = 4):
+    """Build a small Merkle tree and return (root, inclusionProof dict) for index."""
+    leaves = [merkle_leaf_hash(f"entry-{i}".encode()) for i in range(size)]
+    proof = merkle_inclusion_proof(leaves, index)
+    return merkle_root(leaves), {
+        "leafIndex": index,
+        "treeSize": size,
+        "leafHash": leaves[index].hex(),
+        "auditPath": [h.hex() for h in proof],
+    }
+
+
+def _good_receipt():
+    """A receipt whose hash, signature, and inclusion proof all verify.
+
+    Returns (receipt, message, verify, tree_head) sharing one consistent key
+    so each axis can be tampered in isolation.
+    """
+    sign, verify = _ed25519_signer()
+    message = _signed_message()
+    tree_head, proof = _tree_head_and_proof()
+    receipt = {
+        "statementHash": _GOLDEN_HASH,
+        "commitment": _COMMITMENT,
+        "keyId": _KEY_ID,
+        "timestamp": _TIMESTAMP,
+        "signature": base64.b64encode(sign(message)).decode(),
+        "inclusionProof": proof,
+        "logIndex": proof["leafIndex"],
+        "log_status": "included",
+    }
+    return receipt, message, verify, tree_head
+
+
+def test_compute_statement_hash_matches_cloud_fixture() -> None:
+    """(b) The SDK re-derives the exact statementHash the backend returned."""
+    got = compute_statement_hash(_CLAIM, _COMMITMENT, _KEY_ID, _TIMESTAMP)
+    assert got == _GOLDEN_HASH
+
+
+def test_reconstruct_signed_message_mirrors_cloud_shape() -> None:
+    """The signed message carries the exact 11 fields the cloud signs."""
+    message = json.loads(_signed_message())
+    assert message.keys() == {
+        "v", "mode", "statement_hash", "commitment", "commitment_alg",
+        "key_id", "claim_type", "server_timestamp", "action_id",
+        "agent_id", "org_id",
+    }
+    assert message["v"] == 1
+    assert message["mode"] == "attestation"
+    assert message["statement_hash"] == _GOLDEN_HASH
+
+
+def test_tampered_claim_changes_hash_and_does_not_pass() -> None:
+    """(c) A tampered claim re-derives a different hash and fails verification."""
+    tampered = dict(_CLAIM)
+    tampered["subject"] = "agt-EVIL"
+    assert compute_statement_hash(tampered, _COMMITMENT, _KEY_ID, _TIMESTAMP) != _GOLDEN_HASH
+
+    receipt, message, verify, tree_head = _good_receipt()
+    result = verify_attestation_offline(
+        tampered,
+        receipt,
+        signed_message=message,
+        verify_signature=verify,
+        signed_tree_head=tree_head,
+    )
+    assert result["verdict"] == VERDICT_FAIL
+    assert result["statementHash"] != _GOLDEN_HASH
+    by_name = {a["name"]: a["result"] for a in result["axes"]}
+    assert by_name["statement_hash"] == "FAIL"
+
+
+def test_good_receipt_is_not_rederivable_never_plain_pass() -> None:
+    """(d) A good receipt yields the distinct outcome, never a plain PASS."""
+    receipt, message, verify, tree_head = _good_receipt()
+    result = verify_attestation_offline(
+        _CLAIM,
+        receipt,
+        signed_message=message,
+        verify_signature=verify,
+        signed_tree_head=tree_head,
+    )
+    assert result["verdict"] == VERDICT_VERIFIED_NOT_REDERIVABLE
+    assert result["verdict"] != "PASS"
+    by_name = {a["name"]: a["result"] for a in result["axes"]}
+    assert by_name["statement_hash"] == "PASS"
+    assert by_name["signature"] == "PASS"
+    assert by_name["inclusion"] == "PASS"
+    assert by_name["commitment"] == "NOT_REDERIVABLE"
+
+
+def test_tampered_signature_fails() -> None:
+    """Flipping the signature bytes fails the signature axis and the verdict."""
+    receipt, message, verify, tree_head = _good_receipt()
+    raw = base64.b64decode(receipt["signature"])
+    flipped = bytes([raw[0] ^ 0xFF]) + raw[1:]
+    receipt["signature"] = base64.b64encode(flipped).decode()
+
+    result = verify_attestation_offline(
+        _CLAIM,
+        receipt,
+        signed_message=message,
+        verify_signature=verify,
+        signed_tree_head=tree_head,
+    )
+    assert result["verdict"] == VERDICT_FAIL
+    by_name = {a["name"]: a["result"] for a in result["axes"]}
+    assert by_name["signature"] == "FAIL"
+    assert by_name["statement_hash"] == "PASS"
+
+
+def test_tampered_inclusion_proof_fails() -> None:
+    """A proof cut against the wrong tree head fails the inclusion axis."""
+    receipt, message, verify, _ = _good_receipt()
+    wrong_head = merkle_root([merkle_leaf_hash(b"other-leaf")])
+    result = verify_attestation_offline(
+        _CLAIM,
+        receipt,
+        signed_message=message,
+        verify_signature=verify,
+        signed_tree_head=wrong_head,
+    )
+    assert result["verdict"] == VERDICT_FAIL
+    by_name = {a["name"]: a["result"] for a in result["axes"]}
+    assert by_name["inclusion"] == "FAIL"
+    assert by_name["signature"] == "PASS"
+
+
+def test_missing_optional_inputs_is_incomplete_not_pass() -> None:
+    """Without a key or tree head the verdict is INCOMPLETE, still never PASS."""
+    receipt, _message, _verify, _tree_head = _good_receipt()
+    result = verify_attestation_offline(_CLAIM, receipt)
+    assert result["verdict"] == "INCOMPLETE"
+    assert result["verdict"] != "PASS"
+    by_name = {a["name"]: a["result"] for a in result["axes"]}
+    assert by_name["statement_hash"] == "PASS"
+    assert by_name["signature"] == "SKIP"
+    assert by_name["inclusion"] == "SKIP"
+    assert by_name["commitment"] == "NOT_REDERIVABLE"
+
+
+def test_public_surface_exposed_at_package_root() -> None:
+    import asqav
+
+    assert asqav.verify_attestation_offline is verify_attestation_offline
+    assert asqav.compute_statement_hash is compute_statement_hash
+    assert asqav.VERDICT_VERIFIED_NOT_REDERIVABLE == "VERIFIED_COMMITMENT_NOT_REDERIVABLE"

--- a/python/tests/test_commitment.py
+++ b/python/tests/test_commitment.py
@@ -1,0 +1,99 @@
+"""Anti-vacuous tests for asqav.commitment (criterion 281).
+
+Prove the keyed commitment helper is deterministic for fixed inputs, changes
+when any single input changes, mints 16 random opening bytes, and never
+default-generates the caller-held key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import inspect
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav.commitment import commit, new_opening
+
+_KEY = bytes(range(32))
+_OPENING = bytes(range(16))
+_LABEL = "asqav.attestation"
+_VERSION = 1
+_DATA = b"claim-bytes"
+
+# Independent HMAC-SHA256 over opening || label || version(4 BE) || data.
+_GOLDEN = "4895dd9c2ad9a9f35f18d7c60d6957e4a87b017dff65d1316f76d437905fff88"
+
+
+def test_commit_matches_independent_hmac_golden() -> None:
+    """commit() equals a hand-computed HMAC-SHA256 over the framed input."""
+    got = commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
+    assert got == _GOLDEN
+    framed = _OPENING + _LABEL.encode() + _VERSION.to_bytes(4, "big") + _DATA
+    assert got == hmac.new(_KEY, framed, hashlib.sha256).hexdigest()
+
+
+def test_commit_is_deterministic_for_fixed_inputs() -> None:
+    """Same inputs always yield the same lowercase hex digest."""
+    first = commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
+    second = commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
+    assert first == second
+    assert len(first) == 64
+    assert first == first.lower()
+
+
+def test_commit_changes_when_key_changes() -> None:
+    other = commit(bytes(range(1, 33)), _OPENING, _LABEL, _VERSION, _DATA)
+    assert other != commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
+
+
+def test_commit_changes_when_opening_changes() -> None:
+    other = commit(_KEY, new_opening(), _LABEL, _VERSION, _DATA)
+    assert other != commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
+
+
+def test_commit_changes_when_label_changes() -> None:
+    other = commit(_KEY, _OPENING, "asqav.other", _VERSION, _DATA)
+    assert other != commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
+
+
+def test_commit_changes_when_version_changes() -> None:
+    other = commit(_KEY, _OPENING, _LABEL, _VERSION + 1, _DATA)
+    assert other != commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
+
+
+def test_commit_changes_when_data_changes() -> None:
+    other = commit(_KEY, _OPENING, _LABEL, _VERSION, b"other-bytes")
+    assert other != commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
+
+
+def test_version_is_four_big_endian_bytes_in_framing() -> None:
+    """version 1 and 256 differ, proving a 4-byte big-endian field, not a byte."""
+    low = commit(_KEY, _OPENING, _LABEL, 1, _DATA)
+    high = commit(_KEY, _OPENING, _LABEL, 256, _DATA)
+    assert low != high
+
+
+def test_new_opening_is_sixteen_bytes() -> None:
+    assert len(new_opening()) == 16
+    assert isinstance(new_opening(), bytes)
+
+
+def test_new_opening_is_random_across_calls() -> None:
+    """Two openings differ (CSPRNG); a constant opening would be a bug."""
+    assert new_opening() != new_opening()
+
+
+def test_commit_has_no_default_key() -> None:
+    """The key is caller-supplied: commit() must not default-generate it."""
+    params = inspect.signature(commit).parameters
+    assert params["key"].default is inspect.Parameter.empty
+
+
+def test_public_surface_exposed_at_package_root() -> None:
+    import asqav
+
+    assert asqav.commit is commit
+    assert asqav.new_opening is new_opening


### PR DESCRIPTION
## What

Adds two SDK surfaces for the opaque-claim attestation flow.

- `asqav/commitment.py`: `new_opening()` (16 random bytes) and `commit(key, opening, label, version, data)` returning lowercase hex of HMAC-SHA256 over `opening || label || version(4 BE) || data`. The keyed framing follows the IETF KeyTrans draft (https://datatracker.ietf.org/doc/draft-ietf-keytrans-protocol/).
- `asqav/attestation.py`: `verify_attestation_offline(claim, receipt, ...)` plus `compute_statement_hash` and `reconstruct_signed_message`. It re-derives `statementHash` from the ORIGINAL claim, checks the signature over the signed message, checks the inclusion proof against a supplied signed tree head, and returns a distinct `VERIFIED_COMMITMENT_NOT_REDERIVABLE` outcome. It never returns a plain PASS for an attestation receipt, because the commitment is an HMAC sealed with a holder-only key the verifier never has.

## Canonicalization mirrored

The statement-hash and signed-message shapes mirror the merged cloud route byte for byte: `asqav/src/asqav_cloud/api/routes/attestations.py:303-313` (statement payload and hash) and `:325-338` (message payload and canonical bytes). The Merkle helpers mirror `asqav/src/asqav_cloud/core/merkle.py`.

## Key never leaves the caller

`commitment.py` only reads the caller-supplied key inside the HMAC call. It never sends, logs, persists, or default-generates a key. `commit()` has no default for `key` (guarded by a test).

## Tests

- `tests/test_commitment.py`: determinism, sensitivity to every input, 16-byte random opening, golden HMAC vector, no default key.
- `tests/test_attestation_offline.py`: re-derives a statementHash fixture captured from the cloud canonicalization, tampered claim/signature/inclusion all fail, a good receipt yields the distinct not-rederivable verdict and never PASS.

New tests error on `origin/main` (modules absent) and pass with this change. Full SDK suite: 1415 passed, 0 failed, 0 skipped. `ruff check` clean. Diff 725 insertions.