### PR TITLE
feat(sdk): onboarding front-door (login, credential chain, whoami, init)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -12,7 +12,15 @@ pip install asqav
 
 ## Quick start
 
-Get an API key at [asqav.com](https://asqav.com), then sign your first agent action:
+Get an API key at [asqav.com](https://asqav.com). The fastest path is the CLI:
+
+```bash
+pip install "asqav[cli]"
+asqav login        # validates your key, saves it to ~/.asqav/credentials
+asqav init         # prints a ready-to-paste snippet for your project
+```
+
+`asqav login` saves your key so the SDK and CLI resolve it automatically (no `ASQAV_API_KEY` needed). Then sign your first agent action:
 
 ```python
 import asqav
@@ -51,9 +59,12 @@ Pass `compliance_mode=False` on any `agent.sign(...)` call if you want a non-Com
 
 ## CLI
 
-The package ships an `asqav` CLI mirroring the Python API. Set `ASQAV_API_KEY` and run:
+The package ships an `asqav` CLI mirroring the Python API. Start with `asqav login` (or set `ASQAV_API_KEY`) and run:
 
 ```bash
+asqav login                                  # save your key to ~/.asqav/credentials
+asqav whoami                                 # show the active key source + validate it
+asqav init                                   # print a ready-to-paste snippet
 asqav verify <signature_id> [--output json]   # IETF axes when present
 asqav sign --agent-id ID --action-type T --action-json action.json \
            --compliance-mode --receipt-type protectmcp:decision \

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -47,6 +47,7 @@ from asqav._useragent import USER_AGENT
 # Harness hooks (Claude Code PostToolUse/PreToolUse). Distinct from asqav/hooks.py,
 # which is in-process sign callbacks the agent opts into.
 from asqav.cli_hook import hook_app
+from asqav.credentials import resolve_api_key
 
 app = typer.Typer(
     name="asqav",
@@ -604,11 +605,9 @@ def replay(
 @agents_app.command("list")
 def agents_list() -> None:
     """List all agents for your organization."""
-    import os
-
-    api_key = os.environ.get("ASQAV_API_KEY")
+    api_key = resolve_api_key()
     if not api_key:
-        print("Error: ASQAV_API_KEY environment variable required.")
+        print("Error: API key required. Run `asqav login` or set ASQAV_API_KEY.")
         raise typer.Exit(code=1)
 
     import asqav
@@ -638,11 +637,9 @@ def agents_list() -> None:
 @agents_app.command("create")
 def agents_create(name: str = typer.Argument(help="Name for the new agent.")) -> None:
     """Create a new agent."""
-    import os
-
-    api_key = os.environ.get("ASQAV_API_KEY")
+    api_key = resolve_api_key()
     if not api_key:
-        print("Error: ASQAV_API_KEY environment variable required.")
+        print("Error: API key required. Run `asqav login` or set ASQAV_API_KEY.")
         raise typer.Exit(code=1)
 
     import asqav
@@ -878,14 +875,12 @@ def webhooks_delete(webhook_id: str = typer.Argument(help="Webhook ID.")) -> Non
 
 
 def _init_sdk() -> None:
-    """Initialize SDK with API key from environment."""
-    import os
-
+    """Initialize SDK with an API key from the credential chain."""
     import asqav
 
-    api_key = os.environ.get("ASQAV_API_KEY")
+    api_key = resolve_api_key()
     if not api_key:
-        print("Error: ASQAV_API_KEY environment variable required.")
+        print("Error: API key required. Run `asqav login` or set ASQAV_API_KEY.")
         raise typer.Exit(code=1)
     asqav.init(api_key=api_key)
 
@@ -979,9 +974,7 @@ def demo(
 @app.command()
 def quickstart() -> None:
     """Get started with asqav in 60 seconds."""
-    import os
-
-    api_key = os.environ.get("ASQAV_API_KEY")
+    api_key = resolve_api_key()
     if api_key:
         typer.echo(
             typer.style("API key detected.", fg=typer.colors.GREEN, bold=True)
@@ -989,7 +982,7 @@ def quickstart() -> None:
     else:
         typer.echo(
             typer.style(
-                "ASQAV_API_KEY not set. Get one at https://asqav.com",
+                "ASQAV_API_KEY not set. Run `asqav login` or get one at https://asqav.com",
                 fg=typer.colors.YELLOW,
                 bold=True,
             )
@@ -1023,18 +1016,197 @@ def quickstart() -> None:
     typer.echo("4. Run diagnostics:  asqav doctor")
 
 
+# === onboarding commands (login / whoami / status / init) ===
+
+
+def _detect_framework() -> str:
+    """Detect the project framework from dependency manifests in the cwd."""
+    from pathlib import Path
+
+    for fname in ("requirements.txt", "pyproject.toml"):
+        try:
+            text = Path(fname).read_text(encoding="utf-8").lower()
+        except OSError:
+            continue
+        for fw in ("litellm", "langchain", "openai", "anthropic"):
+            if fw in text:
+                return fw
+    return "python"
+
+
+def _onboarding_snippet(framework: str) -> str:
+    """Return a short govern() + @asqav.secure snippet flavoured for the framework."""
+    action = {
+        "openai": "api:openai:chat",
+        "anthropic": "api:anthropic:messages",
+        "litellm": "api:litellm:completion",
+        "langchain": "api:langchain:invoke",
+    }.get(framework, "api:call")
+    return (
+        "import asqav\n"
+        "\n"
+        "# Key resolves from `asqav login` (or ASQAV_API_KEY)\n"
+        'agent = asqav.govern(agent_name="my-agent")\n'
+        "\n"
+        "@asqav.secure\n"
+        "def call_model(prompt: str) -> str:\n"
+        '    return "..."  # your model call\n'
+        "\n"
+        f'sig = agent.sign("{action}", {{"model": "gpt-4o"}})\n'
+        "print(sig.verification_url)\n"
+    )
+
+
+def _resolve_key_source(explicit: str | None) -> tuple[str | None, str]:
+    """Resolve an API key and report which source supplied it (arg/env/file/none)."""
+    import os
+
+    from asqav.credentials import load_credentials
+
+    if explicit:
+        return explicit, "arg"
+    env_key = os.environ.get("ASQAV_API_KEY")
+    if env_key:
+        return env_key, "env"
+    file_key = load_credentials().get("api_key")
+    if isinstance(file_key, str) and file_key:
+        return file_key, "file"
+    return None, "none"
+
+
+@app.command("login")
+def login(
+    api_key: str = typer.Option("", "--api-key", help="Asqav API key (prompted if omitted)."),
+    api_base: str = typer.Option("", "--api-base", help="Override the API base URL."),
+    force: bool = typer.Option(False, "--force", help="Overwrite an existing credentials file."),
+) -> None:
+    """Validate an API key and save it to ~/.asqav/credentials."""
+    from asqav.credentials import credentials_path, save_credentials
+
+    if not api_key:
+        api_key = typer.prompt("Asqav API key", hide_input=True)
+
+    path = credentials_path()
+    if path.exists() and not force:
+        typer.echo(f"Error: {path} already exists. Re-run with --force to overwrite.")
+        raise typer.Exit(code=1)
+
+    import asqav
+    from asqav.client import _get
+
+    base = api_base or None
+    try:
+        asqav.init(api_key=api_key, base_url=base)
+        _get("/agents")
+    except Exception as exc:
+        typer.echo(f"Error: key validation failed: {exc}")
+        typer.echo("Nothing was saved.")
+        raise typer.Exit(code=1)
+
+    written = save_credentials(api_key, base)
+    typer.echo(f"Saved API key to {written}")
+    typer.echo("The SDK and CLI now pick it up automatically (no ASQAV_API_KEY needed).")
+
+
+def _whoami_impl(api_key: str) -> None:
+    from asqav.credentials import resolve_api_base
+
+    key, source = _resolve_key_source(api_key or None)
+    if key is None:
+        typer.echo("No API key found (checked --api-key, ASQAV_API_KEY, ~/.asqav/credentials).")
+        typer.echo("Run `asqav login` to save one.")
+        raise typer.Exit(code=1)
+
+    base = resolve_api_base()
+    typer.echo(f"Key source: {source}")
+    typer.echo(f"API base:   {base}")
+
+    import asqav
+    from asqav.client import _get
+
+    try:
+        asqav.init(api_key=key, base_url=base)
+        data = _get("/agents")
+    except Exception as exc:
+        typer.echo(f"Key rejected by API: {exc}")
+        raise typer.Exit(code=1)
+
+    agents = data if isinstance(data, list) else data.get("agents", [])
+    typer.echo(f"Key valid. {len(agents)} agent(s) accessible.")
+
+
+@app.command("whoami")
+def whoami(
+    api_key: str = typer.Option(
+        "", "--api-key", help="API key (else ASQAV_API_KEY env, else ~/.asqav/credentials)."
+    ),
+) -> None:
+    """Show which API key source is active and validate it against the API."""
+    _whoami_impl(api_key)
+
+
+@app.command("status")
+def status(
+    api_key: str = typer.Option(
+        "", "--api-key", help="API key (else ASQAV_API_KEY env, else ~/.asqav/credentials)."
+    ),
+) -> None:
+    """Alias for `asqav whoami`."""
+    _whoami_impl(api_key)
+
+
+@app.command("init")
+def init_cmd(
+    write: bool = typer.Option(False, "--write", help="Write the snippet to asqav_governance.py."),
+    demo: bool = typer.Option(False, "--demo", help="Run one labelled demo sign."),
+) -> None:
+    """Print a ready-to-paste governance snippet for this project (non-invasive)."""
+    from pathlib import Path
+
+    framework = _detect_framework()
+    typer.echo(f"Detected framework: {framework}")
+    typer.echo("")
+    snippet = _onboarding_snippet(framework)
+    typer.echo(snippet)
+    typer.echo("Hook wiring (Claude Code): asqav hook posttool   # audit tool calls")
+
+    if write:
+        target = Path("asqav_governance.py")
+        if target.exists():
+            typer.echo(f"\n{target} already exists; leaving it untouched.")
+        else:
+            target.write_text(snippet, encoding="utf-8")
+            typer.echo(f"\nWrote {target}")
+
+    if demo:
+        from asqav.credentials import resolve_api_key
+
+        key = resolve_api_key()
+        if not key:
+            typer.echo("\nNo API key resolved; skipping demo. Run `asqav login` first.")
+            return
+        import asqav
+
+        try:
+            agent = asqav.govern(api_key=key, agent_name="asqav-init-demo")
+            sig = agent.sign("asqav:init-demo", {"label": "asqav init demo", "demo": True})
+        except Exception as exc:
+            typer.echo(f"\nDemo sign failed: {exc}")
+            raise typer.Exit(code=1)
+        typer.echo(f"\nDemo signature: {sig.signature_id}")
+        typer.echo(f"Verify it: asqav verify {sig.signature_id}")
+
+
 # === doctor command ===
 
 
 @app.command()
 def doctor() -> None:
     """Validate your governance setup."""
-    import os
-
     all_ok = True
 
     # Check 1: API key
-    api_key = os.environ.get("ASQAV_API_KEY")
+    api_key = resolve_api_key()
     if api_key:
         typer.echo(
             typer.style("PASS", fg=typer.colors.GREEN, bold=True) + "  API key set"
@@ -1042,7 +1214,7 @@ def doctor() -> None:
     else:
         typer.echo(
             typer.style("FAIL", fg=typer.colors.RED, bold=True)
-            + "  ASQAV_API_KEY not set"
+            + "  ASQAV_API_KEY not set (run `asqav login`)"
         )
         all_ok = False
 
@@ -2010,9 +2182,9 @@ def migrate_run(
     # `_post` cannot inject headers, so build a one-off urllib request with X-Maintenance-Key.
     from asqav import init as _init
 
-    api_key = os.environ.get("ASQAV_API_KEY")
+    api_key = resolve_api_key()
     if not api_key:
-        print("Error: ASQAV_API_KEY env var is required.")
+        print("Error: API key required. Run `asqav login` or set ASQAV_API_KEY.")
         raise typer.Exit(code=1)
     _init(api_key=api_key)
 
@@ -2469,13 +2641,13 @@ def shadow_ai_init(
     for path in written:
         print(f"  wrote {path}")
 
-    import os as _os
-    if _os.environ.get("ASQAV_API_KEY"):
+    if resolve_api_key():
         _ensure_shadow_ai_policy()
     else:
         print(
-            "Hint: set ASQAV_API_KEY then run `asqav shadow-ai ensure-policy` to "
-            "register the monitor policy required by the no-false-attestation gate."
+            "Hint: run `asqav login` (or set ASQAV_API_KEY) then run "
+            "`asqav shadow-ai ensure-policy` to register the monitor policy "
+            "required by the no-false-attestation gate."
         )
 
     print("Next: copy .env.template to .env, fill in the values, then `asqav shadow-ai up`.")

--- a/python/src/asqav/cli_hook.py
+++ b/python/src/asqav/cli_hook.py
@@ -23,6 +23,8 @@ except ImportError:
     print("CLI requires typer. Install with: pip install asqav[cli]")
     sys.exit(1)
 
+from asqav.credentials import resolve_api_key
+
 hook_app = typer.Typer(
     name="hook",
     help="Sign Claude Code harness hook events (PostToolUse audit, PreToolUse gate).",
@@ -118,8 +120,8 @@ def _map_event(
 
 
 def _require_identity() -> tuple[str, str]:
-    """Return (api_key, agent_id) from env, or error clearly. No silent no-op."""
-    api_key = os.environ.get("ASQAV_API_KEY")
+    """Return (api_key, agent_id) from the credential chain + env, or error clearly."""
+    api_key = resolve_api_key()
     agent_id = os.environ.get("ASQAV_AGENT_ID")
     missing = [
         name
@@ -128,7 +130,8 @@ def _require_identity() -> tuple[str, str]:
     ]
     if missing:
         print(
-            "Error: " + " and ".join(missing) + " must be set to sign hook events.",
+            "Error: " + " and ".join(missing) + " must be set to sign hook events "
+            "(run `asqav login` for the API key).",
             file=sys.stderr,
         )
         raise typer.Exit(code=1)
@@ -186,7 +189,7 @@ def hook_posttool(
     )
 
     if dry_run:
-        api_key = os.environ.get("ASQAV_API_KEY", "")
+        api_key = resolve_api_key() or ""
         agent_id = os.environ.get("ASQAV_AGENT_ID", "")
         body = _build_body(
             action_type=action_type,
@@ -241,7 +244,7 @@ def hook_pretool(
     )
 
     if dry_run:
-        api_key = os.environ.get("ASQAV_API_KEY", "")
+        api_key = resolve_api_key() or ""
         agent_id = os.environ.get("ASQAV_AGENT_ID", "")
         body = _build_body(
             action_type=action_type,
@@ -254,11 +257,12 @@ def hook_pretool(
         return
 
     # Fail-closed: any failure to reach the signer or sign blocks the tool (exit 2).
-    api_key = os.environ.get("ASQAV_API_KEY")
+    api_key = resolve_api_key()
     agent_id = os.environ.get("ASQAV_AGENT_ID")
     if not api_key or not agent_id:
         print(
-            "asqav hook: ASQAV_API_KEY and ASQAV_AGENT_ID required to gate; blocking.",
+            "asqav hook: ASQAV_API_KEY (or `asqav login`) and ASQAV_AGENT_ID required "
+            "to gate; blocking.",
             file=sys.stderr,
         )
         raise typer.Exit(code=2)

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 from ._sql_match import matches_pattern as _matches_pattern
 from ._useragent import USER_AGENT
+from .credentials import resolve_api_key
 from .patterns import resolve_pattern
 from .retry import with_retry
 
@@ -2874,11 +2875,12 @@ def init(
     """
     global _api_key, _api_base, _client, _mode, _org_salt
 
-    _api_key = api_key or os.environ.get("ASQAV_API_KEY")
+    _api_key = resolve_api_key(api_key)
 
     if not _api_key:
         raise AuthenticationError(
-            "API key required. Set ASQAV_API_KEY or pass api_key to init(). Get yours at asqav.com"
+            "API key required. Run `asqav login`, set ASQAV_API_KEY, or pass api_key "
+            "to init(). A saved key is read from ~/.asqav/credentials. Get yours at asqav.com"
         )
 
     if base_url:

--- a/python/src/asqav/credentials.py
+++ b/python/src/asqav/credentials.py
@@ -1,0 +1,85 @@
+"""File-backed credential layer for the Asqav SDK.
+
+Stores an API key (and optional API base) in ``~/.asqav/credentials`` so the SDK
+and CLI can resolve a key without an environment variable. Resolution mirrors
+:mod:`asqav.local`: explicit argument, then environment, then file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+__all__ = [
+    "CREDENTIALS_PATH",
+    "credentials_path",
+    "load_credentials",
+    "save_credentials",
+    "resolve_api_key",
+    "resolve_api_base",
+]
+
+_DEFAULT_API_BASE = "https://api.asqav.com/api/v1"
+
+CREDENTIALS_PATH = Path(os.path.expanduser("~")) / ".asqav" / "credentials"
+
+
+def credentials_path() -> Path:
+    """Resolve the credentials file location (env override, else ~/.asqav/credentials)."""
+    override = os.environ.get("ASQAV_CREDENTIALS_PATH")
+    if override:
+        return Path(override)
+    return Path(os.path.expanduser("~")) / ".asqav" / "credentials"
+
+
+def load_credentials() -> dict[str, object]:
+    """Read the credentials file. Missing or corrupt file returns {} (never raises)."""
+    try:
+        data = json.loads(credentials_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_credentials(api_key: str, api_base: str | None = None) -> Path:
+    """Write the credentials file with mode 0600 under a mode 0700 ~/.asqav dir."""
+    path = credentials_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+
+    payload: dict[str, str] = {"api_key": api_key}
+    if api_base:
+        payload["api_base"] = api_base
+
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+    path.chmod(0o600)
+    return path
+
+
+def resolve_api_key(explicit: str | None = None) -> str | None:
+    """Resolve an API key: explicit arg, then ASQAV_API_KEY env, then credentials file."""
+    if explicit:
+        return explicit
+    env_key = os.environ.get("ASQAV_API_KEY")
+    if env_key:
+        return env_key
+    file_key = load_credentials().get("api_key")
+    if isinstance(file_key, str) and file_key:
+        return file_key
+    return None
+
+
+def resolve_api_base(explicit: str | None = None) -> str:
+    """Resolve an API base: explicit arg, then ASQAV_API_BASE env, then file, then default."""
+    if explicit:
+        return explicit
+    env_base = os.environ.get("ASQAV_API_BASE")
+    if env_base:
+        return env_base
+    file_base = load_credentials().get("api_base")
+    if isinstance(file_base, str) and file_base:
+        return file_base
+    return _DEFAULT_API_BASE

--- a/python/src/asqav/extras/litellm.py
+++ b/python/src/asqav/extras/litellm.py
@@ -48,6 +48,7 @@ except ImportError:
     CustomLogger = object  # type: ignore[assignment,misc]
 
 from .. import client as _client
+from ..credentials import resolve_api_key
 from ._base import AsqavAdapter
 
 logger = logging.getLogger("asqav")
@@ -306,10 +307,8 @@ class AsqavSigningLogger(CustomLogger):
         self._lock = threading.Lock()
         self._warned = False
 
-        # Key resolution mirrors AsqavAdapter: explicit key, then env, then init() key.
-        resolved_key = (
-            api_key or os.environ.get("ASQAV_API_KEY") or _client._api_key
-        )
+        # Key resolution mirrors AsqavAdapter: explicit key, env, file, then init() key.
+        resolved_key = resolve_api_key(api_key) or _client._api_key
         self._adapter: AsqavAdapter | None = None
         if not resolved_key:
             self._warn_no_key()

--- a/python/src/asqav/pytest_plugin.py
+++ b/python/src/asqav/pytest_plugin.py
@@ -70,14 +70,14 @@ def pytest_configure(config: pytest.Config) -> None:
     if not config.getoption("--asqav"):
         return
 
-    import os
+    from asqav.credentials import resolve_api_key
 
-    if not os.environ.get("ASQAV_API_KEY"):
+    if not resolve_api_key():
         # Configuration error, not a test failure. Exit early so the rest of
         # the run does not partially sign with a half-set-up agent.
         raise pytest.UsageError(
-            "--asqav requires ASQAV_API_KEY in the environment. "
-            "Get one at https://asqav.com."
+            "--asqav requires an API key. Run `asqav login`, set ASQAV_API_KEY, "
+            "or save ~/.asqav/credentials. Get one at https://asqav.com."
         )
 
     import asqav

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Test-suite isolation for the file-backed credential layer.
+
+Points ASQAV_CREDENTIALS_PATH at a per-test nonexistent path so no test reads a
+real ~/.asqav/credentials file, which would otherwise flip the "no key" paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_asqav_credentials(tmp_path, monkeypatch):
+    monkeypatch.setenv("ASQAV_CREDENTIALS_PATH", str(tmp_path / "credentials"))

--- a/python/tests/test_credentials.py
+++ b/python/tests/test_credentials.py
@@ -1,0 +1,285 @@
+"""Tests for the file-backed credential layer and the onboarding CLI commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from typer.testing import CliRunner  # noqa: E402
+
+from asqav import credentials as creds  # noqa: E402
+from asqav.cli import app  # noqa: E402
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Use the default ~/.asqav path under a temp HOME (drop the env override)."""
+    monkeypatch.delenv("ASQAV_CREDENTIALS_PATH", raising=False)
+    monkeypatch.delenv("ASQAV_API_KEY", raising=False)
+    monkeypatch.delenv("ASQAV_API_BASE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+# === credentials module ===
+
+
+def test_default_path_under_home(home) -> None:
+    assert creds.credentials_path() == home / ".asqav" / "credentials"
+
+
+def test_load_missing_file_returns_empty(home) -> None:
+    assert creds.load_credentials() == {}
+
+
+def test_resolve_api_key_missing_returns_none(home) -> None:
+    assert creds.resolve_api_key() is None
+
+
+def test_save_load_roundtrip(home) -> None:
+    creds.save_credentials("sk_file_123", "https://example.test/api/v1")
+    assert creds.load_credentials() == {
+        "api_key": "sk_file_123",
+        "api_base": "https://example.test/api/v1",
+    }
+
+
+def test_save_without_api_base_omits_key(home) -> None:
+    creds.save_credentials("sk_only")
+    assert creds.load_credentials() == {"api_key": "sk_only"}
+
+
+def test_saved_file_mode_is_0600(home) -> None:
+    path = creds.save_credentials("sk_secret")
+    assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+
+
+def test_credentials_dir_mode_is_0700(home) -> None:
+    creds.save_credentials("sk_secret")
+    assert stat.S_IMODE(os.stat(home / ".asqav").st_mode) == 0o700
+
+
+def test_corrupt_file_returns_empty(home) -> None:
+    path = home / ".asqav" / "credentials"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not valid json", encoding="utf-8")
+    assert creds.load_credentials() == {}
+    assert creds.resolve_api_key() is None
+
+
+def test_resolve_precedence_arg_beats_env_beats_file(home, monkeypatch) -> None:
+    creds.save_credentials("sk_file")
+    monkeypatch.setenv("ASQAV_API_KEY", "sk_env")
+    assert creds.resolve_api_key("sk_arg") == "sk_arg"
+    assert creds.resolve_api_key() == "sk_env"
+    monkeypatch.delenv("ASQAV_API_KEY")
+    assert creds.resolve_api_key() == "sk_file"
+
+
+def test_resolve_api_base_precedence_and_default(home, monkeypatch) -> None:
+    assert creds.resolve_api_base() == "https://api.asqav.com/api/v1"
+    creds.save_credentials("sk", "https://file.test/api")
+    assert creds.resolve_api_base() == "https://file.test/api"
+    monkeypatch.setenv("ASQAV_API_BASE", "https://env.test/api")
+    assert creds.resolve_api_base() == "https://env.test/api"
+    assert creds.resolve_api_base("https://arg.test/api") == "https://arg.test/api"
+
+
+def test_credentials_path_env_override(home, monkeypatch) -> None:
+    override = home / "custom" / "creds.json"
+    monkeypatch.setenv("ASQAV_CREDENTIALS_PATH", str(override))
+    assert creds.credentials_path() == override
+    creds.save_credentials("sk_override")
+    assert override.exists()
+    assert creds.resolve_api_key() == "sk_override"
+
+
+# === login command ===
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_login_saves_credentials(mock_init: MagicMock, mock_get: MagicMock, tmp_path) -> None:
+    mock_get.return_value = {"agents": []}
+    result = runner.invoke(app, ["login", "--api-key", "sk_test_123"])
+    assert result.exit_code == 0, result.output
+    assert "Saved API key" in result.output
+    saved = json.loads((tmp_path / "credentials").read_text())
+    assert saved["api_key"] == "sk_test_123"
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_login_does_not_save_on_validation_failure(
+    mock_init: MagicMock, mock_get: MagicMock, tmp_path
+) -> None:
+    from asqav.client import AuthenticationError
+
+    mock_get.side_effect = AuthenticationError("Invalid API key")
+    result = runner.invoke(app, ["login", "--api-key", "sk_bad"])
+    assert result.exit_code == 1
+    assert "validation failed" in result.output
+    assert not (tmp_path / "credentials").exists()
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_login_refuses_overwrite_without_force(
+    mock_init: MagicMock, mock_get: MagicMock, tmp_path
+) -> None:
+    mock_get.return_value = {"agents": []}
+    assert runner.invoke(app, ["login", "--api-key", "sk_one"]).exit_code == 0
+    second = runner.invoke(app, ["login", "--api-key", "sk_two"])
+    assert second.exit_code == 1
+    assert "already exists" in second.output
+    saved = json.loads((tmp_path / "credentials").read_text())
+    assert saved["api_key"] == "sk_one"
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_login_force_overwrites(
+    mock_init: MagicMock, mock_get: MagicMock, tmp_path
+) -> None:
+    mock_get.return_value = {"agents": []}
+    runner.invoke(app, ["login", "--api-key", "sk_one"])
+    result = runner.invoke(app, ["login", "--api-key", "sk_two", "--force"])
+    assert result.exit_code == 0
+    saved = json.loads((tmp_path / "credentials").read_text())
+    assert saved["api_key"] == "sk_two"
+
+
+# === whoami / status commands ===
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_whoami_reports_env_source(
+    mock_init: MagicMock, mock_get: MagicMock, monkeypatch
+) -> None:
+    monkeypatch.setenv("ASQAV_API_KEY", "sk_env")
+    mock_get.return_value = {"agents": [{"agent_id": "a1"}, {"agent_id": "a2"}]}
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 0, result.output
+    assert "Key source: env" in result.output
+    assert "Key valid" in result.output
+    assert "2 agent(s)" in result.output
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_whoami_reports_file_source(
+    mock_init: MagicMock, mock_get: MagicMock, tmp_path, monkeypatch
+) -> None:
+    monkeypatch.delenv("ASQAV_API_KEY", raising=False)
+    (tmp_path / "credentials").write_text(json.dumps({"api_key": "sk_file"}))
+    mock_get.return_value = []
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 0, result.output
+    assert "Key source: file" in result.output
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_whoami_reports_arg_source(
+    mock_init: MagicMock, mock_get: MagicMock, monkeypatch
+) -> None:
+    monkeypatch.delenv("ASQAV_API_KEY", raising=False)
+    mock_get.return_value = []
+    result = runner.invoke(app, ["whoami", "--api-key", "sk_arg"])
+    assert result.exit_code == 0
+    assert "Key source: arg" in result.output
+
+
+def test_whoami_no_key_exits_nonzero(monkeypatch) -> None:
+    monkeypatch.delenv("ASQAV_API_KEY", raising=False)
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 1
+    assert "asqav login" in result.output
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_whoami_rejected_key_exits_nonzero(
+    mock_init: MagicMock, mock_get: MagicMock, monkeypatch
+) -> None:
+    from asqav.client import AuthenticationError
+
+    monkeypatch.setenv("ASQAV_API_KEY", "sk_bad")
+    mock_get.side_effect = AuthenticationError("Invalid API key")
+    result = runner.invoke(app, ["whoami"])
+    assert result.exit_code == 1
+    assert "rejected" in result.output
+
+
+@patch("asqav.client._get")
+@patch("asqav.init")
+def test_status_alias_reports_source(
+    mock_init: MagicMock, mock_get: MagicMock, monkeypatch
+) -> None:
+    monkeypatch.setenv("ASQAV_API_KEY", "sk_env")
+    mock_get.return_value = []
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "Key source: env" in result.output
+
+
+# === init command ===
+
+
+def test_init_prints_snippet_without_writing(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0, result.output
+    assert "Detected framework: python" in result.output
+    assert "asqav.govern" in result.output
+    assert "@asqav.secure" in result.output
+    assert os.listdir(tmp_path) == []
+
+
+def test_init_detects_framework(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "requirements.txt").write_text("litellm>=1.0\n")
+    result = runner.invoke(app, ["init"])
+    assert "Detected framework: litellm" in result.output
+    assert "api:litellm:completion" in result.output
+
+
+def test_init_write_creates_file(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--write"])
+    assert result.exit_code == 0
+    written = tmp_path / "asqav_governance.py"
+    assert written.exists()
+    assert "asqav.govern" in written.read_text()
+
+
+def test_init_demo_skips_without_key(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("ASQAV_API_KEY", raising=False)
+    result = runner.invoke(app, ["init", "--demo"])
+    assert result.exit_code == 0
+    assert "skipping demo" in result.output
+
+
+@patch("asqav.govern")
+def test_init_demo_signs_with_key(
+    mock_govern: MagicMock, tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ASQAV_API_KEY", "sk_env")
+    mock_govern.return_value.sign.return_value = MagicMock(signature_id="sig_demo")
+    result = runner.invoke(app, ["init", "--demo"])
+    assert result.exit_code == 0, result.output
+    assert "sig_demo" in result.output
+    assert "asqav verify sig_demo" in result.output
+    mock_govern.assert_called_once_with(api_key="sk_env", agent_name="asqav-init-demo")


### PR DESCRIPTION
## The gap

Activation is the constraint. The Python SDK only resolved an API key from an explicit arg or the ASQAV_API_KEY env var, and there was no login, whoami, or project scaffolding command. A first-time user had to export an env var by hand before anything worked.

## What was added

- A file credential layer at ~/.asqav/credentials (JSON with api_key and an optional api_base, file mode 0600 under a mode 0700 directory).
- asqav login: validates the key with an authed GET /agents, then saves it. Refuses to overwrite without --force.
- asqav whoami (alias asqav status): reports which source resolved the key (arg, env, file, or none), prints the base URL, and validates against the API. Exits nonzero when a key is present but rejected.
- asqav init: detects the framework from requirements.txt / pyproject.toml and prints a ready-to-paste govern() + @asqav.secure snippet plus the hook wiring line. Non-invasive by default. --write saves the snippet, --demo runs one labelled sign (agent asqav-init-demo) when a key resolves.

## Precedence chain

resolve_api_key: explicit arg, then ASQAV_API_KEY, then the credentials file. resolve_api_base: explicit arg, then ASQAV_API_BASE, then the file, then the default https://api.asqav.com/api/v1. The path honors ASQAV_CREDENTIALS_PATH (mirrors ASQAV_QUEUE_DIR in asqav.local).

## Refactor surface

init() in client.py is the central site and uses resolve_api_key, which propagates to govern() and every SDK call. The direct env reads moved onto the chain in cli.py (agents list/create, sync, quickstart, doctor check 1, migrate, shadow-ai init), cli_hook.py (identity, dry-run, and gate paths), pytest_plugin.py, and extras/litellm.py. Command signatures are unchanged and the existing error behavior is preserved (messages mention asqav login).

## Test evidence

PYTHONPATH=python/src pytest python/tests -q reports 1439 passed, 2 skipped (pre-existing litellm/haystack stub paths), 0 failed. New coverage in tests/test_credentials.py: precedence (arg beats env beats file), save/load roundtrip, 0600 file and 0700 dir modes, missing and corrupt files, plus CLI tests for login (mocked validation, temp HOME), whoami source reporting, and init printing a snippet without writing files. A conftest fixture points ASQAV_CREDENTIALS_PATH at a temp path so the suite never reads a real credentials file. ruff check python/src is clean.

## TS mirror

The TypeScript SDK mirror follows in a separate change, matching the same file format and precedence chain.