### PR TITLE
feat(sdk-ts): onboarding front-door (login, credential chain, whoami, init)

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -12,7 +12,15 @@ npm install @asqav/sdk
 
 ## Quick start
 
-Get an API key at [asqav.com](https://asqav.com), then sign your first agent action:
+Get an API key at [asqav.com](https://asqav.com). The fastest path is the CLI:
+
+```bash
+npm install -g @asqav/sdk
+asqav login        # validates your key, saves it to ~/.asqav/credentials
+asqav init         # prints a ready-to-paste snippet for your project
+```
+
+`asqav login` saves your key so the SDK and CLI resolve it automatically (no `ASQAV_API_KEY` needed). Then sign your first agent action:
 
 ```ts
 import { govern } from "@asqav/sdk";
@@ -43,9 +51,12 @@ Pass `complianceMode: false` on any `agent.sign(...)` call if you want a non-Com
 
 ## CLI
 
-The package ships an `asqav` binary mirroring the Python CLI surface. Set `ASQAV_API_KEY` and run:
+The package ships an `asqav` binary mirroring the Python CLI surface. Start with `asqav login` (or set `ASQAV_API_KEY`) and run:
 
 ```bash
+asqav login                                   # save your key to ~/.asqav/credentials
+asqav whoami                                  # show the active key source + validate it
+asqav init                                    # print a ready-to-paste snippet
 asqav verify <signature_id> [--output json]   # IETF axes when present
 asqav sign --agent-id ID --action-type T --action-json action.json \
            --receipt-type protectmcp:decision \

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -1018,19 +1018,53 @@ function resolveKeySource(explicit?: string): [string | null, string] {
   return [null, "none"];
 }
 
-function promptHidden(query: string): Promise<string> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-    terminal: false,
-  });
+// Reads a line without echoing keystrokes. On a TTY, raw mode
+// suppresses echo; on a pipe, readline is safe (nothing is echoed).
+export function promptHidden(query: string): Promise<string> {
   process.stdout.write(query);
-  return new Promise((resolve) => {
-    rl.question("", (answer) => {
-      process.stdout.write("\n");
-      rl.close();
-      resolve(answer.trim());
+
+  if (!process.stdin.isTTY) {
+    const rl = readline.createInterface({ input: process.stdin, terminal: false });
+    return new Promise((resolve) => {
+      rl.question("", (answer) => {
+        rl.close();
+        resolve(answer.trim());
+      });
     });
+  }
+
+  return new Promise((resolve) => {
+    const stdin = process.stdin;
+    let buf = "";
+
+    const cleanup = () => {
+      stdin.removeListener("data", onData);
+      stdin.setRawMode(false);
+      stdin.pause();
+    };
+
+    const onData = (chunk: Buffer) => {
+      for (const ch of chunk.toString("utf8")) {
+        if (ch === "\u0003") {
+          cleanup();
+          process.stdout.write("\n");
+          process.exit(130);
+        } else if (ch === "\r" || ch === "\n") {
+          cleanup();
+          process.stdout.write("\n");
+          resolve(buf);
+          return;
+        } else if (ch === "\x7f" || ch === "\b") {
+          buf = buf.slice(0, -1);
+        } else {
+          buf += ch;
+        }
+      }
+    };
+
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on("data", onData);
   });
 }
 

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -19,11 +19,14 @@
  * truth for what a given key may do.
  */
 
+import fs from "node:fs";
+import readline from "node:readline";
 import {
   Agent,
   APIError,
   BudgetTracker,
   generateKeypair,
+  govern,
   init,
   listSessions,
   request,
@@ -32,6 +35,13 @@ import {
   type LocalSigningAlgorithm,
   type SignatureResponse,
 } from "./index.js";
+import {
+  credentialsPath,
+  loadCredentials,
+  resolveApiBase,
+  resolveApiKey,
+  saveCredentials,
+} from "./credentials.js";
 import { SDK_VERSION, userAgentHeaders } from "./userAgent.js";
 
 export const CLI_VERSION = SDK_VERSION;
@@ -42,10 +52,11 @@ function die(msg: string, code = 1): never {
 }
 
 function ensureApiKey(): void {
-  if (!process.env.ASQAV_API_KEY) {
-    die("Error: ASQAV_API_KEY environment variable required.");
+  const apiKey = resolveApiKey();
+  if (!apiKey) {
+    die("Error: API key required. Run `asqav login` or set ASQAV_API_KEY.");
   }
-  init({ apiKey: process.env.ASQAV_API_KEY });
+  init({ apiKey });
 }
 
 function parseFlag(args: string[], name: string): string | undefined {
@@ -83,7 +94,7 @@ async function cmdVerify(args: string[]): Promise<void> {
   if (!sigId) die("Usage: asqav verify <signature_id> [--output text|json]");
   const output = parseFlag(args, "output") ?? "text";
   // Verify is public, but `request` short-circuits on missing config; init with any key.
-  init({ apiKey: process.env.ASQAV_API_KEY ?? "anon" });
+  init({ apiKey: resolveApiKey() ?? "anon" });
   try {
     const r = await verifySignature(sigId);
     if (output === "json") {
@@ -908,8 +919,9 @@ async function cmdMigrateRun(args: string[]): Promise<void> {
   if (!maintenanceKey) {
     die("Error: ASQAV_MAINTENANCE_KEY env var is required for migration commands.");
   }
-  if (!process.env.ASQAV_API_KEY) {
-    die("Error: ASQAV_API_KEY env var is required.");
+  const apiKey = resolveApiKey();
+  if (!apiKey) {
+    die("Error: API key required. Run `asqav login` or set ASQAV_API_KEY.");
   }
   const baseUrl = process.env.ASQAV_API_URL ?? "https://api.asqav.com/api/v1";
   const url = `${baseUrl.replace(/\/+$/, "")}/maintenance/run-migration-${migration}`;
@@ -917,7 +929,7 @@ async function cmdMigrateRun(args: string[]): Promise<void> {
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        "X-API-Key": process.env.ASQAV_API_KEY,
+        "X-API-Key": apiKey,
         "X-Maintenance-Key": maintenanceKey,
         "Content-Type": "application/json",
         ...userAgentHeaders(),
@@ -939,6 +951,194 @@ async function cmdMigrateRun(args: string[]): Promise<void> {
   }
 }
 
+// === onboarding commands (login / whoami / status / init) ===
+
+function detectFramework(): string {
+  let raw: string;
+  try {
+    raw = fs.readFileSync("package.json", "utf-8");
+  } catch {
+    return "typescript";
+  }
+  let names: string[] = [];
+  try {
+    const pkg = JSON.parse(raw) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    names = [
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ];
+  } catch {
+    return "typescript";
+  }
+  const has = (needle: string) =>
+    names.some((n) => n === needle || n.startsWith(`${needle}/`));
+  if (has("langchain") || has("@langchain/core")) return "langchain";
+  if (has("@openai/agents")) return "openai-agents";
+  if (has("openai")) return "openai";
+  if (has("@anthropic-ai/sdk") || has("anthropic")) return "anthropic";
+  if (has("ai")) return "vercel-ai";
+  if (has("@mastra/core") || has("mastra")) return "mastra";
+  return "typescript";
+}
+
+function onboardingSnippet(framework: string): string {
+  const action =
+    {
+      openai: "api:openai:chat",
+      anthropic: "api:anthropic:messages",
+      langchain: "api:langchain:invoke",
+      "vercel-ai": "api:vercel-ai:generateText",
+      mastra: "api:mastra:generate",
+      "openai-agents": "api:openai-agents:run",
+    }[framework] ?? "api:call";
+  return (
+    'import { govern } from "@asqav/sdk";\n' +
+    "\n" +
+    "// Key resolves from `asqav login` (or ASQAV_API_KEY)\n" +
+    'const agent = await govern({ agentName: "my-agent" });\n' +
+    "\n" +
+    "const sig = await agent.sign({\n" +
+    `  actionType: "${action}",\n` +
+    '  context: { model: "gpt-4o" },\n' +
+    "});\n" +
+    "\n" +
+    "console.log(sig.verificationUrl);\n"
+  );
+}
+
+function resolveKeySource(explicit?: string): [string | null, string] {
+  if (explicit) return [explicit, "arg"];
+  const envKey = process.env.ASQAV_API_KEY;
+  if (envKey) return [envKey, "env"];
+  const fileKey = loadCredentials().api_key;
+  if (typeof fileKey === "string" && fileKey) return [fileKey, "file"];
+  return [null, "none"];
+}
+
+function promptHidden(query: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+  });
+  process.stdout.write(query);
+  return new Promise((resolve) => {
+    rl.question("", (answer) => {
+      process.stdout.write("\n");
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function cmdLogin(args: string[]): Promise<void> {
+  let apiKey = parseFlag(args, "api-key");
+  const apiBase = parseFlag(args, "api-base");
+  const force = hasFlag(args, "force");
+
+  if (!apiKey) {
+    apiKey = await promptHidden("Asqav API key: ");
+  }
+  if (!apiKey) {
+    die("Error: an API key is required.");
+  }
+
+  const target = credentialsPath();
+  if (fs.existsSync(target) && !force) {
+    die(`Error: ${target} already exists. Re-run with --force to overwrite.`);
+  }
+
+  const base = apiBase || undefined;
+  try {
+    init({ apiKey, baseUrl: base });
+    await request<unknown>("GET", "/agents");
+  } catch (err) {
+    die(`Error: key validation failed: ${(err as Error).message}\nNothing was saved.`);
+  }
+
+  const written = saveCredentials(apiKey, base);
+  process.stdout.write(`Saved API key to ${written}\n`);
+  process.stdout.write(
+    "The SDK and CLI now pick it up automatically (no ASQAV_API_KEY needed).\n",
+  );
+}
+
+async function whoamiImpl(explicitKey?: string): Promise<void> {
+  const [key, source] = resolveKeySource(explicitKey);
+  if (key === null) {
+    process.stdout.write(
+      "No API key found (checked --api-key, ASQAV_API_KEY, ~/.asqav/credentials).\n",
+    );
+    process.stdout.write("Run `asqav login` to save one.\n");
+    process.exit(1);
+  }
+
+  const base = resolveApiBase();
+  process.stdout.write(`Key source: ${source}\n`);
+  process.stdout.write(`API base:   ${base}\n`);
+
+  let data: unknown;
+  try {
+    init({ apiKey: key, baseUrl: base });
+    data = await request<unknown>("GET", "/agents");
+  } catch (err) {
+    die(`Key rejected by API: ${(err as Error).message}`);
+  }
+
+  const list = Array.isArray(data) ? data : ((data as { agents?: unknown[] })?.agents ?? []);
+  process.stdout.write(`Key valid. ${list.length} agent(s) accessible.\n`);
+}
+
+async function cmdWhoami(args: string[]): Promise<void> {
+  return whoamiImpl(parseFlag(args, "api-key"));
+}
+
+async function cmdStatus(args: string[]): Promise<void> {
+  return whoamiImpl(parseFlag(args, "api-key"));
+}
+
+async function cmdInit(args: string[]): Promise<void> {
+  const write = hasFlag(args, "write");
+  const demo = hasFlag(args, "demo");
+
+  const framework = detectFramework();
+  process.stdout.write(`Detected framework: ${framework}\n\n`);
+  const snippet = onboardingSnippet(framework);
+  process.stdout.write(snippet);
+
+  if (write) {
+    const target = "asqav_governance.ts";
+    if (fs.existsSync(target)) {
+      process.stdout.write(`\n${target} already exists; leaving it untouched.\n`);
+    } else {
+      fs.writeFileSync(target, snippet, "utf-8");
+      process.stdout.write(`\nWrote ${target}\n`);
+    }
+  }
+
+  if (demo) {
+    const key = resolveApiKey();
+    if (!key) {
+      process.stdout.write("\nNo API key resolved; skipping demo. Run `asqav login` first.\n");
+      return;
+    }
+    try {
+      const agent = await govern({ apiKey: key, agentName: "asqav-init-demo" });
+      const sig = await agent.sign({
+        actionType: "asqav:init-demo",
+        context: { label: "asqav init demo", demo: true },
+      });
+      process.stdout.write(`\nDemo signature: ${sig.signatureId}\n`);
+      process.stdout.write(`Verify it: asqav verify ${sig.signatureId}\n`);
+    } catch (err) {
+      die(`Demo sign failed: ${(err as Error).message}`);
+    }
+  }
+}
+
 // === Help / usage ===
 
 function printHelp(): void {
@@ -946,6 +1146,10 @@ function printHelp(): void {
 
 Usage:
   asqav --version
+  asqav login [--api-key KEY] [--api-base URL] [--force]    save key to ~/.asqav/credentials
+  asqav whoami [--api-key KEY]                               show active key source + validate
+  asqav status [--api-key KEY]                               alias for whoami
+  asqav init [--write] [--demo]                              print a ready-to-paste snippet
   asqav verify <signature_id> [--output text|json]
   asqav sign --agent-id ID --action-type T [--no-compliance-mode] [--action-json PATH|-]
              [--receipt-type protectmcp:decision|...] [--risk-class low|medium|high|unknown]
@@ -973,7 +1177,7 @@ Usage:
   asqav keys generate --algorithm ed25519|es256 [--out priv.pem]
   asqav migrate run v3-20|v3-21|v3-22                      X-Maintenance-Key required
 
-Set ASQAV_API_KEY to authenticate. Get a key at https://asqav.com.
+Run \`asqav login\` (or set ASQAV_API_KEY) to authenticate. Get a key at https://asqav.com.
 Admin commands (org halt/resume) read a dashboard session token from ASQAV_SESSION_TOKEN.
 `);
 }
@@ -992,6 +1196,14 @@ export async function runCli(argv: string[]): Promise<void> {
   }
 
   switch (first) {
+    case "login":
+      return cmdLogin(rest);
+    case "whoami":
+      return cmdWhoami(rest);
+    case "status":
+      return cmdStatus(rest);
+    case "init":
+      return cmdInit(rest);
     case "verify":
       return cmdVerify(rest);
     case "sign":

--- a/typescript/src/credentials.ts
+++ b/typescript/src/credentials.ts
@@ -1,0 +1,70 @@
+/**
+ * File-backed credential layer for the Asqav SDK.
+ *
+ * Stores an API key (and optional API base) in ~/.asqav/credentials so the SDK
+ * and CLI can resolve a key without an environment variable. Resolution mirrors
+ * the Python half: explicit argument, then environment, then file.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_API_BASE = "https://api.asqav.com/api/v1";
+
+export const CREDENTIALS_PATH = path.join(os.homedir(), ".asqav", "credentials");
+
+/** Resolve the credentials file location (env override, else ~/.asqav/credentials). */
+export function credentialsPath(): string {
+  const override = process.env.ASQAV_CREDENTIALS_PATH;
+  if (override) return override;
+  return path.join(os.homedir(), ".asqav", "credentials");
+}
+
+/** Read the credentials file. Missing or corrupt file returns {} (never throws). */
+export function loadCredentials(): Record<string, unknown> {
+  try {
+    const data = JSON.parse(fs.readFileSync(credentialsPath(), "utf-8"));
+    if (data !== null && typeof data === "object" && !Array.isArray(data)) {
+      return data as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/** Write the credentials file with mode 0600 under a mode 0700 ~/.asqav dir. */
+export function saveCredentials(apiKey: string, apiBase?: string): string {
+  const file = credentialsPath();
+  const dir = path.dirname(file);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(dir, 0o700);
+
+  const payload: Record<string, string> = { api_key: apiKey };
+  if (apiBase) payload.api_base = apiBase;
+
+  fs.writeFileSync(file, JSON.stringify(payload, null, 2), { mode: 0o600 });
+  fs.chmodSync(file, 0o600);
+  return file;
+}
+
+/** Resolve an API key: explicit arg, then ASQAV_API_KEY env, then credentials file. */
+export function resolveApiKey(explicit?: string): string | null {
+  if (explicit) return explicit;
+  const envKey = process.env.ASQAV_API_KEY;
+  if (envKey) return envKey;
+  const fileKey = loadCredentials().api_key;
+  if (typeof fileKey === "string" && fileKey) return fileKey;
+  return null;
+}
+
+/** Resolve an API base: explicit arg, then ASQAV_API_BASE env, then file, then default. */
+export function resolveApiBase(explicit?: string): string {
+  if (explicit) return explicit;
+  const envBase = process.env.ASQAV_API_BASE;
+  if (envBase) return envBase;
+  const fileBase = loadCredentials().api_base;
+  if (typeof fileBase === "string" && fileBase) return fileBase;
+  return DEFAULT_API_BASE;
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -32,6 +32,7 @@ import {
 import { runDetectors } from "./detectors.js";
 import { userAgentHeaders } from "./userAgent.js";
 import { deriveChainHash } from "./replay.js";
+import { resolveApiKey } from "./credentials.js";
 
 export { SDK_VERSION, USER_AGENT, userAgentHeaders } from "./userAgent.js";
 
@@ -991,10 +992,11 @@ export interface PreflightResult {
 // === init ===
 
 export function init(options: InitOptions = {}): void {
-  const apiKey = options.apiKey ?? process.env.ASQAV_API_KEY ?? null;
+  const apiKey = resolveApiKey(options.apiKey);
   if (!apiKey) {
     throw new AuthenticationError(
-      "API key required. Set ASQAV_API_KEY or pass apiKey to init(). Get yours at asqav.com",
+      "API key required. Run `asqav login`, set ASQAV_API_KEY, or pass apiKey " +
+        "to init(). A saved key is read from ~/.asqav/credentials. Get yours at asqav.com",
     );
   }
   config.apiKey = apiKey;

--- a/typescript/tests/credentials.test.ts
+++ b/typescript/tests/credentials.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runCli } from "../src/cli.js";
+import { _resetForTests } from "../src/index.js";
+import {
+  credentialsPath,
+  loadCredentials,
+  resolveApiBase,
+  resolveApiKey,
+  saveCredentials,
+} from "../src/credentials.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const AGENT_CREATED = {
+  agent_id: "agt_demo",
+  name: "n",
+  public_key: "pk",
+  key_id: "kid",
+  algorithm: "ml-dsa-65",
+  capabilities: [],
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const SIGN_RESPONSE = {
+  signature: "sig_b64",
+  signature_id: "sig_demo",
+  action_id: "act_1",
+  timestamp: "2026-01-01T00:00:00Z",
+  verification_url: "https://verify.example/sig_demo",
+  algorithm: "ml-dsa-65",
+};
+
+describe("credentials layer + onboarding CLI (TypeScript)", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  const tempDirs: string[] = [];
+  const savedEnv: Record<string, string | undefined> = {};
+  const ENV_KEYS = ["ASQAV_CREDENTIALS_PATH", "ASQAV_API_KEY", "ASQAV_API_BASE", "HOME"];
+
+  beforeEach(() => {
+    _resetForTests();
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "asqav-creds-"));
+    tempDirs.push(tmp);
+    // Isolate the file-backed chain so no test reads a real ~/.asqav/credentials.
+    process.env.ASQAV_CREDENTIALS_PATH = path.join(tmp, "credentials");
+    delete process.env.ASQAV_API_KEY;
+    delete process.env.ASQAV_API_BASE;
+
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__EXIT__${code ?? 0}`);
+    }) as never);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    vi.restoreAllMocks();
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function output(): string {
+    const out = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+    const err = stderrSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("");
+    return out + err;
+  }
+
+  // Switch to the default ~/.asqav path under a temp HOME (drop the env override),
+  // mirroring the Python `home` fixture.
+  function useDefaultPath(): string {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "asqav-home-"));
+    tempDirs.push(home);
+    delete process.env.ASQAV_CREDENTIALS_PATH;
+    delete process.env.ASQAV_API_KEY;
+    delete process.env.ASQAV_API_BASE;
+    process.env.HOME = home;
+    return home;
+  }
+
+  // Run a callback in an empty temp cwd (for `init` framework detection).
+  async function inTempCwd(fn: (cwd: string) => Promise<void>): Promise<void> {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "asqav-cwd-"));
+    tempDirs.push(cwd);
+    const orig = process.cwd();
+    process.chdir(cwd);
+    try {
+      await fn(cwd);
+    } finally {
+      process.chdir(orig);
+    }
+  }
+
+  // === credentials module ===
+
+  it("default path lives under the home dir", () => {
+    const home = useDefaultPath();
+    expect(credentialsPath()).toBe(path.join(home, ".asqav", "credentials"));
+  });
+
+  it("load on a missing file returns {}", () => {
+    useDefaultPath();
+    expect(loadCredentials()).toEqual({});
+  });
+
+  it("resolveApiKey on a missing file returns null", () => {
+    useDefaultPath();
+    expect(resolveApiKey()).toBeNull();
+  });
+
+  it("save/load roundtrip", () => {
+    useDefaultPath();
+    saveCredentials("sk_file_123", "https://example.test/api/v1");
+    expect(loadCredentials()).toEqual({
+      api_key: "sk_file_123",
+      api_base: "https://example.test/api/v1",
+    });
+  });
+
+  it("save without api_base omits the key", () => {
+    useDefaultPath();
+    saveCredentials("sk_only");
+    expect(loadCredentials()).toEqual({ api_key: "sk_only" });
+  });
+
+  it("saved file mode is 0600", () => {
+    useDefaultPath();
+    const file = saveCredentials("sk_secret");
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("credentials dir mode is 0700", () => {
+    const home = useDefaultPath();
+    saveCredentials("sk_secret");
+    expect(fs.statSync(path.join(home, ".asqav")).mode & 0o777).toBe(0o700);
+  });
+
+  it("corrupt file returns {} and resolves no key", () => {
+    const home = useDefaultPath();
+    const dir = path.join(home, ".asqav");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "credentials"), "{not valid json");
+    expect(loadCredentials()).toEqual({});
+    expect(resolveApiKey()).toBeNull();
+  });
+
+  it("resolve precedence: arg beats env beats file", () => {
+    useDefaultPath();
+    saveCredentials("sk_file");
+    process.env.ASQAV_API_KEY = "sk_env";
+    expect(resolveApiKey("sk_arg")).toBe("sk_arg");
+    expect(resolveApiKey()).toBe("sk_env");
+    delete process.env.ASQAV_API_KEY;
+    expect(resolveApiKey()).toBe("sk_file");
+  });
+
+  it("resolveApiBase precedence and default", () => {
+    useDefaultPath();
+    expect(resolveApiBase()).toBe("https://api.asqav.com/api/v1");
+    saveCredentials("sk", "https://file.test/api");
+    expect(resolveApiBase()).toBe("https://file.test/api");
+    process.env.ASQAV_API_BASE = "https://env.test/api";
+    expect(resolveApiBase()).toBe("https://env.test/api");
+    expect(resolveApiBase("https://arg.test/api")).toBe("https://arg.test/api");
+  });
+
+  it("ASQAV_CREDENTIALS_PATH overrides the location", () => {
+    const home = useDefaultPath();
+    const override = path.join(home, "custom", "creds.json");
+    process.env.ASQAV_CREDENTIALS_PATH = override;
+    expect(credentialsPath()).toBe(override);
+    saveCredentials("sk_override");
+    expect(fs.existsSync(override)).toBe(true);
+    expect(resolveApiKey()).toBe("sk_override");
+  });
+
+  // === login command ===
+
+  it("login saves credentials after validation", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse({ agents: [] }));
+    await runCli(["login", "--api-key", "sk_test_123"]);
+    expect(output()).toContain("Saved API key");
+    const saved = JSON.parse(fs.readFileSync(process.env.ASQAV_CREDENTIALS_PATH!, "utf-8"));
+    expect(saved.api_key).toBe("sk_test_123");
+  });
+
+  it("login does not save on validation failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ error: "Invalid API key" }, 401),
+    );
+    try {
+      await runCli(["login", "--api-key", "sk_bad"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("validation failed");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fs.existsSync(process.env.ASQAV_CREDENTIALS_PATH!)).toBe(false);
+  });
+
+  it("login refuses overwrite without --force", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ agents: [] }));
+    await runCli(["login", "--api-key", "sk_one"]);
+    try {
+      await runCli(["login", "--api-key", "sk_two"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("already exists");
+    const saved = JSON.parse(fs.readFileSync(process.env.ASQAV_CREDENTIALS_PATH!, "utf-8"));
+    expect(saved.api_key).toBe("sk_one");
+  });
+
+  it("login --force overwrites", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ agents: [] }));
+    await runCli(["login", "--api-key", "sk_one"]);
+    await runCli(["login", "--api-key", "sk_two", "--force"]);
+    const saved = JSON.parse(fs.readFileSync(process.env.ASQAV_CREDENTIALS_PATH!, "utf-8"));
+    expect(saved.api_key).toBe("sk_two");
+  });
+
+  // === whoami / status commands ===
+
+  it("whoami reports the env source", async () => {
+    process.env.ASQAV_API_KEY = "sk_env";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ agents: [{ agent_id: "a1" }, { agent_id: "a2" }] }),
+    );
+    await runCli(["whoami"]);
+    expect(output()).toContain("Key source: env");
+    expect(output()).toContain("Key valid");
+    expect(output()).toContain("2 agent(s)");
+  });
+
+  it("whoami reports the file source", async () => {
+    fs.writeFileSync(
+      process.env.ASQAV_CREDENTIALS_PATH!,
+      JSON.stringify({ api_key: "sk_file" }),
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse([]));
+    await runCli(["whoami"]);
+    expect(output()).toContain("Key source: file");
+  });
+
+  it("whoami reports the arg source", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse([]));
+    await runCli(["whoami", "--api-key", "sk_arg"]);
+    expect(output()).toContain("Key source: arg");
+  });
+
+  it("whoami with no key exits nonzero", async () => {
+    try {
+      await runCli(["whoami"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("asqav login");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("whoami with a rejected key exits nonzero", async () => {
+    process.env.ASQAV_API_KEY = "sk_bad";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ error: "Invalid API key" }, 401),
+    );
+    try {
+      await runCli(["whoami"]);
+    } catch {
+      // exit
+    }
+    expect(output()).toContain("rejected");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("status alias reports the source", async () => {
+    process.env.ASQAV_API_KEY = "sk_env";
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse([]));
+    await runCli(["status"]);
+    expect(output()).toContain("Key source: env");
+  });
+
+  // === init command ===
+
+  it("init prints a snippet without writing", async () => {
+    await inTempCwd(async (cwd) => {
+      await runCli(["init"]);
+      expect(output()).toContain("Detected framework: typescript");
+      expect(output()).toContain("govern");
+      expect(output()).toContain("agent.sign");
+      expect(fs.readdirSync(cwd)).toEqual([]);
+    });
+  });
+
+  it("init detects the framework from package.json", async () => {
+    await inTempCwd(async (cwd) => {
+      fs.writeFileSync(
+        path.join(cwd, "package.json"),
+        JSON.stringify({ dependencies: { openai: "^4.0.0" } }),
+      );
+      await runCli(["init"]);
+      expect(output()).toContain("Detected framework: openai");
+      expect(output()).toContain("api:openai:chat");
+    });
+  });
+
+  it("init --write creates asqav_governance.ts", async () => {
+    await inTempCwd(async (cwd) => {
+      await runCli(["init", "--write"]);
+      const written = path.join(cwd, "asqav_governance.ts");
+      expect(fs.existsSync(written)).toBe(true);
+      expect(fs.readFileSync(written, "utf-8")).toContain("govern");
+    });
+  });
+
+  it("init --demo skips without a key", async () => {
+    await inTempCwd(async () => {
+      await runCli(["init", "--demo"]);
+      expect(output()).toContain("skipping demo");
+    });
+  });
+
+  it("init --demo signs with a resolved key", async () => {
+    process.env.ASQAV_API_KEY = "sk_env";
+    await inTempCwd(async () => {
+      vi.spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(jsonResponse(AGENT_CREATED))
+        .mockResolvedValueOnce(jsonResponse(SIGN_RESPONSE));
+      await runCli(["init", "--demo"]);
+      expect(output()).toContain("sig_demo");
+      expect(output()).toContain("asqav verify sig_demo");
+    });
+  });
+});

--- a/typescript/tests/credentials.test.ts
+++ b/typescript/tests/credentials.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { runCli } from "../src/cli.js";
+import { PassThrough } from "node:stream";
+import { promptHidden, runCli } from "../src/cli.js";
 import { _resetForTests } from "../src/index.js";
 import {
   credentialsPath,
@@ -344,5 +346,74 @@ describe("credentials layer + onboarding CLI (TypeScript)", () => {
       expect(output()).toContain("sig_demo");
       expect(output()).toContain("asqav verify sig_demo");
     });
+  });
+
+  // === promptHidden ===
+
+  it("promptHidden non-TTY reads a line from piped stdin", async () => {
+    const stream = new PassThrough();
+    const origStdin = process.stdin;
+    Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+    try {
+      const p = promptHidden("Key: ");
+      stream.write("sk_piped_123\n");
+      stream.end();
+      await expect(p).resolves.toBe("sk_piped_123");
+    } finally {
+      Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
+    }
+  });
+
+  it("promptHidden TTY uses raw mode and suppresses echo", async () => {
+    const fake = new EventEmitter() as EventEmitter & {
+      isTTY: boolean;
+      setRawMode: ReturnType<typeof vi.fn>;
+      resume: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    fake.isTTY = true;
+    fake.setRawMode = vi.fn();
+    fake.resume = vi.fn();
+    fake.pause = vi.fn();
+
+    const origStdin = process.stdin;
+    Object.defineProperty(process, "stdin", { value: fake, configurable: true });
+    try {
+      const p = promptHidden("Key: ");
+      fake.emit("data", Buffer.from("a"));
+      fake.emit("data", Buffer.from("b"));
+      fake.emit("data", Buffer.from("\r"));
+      await expect(p).resolves.toBe("ab");
+      expect(fake.setRawMode).toHaveBeenCalledWith(true);
+      expect(fake.setRawMode).toHaveBeenCalledWith(false);
+      expect(fake.pause).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
+    }
+  });
+
+  it("promptHidden TTY handles backspace", async () => {
+    const fake = new EventEmitter() as EventEmitter & {
+      isTTY: boolean;
+      setRawMode: ReturnType<typeof vi.fn>;
+      resume: ReturnType<typeof vi.fn>;
+      pause: ReturnType<typeof vi.fn>;
+    };
+    fake.isTTY = true;
+    fake.setRawMode = vi.fn();
+    fake.resume = vi.fn();
+    fake.pause = vi.fn();
+
+    const origStdin = process.stdin;
+    Object.defineProperty(process, "stdin", { value: fake, configurable: true });
+    try {
+      const p = promptHidden("Key: ");
+      fake.emit("data", Buffer.from("abc"));
+      fake.emit("data", Buffer.from("\x7f"));
+      fake.emit("data", Buffer.from("\r"));
+      await expect(p).resolves.toBe("ab");
+    } finally {
+      Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
+    }
   });
 });


### PR DESCRIPTION
## What

Mirrors the Python onboarding front-door (PR #390) into the TypeScript SDK. Same credentials file format, same resolution chain, same CLI commands.

## Shared credentials format (matches Python exactly)

- Path: ~/.asqav/credentials, overridable via ASQAV_CREDENTIALS_PATH.
- JSON: {"api_key": "...", "api_base": "..."} with api_base omitted when unset, indent 2.
- File mode 0600, parent dir mode 0700.
- resolveApiKey: explicit arg, then ASQAV_API_KEY, then file api_key, then null.
- resolveApiBase: explicit arg, then ASQAV_API_BASE, then file api_base, then https://api.asqav.com/api/v1.
- loadCredentials: missing or corrupt file returns {} and never throws.

## TS refactor surface

- New typescript/src/credentials.ts (CREDENTIALS_PATH, credentialsPath, loadCredentials, saveCredentials, resolveApiKey, resolveApiBase).
- index.ts init() resolves the key through resolveApiKey and the missing-key error points at asqav login.
- cli.ts env reads refactored onto resolveApiKey: ensureApiKey, the verify anon init, and the migrate X-API-Key header. Exit behavior preserved.
- New CLI commands: login (validates with GET /agents, saves, refuses overwrite without --force), whoami plus a status alias (reports key source arg/env/file/none, validates), init (prints a govern() snippet, detects framework from package.json, --write, --demo).
- README quickstart starts with asqav login and asqav init.

## Verification

- npm run lint (tsc --noEmit): clean, no type errors.
- npm run build (tsup): clean.
- npm test (vitest run): 652 passed, 0 skipped, 0 failed across 47 files.
- New tests/credentials.test.ts: 26 passed (precedence, roundtrip, 0600 mode, corrupt file, login/whoami/init via mocked fetch).

Draft for review. Not merged, not marked ready, not published to npm.