### PR TITLE
fix(sdk): authproof regex cross-language agreement + agent_id fallback (245,232)

### DIFF
--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -128,8 +128,26 @@ class AsqavNativeAdapter(FormatAdapter):
         kid = self.extract_signature(doc).kid
         pk, status, _alg = _vr.resolve_key(jwks, kid)
         if pk is None:
+            # Cloud receipts set kid to the issuer id; when that resolves nothing,
+            # fall back to the agent's own key, mirroring run(). agent_id is
+            # attacker-controlled, so resolve_key_by_agent_id trusts only a key
+            # whose published issuer_id matches the one the receipt claims.
+            fallback = self._resolve_key_by_agent(doc, jwks)
+            if fallback is not None:
+                return fallback
             return None, f"kid {kid!r} not in jwks directory"
         return pk, f"resolved kid {kid} (status={status})"
+
+    def _resolve_key_by_agent(self, doc: dict, jwks: dict) -> tuple[bytes, str] | None:
+        """Resolve the signing key by the receipt's agent_id when the kid is absent."""
+        payload = _payload(doc)
+        agent_id = payload.get("agent_id") or doc.get("agent_id")
+        pk, status, _alg, kid, _issuer = _vr.resolve_key_by_agent_id(
+            jwks, agent_id, payload.get("issuer_id")
+        )
+        if pk is None:
+            return None
+        return pk, f"resolved agent key {kid} (status={status})"
 
     def signing_input(self, doc: dict) -> bytes:
         if _is_hash_mode(doc):

--- a/python/src/asqav/verifier/oracle/adapters/authproof.py
+++ b/python/src/asqav/verifier/oracle/adapters/authproof.py
@@ -29,7 +29,10 @@ from typing import Any
 from ..adapter import ChainStep, FormatAdapter, SignatureMaterial
 
 #: A shipping-SDK delegationId is ``auth-<epoch_ms>-<5 base36 chars>``.
-_DELEGATION_ID = re.compile(r"^auth-\d+-[a-z0-9]{5}$")
+#: ``[0-9]`` (not ``\d``) and ``\A``/``\Z`` (not ``^``/``$``) keep this byte-for-byte
+#: with the ECMAScript regex: ``\d`` would admit non-ASCII digits and ``$`` would
+#: accept a trailing newline, both of which the TypeScript validator rejects.
+_DELEGATION_ID = re.compile(r"\Aauth-[0-9]+-[a-z0-9]{5}\Z")
 
 #: Fields the SDK always writes, used for the structural check.
 _REQUIRED = (

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -849,30 +849,45 @@ def run_structured(
             }
         )
     else:
+        _raw_sig = sig_obj.get("sig", "")
+        sig_bytes = _b64decode(_raw_sig) if isinstance(_raw_sig, str) else b""
+        sig_res = verify_signature(pk, msg, sig_bytes, alg or jwks_alg)
+        eff_status, eff_kid = status, kid
+        eff_issuer = resolve_key_issuer(jwks, kid)
+        eff_revoked_at = resolve_revoked_at(jwks, kid)
+        # Cloud receipts sign with the agent key though kid is the issuer id; fall
+        # back, mirroring run(). agent_id is attacker-controlled, so trust only a
+        # key whose published issuer_id matches the claimed issuer.
+        if sig_res[0] != "PASS":
+            agent_id = payload.get("agent_id") or envelope.get("agent_id")
+            pk_a, status_a, alg_a, kid_a, issuer_a = resolve_key_by_agent_id(
+                jwks, agent_id, payload.get("issuer_id")
+            )
+            if pk_a is not None:
+                sig_res_a = verify_signature(pk_a, msg, sig_bytes, alg_a or alg or jwks_alg)
+                if sig_res_a[0] == "PASS":
+                    sig_res = sig_res_a
+                    eff_status, eff_kid = status_a, kid_a
+                    eff_issuer = issuer_a
+                    eff_revoked_at = resolve_revoked_at(jwks, kid_a)
         axes.append(
             {
                 "name": "issuer_key",
                 "result": "PASS",
-                "note": f"resolved kid {kid} (status={status})",
+                "note": f"resolved signing key {eff_kid} (status={eff_status})",
             }
         )
         # kid picks the key and the attacker picks the kid, so bind the key that
         # actually verified back to the issuer the receipt claims.
-        bind_r, bind_n = check_issuer_binding(
-            resolve_key_issuer(jwks, kid), payload.get("issuer_id")
-        )
+        bind_r, bind_n = check_issuer_binding(eff_issuer, payload.get("issuer_id"))
         axes.append({"name": "issuer_bind", "result": bind_r, "note": bind_n})
-        revoked_at = resolve_revoked_at(jwks, kid)
         # Offline anchor presence is not trusted timing; pass False so a forged
         # anchor never upgrades a revoked key to PASS (hosted /verify does).
         ks_r, ks_n = check_key_status(
-            status, payload.get("issued_at", ""), revoked_at, False
+            eff_status, payload.get("issued_at", ""), eff_revoked_at, False
         )
         axes.append({"name": "key_status", "result": ks_r, "note": ks_n})
-        _raw_sig = sig_obj.get("sig", "")
-        sig_bytes = _b64decode(_raw_sig) if isinstance(_raw_sig, str) else b""
-        sig_r, sig_n = verify_signature(pk, msg, sig_bytes, alg or jwks_alg)
-        axes.append({"name": "signature", "result": sig_r, "note": sig_n})
+        axes.append({"name": "signature", "result": sig_res[0], "note": sig_res[1]})
 
     chain_r, chain_n = check_chain(payload, predecessor_payload)
     axes.append({"name": "chain", "result": chain_r, "note": chain_n})

--- a/python/tests/test_authproof_delegation_cases.py
+++ b/python/tests/test_authproof_delegation_cases.py
@@ -1,0 +1,50 @@
+"""Shared authproof delegationId format table, Python half.
+
+One JSON table drives both the Python and the TypeScript authproof adapter. Each
+case feeds a delegationId through this language's format-detection validator and
+pins the boolean, so a regex that drifts between languages (a Unicode ``\\d``, a
+``$`` that swallows a trailing newline) fails a suite instead of waiting for a
+reviewer. The TypeScript half lives in
+typescript/tests/authproof-delegation-cases.test.ts and reads the same file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from asqav.verifier.oracle.adapters.authproof import AuthproofAdapter
+
+CASES_FILE = Path(__file__).parent.parent.parent / "verifier" / "authproof-delegation-cases.json"
+CASES = json.loads(CASES_FILE.read_text())["cases"]
+
+_ADAPTER = AuthproofAdapter()
+
+
+def _skeleton(delegation_id: str) -> dict:
+    """A receipt that satisfies every detect() condition except the delegationId.
+
+    Only the delegationId varies across cases, so the detect() boolean isolates
+    the delegationId regex - the thing the cross-language table pins.
+    """
+    return {
+        "delegationId": delegation_id,
+        "issuedAt": 1719000000000,
+        "scope": "session",
+        "boundaries": {"maxActions": 1},
+        "timeWindow": {"start": 0, "end": 1},
+        "operatorInstructions": "carry out the agreed task",
+        "instructionsHash": "sha256:" + "a" * 64,
+        "signerPublicKey": {"kty": "EC", "crv": "P-256", "x": "AA", "y": "AA"},
+        "signature": "ab" * 64,
+    }
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c["name"] for c in CASES])
+def test_delegation_id_agreement(case: dict) -> None:
+    assert _ADAPTER.detect(_skeleton(case["value"])) == case["expected"], (
+        f"{case['name']}: {case['value']!r} detected as "
+        f"{_ADAPTER.detect(_skeleton(case['value']))}, expected {case['expected']}"
+    )

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -419,6 +419,106 @@ from asqav.verifier import verify_receipt as _vr  # noqa: E402
 
 
 @requires_ed25519
+def test_asqav_native_agent_id_fallback_resolves_absent_kid() -> None:
+    """When signature.kid resolves nothing, the adapter falls back to the agent's
+    own key (bound to the claimed issuer), mirroring run(): the receipt verifies."""
+    import base64
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    sk = Ed25519PrivateKey.generate()
+    pk_raw = sk.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    payload = {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-06-19T00:00:00.000000Z",
+        "issuer_id": "org-1",
+        "agent_id": "agt_probe",
+        "action_ref": "sha256:" + "8" * 64,
+        "payload_digest": {"hash": "8" * 64, "size": 512},
+        "policy_digest": "sha256:" + "3" * 64,
+        "previousReceiptHash": "0" * 64,
+        "decision": "allow",
+    }
+    ad = AsqavNativeAdapter()
+    doc = {
+        "payload": payload,
+        "signature": {"alg": "Ed25519", "kid": "absent-kid", "sig": ""},
+        "anchors": [],
+    }
+    doc["signature"]["sig"] = base64.b64encode(sk.sign(ad.signing_input(doc))).decode()
+    # The key publishes agent_id + issuer_id but a kid the receipt never names, so
+    # the direct kid lookup misses and only the agent_id fallback resolves it.
+    jwks = {
+        "keys": [
+            {
+                "kid": "agent-key-1",
+                "agent_id": "agt_probe",
+                "issuer_id": "org-1",
+                "alg": "Ed25519",
+                "public_key": base64.b64encode(pk_raw).decode(),
+                "status": "active",
+            }
+        ]
+    }
+    res = verify(doc, ADAPTERS, key_provider=jwks)
+    assert res.fmt == "asqav-native"
+    assert res.axis("signature").result == crypto.PASS
+    assert res.verdict == "PASS"
+
+
+@requires_ed25519
+def test_asqav_native_agent_id_fallback_binds_issuer() -> None:
+    """The agent_id fallback trusts only a key whose issuer_id matches the claim: a
+    key bound to a different issuer never resolves, so the signature stays SKIPPED."""
+    import base64
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    sk = Ed25519PrivateKey.generate()
+    pk_raw = sk.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    payload = {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-06-19T00:00:00.000000Z",
+        "issuer_id": "org-victim",
+        "agent_id": "agt_probe",
+        "action_ref": "sha256:" + "8" * 64,
+        "payload_digest": {"hash": "8" * 64, "size": 512},
+        "policy_digest": "sha256:" + "3" * 64,
+        "previousReceiptHash": "0" * 64,
+        "decision": "allow",
+    }
+    ad = AsqavNativeAdapter()
+    doc = {
+        "payload": payload,
+        "signature": {"alg": "Ed25519", "kid": "absent-kid", "sig": ""},
+        "anchors": [],
+    }
+    doc["signature"]["sig"] = base64.b64encode(sk.sign(ad.signing_input(doc))).decode()
+    jwks = {
+        "keys": [
+            {
+                "kid": "agent-key-1",
+                "agent_id": "agt_probe",
+                "issuer_id": "org-attacker",  # right agent_id, wrong issuer
+                "alg": "Ed25519",
+                "public_key": base64.b64encode(pk_raw).decode(),
+                "status": "active",
+            }
+        ]
+    }
+    res = verify(doc, ADAPTERS, key_provider=jwks)
+    assert res.fmt == "asqav-native"
+    assert res.verdict != "PASS"
+    assert res.axis("signature").result in (crypto.FAIL, crypto.SKIPPED)
+
+
+@requires_ed25519
 def test_wrong_key_resolution_fails_signature() -> None:
     """A receipt verified against a different valid Ed25519 key FAILs the signature axis."""
     doc = _load("aerf-01-genesis", "receipt.json")

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -359,6 +359,49 @@ def test_run_tampered_payload_fails() -> None:
     assert v.run(_envelope(payload, sig), jwks, None) == 1
 
 
+# === run_structured mirrors run()'s agent_id fallback ===
+
+
+def test_run_structured_agent_id_fallback_passes_legit_multi_agent() -> None:
+    """run_structured mirrors run(): the issuer-kid resolves the wrong sibling, the
+    signature fails, and the agent_id fallback resolves the real signer -> PASS."""
+    ml = _ml_dsa_65()
+    a1_pk, _a1_sk = ml.keygen()
+    a2_pk, a2_sk = ml.keygen()
+    payload = _valid_payload("org-legit", "agt_two")
+    sig = ml.sign(a2_sk, v.canonical_json(payload))  # signed by agent two
+    jwks = {
+        "keys": [
+            _jwks_key("agent-one", "agt_one", "org-legit", a1_pk),  # issuer-kid hits this
+            _jwks_key("agent-two", "agt_two", "org-legit", a2_pk),  # real signer via agent_id
+        ]
+    }
+    out = v.run_structured(_envelope(payload, sig), jwks, None)
+    axes = {a["name"]: a["result"] for a in out["axes"]}
+    assert out["verdict"] == "PASS"
+    assert axes["signature"] == "PASS"
+    assert axes["issuer_bind"] == "PASS"
+
+
+def test_run_structured_agent_id_fallback_rejects_forged_issuer() -> None:
+    """run_structured inherits run()'s bind: a receipt signed by org-attacker's key
+    but claiming issuer_id=org-victim FAILs, since the fallback trusts only a key
+    whose issuer_id equals the claimed issuer."""
+    ml = _ml_dsa_65()
+    attacker_pk, attacker_sk = ml.keygen()
+    victim_pk, _victim_sk = ml.keygen()
+    payload = _valid_payload("org-victim", "agt_attacker")
+    sig = ml.sign(attacker_sk, v.canonical_json(payload))  # signed with attacker key
+    jwks = {
+        "keys": [
+            _jwks_key("victim-key", "agt_victim", "org-victim", victim_pk),
+            _jwks_key("attacker-key", "agt_attacker", "org-attacker", attacker_pk),
+        ]
+    }
+    out = v.run_structured(_envelope(payload, sig), jwks, None)
+    assert out["verdict"] == "FAIL"
+
+
 # === the kid path must bind the verifying key to the claimed issuer too ===
 
 

--- a/typescript/src/verifier/adapters/authproof.ts
+++ b/typescript/src/verifier/adapters/authproof.ts
@@ -21,8 +21,13 @@ import {
   type SignatureMaterial,
 } from "../adapter.js";
 
-/** A shipping-SDK delegationId is `auth-<epoch_ms>-<5 base36 chars>`. */
-const DELEGATION_ID = /^auth-\d+-[a-z0-9]{5}$/;
+/**
+ * A shipping-SDK delegationId is `auth-<epoch_ms>-<5 base36 chars>`.
+ * `[0-9]` (not `\d`) spells out the ASCII digit class so the pattern reads
+ * identical to the Python validator's; ECMAScript `^`/`$` are already strict
+ * (no trailing newline) and `\d` is already ASCII here, so this is the anchor.
+ */
+const DELEGATION_ID = /^auth-[0-9]+-[a-z0-9]{5}$/;
 
 /** Fields the SDK always writes, used for the structural check. */
 const REQUIRED = [

--- a/typescript/tests/authproof-delegation-cases.test.ts
+++ b/typescript/tests/authproof-delegation-cases.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared authproof delegationId format table, TypeScript half.
+ *
+ * One JSON table drives both authproof adapters. Each case feeds a delegationId
+ * through this language's format-detection validator and pins the boolean, so a
+ * regex that drifts between languages fails a suite instead of waiting for a
+ * reviewer. The Python half lives in
+ * python/tests/test_authproof_delegation_cases.py and reads the same file.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { AuthproofAdapter } from "../src/verifier/adapters/authproof.js";
+
+interface Case {
+  name: string;
+  value: string;
+  expected: boolean;
+}
+
+const CASES_FILE = resolve(__dirname, "..", "..", "verifier", "authproof-delegation-cases.json");
+const CASES = (JSON.parse(readFileSync(CASES_FILE, "utf-8")) as { cases: Case[] }).cases;
+
+/** A receipt satisfying every detect() condition except the delegationId, so the
+ *  detect() boolean isolates the delegationId regex the table pins. */
+function skeleton(delegationId: string): Record<string, unknown> {
+  return {
+    delegationId,
+    issuedAt: 1719000000000,
+    scope: "session",
+    boundaries: { maxActions: 1 },
+    timeWindow: { start: 0, end: 1 },
+    operatorInstructions: "carry out the agreed task",
+    instructionsHash: "sha256:" + "a".repeat(64),
+    signerPublicKey: { kty: "EC", crv: "P-256", x: "AA", y: "AA" },
+    signature: "ab".repeat(64),
+  };
+}
+
+describe("authproof delegationId cross-language agreement", () => {
+  const adapter = new AuthproofAdapter();
+  for (const c of CASES) {
+    it(c.name, () => {
+      expect(adapter.detect(skeleton(c.value)), `${c.name}: ${JSON.stringify(c.value)}`).toBe(
+        c.expected,
+      );
+    });
+  }
+});

--- a/verifier/authproof-delegation-cases.json
+++ b/verifier/authproof-delegation-cases.json
@@ -1,0 +1,23 @@
+{
+  "note": "Cross-language authproof delegationId format table. Both the Python and the TypeScript authproof adapters feed every value through their own delegationId validator (the format-detection regex) and assert the same boolean. The two divergence cases that pin the agreement are 'timestamp uses non-ASCII digits' (Python \\d would admit them, ECMAScript and [0-9] reject) and 'trailing newline' (Python $ would accept it, ECMAScript and \\Z reject).",
+  "cases": [
+    {"name": "canonical id", "value": "auth-1719000000000-ab1de", "expected": true},
+    {"name": "zero timestamp and suffix", "value": "auth-0-00000", "expected": true},
+    {"name": "high base36 suffix", "value": "auth-999-zzzzz", "expected": true},
+    {"name": "digits in the suffix", "value": "auth-123-9a8b7", "expected": true},
+    {"name": "trailing newline", "value": "auth-1719000000000-ab1de\n", "expected": false},
+    {"name": "trailing carriage return", "value": "auth-1719000000000-ab1de\r", "expected": false},
+    {"name": "leading newline", "value": "\nauth-1719000000000-ab1de", "expected": false},
+    {"name": "timestamp uses non-ASCII digits", "value": "auth-\u0661\u0662\u0663-ab1de", "expected": false},
+    {"name": "suffix a single non-ASCII digit", "value": "auth-1719000000000-\u0661\u0662\u0663\u0664\u0665", "expected": false},
+    {"name": "suffix too short", "value": "auth-1719000000000-ab1d", "expected": false},
+    {"name": "suffix too long", "value": "auth-1719000000000-ab1def", "expected": false},
+    {"name": "uppercase suffix", "value": "auth-1719000000000-AB1DE", "expected": false},
+    {"name": "empty timestamp", "value": "auth--ab1de", "expected": false},
+    {"name": "punctuation in the suffix", "value": "auth-1719000000000-ab1d!", "expected": false},
+    {"name": "leading junk", "value": "xauth-1719000000000-ab1de", "expected": false},
+    {"name": "trailing junk", "value": "auth-1719000000000-ab1de-x", "expected": false},
+    {"name": "uppercase prefix", "value": "AUTH-1719000000000-ab1de", "expected": false},
+    {"name": "empty string", "value": "", "expected": false}
+  ]
+}


### PR DESCRIPTION
Two SDK-scoped goal-11 criteria, one atomic commit each.

## 245 authproof regex cross-language agreement

FINDING: the authproof delegationId format regex diverged between languages.
Python compiled `^auth-\d+-[a-z0-9]{5}$` whose `\d` admits non-ASCII digits and
whose `$` accepts a trailing newline, while the ECMAScript validator rejects
both.
SOURCE: `python/src/asqav/verifier/oracle/adapters/authproof.py:32` and
`typescript/src/verifier/adapters/authproof.ts:25`.
FIX: pin both to an explicit ASCII `[0-9]` class and a full-string anchor
(Python `\A...\Z`, TypeScript `^...$`). Added a shared table
`verifier/authproof-delegation-cases.json` read by parallel Python and
TypeScript tests asserting the same boolean for valid and invalid delegationIds,
including a non-ASCII-digit case and a trailing-newline case that each validator
judged differently before this change.

## 232 oracle/run_structured agent_id fallback

FINDING: `run()` resolves a cloud receipt's signing key by agent_id when the
signature does not verify under the kid-resolved key, but `run_structured` and
the asqav-native oracle adapter called plain `resolve_key` with no such
fallback, so a receipt whose kid does not name its signing key could not verify
on those two surfaces.
SOURCE: `resolve_key_by_agent_id` at
`python/src/asqav/verifier/verify_receipt.py:358` (used by `run()` at :692),
missing from `run_structured` (:835) and the oracle adapter
`asqav_native.py:129`.
FIX: mirror `run()` in both surfaces. `run_structured` falls back to
`resolve_key_by_agent_id` when the kid-resolved key fails the signature, and the
oracle adapter falls back to it when the kid resolves nothing. Both keep the
issuer_id bind that `resolve_key_by_agent_id` enforces (agent_id is
attacker-controlled). Added tests: `run_structured` passes the legit
multi-agent case and rejects a forged issuer, and the oracle adapter resolves an
absent kid by agent_id while refusing a key bound to a different issuer.

## Verification

- Python: 1461 passed, 2 skipped (full suite).
- TypeScript: `tsc --noEmit` clean, 673 tests passed across 48 files.

Not for merge or publish from this PR.
