### PR TITLE
feat(sdk): authoritative code-authorship path with advisory client digest

### DIFF
--- a/conformance/vectors.json
+++ b/conformance/vectors.json
@@ -182,16 +182,16 @@
       "reason": "Closed-vocabulary value; manifest-only placement preserves signed-payload bytes."
     },
     {
-      "name": "capture_topology_ebpf_observer",
-      "description": "Audit Pack manifest entry stamped with capture_topology=ebpf_observer. Producer-side metadata; lives in `manifest`, never in the signed payload.",
+      "name": "capture_topology_github_sha_pull",
+      "description": "Audit Pack manifest entry stamped with capture_topology=github_sha_pull, the server-stamped authoritative code-authorship capture layer. Lives in `manifest`, never in the signed payload.",
       "input": {
         "action_type": "api:call",
         "context": {"tool": "database.query"},
-        "manifest": {"capture_topology": "ebpf_observer"}
+        "manifest": {"capture_topology": "github_sha_pull"}
       },
-      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"ebpf_observer\"}}",
-      "sha256": "57d912d39dd720ea6ceb3bfbf7103c45f74519e5a4e9583211cf24fda0d33491",
-      "capture_topology": "ebpf_observer",
+      "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"github_sha_pull\"}}",
+      "sha256": "1a242ac2766e99b3e9bf00d7bb25ff251fdc1a1b59d77bbbe537723755fef4b6",
+      "capture_topology": "github_sha_pull",
       "expected_verify": true,
       "reason": "Closed-vocabulary value; manifest-only placement preserves signed-payload bytes."
     },
@@ -221,7 +221,7 @@
       "sha256": "d2a306e1c437b467c431b7d1b4a70c1190aec10642e43ac002c55bb84dd3e617",
       "capture_topology": "rootkit",
       "expected_verify": false,
-      "reason": "capture_topology is a closed Literal of {in_process_sdk, network_proxy, browser_extension, ebpf_observer, mcp_proxy}; any other value is rejected client-side."
+      "reason": "capture_topology is a closed Literal of {in_process_sdk, network_proxy, browser_extension, mcp_proxy, passive_telemetry, github_sha_pull}; any other value is rejected client-side."
     },
     {
       "name": "counterparty_binding_happy_path",

--- a/github-action/README.md
+++ b/github-action/README.md
@@ -1,25 +1,29 @@
 # Asqav Code-Authorship Receipt Action
 
-Sign an Asqav code-authorship receipt from a CI run. On every pull request this
-action records who authored a code change and signs that record with ML-DSA-65
-(FIPS 204) server-side, then writes it out as an in-toto Statement.
+Record an Asqav code-authorship receipt from a CI run. On every pull request the
+action computes an advisory digest of the change and asks the Asqav server to
+sign an authoritative record of who authored it. The server signs with ML-DSA-65
+(FIPS 204) and writes the record out as an in-toto Statement.
 
 ## What it proves and what it does not
 
-This action signs a small, honest set of facts:
+The action does two honest things: it computes an advisory change digest (the
+SHA-256 of `git diff <base>..<head>`), and it calls the Asqav server. The
+server then does the authoritative work:
 
-- a change existed, namely the diff between a base commit and the head commit,
-  captured as a SHA-256 digest,
-- that change was key-authored, since the Asqav agent key signed the record,
-- the record was chained at time T, as the receipt is hash-chained and
-  timestamped by Asqav.
+- it re-fetches the commit by sha from the repository,
+- it recomputes the canonical diff itself,
+- it signs an in-toto Statement whose `subject[0].digest.sha256` is the
+  SERVER-recomputed diff hash, not the action's advisory value.
 
-It does not verify the code, does not re-run the diff, does not resolve the
-refs, and does not attest the model. The author identity, the tool, and any
-model fields are producer-asserted. Model fields are always recorded with
-`attestation_source=github-actions-input` so they can never be read as
-Asqav-verified. In short: the receipt proves a change with a given digest was
-recorded and key-signed at a point in time, nothing more.
+The action's digest is advisory. The server reports `digest_match` to say
+whether the advisory value agreed with its own recomputation, and that flag is
+informational: the binding subject is always the server digest. The author
+identity is producer-asserted and recorded, never verified by Asqav.
+
+So the receipt proves a server-verified change to a given commit was recorded
+and key-signed at a point in time. The server independently re-derived the diff,
+and the binding digest rests on that recomputation rather than on the action.
 
 ## Usage
 
@@ -32,71 +36,92 @@ permissions:
   contents: read
 
 jobs:
-  sign:
+  record:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # full history so the base..head diff is available
 
-      - name: Sign Asqav code-authorship receipt
+      - name: Record Asqav code-authorship receipt
         id: asqav
         uses: jagmarques/asqav-sdk/github-action@main
         with:
           asqav-api-key: ${{ secrets.ASQAV_API_KEY }}
-          asqav-agent-id: ${{ secrets.ASQAV_AGENT_ID }}
           change-class: write
-          model-id: claude-opus-4-8
-          model-version: "2026-05"
+          author: model:claude-opus-4-8
 
       - name: Show receipt
         run: |
-          echo "signature: ${{ steps.asqav.outputs.signature-id }}"
-          echo "verify:    ${{ steps.asqav.outputs.verification-url }}"
-          echo "in-toto:   ${{ steps.asqav.outputs.intoto-statement-path }}"
+          echo "signature:    ${{ steps.asqav.outputs.signature-id }}"
+          echo "digest-match: ${{ steps.asqav.outputs.digest-match }}"
+          echo "server-digest:${{ steps.asqav.outputs.server-digest }}"
+          echo "in-toto:      ${{ steps.asqav.outputs.intoto-statement-path }}"
 ```
 
-`fetch-depth: 0` matters: the action digests `git diff <base>..<head>`, so the
-base commit must be present in the checkout.
+`fetch-depth: 0` matters: the action digests `git diff <base>..<head>` for its
+advisory value, so the base commit must be present in the checkout.
 
 ## Inputs
 
 | Input            | Required | Default          | Description |
 | ---------------- | -------- | ---------------- | ----------- |
-| `asqav-api-key`  | yes      |                  | Asqav API key in the form `sk_...`. Pass via a repository secret. |
-| `asqav-agent-id` | yes      |                  | Asqav agent id whose key signs the receipt. |
+| `asqav-api-key`  | yes      |                  | Asqav API key (`sk_...`) with the `code_authorship:write` scope. Pass via a repository secret. |
 | `change-class`   | no       | `write`          | One of `read`, `write`, `delete`, `execute`, `deploy`. |
-| `model-id`       | no       | empty            | Producer-asserted model id. Recorded, never verified. |
-| `model-version`  | no       | empty            | Producer-asserted model version. Recorded, never verified. |
-| `tool`           | no       | `github-actions` | Producer-asserted authoring tool label. |
+| `author`         | no       | empty            | Producer-asserted author identity (for example `human:alice@example.com` or `model:claude-opus-4-8`). Recorded, never verified. |
+| `anchor`         | no       | PR URL           | Anchor reference. Defaults to the pull request URL (or the run URL). |
 
 ## Outputs
 
 | Output                  | Description |
 | ----------------------- | ----------- |
-| `signature-id`          | Asqav signature id of the signed receipt. |
-| `verification-url`      | Public URL to verify the signed receipt. |
+| `signature-id`          | Asqav signature id of the recorded receipt. |
+| `digest-match`          | `true` when the advisory digest agreed with the server digest, else `false`. |
+| `server-digest`         | The server-recomputed diff digest bound into the Statement subject. |
+| `capture-layer`         | The authoritative capture layer stamped by the server (`github_sha_pull`). |
 | `intoto-statement-path` | Path to the emitted in-toto Statement v1 file. |
 
 ## How the receipt is derived
 
 The action reads the git context from the GitHub Actions environment:
 
-- `repo_ref` from `GITHUB_REPOSITORY`,
+- `repo` from `GITHUB_REPOSITORY`,
 - `commit_sha` from `GITHUB_SHA`,
 - `base_sha` from the pull request base in the event payload,
-- `change_ref` from the pull request URL,
-- `change_digest` = `sha256:` + SHA-256 of `git diff <base>..<head>`.
+- `change_digest` (advisory) = `sha256:` + SHA-256 of `git diff <base>..<head>`.
 
-It then calls `agent.sign(...)` with
-`receipt_type="protectmcp:lifecycle:code_authorship"`, `compliance_mode=True`,
-and `policy_decision="none"`, since a code-authorship receipt records no policy
-evaluation and signs under the no-policy opt-out.
+It then calls `POST /v1/code-authorship` with
+`{repo, commit_sha, base_sha, change_digest}` plus the optional `change_class`,
+`author`, and `anchor`. The server re-fetches the commit, recomputes the
+canonical diff, and returns the signed in-toto Statement, the receipt, the
+signing key id, the JWKS url, the `server_digest`, and `digest_match`. The
+action writes the server's Statement to disk verbatim.
+
+## How a third party verifies it
+
+The receipt is independently checkable without trusting the action or the
+producer:
+
+1. re-fetch the `commit_sha` from the repository,
+2. recompute the canonical diff: the sorted changed-files list, each entry
+   `{path, status, additions, deletions, patch}`, canonicalized with JCS
+   (the JSON Canonicalization Scheme),
+3. SHA-256 those canonical bytes and confirm the result equals
+   `subject[0].digest.sha256` in the Statement,
+4. verify the ML-DSA-65 signature over the Statement using the key published at
+   the `jwks_url`, resolved by the `kid`.
+
+A match on step 3 proves the server bound the receipt to a diff anyone can
+re-derive from the public commit. The `capture_layer` is `github_sha_pull`,
+which is the authoritative layer: the server pulled the commit by sha and
+recomputed the diff itself. A receipt carrying `in_process_sdk` or
+`passive_telemetry` is a client self-report and is observation only, never an
+authoritative decision receipt.
 
 ## in-toto interop
 
-The signed receipt is also wrapped as an
-[in-toto Statement v1](https://github.com/in-toto/attestation) and written to a
+The server's signed receipt is an
+[in-toto Statement v1](https://github.com/in-toto/attestation) written to a
 file. The shape is:
 
 ```json
@@ -105,18 +130,21 @@ file. The shape is:
   "subject": [
     {
       "name": "<owner/repo>@<commit_sha>",
-      "digest": { "sha256": "<commit_sha>" }
+      "digest": { "sha256": "<server-recomputed diff hash>" }
     }
   ],
-  "predicateType": "https://asqav.com/CodeAuthorship/v1",
-  "predicate": { "...the signed receipt payload, signature alg ML-DSA-65..." }
+  "predicateType": "https://asqav.com/attestation/code-authorship/v1",
+  "predicate": {
+    "capture_layer": "github_sha_pull",
+    "asset_class": "code",
+    "advisory_client_digest": "sha256:<the action's advisory digest>",
+    "digest_match": true
+  }
 }
 ```
 
-Because the receipt is emitted as a standard in-toto Statement, it slots into
-the same attestation workflows that already consume in-toto, including Sigstore
-Rekor transparency-log entries and GitHub Artifact Attestations. Upload the file
-as a build artifact, push it to a transparency log, or attach it to a release
-the same way you would any other in-toto predicate. The Asqav predicate carries
-the ML-DSA-65 signature envelope, so a consumer can re-verify the Asqav receipt
-independently of the surrounding attestation envelope.
+Because the receipt is a standard in-toto Statement, it slots into the same
+attestation workflows that already consume in-toto, including Sigstore Rekor
+transparency-log entries and GitHub Artifact Attestations. Upload the file as a
+build artifact, push it to a transparency log, or attach it to a release the
+same way you would any other in-toto predicate.

--- a/github-action/action.yml
+++ b/github-action/action.yml
@@ -1,8 +1,9 @@
 name: "Asqav Code-Authorship Receipt"
 description: >-
-  Sign an Asqav code-authorship receipt from a CI run. Records who authored a
-  code change (commit, base, diff digest, producer-asserted author) and signs
-  it with ML-DSA-65 server-side. Also emits the receipt as an in-toto Statement.
+  Record an Asqav code-authorship receipt from a CI run. Computes an advisory
+  diff digest and posts it to POST /v1/code-authorship. The server re-fetches
+  the commit, recomputes the canonical diff, and signs the authoritative
+  in-toto Statement. Emits the server envelope as an in-toto Statement file.
 author: "Asqav"
 branding:
   icon: "git-commit"
@@ -10,37 +11,42 @@ branding:
 
 inputs:
   asqav-api-key:
-    description: "Asqav API key (sk_...). Pass via a repository secret."
-    required: true
-  asqav-agent-id:
-    description: "Asqav agent id whose key signs the receipt."
+    description: >-
+      Asqav API key (sk_...) with the code_authorship:write scope. Pass via a
+      repository secret.
     required: true
   change-class:
     description: "Change class: read | write | delete | execute | deploy."
     required: false
     default: "write"
-  model-id:
+  author:
     description: >-
-      Optional producer-asserted model id if a model authored the change. Always
-      recorded with attestation_source=github-actions-input, never verified.
+      Optional producer-asserted author identity (for example
+      human:alice@example.com or model:claude-opus-4-8). Recorded, never verified.
     required: false
     default: ""
-  model-version:
-    description: "Optional producer-asserted model version. Never verified."
+  anchor:
+    description: >-
+      Optional anchor reference. Defaults to the pull request URL (or the run
+      URL) read from the GitHub Actions event.
     required: false
     default: ""
-  tool:
-    description: "Producer-asserted authoring tool label."
-    required: false
-    default: "github-actions"
 
 outputs:
   signature-id:
-    description: "The Asqav signature id of the signed code-authorship receipt."
+    description: "Asqav signature id of the recorded code-authorship receipt."
     value: ${{ steps.sign.outputs.signature-id }}
-  verification-url:
-    description: "Public URL to verify the signed receipt."
-    value: ${{ steps.sign.outputs.verification-url }}
+  digest-match:
+    description: >-
+      "true" when the advisory diff digest agreed with the server-recomputed
+      digest, else "false".
+    value: ${{ steps.sign.outputs.digest-match }}
+  server-digest:
+    description: "The server-recomputed diff digest bound into the Statement subject."
+    value: ${{ steps.sign.outputs.server-digest }}
+  capture-layer:
+    description: "The authoritative capture layer stamped by the server (github_sha_pull)."
+    value: ${{ steps.sign.outputs.capture-layer }}
   intoto-statement-path:
     description: "Path to the emitted in-toto Statement v1 file."
     value: ${{ steps.sign.outputs.intoto-statement-path }}
@@ -55,16 +61,14 @@ runs:
 
     - name: Install Asqav SDK
       shell: bash
-      run: python -m pip install --upgrade "asqav>=0.5.7"
+      run: python -m pip install --upgrade "${{ github.action_path }}/../python"
 
-    - name: Sign code-authorship receipt
+    - name: Record code-authorship receipt
       id: sign
       shell: bash
       env:
         ASQAV_API_KEY: ${{ inputs.asqav-api-key }}
-        ASQAV_AGENT_ID: ${{ inputs.asqav-agent-id }}
         ASQAV_CHANGE_CLASS: ${{ inputs.change-class }}
-        ASQAV_MODEL_ID: ${{ inputs.model-id }}
-        ASQAV_MODEL_VERSION: ${{ inputs.model-version }}
-        ASQAV_TOOL: ${{ inputs.tool }}
+        ASQAV_AUTHOR: ${{ inputs.author }}
+        ASQAV_ANCHOR: ${{ inputs.anchor }}
       run: python "${{ github.action_path }}/sign_code_authorship.py"

--- a/github-action/sign_code_authorship.py
+++ b/github-action/sign_code_authorship.py
@@ -1,37 +1,32 @@
 #!/usr/bin/env python3
-"""Sign an Asqav code-authorship receipt from a GitHub Actions run.
+"""Record an Asqav code-authorship receipt from a GitHub Actions run.
 
-Honest scope: this script signs what git reports (the commit, its base, and a
-digest of the diff between them) plus the Asqav agent key. Everything else on
-the receipt is producer-asserted and recorded, never verified by Asqav. Model
-authorship fields (`model_id` / `model_version`) are ALWAYS sent under
-`authored_by.attestation_source="github-actions-input"` so they can never be
-read as an Asqav-verified attestation.
+Honest scope: the action computes an ADVISORY change digest (sha256 of
+``git diff base..head``) and posts ``{repo, commit_sha, base_sha,
+change_digest}`` to ``POST /v1/code-authorship``. The Asqav server re-fetches
+the commit, recomputes the canonical diff, and signs the authoritative in-toto
+Statement. ``subject[0].digest.sha256`` is the SERVER-recomputed diff hash, not
+the action's advisory value. ``digest_match`` only reports whether the advisory
+digest agreed with the server's.
 
-The signed receipt is also wrapped as an in-toto Statement v1 and written to a
-file so it interoperates with attestation tooling that consumes in-toto.
+The action writes the server's authoritative in-toto Statement to a file so it
+interoperates with attestation tooling that consumes in-toto.
 """
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
-import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Any
 
-RECEIPT_TYPE = "protectmcp:lifecycle:code_authorship"
-PREDICATE_TYPE = "https://asqav.com/CodeAuthorship/v1"
 INTOTO_STATEMENT_TYPE = "https://in-toto.io/Statement/v1"
-#: Fixed label so model authorship is always recorded as producer-asserted.
-ATTESTATION_SOURCE = "github-actions-input"
 
 
 @dataclass
 class GitContext:
-    """The git facts the receipt binds to, read from the GitHub Actions env."""
+    """The git facts the request binds to, read from the GitHub Actions env."""
 
     repo_ref: str
     commit_sha: str
@@ -40,125 +35,15 @@ class GitContext:
     change_digest: str
 
 
-def _run_git_diff(base_sha: str, head_sha: str) -> str:
-    """Return the textual `git diff <base>..<head>`.
-
-    Raises CalledProcessError if git fails so the action surfaces the problem
-    rather than silently signing an empty digest.
-    """
-    out = subprocess.run(
-        ["git", "diff", f"{base_sha}..{head_sha}"],
-        check=True,
-        capture_output=True,
-    )
-    return out.stdout.decode("utf-8", errors="replace")
-
-
 def compute_change_digest(base_sha: str | None, head_sha: str, diff_text: str | None = None) -> str:
-    """Compute `change_digest` = "sha256:" + sha256(`git diff base..head`).
+    """Compute the ADVISORY ``change_digest`` = ``sha256:`` + sha256(diff).
 
-    When `diff_text` is supplied it is hashed directly (used by tests and to
-    avoid re-shelling). When it is None and a base is known, the diff is read
-    from git. When no base is known, the bare head sha is hashed so the field
-    is always a well-formed sha256:<64 hex> existence proof.
-
-    Always returns the cloud wire form `sha256:<64 lowercase hex>`.
+    Delegates to the SDK so the action and the SDK agree byte-for-byte. The
+    digest is advisory: the server recomputes its own and signs that.
     """
-    if diff_text is None:
-        if base_sha:
-            diff_text = _run_git_diff(base_sha, head_sha)
-        else:
-            diff_text = head_sha
-    digest = hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
-    return f"sha256:{digest}"
+    from asqav.code_authorship import compute_advisory_digest
 
-
-def build_authored_by(
-    *,
-    agent_id: str | None,
-    model_id: str | None,
-    model_version: str | None,
-    tool: str | None,
-) -> dict[str, Any]:
-    """Build the producer-asserted `authored_by` object.
-
-    `attestation_source` is ALWAYS set to ``github-actions-input`` so any model
-    authorship claim is recorded as producer-asserted and is never read as an
-    Asqav-verified attestation. The SDK enforces that a populated model_id /
-    model_version requires attestation_source; we satisfy that unconditionally.
-    """
-    authored_by: dict[str, Any] = {"attestation_source": ATTESTATION_SOURCE}
-    if agent_id:
-        authored_by["agent_id"] = agent_id
-    if model_id:
-        authored_by["model_id"] = model_id
-    if model_version:
-        authored_by["model_version"] = model_version
-    if tool:
-        authored_by["tool"] = tool
-    return authored_by
-
-
-def _bare_change_digest_hex(change_digest: str) -> str:
-    """Strip the `sha256:` prefix from a change_digest for the in-toto subject."""
-    return change_digest.split(":", 1)[-1]
-
-
-def build_intoto_statement(
-    *,
-    repo_ref: str,
-    commit_sha: str,
-    change_digest: str,
-    signed_receipt: dict[str, Any],
-) -> dict[str, Any]:
-    """Wrap the signed receipt payload as an in-toto Statement v1.
-
-    Subject names the repo at the signed commit and carries the bare commit
-    sha as its sha256 digest (the resource the attestation is about). The
-    predicate is the returned signed receipt payload, including the ML-DSA-65
-    signature envelope, so a consumer can re-verify it offline.
-    """
-    return {
-        "_type": INTOTO_STATEMENT_TYPE,
-        "subject": [
-            {
-                "name": f"{repo_ref}@{commit_sha}",
-                "digest": {"sha256": commit_sha},
-            }
-        ],
-        "predicateType": PREDICATE_TYPE,
-        "predicate": signed_receipt,
-    }
-
-
-def _signed_receipt_payload(response: Any) -> dict[str, Any]:
-    """Project the SDK SignatureResponse into a JSON-able signed-receipt payload.
-
-    Prefers the cloud three-key compliance payload when present; always carries
-    the signature envelope (alg/kid/sig, alg=ML-DSA-65) plus the identifiers a
-    verifier needs.
-    """
-    envelope = None
-    try:
-        envelope = response.signature_envelope()
-    except Exception:
-        envelope = None
-    payload: dict[str, Any] = {
-        "signature_id": response.signature_id,
-        "action_id": response.action_id,
-        "receipt_type": response.receipt_type or RECEIPT_TYPE,
-        "algorithm": response.algorithm,
-        "signature": envelope if envelope is not None else response.signature,
-        "verification_url": response.verification_url,
-        "timestamp": response.timestamp,
-    }
-    if getattr(response, "payload", None) is not None:
-        payload["payload"] = response.payload
-    if getattr(response, "anchors", None) is not None:
-        payload["anchors"] = response.anchors
-    if getattr(response, "previous_receipt_hash", None) is not None:
-        payload["previous_receipt_hash"] = response.previous_receipt_hash
-    return payload
+    return compute_advisory_digest(base_sha, head_sha, diff_text=diff_text)
 
 
 def _read_git_context() -> GitContext:
@@ -166,8 +51,7 @@ def _read_git_context() -> GitContext:
 
     repo_ref  <- GITHUB_REPOSITORY (owner/repo)
     commit_sha<- GITHUB_SHA
-    base_sha  <- the PR base sha read from the event payload (pull_request.base.sha),
-                 else GITHUB_BASE_REF resolved, else None
+    base_sha  <- the PR base sha from the event payload (pull_request.base.sha)
     change_ref<- the PR html_url from the event payload, else the run URL
     """
     repo_ref = os.environ.get("GITHUB_REPOSITORY", "")
@@ -211,68 +95,63 @@ def _write_github_output(values: dict[str, str]) -> None:
             fh.write(f"{key}={value}\n")
 
 
+def _signature_id(result: Any) -> str:
+    """Read the signature id from the server receipt, best-effort."""
+    receipt = getattr(result, "receipt", None) or {}
+    if isinstance(receipt, dict):
+        value = receipt.get("signature_id")
+        if isinstance(value, str):
+            return value
+    return ""
+
+
 def sign_and_export(
     *,
     api_key: str,
-    agent_id: str,
     change_class: str,
-    model_id: str | None,
-    model_version: str | None,
-    tool: str | None,
+    author: str | None,
     intoto_path: str,
     git_ctx: GitContext | None = None,
+    anchor: str | None = None,
 ) -> dict[str, str]:
-    """Sign the code-authorship receipt and emit the in-toto Statement.
+    """Post the advisory digest and emit the server's authoritative Statement.
 
-    Returns a dict of the GitHub outputs: signature-id, verification-url,
+    Returns the GitHub outputs: signature-id, digest-match, server-digest,
     intoto-statement-path.
     """
     import asqav
+    from asqav.code_authorship import submit_code_authorship
 
     ctx = git_ctx or _read_git_context()
 
     asqav.init(api_key=api_key)
-    agent = asqav.Agent.get(agent_id)
-
-    authored_by = build_authored_by(
-        agent_id=agent_id,
-        model_id=model_id,
-        model_version=model_version,
-        tool=tool,
-    )
-
-    response = agent.sign(
-        "code:authorship",
-        receipt_type=RECEIPT_TYPE,
-        compliance_mode=True,
-        policy_decision="none",
-        repo_ref=ctx.repo_ref,
+    result = submit_code_authorship(
+        repo=ctx.repo_ref,
         commit_sha=ctx.commit_sha,
         base_sha=ctx.base_sha,
         change_digest=ctx.change_digest,
-        change_ref=ctx.change_ref,
-        change_approval_ref=ctx.change_ref,
         change_class=change_class,
-        authored_by=authored_by,
+        author=author,
+        anchor=anchor or ctx.change_ref,
     )
 
-    signed_payload = _signed_receipt_payload(response)
-    statement = build_intoto_statement(
-        repo_ref=ctx.repo_ref,
-        commit_sha=ctx.commit_sha,
-        change_digest=ctx.change_digest,
-        signed_receipt=signed_payload,
-    )
+    # The server's envelope IS the authoritative in-toto Statement. Write it
+    # verbatim so the bound subject digest is the server-recomputed value.
     with open(intoto_path, "w", encoding="utf-8") as fh:
-        json.dump(statement, fh, indent=2, sort_keys=True)
+        json.dump(result.envelope, fh, indent=2, sort_keys=True)
 
-    print(f"Signed code-authorship receipt: {response.signature_id}")
-    print(f"Verify at: {response.verification_url}")
+    signature_id = _signature_id(result)
+    print(f"Recorded code-authorship receipt: {signature_id or '(no signature id)'}")
+    print(f"capture_layer={result.capture_layer} digest_match={result.digest_match}")
+    if result.subject_digest:
+        print(f"server subject digest: {result.subject_digest}")
     print(f"in-toto Statement written to: {intoto_path}")
 
     outputs = {
-        "signature-id": response.signature_id,
-        "verification-url": response.verification_url,
+        "signature-id": signature_id,
+        "digest-match": "true" if result.digest_match else "false",
+        "server-digest": result.server_digest or "",
+        "capture-layer": result.capture_layer or "",
         "intoto-statement-path": intoto_path,
     }
     _write_github_output(outputs)
@@ -281,18 +160,16 @@ def sign_and_export(
 
 def main() -> int:
     api_key = os.environ.get("ASQAV_API_KEY", "")
-    agent_id = os.environ.get("ASQAV_AGENT_ID", "")
-    if not api_key or not agent_id:
+    if not api_key:
         print(
-            "ERROR: ASQAV_API_KEY and ASQAV_AGENT_ID must be set.",
+            "ERROR: ASQAV_API_KEY must be set, with the code_authorship:write scope.",
             file=sys.stderr,
         )
         return 2
 
     change_class = os.environ.get("ASQAV_CHANGE_CLASS", "write") or "write"
-    model_id = os.environ.get("ASQAV_MODEL_ID") or None
-    model_version = os.environ.get("ASQAV_MODEL_VERSION") or None
-    tool = os.environ.get("ASQAV_TOOL") or "github-actions"
+    author = os.environ.get("ASQAV_AUTHOR") or None
+    anchor = os.environ.get("ASQAV_ANCHOR") or None
 
     workspace = os.environ.get("GITHUB_WORKSPACE", os.getcwd())
     intoto_path = os.environ.get(
@@ -303,15 +180,13 @@ def main() -> int:
     try:
         sign_and_export(
             api_key=api_key,
-            agent_id=agent_id,
             change_class=change_class,
-            model_id=model_id,
-            model_version=model_version,
-            tool=tool,
+            author=author,
             intoto_path=intoto_path,
+            anchor=anchor,
         )
     except Exception as exc:  # noqa: BLE001 - surface any failure to the runner
-        print(f"ERROR signing code-authorship receipt: {exc}", file=sys.stderr)
+        print(f"ERROR recording code-authorship receipt: {exc}", file=sys.stderr)
         return 1
     return 0
 

--- a/github-action/test_sign_code_authorship.py
+++ b/github-action/test_sign_code_authorship.py
@@ -1,29 +1,41 @@
-"""Pure unit tests for the code-authorship signing action.
+"""Unit tests for the code-authorship recording action.
 
-No network, no real Asqav API. The SDK sign call is mocked. These tests cover
-the three load-bearing pieces of the action:
+No network, no real Asqav API. The server call (asqav.client._post) is mocked.
+These tests cover the load-bearing pieces of the action:
 
-1. change_digest computation (wire form + diff hashing).
-2. authored_by attestation_source enforcement (always present).
-3. the in-toto Statement v1 wrapper shape (valid JSON, _type, predicateType,
-   subject).
+1. advisory change_digest computation (wire form + diff hashing),
+2. the action posts the ADVISORY digest to POST /v1/code-authorship,
+3. the written in-toto Statement binds the SERVER subject digest (not the
+   advisory one), and digest_match reports advisory-vs-server agreement.
 """
 
 import hashlib
 import json
 import sys
-import types
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+ACTION_DIR = Path(__file__).resolve().parent
+SDK_SRC = ACTION_DIR.parent / "python" / "src"
+sys.path.insert(0, str(ACTION_DIR))
+sys.path.insert(0, str(SDK_SRC))
+
+# A globally installed `asqav` (or an editable install pointing at another
+# checkout) can shadow the in-repo SDK. Purge any cached import so the module
+# under test resolves to this worktree's python/src.
+for _name in [m for m in list(sys.modules) if m == "asqav" or m.startswith("asqav.")]:
+    del sys.modules[_name]
 
 import sign_code_authorship as mod  # noqa: E402
 
+from asqav.code_authorship import CODE_AUTHORSHIP_PATH  # noqa: E402
 
-# --- change_digest computation ------------------------------------------------
+SERVER_HEX = "f" * 64
+ADVISORY_HEX = "1" * 64
+
+
+# --- advisory change_digest computation --------------------------------------
 
 
 def test_change_digest_hashes_supplied_diff_text():
@@ -46,170 +58,133 @@ def test_change_digest_falls_back_to_head_sha_without_base():
     assert mod.compute_change_digest(None, head, diff_text=None) == expected
 
 
-# --- authored_by attestation_source enforcement -------------------------------
+# --- server response builders -------------------------------------------------
 
 
-def test_authored_by_always_has_attestation_source():
-    ab = mod.build_authored_by(
-        agent_id="agent-1", model_id=None, model_version=None, tool=None
-    )
-    assert ab["attestation_source"] == "github-actions-input"
-
-
-def test_authored_by_model_fields_carry_attestation_source():
-    ab = mod.build_authored_by(
-        agent_id="agent-1",
-        model_id="claude-opus-4-8",
-        model_version="2026-05",
-        tool="github-actions",
-    )
-    # Model claim present -> attestation_source MUST be present (SDK requires it).
-    assert ab["model_id"] == "claude-opus-4-8"
-    assert ab["model_version"] == "2026-05"
-    assert ab["attestation_source"] == "github-actions-input"
-    assert ab["tool"] == "github-actions"
-
-
-def test_authored_by_omits_empty_optional_fields():
-    ab = mod.build_authored_by(
-        agent_id=None, model_id=None, model_version=None, tool=None
-    )
-    assert ab == {"attestation_source": "github-actions-input"}
-
-
-# --- in-toto Statement wrapper shape ------------------------------------------
-
-
-def _sample_receipt():
+def _server_envelope(*, server_hex: str, digest_match: bool, advisory: str) -> dict:
     return {
-        "signature_id": "sig_123",
-        "algorithm": "ML-DSA-65",
-        "signature": {"alg": "ML-DSA-65", "kid": "key_1", "sig": "AAAA"},
-        "receipt_type": mod.RECEIPT_TYPE,
+        "_type": "https://in-toto.io/Statement/v1",
+        "subject": [
+            {"name": "owner/repo@" + "c" * 40, "digest": {"sha256": server_hex}}
+        ],
+        "predicateType": "https://asqav.com/attestation/code-authorship/v1",
+        "predicate": {
+            "capture_layer": "github_sha_pull",
+            "asset_class": "code",
+            "advisory_client_digest": advisory,
+            "digest_match": digest_match,
+        },
     }
 
 
-def test_intoto_statement_shape():
-    commit = "f" * 40
-    stmt = mod.build_intoto_statement(
-        repo_ref="owner/repo",
-        commit_sha=commit,
-        change_digest="sha256:" + "0" * 64,
-        signed_receipt=_sample_receipt(),
-    )
-    # Valid JSON round-trip.
-    reparsed = json.loads(json.dumps(stmt))
-    assert reparsed["_type"] == "https://in-toto.io/Statement/v1"
-    assert reparsed["predicateType"] == "https://asqav.com/CodeAuthorship/v1"
-    assert reparsed["subject"] == [
-        {"name": f"owner/repo@{commit}", "digest": {"sha256": commit}}
-    ]
-    # Predicate carries the signed receipt incl ML-DSA-65 envelope.
-    assert reparsed["predicate"]["algorithm"] == "ML-DSA-65"
-    assert reparsed["predicate"]["signature"]["alg"] == "ML-DSA-65"
+def _server_response(*, server_hex: str, digest_match: bool, advisory: str) -> dict:
+    return {
+        "envelope": _server_envelope(
+            server_hex=server_hex, digest_match=digest_match, advisory=advisory
+        ),
+        "receipt": {"signature_id": "sig_ca", "algorithm": "ML-DSA-65"},
+        "kid": "key_ca",
+        "jwks_url": "https://api.asqav.com/.well-known/jwks.json",
+        "server_digest": "sha256:" + server_hex,
+        "digest_match": digest_match,
+    }
 
 
-# --- end-to-end with a mocked SDK ---------------------------------------------
+# --- end-to-end with a mocked server -----------------------------------------
 
 
-@dataclass
-class _FakeResponse:
-    signature_id: str = "sig_abc"
-    action_id: str = "act_abc"
-    receipt_type: str = mod.RECEIPT_TYPE
-    algorithm: str = "ML-DSA-65"
-    signature: object = None
-    verification_url: str = "https://asqav.com/v/sig_abc"
-    timestamp: float = 1234.0
-    payload: object = None
-    anchors: object = None
-    previous_receipt_hash: object = None
+def test_sign_and_export_posts_advisory_and_binds_server_subject(monkeypatch, tmp_path):
+    captured: dict = {}
+    advisory = "sha256:" + ADVISORY_HEX
 
-    def __post_init__(self):
-        if self.signature is None:
-            self.signature = {"alg": "ML-DSA-65", "kid": "key_1", "sig": "AAAA"}
+    def fake_post(path: str, body: dict) -> dict:
+        captured["path"] = path
+        captured["body"] = body
+        # The server recomputes a DIFFERENT digest than the advisory one.
+        return _server_response(
+            server_hex=SERVER_HEX, digest_match=False, advisory=advisory
+        )
 
-    def signature_envelope(self):
-        if isinstance(self.signature, dict):
-            return self.signature
-        return None
-
-
-def _install_fake_asqav(monkeypatch, captured):
-    fake = types.ModuleType("asqav")
-
-    def fake_init(api_key=None, **kwargs):
-        captured["api_key"] = api_key
-
-    class FakeAgent:
-        def __init__(self, agent_id):
-            self.agent_id = agent_id
-
-        @classmethod
-        def get(cls, agent_id):
-            captured["agent_id"] = agent_id
-            return cls(agent_id)
-
-        def sign(self, action_type, **kwargs):
-            captured["action_type"] = action_type
-            captured["sign_kwargs"] = kwargs
-            return _FakeResponse()
-
-    fake.init = fake_init
-    fake.Agent = FakeAgent
-    monkeypatch.setitem(sys.modules, "asqav", fake)
-
-
-def test_sign_and_export_passes_honest_fields(monkeypatch, tmp_path):
-    captured = {}
-    _install_fake_asqav(monkeypatch, captured)
+    monkeypatch.setattr("asqav.client._post", fake_post)
 
     ctx = mod.GitContext(
         repo_ref="owner/repo",
         commit_sha="c" * 40,
         base_sha="b" * 40,
         change_ref="https://github.com/owner/repo/pull/7",
-        change_digest="sha256:" + "1" * 64,
+        change_digest=advisory,
     )
     intoto_path = tmp_path / "out.intoto.jsonl"
 
     outputs = mod.sign_and_export(
         api_key="sk_test",
-        agent_id="agent-1",
         change_class="write",
-        model_id="claude-opus-4-8",
-        model_version="2026-05",
-        tool="github-actions",
+        author="model:claude-opus-4-8",
         intoto_path=str(intoto_path),
         git_ctx=ctx,
     )
 
-    kwargs = captured["sign_kwargs"]
-    # Honest-scope invariants on the sign call.
-    assert kwargs["receipt_type"] == mod.RECEIPT_TYPE
-    assert kwargs["compliance_mode"] is True
-    assert kwargs["policy_decision"] == "none"
-    assert kwargs["repo_ref"] == "owner/repo"
-    assert kwargs["commit_sha"] == "c" * 40
-    assert kwargs["base_sha"] == "b" * 40
-    assert kwargs["change_digest"] == "sha256:" + "1" * 64
-    assert kwargs["change_class"] == "write"
-    # Model claim is always producer-asserted.
-    assert kwargs["authored_by"]["attestation_source"] == "github-actions-input"
-    assert kwargs["authored_by"]["model_id"] == "claude-opus-4-8"
+    # The action posts to /v1/code-authorship with the ADVISORY digest.
+    assert captured["path"] == CODE_AUTHORSHIP_PATH
+    body = captured["body"]
+    assert body["repo"] == "owner/repo"
+    assert body["commit_sha"] == "c" * 40
+    assert body["base_sha"] == "b" * 40
+    assert body["change_digest"] == advisory
+    assert body["change_class"] == "write"
+    assert body["author"] == "model:claude-opus-4-8"
+    assert body["anchor"] == "https://github.com/owner/repo/pull/7"
 
-    # Outputs.
-    assert outputs["signature-id"] == "sig_abc"
-    assert outputs["verification-url"] == "https://asqav.com/v/sig_abc"
-    assert outputs["intoto-statement-path"] == str(intoto_path)
-
-    # in-toto file is valid JSON with the right shape.
+    # The written Statement binds the SERVER subject digest, not the advisory one.
     stmt = json.loads(intoto_path.read_text())
     assert stmt["_type"] == "https://in-toto.io/Statement/v1"
-    assert stmt["predicateType"] == "https://asqav.com/CodeAuthorship/v1"
-    assert stmt["subject"][0]["name"] == "owner/repo@" + "c" * 40
-    assert stmt["subject"][0]["digest"]["sha256"] == "c" * 40
-    assert stmt["predicate"]["algorithm"] == "ML-DSA-65"
+    assert stmt["predicateType"] == "https://asqav.com/attestation/code-authorship/v1"
+    assert stmt["subject"][0]["digest"]["sha256"] == SERVER_HEX
+    assert stmt["subject"][0]["digest"]["sha256"] != ADVISORY_HEX
+    assert stmt["predicate"]["capture_layer"] == "github_sha_pull"
+    assert stmt["predicate"]["advisory_client_digest"] == advisory
+
+    # digest_match reports the advisory-vs-server disagreement.
+    assert outputs["digest-match"] == "false"
+    assert outputs["server-digest"] == "sha256:" + SERVER_HEX
+    assert outputs["capture-layer"] == "github_sha_pull"
+    assert outputs["signature-id"] == "sig_ca"
+    assert outputs["intoto-statement-path"] == str(intoto_path)
+
+
+def test_sign_and_export_reports_digest_match_true(monkeypatch, tmp_path):
+    advisory = "sha256:" + ADVISORY_HEX
+
+    def fake_post(path: str, body: dict) -> dict:
+        # Server recomputation agrees with the advisory digest.
+        return _server_response(
+            server_hex=ADVISORY_HEX, digest_match=True, advisory=advisory
+        )
+
+    monkeypatch.setattr("asqav.client._post", fake_post)
+
+    ctx = mod.GitContext(
+        repo_ref="owner/repo",
+        commit_sha="c" * 40,
+        base_sha="b" * 40,
+        change_ref=None,
+        change_digest=advisory,
+    )
+    intoto_path = tmp_path / "out.intoto.jsonl"
+
+    outputs = mod.sign_and_export(
+        api_key="sk_test",
+        change_class="write",
+        author=None,
+        intoto_path=str(intoto_path),
+        git_ctx=ctx,
+    )
+
+    assert outputs["digest-match"] == "true"
+    assert outputs["server-digest"] == "sha256:" + ADVISORY_HEX
+    stmt = json.loads(intoto_path.read_text())
+    assert stmt["subject"][0]["digest"]["sha256"] == ADVISORY_HEX
+    assert stmt["predicate"]["digest_match"] is True
 
 
 if __name__ == "__main__":

--- a/python/README.md
+++ b/python/README.md
@@ -147,7 +147,7 @@ sig = agent.sign(
 )
 ```
 
-`capture_topology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `ebpf_observer`, and `mcp_proxy`. Only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
+`capture_topology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `mcp_proxy`, and `github_sha_pull`. A client-supplied `capture_topology` is advisory: the server stamps the authoritative value from the ingress route, and for code-authorship that authoritative value is `github_sha_pull`, set only after the server re-fetches the commit and recomputes the diff. Only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
 
 ### Configuration change receipts, rule 9
 

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -47,19 +47,6 @@ from .attestation import (
     verify_merkle_inclusion,
 )
 from .canonicalize import canonicalize, canonicalize_tool_args, hash_action
-from .code_authorship import (
-    AUTHORITATIVE_CAPTURE_LAYER,
-    CODE_AUTHORSHIP_ASSET_CLASS,
-    CODE_AUTHORSHIP_PATH,
-    CODE_AUTHORSHIP_PREDICATE_TYPE,
-    CODE_AUTHORSHIP_WRITE_SCOPE,
-    OBSERVATION_ONLY_CAPTURE_LAYERS,
-    CodeAuthorshipResult,
-    CodeAuthorshipVerification,
-    compute_advisory_digest,
-    submit_code_authorship,
-    verify_code_authorship_envelope,
-)
 from .client import (
     CAPTURE_TOPOLOGY_NAMESPACE,
     CODE_AUTHORSHIP_DOCS_URL,
@@ -152,6 +139,19 @@ from .client import (
     verify_compliance_receipt,
     verify_output,
     verify_signature,
+)
+from .code_authorship import (
+    AUTHORITATIVE_CAPTURE_LAYER,
+    CODE_AUTHORSHIP_ASSET_CLASS,
+    CODE_AUTHORSHIP_PATH,
+    CODE_AUTHORSHIP_PREDICATE_TYPE,
+    CODE_AUTHORSHIP_WRITE_SCOPE,
+    OBSERVATION_ONLY_CAPTURE_LAYERS,
+    CodeAuthorshipResult,
+    CodeAuthorshipVerification,
+    compute_advisory_digest,
+    submit_code_authorship,
+    verify_code_authorship_envelope,
 )
 from .commitment import commit, new_opening
 from .compliance import ComplianceBundle, export_bundle, fetch_audit_pack

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -47,6 +47,19 @@ from .attestation import (
     verify_merkle_inclusion,
 )
 from .canonicalize import canonicalize, canonicalize_tool_args, hash_action
+from .code_authorship import (
+    AUTHORITATIVE_CAPTURE_LAYER,
+    CODE_AUTHORSHIP_ASSET_CLASS,
+    CODE_AUTHORSHIP_PATH,
+    CODE_AUTHORSHIP_PREDICATE_TYPE,
+    CODE_AUTHORSHIP_WRITE_SCOPE,
+    OBSERVATION_ONLY_CAPTURE_LAYERS,
+    CodeAuthorshipResult,
+    CodeAuthorshipVerification,
+    compute_advisory_digest,
+    submit_code_authorship,
+    verify_code_authorship_envelope,
+)
 from .client import (
     CAPTURE_TOPOLOGY_NAMESPACE,
     CODE_AUTHORSHIP_DOCS_URL,
@@ -326,6 +339,18 @@ __all__ = [
     "RiskSnapshot",
     "CODE_AUTHORSHIP_DOCS_URL",
     "AuthoredBy",
+    # Authoritative code-authorship path (POST /v1/code-authorship)
+    "AUTHORITATIVE_CAPTURE_LAYER",
+    "CODE_AUTHORSHIP_ASSET_CLASS",
+    "CODE_AUTHORSHIP_PATH",
+    "CODE_AUTHORSHIP_PREDICATE_TYPE",
+    "CODE_AUTHORSHIP_WRITE_SCOPE",
+    "OBSERVATION_ONLY_CAPTURE_LAYERS",
+    "CodeAuthorshipResult",
+    "CodeAuthorshipVerification",
+    "compute_advisory_digest",
+    "submit_code_authorship",
+    "verify_code_authorship_envelope",
     "SKEW_BOUND_SECONDS",
     "ComplianceReceiptVerification",
     "verify_compliance_receipt",

--- a/python/src/asqav/cli_hook.py
+++ b/python/src/asqav/cli_hook.py
@@ -23,6 +23,7 @@ except ImportError:
     print("CLI requires typer. Install with: pip install asqav[cli]")
     sys.exit(1)
 
+from asqav.code_authorship import CODE_AUTHORSHIP_WRITE_SCOPE
 from asqav.credentials import resolve_api_key
 
 hook_app = typer.Typer(
@@ -30,6 +31,9 @@ hook_app = typer.Typer(
     help="Sign Claude Code harness hook events (PostToolUse audit, PreToolUse gate).",
     no_args_is_help=True,
 )
+
+#: API-key scope the code-authorship command requires on the configured key.
+REQUIRED_SCOPE = CODE_AUTHORSHIP_WRITE_SCOPE
 
 # rule 8 accepts only these two receipt_types under passive_telemetry. A posttool
 # receipt is structurally pinned to this set so it cannot claim a decision.
@@ -279,3 +283,77 @@ def hook_pretool(
         print(f"asqav hook: signer unreachable, blocking tool call: {exc}", file=sys.stderr)
         raise typer.Exit(code=2) from exc
     print(f"permit {sig.signature_id}", file=sys.stderr)
+
+
+@hook_app.command("code-authorship")
+def hook_code_authorship(
+    repo: str = typer.Option(..., "--repo", help="Repository as owner/name."),
+    commit_sha: str = typer.Option(..., "--commit-sha", help="Head commit sha the change is bound to."),
+    base_sha: str = typer.Option("", "--base-sha", help="Base commit sha for the advisory diff."),
+    change_class: str = typer.Option("write", "--change-class", help="read | write | delete | execute | deploy."),
+    author: str = typer.Option("", "--author", help="Producer-asserted author identity."),
+    anchor: str = typer.Option("", "--anchor", help="Optional anchor reference (PR url, ticket)."),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Compute the advisory digest and print the request body. No network call.",
+    ),
+) -> None:
+    """Record code authorship via POST /v1/code-authorship.
+
+    Computes an ADVISORY change digest (sha256 of ``git diff base..head``) and
+    posts it with the repo and commit. The server re-fetches the commit,
+    recomputes the canonical diff, and signs the authoritative in-toto
+    Statement. ``subject[0].digest.sha256`` is the server digest, and
+    ``digest_match`` reports whether the advisory value agreed. Requires a key
+    with the ``code_authorship:write`` scope.
+    """
+    from asqav.code_authorship import compute_advisory_digest, submit_code_authorship
+
+    advisory = compute_advisory_digest(base_sha or None, commit_sha)
+
+    if dry_run:
+        body = {
+            "repo": repo,
+            "commit_sha": commit_sha,
+            "change_digest": advisory,
+            "change_class": change_class,
+        }
+        if base_sha:
+            body["base_sha"] = base_sha
+        if author:
+            body["author"] = author
+        if anchor:
+            body["anchor"] = anchor
+        print(json_mod.dumps(body, indent=2, default=str))
+        return
+
+    api_key = resolve_api_key()
+    if not api_key:
+        print(
+            "Error: ASQAV_API_KEY (or `asqav login`) must be set, with the "
+            f"{REQUIRED_SCOPE} scope, to record code authorship.",
+            file=sys.stderr,
+        )
+        raise typer.Exit(code=1)
+
+    import asqav
+
+    asqav.init(api_key=api_key)
+    try:
+        result = submit_code_authorship(
+            repo=repo,
+            commit_sha=commit_sha,
+            base_sha=base_sha or None,
+            change_digest=advisory,
+            change_class=change_class,
+            author=author or None,
+            anchor=anchor or None,
+        )
+    except Exception as exc:
+        print(f"asqav hook: code-authorship recording failed: {exc}", file=sys.stderr)
+        raise typer.Exit(code=1) from exc
+
+    print(f"capture_layer={result.capture_layer} digest_match={result.digest_match}", file=sys.stderr)
+    if result.subject_digest:
+        print(f"server subject digest: {result.subject_digest}", file=sys.stderr)

--- a/python/src/asqav/cli_hook.py
+++ b/python/src/asqav/cli_hook.py
@@ -288,9 +288,13 @@ def hook_pretool(
 @hook_app.command("code-authorship")
 def hook_code_authorship(
     repo: str = typer.Option(..., "--repo", help="Repository as owner/name."),
-    commit_sha: str = typer.Option(..., "--commit-sha", help="Head commit sha the change is bound to."),
+    commit_sha: str = typer.Option(
+        ..., "--commit-sha", help="Head commit sha the change is bound to."
+    ),
     base_sha: str = typer.Option("", "--base-sha", help="Base commit sha for the advisory diff."),
-    change_class: str = typer.Option("write", "--change-class", help="read | write | delete | execute | deploy."),
+    change_class: str = typer.Option(
+        "write", "--change-class", help="read | write | delete | execute | deploy."
+    ),
     author: str = typer.Option("", "--author", help="Producer-asserted author identity."),
     anchor: str = typer.Option("", "--anchor", help="Optional anchor reference (PR url, ticket)."),
     dry_run: bool = typer.Option(
@@ -354,6 +358,9 @@ def hook_code_authorship(
         print(f"asqav hook: code-authorship recording failed: {exc}", file=sys.stderr)
         raise typer.Exit(code=1) from exc
 
-    print(f"capture_layer={result.capture_layer} digest_match={result.digest_match}", file=sys.stderr)
+    print(
+        f"capture_layer={result.capture_layer} digest_match={result.digest_match}",
+        file=sys.stderr,
+    )
     if result.subject_digest:
         print(f"server subject digest: {result.subject_digest}", file=sys.stderr)

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -330,15 +330,18 @@ SANDBOX_STATE_NAMESPACE: frozenset[str] = frozenset({"enabled", "disabled", "una
 WITNESS_NAMESPACE: frozenset[str] = frozenset({"rfc3161", "opentimestamps"})
 
 #: Producer-side `capture_topology` vocabulary mirrored from the cloud
-#: SignRequest Literal. See docs/capture-topology.md.
+#: SignRequest Literal. See docs/capture-topology.md. A client-supplied
+#: capture_topology is ADVISORY: the server stamps the authoritative value
+#: from the ingress route (for code-authorship that is `github_sha_pull`,
+#: set only after the server re-fetches the commit and recomputes the diff).
 CAPTURE_TOPOLOGY_NAMESPACE: frozenset[str] = frozenset(
     {
         "in_process_sdk",
         "network_proxy",
         "browser_extension",
-        "ebpf_observer",
         "mcp_proxy",
         "passive_telemetry",
+        "github_sha_pull",
     }
 )
 
@@ -355,9 +358,9 @@ CaptureTopology = Literal[
     "in_process_sdk",
     "network_proxy",
     "browser_extension",
-    "ebpf_observer",
     "mcp_proxy",
     "passive_telemetry",
+    "github_sha_pull",
 ]
 
 # Verifier rejects receipts further than this from the wall clock.
@@ -1806,9 +1809,11 @@ class Agent:
                 Only the name string travels; the prompt does not.
             capture_topology: Producer-side topology. One of
                 ``in_process_sdk``, ``network_proxy``, ``browser_extension``,
-                ``ebpf_observer``, ``mcp_proxy``, ``passive_telemetry``.
+                ``mcp_proxy``, ``passive_telemetry``, ``github_sha_pull``.
                 Stamped on the audit-pack manifest entry; never on the
-                signed payload. ``passive_telemetry`` requires
+                signed payload. Client-supplied capture_topology is ADVISORY:
+                the server stamps the authoritative value from the ingress
+                route. ``passive_telemetry`` requires
                 ``receipt_type='protectmcp:observation'`` (false-attestation guard).
             result_digest: NSA CSI U/OO/6030316-26 alignment.
                 ``sha256:<hex>`` of the tool output. Caller-supplied and

--- a/python/src/asqav/code_authorship.py
+++ b/python/src/asqav/code_authorship.py
@@ -1,0 +1,265 @@
+"""SDK half of the un-bypassable code-authorship path.
+
+POST /v1/code-authorship is the authoritative ingress: the client supplies an
+ADVISORY change digest (sha256 of ``git diff base..head``) and the server
+re-fetches the commit, recomputes the canonical diff, and signs an in-toto
+Statement whose ``subject[0].digest.sha256`` is the SERVER-recomputed hash.
+The client digest is never trusted. ``digest_match`` only reports whether the
+advisory value agreed with the server's.
+
+The authoritative capture layer for a code-authorship receipt is
+``github_sha_pull``. A receipt whose capture layer is ``in_process_sdk`` or
+``passive_telemetry`` is a client self-report and can NEVER be an authoritative
+decision receipt (observation only), mirroring the cloud's
+``observation_decision_not_allowed`` rule.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any
+
+#: API-key scope required to call POST /v1/code-authorship.
+CODE_AUTHORSHIP_WRITE_SCOPE: str = "code_authorship:write"
+
+#: Endpoint path (joined onto the configured API base).
+CODE_AUTHORSHIP_PATH: str = "/code-authorship"
+
+#: predicateType of the authoritative code-authorship in-toto Statement.
+CODE_AUTHORSHIP_PREDICATE_TYPE: str = "https://asqav.com/attestation/code-authorship/v1"
+
+#: in-toto Statement v1 type carried by the envelope.
+INTOTO_STATEMENT_TYPE: str = "https://in-toto.io/Statement/v1"
+
+#: asset_class the server stamps on the code-authorship predicate.
+CODE_AUTHORSHIP_ASSET_CLASS: str = "code"
+
+#: The ONLY capture layer that makes a code-authorship receipt authoritative.
+#: The server stamps it after re-fetching the commit and recomputing the diff.
+AUTHORITATIVE_CAPTURE_LAYER: str = "github_sha_pull"
+
+#: Capture layers that are client self-reports. A code-authorship receipt
+#: carrying one of these is observation only and never an authoritative
+#: decision receipt.
+OBSERVATION_ONLY_CAPTURE_LAYERS: frozenset[str] = frozenset(
+    {"in_process_sdk", "passive_telemetry"}
+)
+
+#: Verdict tokens for :func:`verify_code_authorship_envelope`.
+VERDICT_PASS: str = "PASS"
+VERDICT_REJECT: str = "REJECT"
+
+
+def compute_advisory_digest(
+    base_sha: str | None,
+    head_sha: str,
+    diff_text: str | None = None,
+) -> str:
+    """Compute the ADVISORY change digest ``sha256:<hex>``.
+
+    The advisory digest is sha256 of ``git diff base..head``. When ``diff_text``
+    is supplied it is hashed directly (tests, or callers that already hold the
+    diff). With no base the bare head sha is hashed so the field is always a
+    well-formed ``sha256:<64 hex>`` existence proof. The server recomputes its
+    own digest and signs that. This value only lets the server report
+    ``digest_match``.
+    """
+    if diff_text is None:
+        if base_sha:
+            out = subprocess.run(
+                ["git", "diff", f"{base_sha}..{head_sha}"],
+                check=True,
+                capture_output=True,
+            )
+            diff_text = out.stdout.decode("utf-8", errors="replace")
+        else:
+            diff_text = head_sha
+    return "sha256:" + hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
+
+
+def _bare_hex(digest: str | None) -> str | None:
+    """Strip a ``sha256:`` prefix to the bare hex, or None when absent."""
+    if not isinstance(digest, str) or not digest:
+        return None
+    return digest.split(":", 1)[-1]
+
+
+@dataclass
+class CodeAuthorshipResult:
+    """Parsed response from POST /v1/code-authorship.
+
+    ``envelope`` is the server-signed in-toto Statement. ``subject_digest`` is
+    the SERVER-recomputed diff hash bound into ``subject[0].digest.sha256``.
+    ``digest_match`` reports whether the advisory client digest agreed.
+    """
+
+    envelope: dict[str, Any]
+    receipt: dict[str, Any]
+    kid: str | None
+    jwks_url: str | None
+    server_digest: str | None
+    digest_match: bool
+    subject_digest: str | None
+    capture_layer: str | None
+    asset_class: str | None
+    advisory_client_digest: str | None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_response(cls, data: dict[str, Any]) -> "CodeAuthorshipResult":
+        """Project the wire response into a result, reading the Statement fields."""
+        envelope = data.get("envelope") if isinstance(data.get("envelope"), dict) else {}
+        receipt = data.get("receipt") if isinstance(data.get("receipt"), dict) else {}
+
+        subject_digest: str | None = None
+        subject = envelope.get("subject")
+        if isinstance(subject, list) and subject and isinstance(subject[0], dict):
+            digest_obj = subject[0].get("digest")
+            if isinstance(digest_obj, dict):
+                value = digest_obj.get("sha256")
+                subject_digest = value if isinstance(value, str) else None
+
+        predicate = envelope.get("predicate") if isinstance(envelope.get("predicate"), dict) else {}
+        capture_layer = predicate.get("capture_layer")
+        asset_class = predicate.get("asset_class")
+        advisory = predicate.get("advisory_client_digest")
+
+        return cls(
+            envelope=envelope,
+            receipt=receipt,
+            kid=data.get("kid") if isinstance(data.get("kid"), str) else None,
+            jwks_url=data.get("jwks_url") if isinstance(data.get("jwks_url"), str) else None,
+            server_digest=data.get("server_digest") if isinstance(data.get("server_digest"), str) else None,
+            digest_match=bool(data.get("digest_match")),
+            subject_digest=subject_digest,
+            capture_layer=capture_layer if isinstance(capture_layer, str) else None,
+            asset_class=asset_class if isinstance(asset_class, str) else None,
+            advisory_client_digest=advisory if isinstance(advisory, str) else None,
+            raw=data,
+        )
+
+    @property
+    def subject_matches_server(self) -> bool:
+        """True when the bound subject digest equals the server-recomputed digest."""
+        if self.subject_digest is None or self.server_digest is None:
+            return False
+        return self.subject_digest == _bare_hex(self.server_digest)
+
+
+def submit_code_authorship(
+    *,
+    repo: str,
+    commit_sha: str,
+    base_sha: str | None = None,
+    change_digest: str | None = None,
+    change_class: str | None = None,
+    author: str | None = None,
+    anchor: str | None = None,
+) -> CodeAuthorshipResult:
+    """POST an advisory code-authorship record to /v1/code-authorship.
+
+    ``change_digest`` is ADVISORY (sha256 of ``git diff base..head``). The
+    server recomputes the authoritative digest and signs it. Requires
+    ``asqav.init(api_key=...)`` with a key holding the ``code_authorship:write``
+    scope. Returns the parsed authoritative envelope.
+    """
+    from . import client as _client
+
+    body: dict[str, Any] = {"repo": repo, "commit_sha": commit_sha}
+    if base_sha:
+        body["base_sha"] = base_sha
+    if change_digest:
+        body["change_digest"] = change_digest
+    if change_class:
+        body["change_class"] = change_class
+    if author:
+        body["author"] = author
+    if anchor:
+        body["anchor"] = anchor
+
+    data = _client._post(CODE_AUTHORSHIP_PATH, body)
+    return CodeAuthorshipResult.from_response(data)
+
+
+@dataclass
+class CodeAuthorshipVerification:
+    """Outcome of the code-authorship envelope check.
+
+    ``authoritative`` is true only when the capture layer is ``github_sha_pull``.
+    ``observation_only`` is true when the capture layer is a client self-report
+    (``in_process_sdk`` / ``passive_telemetry``), which can never be authoritative.
+    """
+
+    verdict: str
+    authoritative: bool
+    observation_only: bool
+    capture_layer: str | None
+    subject_digest: str | None
+    reasons: list[str] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return self.verdict == VERDICT_PASS
+
+
+def verify_code_authorship_envelope(envelope: dict[str, Any]) -> CodeAuthorshipVerification:
+    """Verify the code-authorship structural + capture-layer invariant.
+
+    Checks the in-toto Statement shape (``_type``, ``predicateType``), that
+    ``subject[0].digest.sha256`` is present, and the capture-layer rule:
+    ``github_sha_pull`` is authoritative, ``in_process_sdk`` / ``passive_telemetry``
+    are observation only and never authoritative. The cryptographic DSSE
+    signature is verified by the standalone verifier or the hosted /verify. The
+    cloud is the authoritative verifier and this helper is a convenience.
+    """
+    reasons: list[str] = []
+
+    if not isinstance(envelope, dict):
+        return CodeAuthorshipVerification(
+            verdict=VERDICT_REJECT,
+            authoritative=False,
+            observation_only=False,
+            capture_layer=None,
+            subject_digest=None,
+            reasons=["envelope_not_an_object"],
+        )
+
+    if envelope.get("_type") != INTOTO_STATEMENT_TYPE:
+        reasons.append("code_authorship_envelope_not_intoto_statement")
+    if envelope.get("predicateType") != CODE_AUTHORSHIP_PREDICATE_TYPE:
+        reasons.append("code_authorship_wrong_predicate_type")
+
+    subject_digest: str | None = None
+    subject = envelope.get("subject")
+    if isinstance(subject, list) and subject and isinstance(subject[0], dict):
+        digest_obj = subject[0].get("digest")
+        if isinstance(digest_obj, dict) and isinstance(digest_obj.get("sha256"), str):
+            subject_digest = digest_obj["sha256"]
+    if not subject_digest:
+        reasons.append("code_authorship_missing_subject_digest")
+
+    predicate = envelope.get("predicate") if isinstance(envelope.get("predicate"), dict) else {}
+    capture_layer = predicate.get("capture_layer")
+    capture_layer = capture_layer if isinstance(capture_layer, str) else None
+
+    observation_only = capture_layer in OBSERVATION_ONLY_CAPTURE_LAYERS
+    authoritative = capture_layer == AUTHORITATIVE_CAPTURE_LAYER
+
+    if observation_only:
+        reasons.append("observation_capture_layer_not_authoritative")
+    elif capture_layer is None:
+        reasons.append("code_authorship_missing_capture_layer")
+    elif not authoritative:
+        reasons.append("code_authorship_capture_layer_not_github_sha_pull")
+
+    verdict = VERDICT_PASS if not reasons else VERDICT_REJECT
+    return CodeAuthorshipVerification(
+        verdict=verdict,
+        authoritative=authoritative,
+        observation_only=observation_only,
+        capture_layer=capture_layer,
+        subject_digest=subject_digest,
+        reasons=reasons,
+    )

--- a/python/src/asqav/code_authorship.py
+++ b/python/src/asqav/code_authorship.py
@@ -131,7 +131,9 @@ class CodeAuthorshipResult:
             receipt=receipt,
             kid=data.get("kid") if isinstance(data.get("kid"), str) else None,
             jwks_url=data.get("jwks_url") if isinstance(data.get("jwks_url"), str) else None,
-            server_digest=data.get("server_digest") if isinstance(data.get("server_digest"), str) else None,
+            server_digest=(
+                data.get("server_digest") if isinstance(data.get("server_digest"), str) else None
+            ),
             digest_match=bool(data.get("digest_match")),
             subject_digest=subject_digest,
             capture_layer=capture_layer if isinstance(capture_layer, str) else None,

--- a/python/tests/test_client_capture_topology.py
+++ b/python/tests/test_client_capture_topology.py
@@ -122,11 +122,21 @@ def test_capture_topology_namespace_matches_cloud_literal() -> None:
             "in_process_sdk",
             "network_proxy",
             "browser_extension",
-            "ebpf_observer",
             "mcp_proxy",
             "passive_telemetry",
+            "github_sha_pull",
         }
     )
+
+
+def test_capture_topology_ebpf_observer_removed() -> None:
+    """The capture_topology vocabulary excludes ebpf_observer."""
+    assert "ebpf_observer" not in CAPTURE_TOPOLOGY_NAMESPACE
+
+
+def test_capture_topology_github_sha_pull_accepted() -> None:
+    """github_sha_pull (the server-stamped code-authorship layer) is accepted."""
+    assert "github_sha_pull" in CAPTURE_TOPOLOGY_NAMESPACE
 
 
 def test_capture_topology_is_re_exported_at_top_level() -> None:

--- a/python/tests/test_code_authorship.py
+++ b/python/tests/test_code_authorship.py
@@ -1,0 +1,286 @@
+"""SDK half of the authoritative code-authorship path (POST /v1/code-authorship).
+
+The client supplies an ADVISORY change digest. The server re-fetches the commit,
+recomputes the canonical diff, and signs an in-toto Statement whose
+``subject[0].digest.sha256`` is the SERVER digest. These tests pin: the advisory
+digest computation, the wire body the submit helper posts, the authoritative
+envelope parsing, and the capture-layer observation-decision rule
+(``github_sha_pull`` is authoritative; ``in_process_sdk`` / ``passive_telemetry``
+are observation only and never authoritative).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import asqav
+from asqav.code_authorship import (
+    AUTHORITATIVE_CAPTURE_LAYER,
+    CODE_AUTHORSHIP_ASSET_CLASS,
+    CODE_AUTHORSHIP_PATH,
+    CODE_AUTHORSHIP_PREDICATE_TYPE,
+    CODE_AUTHORSHIP_WRITE_SCOPE,
+    INTOTO_STATEMENT_TYPE,
+    OBSERVATION_ONLY_CAPTURE_LAYERS,
+    CodeAuthorshipResult,
+    compute_advisory_digest,
+    submit_code_authorship,
+    verify_code_authorship_envelope,
+)
+
+
+# === constants + scope ===
+
+
+def test_scope_constant_matches_backend_contract() -> None:
+    """The required API-key scope is code_authorship:write."""
+    assert CODE_AUTHORSHIP_WRITE_SCOPE == "code_authorship:write"
+
+
+def test_scope_constant_reexported_on_cli_hook() -> None:
+    """cli_hook exposes the same scope as REQUIRED_SCOPE."""
+    from asqav import cli_hook
+
+    assert cli_hook.REQUIRED_SCOPE == CODE_AUTHORSHIP_WRITE_SCOPE
+
+
+def test_predicate_type_and_asset_class_match_contract() -> None:
+    assert CODE_AUTHORSHIP_PREDICATE_TYPE == "https://asqav.com/attestation/code-authorship/v1"
+    assert CODE_AUTHORSHIP_ASSET_CLASS == "code"
+    assert AUTHORITATIVE_CAPTURE_LAYER == "github_sha_pull"
+    assert OBSERVATION_ONLY_CAPTURE_LAYERS == frozenset({"in_process_sdk", "passive_telemetry"})
+
+
+# === advisory digest computation ===
+
+
+def test_advisory_digest_hashes_supplied_diff_text() -> None:
+    diff = "diff --git a/x b/x\n+hello\n"
+    expected = "sha256:" + hashlib.sha256(diff.encode("utf-8")).hexdigest()
+    assert compute_advisory_digest("base", "head", diff_text=diff) == expected
+
+
+def test_advisory_digest_is_sha256_wire_form() -> None:
+    digest = compute_advisory_digest("base", "head", diff_text="anything")
+    assert digest.startswith("sha256:")
+    hex_part = digest.split(":", 1)[1]
+    assert len(hex_part) == 64
+    assert all(c in "0123456789abcdef" for c in hex_part)
+
+
+def test_advisory_digest_falls_back_to_head_sha_without_base() -> None:
+    head = "a" * 40
+    expected = "sha256:" + hashlib.sha256(head.encode("utf-8")).hexdigest()
+    assert compute_advisory_digest(None, head) == expected
+
+
+# === envelope builders ===
+
+
+def _server_envelope(
+    *,
+    server_digest_hex: str,
+    capture_layer: str,
+    advisory: str = "sha256:" + "1" * 64,
+    digest_match: bool = True,
+    predicate_type: str = CODE_AUTHORSHIP_PREDICATE_TYPE,
+    statement_type: str = INTOTO_STATEMENT_TYPE,
+    include_subject_digest: bool = True,
+) -> dict:
+    subject: list = []
+    if include_subject_digest:
+        subject = [{"name": "owner/repo@" + "c" * 40, "digest": {"sha256": server_digest_hex}}]
+    return {
+        "_type": statement_type,
+        "subject": subject,
+        "predicateType": predicate_type,
+        "predicate": {
+            "capture_layer": capture_layer,
+            "asset_class": CODE_AUTHORSHIP_ASSET_CLASS,
+            "advisory_client_digest": advisory,
+            "digest_match": digest_match,
+        },
+    }
+
+
+def _server_response(
+    *,
+    server_digest_hex: str,
+    capture_layer: str = "github_sha_pull",
+    digest_match: bool = True,
+) -> dict:
+    return {
+        "envelope": _server_envelope(server_digest_hex=server_digest_hex, capture_layer=capture_layer),
+        "receipt": {"signature_id": "sig_ca", "algorithm": "ML-DSA-65"},
+        "kid": "key_ca",
+        "jwks_url": "https://api.asqav.com/.well-known/jwks.json",
+        "server_digest": "sha256:" + server_digest_hex,
+        "digest_match": digest_match,
+    }
+
+
+# === submit helper ===
+
+
+def test_submit_posts_advisory_digest_to_code_authorship_endpoint() -> None:
+    captured: dict = {}
+    server_hex = "f" * 64
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["path"] = path
+        captured["body"] = body
+        return _server_response(server_digest_hex=server_hex)
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        result = submit_code_authorship(
+            repo="owner/repo",
+            commit_sha="c" * 40,
+            base_sha="b" * 40,
+            change_digest="sha256:" + "1" * 64,
+            change_class="write",
+            author="human:alice@example.com",
+            anchor="https://github.com/owner/repo/pull/7",
+        )
+
+    assert captured["path"] == CODE_AUTHORSHIP_PATH
+    body = captured["body"]
+    assert body["repo"] == "owner/repo"
+    assert body["commit_sha"] == "c" * 40
+    assert body["base_sha"] == "b" * 40
+    # The client digest is advisory. It travels so the server can report a match.
+    assert body["change_digest"] == "sha256:" + "1" * 64
+    assert body["change_class"] == "write"
+    assert body["author"] == "human:alice@example.com"
+    assert body["anchor"] == "https://github.com/owner/repo/pull/7"
+
+    # The authoritative subject digest is the SERVER value, not the client's.
+    assert result.subject_digest == server_hex
+    assert result.server_digest == "sha256:" + server_hex
+    assert result.capture_layer == "github_sha_pull"
+    assert result.kid == "key_ca"
+    assert result.subject_matches_server is True
+
+
+def test_submit_omits_absent_optional_fields() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _server_response(server_digest_hex="e" * 64)
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        submit_code_authorship(repo="owner/repo", commit_sha="c" * 40)
+
+    body = captured["body"]
+    assert body == {"repo": "owner/repo", "commit_sha": "c" * 40}
+
+
+def test_result_exposes_digest_match_semantics() -> None:
+    """digest_match reports advisory-vs-server agreement. The subject is the server's."""
+    advisory = "sha256:" + "1" * 64
+    server_hex = "2" * 64
+    envelope = _server_envelope(
+        server_digest_hex=server_hex,
+        capture_layer="github_sha_pull",
+        advisory=advisory,
+        digest_match=False,
+    )
+    result = CodeAuthorshipResult.from_response(
+        {
+            "envelope": envelope,
+            "receipt": {},
+            "kid": "k",
+            "jwks_url": "u",
+            "server_digest": "sha256:" + server_hex,
+            "digest_match": False,
+        }
+    )
+    # Advisory digest disagreed, but the bound subject is still the server digest.
+    assert result.digest_match is False
+    assert result.advisory_client_digest == advisory
+    assert result.subject_digest == server_hex
+    assert result.subject_matches_server is True
+
+
+# === capture-layer observation-decision rule ===
+
+
+def test_github_sha_pull_envelope_is_authoritative_and_passes() -> None:
+    envelope = _server_envelope(server_digest_hex="a" * 64, capture_layer="github_sha_pull")
+    verification = verify_code_authorship_envelope(envelope)
+    assert verification.passed
+    assert verification.verdict == "PASS"
+    assert verification.authoritative is True
+    assert verification.observation_only is False
+    assert verification.capture_layer == "github_sha_pull"
+    assert verification.subject_digest == "a" * 64
+
+
+@pytest.mark.parametrize("layer", sorted(OBSERVATION_ONLY_CAPTURE_LAYERS))
+def test_observation_capture_layer_is_never_authoritative(layer: str) -> None:
+    """in_process_sdk and passive_telemetry are observation only, never a decision."""
+    envelope = _server_envelope(server_digest_hex="a" * 64, capture_layer=layer)
+    verification = verify_code_authorship_envelope(envelope)
+    assert verification.passed is False
+    assert verification.verdict == "REJECT"
+    assert verification.authoritative is False
+    assert verification.observation_only is True
+    assert "observation_capture_layer_not_authoritative" in verification.reasons
+
+
+def test_missing_subject_digest_rejected() -> None:
+    envelope = _server_envelope(
+        server_digest_hex="a" * 64,
+        capture_layer="github_sha_pull",
+        include_subject_digest=False,
+    )
+    verification = verify_code_authorship_envelope(envelope)
+    assert verification.passed is False
+    assert "code_authorship_missing_subject_digest" in verification.reasons
+
+
+def test_wrong_predicate_type_rejected() -> None:
+    envelope = _server_envelope(
+        server_digest_hex="a" * 64,
+        capture_layer="github_sha_pull",
+        predicate_type="https://example.com/wrong/v1",
+    )
+    verification = verify_code_authorship_envelope(envelope)
+    assert verification.passed is False
+    assert "code_authorship_wrong_predicate_type" in verification.reasons
+
+
+def test_unknown_capture_layer_not_authoritative() -> None:
+    envelope = _server_envelope(server_digest_hex="a" * 64, capture_layer="network_proxy")
+    verification = verify_code_authorship_envelope(envelope)
+    assert verification.passed is False
+    assert verification.authoritative is False
+    assert verification.observation_only is False
+    assert "code_authorship_capture_layer_not_github_sha_pull" in verification.reasons
+
+
+def test_non_object_envelope_rejected_cleanly() -> None:
+    verification = verify_code_authorship_envelope(None)  # type: ignore[arg-type]
+    assert verification.passed is False
+    assert "envelope_not_an_object" in verification.reasons
+
+
+# === public surface ===
+
+
+def test_public_surface_reexported() -> None:
+    assert asqav.CODE_AUTHORSHIP_WRITE_SCOPE == CODE_AUTHORSHIP_WRITE_SCOPE
+    assert asqav.submit_code_authorship is submit_code_authorship
+    assert asqav.verify_code_authorship_envelope is verify_code_authorship_envelope
+    assert asqav.compute_advisory_digest is compute_advisory_digest
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/python/tests/test_conformance_vectors.py
+++ b/python/tests/test_conformance_vectors.py
@@ -16,13 +16,15 @@ import pytest
 VECTORS_PATH = Path(__file__).parent.parent.parent / "conformance" / "vectors.json"
 
 # Closed Literal mirrored from the cloud SignRequest and IETF draft -04 appendix.
+# passive_telemetry is observation-only and tested separately. github_sha_pull is
+# the server-stamped authoritative code-authorship capture layer.
 CAPTURE_TOPOLOGY_VOCABULARY: frozenset[str] = frozenset(
     {
         "in_process_sdk",
         "network_proxy",
         "browser_extension",
-        "ebpf_observer",
         "mcp_proxy",
+        "github_sha_pull",
     }
 )
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -139,7 +139,7 @@ const sig = await agent.sign({
 });
 ```
 
-`captureTopology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `ebpf_observer`, and `mcp_proxy`. Only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
+`captureTopology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `mcp_proxy`, and `github_sha_pull`. A client-supplied `captureTopology` is advisory: the server stamps the authoritative value from the ingress route, and for code-authorship that authoritative value is `github_sha_pull`, set only after the server re-fetches the commit and recomputes the diff. Only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
 
 ### Configuration change receipts, rule 9
 

--- a/typescript/src/codeAuthorship.ts
+++ b/typescript/src/codeAuthorship.ts
@@ -1,0 +1,272 @@
+/**
+ * SDK half of the un-bypassable code-authorship path.
+ *
+ * POST /v1/code-authorship is the authoritative ingress. The client supplies an
+ * ADVISORY change digest (sha256 of `git diff base..head`) and the server
+ * re-fetches the commit, recomputes the canonical diff, and signs an in-toto
+ * Statement whose `subject[0].digest.sha256` is the SERVER-recomputed hash. The
+ * client digest is never trusted. `digest_match` only reports whether the
+ * advisory value agreed with the server's.
+ *
+ * The authoritative capture layer for a code-authorship receipt is
+ * `github_sha_pull`. A receipt whose capture layer is `in_process_sdk` or
+ * `passive_telemetry` is a client self-report and can NEVER be an authoritative
+ * decision receipt (observation only), mirroring the cloud's
+ * `observation_decision_not_allowed` rule.
+ */
+
+import { createHash } from "node:crypto";
+
+import { request } from "./index.js";
+
+/** API-key scope required to call POST /v1/code-authorship. */
+export const CODE_AUTHORSHIP_WRITE_SCOPE = "code_authorship:write";
+
+/** Endpoint path (joined onto the configured API base). */
+export const CODE_AUTHORSHIP_PATH = "/code-authorship";
+
+/** predicateType of the authoritative code-authorship in-toto Statement. */
+export const CODE_AUTHORSHIP_PREDICATE_TYPE =
+  "https://asqav.com/attestation/code-authorship/v1";
+
+/** in-toto Statement v1 type carried by the envelope. */
+export const INTOTO_STATEMENT_TYPE = "https://in-toto.io/Statement/v1";
+
+/** asset_class the server stamps on the code-authorship predicate. */
+export const CODE_AUTHORSHIP_ASSET_CLASS = "code";
+
+/**
+ * The ONLY capture layer that makes a code-authorship receipt authoritative.
+ * The server stamps it after re-fetching the commit and recomputing the diff.
+ */
+export const AUTHORITATIVE_CAPTURE_LAYER = "github_sha_pull";
+
+/**
+ * Capture layers that are client self-reports. A code-authorship receipt
+ * carrying one of these is observation only and never an authoritative
+ * decision receipt.
+ */
+export const OBSERVATION_ONLY_CAPTURE_LAYERS = [
+  "in_process_sdk",
+  "passive_telemetry",
+] as const;
+
+/** Verdict tokens for verifyCodeAuthorshipEnvelope. */
+export const VERDICT_PASS = "PASS";
+export const VERDICT_REJECT = "REJECT";
+
+/**
+ * Compute the ADVISORY change digest `sha256:<hex>`.
+ *
+ * The advisory digest is sha256 of `git diff base..head`. When `diffText` is
+ * supplied it is hashed directly. With no diff the bare head sha is hashed so
+ * the field is always a well-formed `sha256:<64 hex>` existence proof. The
+ * server recomputes its own digest and signs that. This value only lets the
+ * server report `digest_match`.
+ */
+export function computeAdvisoryDigest(
+  headSha: string,
+  diffText?: string,
+): string {
+  const material = diffText !== undefined && diffText !== "" ? diffText : headSha;
+  return "sha256:" + createHash("sha256").update(material, "utf8").digest("hex");
+}
+
+function bareHex(digest: unknown): string | undefined {
+  if (typeof digest !== "string" || digest === "") {
+    return undefined;
+  }
+  return digest.split(":").slice(1).join(":") || digest;
+}
+
+/** Parsed response from POST /v1/code-authorship. */
+export interface CodeAuthorshipResult {
+  /** The server-signed in-toto Statement. */
+  envelope: Record<string, unknown>;
+  /** The signed receipt carrying the signature envelope. */
+  receipt: Record<string, unknown>;
+  kid?: string;
+  jwksUrl?: string;
+  /** The server-recomputed diff hash, `sha256:<hex>`. */
+  serverDigest?: string;
+  /** Whether the advisory client digest agreed with the server digest. */
+  digestMatch: boolean;
+  /** The SERVER digest bound into `subject[0].digest.sha256` (bare hex). */
+  subjectDigest?: string;
+  captureLayer?: string;
+  assetClass?: string;
+  advisoryClientDigest?: string;
+  raw: Record<string, unknown>;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Project the wire response into a result, reading the Statement fields. */
+export function parseCodeAuthorshipResponse(
+  data: Record<string, unknown>,
+): CodeAuthorshipResult {
+  const envelope = asRecord(data.envelope);
+  const receipt = asRecord(data.receipt);
+
+  let subjectDigest: string | undefined;
+  const subject = envelope.subject;
+  if (Array.isArray(subject) && subject.length > 0) {
+    const digestObj = asRecord(asRecord(subject[0]).digest);
+    subjectDigest = asString(digestObj.sha256);
+  }
+
+  const predicate = asRecord(envelope.predicate);
+
+  return {
+    envelope,
+    receipt,
+    kid: asString(data.kid),
+    jwksUrl: asString(data.jwks_url),
+    serverDigest: asString(data.server_digest),
+    digestMatch: Boolean(data.digest_match),
+    subjectDigest,
+    captureLayer: asString(predicate.capture_layer),
+    assetClass: asString(predicate.asset_class),
+    advisoryClientDigest: asString(predicate.advisory_client_digest),
+    raw: data,
+  };
+}
+
+/** True when the bound subject digest equals the server-recomputed digest. */
+export function subjectMatchesServer(result: CodeAuthorshipResult): boolean {
+  if (result.subjectDigest === undefined || result.serverDigest === undefined) {
+    return false;
+  }
+  return result.subjectDigest === bareHex(result.serverDigest);
+}
+
+/** Options for submitCodeAuthorship. `changeDigest` is advisory. */
+export interface CodeAuthorshipOptions {
+  repo: string;
+  commitSha: string;
+  baseSha?: string;
+  changeDigest?: string;
+  changeClass?: string;
+  author?: string;
+  anchor?: string;
+}
+
+/**
+ * POST an advisory code-authorship record to /v1/code-authorship.
+ *
+ * `changeDigest` is ADVISORY (sha256 of `git diff base..head`). The server
+ * recomputes the authoritative digest and signs it. Requires `init({ apiKey })`
+ * with a key holding the `code_authorship:write` scope. Returns the parsed
+ * authoritative envelope.
+ */
+export async function submitCodeAuthorship(
+  options: CodeAuthorshipOptions,
+): Promise<CodeAuthorshipResult> {
+  const body: Record<string, unknown> = {
+    repo: options.repo,
+    commit_sha: options.commitSha,
+  };
+  if (options.baseSha) body.base_sha = options.baseSha;
+  if (options.changeDigest) body.change_digest = options.changeDigest;
+  if (options.changeClass) body.change_class = options.changeClass;
+  if (options.author) body.author = options.author;
+  if (options.anchor) body.anchor = options.anchor;
+
+  const data = await request<Record<string, unknown>>(
+    "POST",
+    CODE_AUTHORSHIP_PATH,
+    body,
+  );
+  return parseCodeAuthorshipResponse(data);
+}
+
+/** Outcome of the code-authorship envelope check. */
+export interface CodeAuthorshipVerification {
+  verdict: string;
+  /** True only when the capture layer is `github_sha_pull`. */
+  authoritative: boolean;
+  /** True when the capture layer is a client self-report (observation only). */
+  observationOnly: boolean;
+  captureLayer?: string;
+  subjectDigest?: string;
+  reasons: string[];
+}
+
+/**
+ * Verify the code-authorship structural + capture-layer invariant.
+ *
+ * Checks the in-toto Statement shape (`_type`, `predicateType`), that
+ * `subject[0].digest.sha256` is present, and the capture-layer rule:
+ * `github_sha_pull` is authoritative, `in_process_sdk` / `passive_telemetry`
+ * are observation only and never authoritative. The cryptographic DSSE
+ * signature is verified by the standalone verifier or the hosted /verify. The
+ * cloud is the authoritative verifier and this helper is a convenience.
+ */
+export function verifyCodeAuthorshipEnvelope(
+  envelope: unknown,
+): CodeAuthorshipVerification {
+  const reasons: string[] = [];
+
+  if (envelope === null || typeof envelope !== "object" || Array.isArray(envelope)) {
+    return {
+      verdict: VERDICT_REJECT,
+      authoritative: false,
+      observationOnly: false,
+      captureLayer: undefined,
+      subjectDigest: undefined,
+      reasons: ["envelope_not_an_object"],
+    };
+  }
+
+  const env = envelope as Record<string, unknown>;
+
+  if (env._type !== INTOTO_STATEMENT_TYPE) {
+    reasons.push("code_authorship_envelope_not_intoto_statement");
+  }
+  if (env.predicateType !== CODE_AUTHORSHIP_PREDICATE_TYPE) {
+    reasons.push("code_authorship_wrong_predicate_type");
+  }
+
+  let subjectDigest: string | undefined;
+  const subject = env.subject;
+  if (Array.isArray(subject) && subject.length > 0) {
+    const digestObj = asRecord(asRecord(subject[0]).digest);
+    subjectDigest = asString(digestObj.sha256);
+  }
+  if (!subjectDigest) {
+    reasons.push("code_authorship_missing_subject_digest");
+  }
+
+  const predicate = asRecord(env.predicate);
+  const captureLayer = asString(predicate.capture_layer);
+
+  const observationOnly = (
+    OBSERVATION_ONLY_CAPTURE_LAYERS as readonly string[]
+  ).includes(captureLayer ?? "");
+  const authoritative = captureLayer === AUTHORITATIVE_CAPTURE_LAYER;
+
+  if (observationOnly) {
+    reasons.push("observation_capture_layer_not_authoritative");
+  } else if (captureLayer === undefined) {
+    reasons.push("code_authorship_missing_capture_layer");
+  } else if (!authoritative) {
+    reasons.push("code_authorship_capture_layer_not_github_sha_pull");
+  }
+
+  return {
+    verdict: reasons.length === 0 ? VERDICT_PASS : VERDICT_REJECT,
+    authoritative,
+    observationOnly,
+    captureLayer,
+    subjectDigest,
+    reasons,
+  };
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -215,6 +215,26 @@ export {
 } from "./algorithms.js";
 export { resolveMode, isAsqavCloudHost, type Mode } from "./mode.js";
 export { BudgetTracker, type BudgetCheckResult, type BudgetTrackerOptions } from "./budget.js";
+// Authoritative code-authorship path (POST /v1/code-authorship).
+export {
+  AUTHORITATIVE_CAPTURE_LAYER,
+  CODE_AUTHORSHIP_ASSET_CLASS,
+  CODE_AUTHORSHIP_PATH,
+  CODE_AUTHORSHIP_PREDICATE_TYPE,
+  CODE_AUTHORSHIP_WRITE_SCOPE,
+  INTOTO_STATEMENT_TYPE,
+  OBSERVATION_ONLY_CAPTURE_LAYERS,
+  VERDICT_PASS,
+  VERDICT_REJECT,
+  computeAdvisoryDigest,
+  parseCodeAuthorshipResponse,
+  submitCodeAuthorship,
+  subjectMatchesServer,
+  verifyCodeAuthorshipEnvelope,
+  type CodeAuthorshipOptions,
+  type CodeAuthorshipResult,
+  type CodeAuthorshipVerification,
+} from "./codeAuthorship.js";
 // Structured receipts (criterion 328): opt-in schema validation helpers.
 export {
   ValidationError,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -121,14 +121,18 @@ export const SANDBOX_STATE_NAMESPACE = ["enabled", "disabled", "unavailable"] as
 export type SandboxState = (typeof SANDBOX_STATE_NAMESPACE)[number];
 
 /** Producer-side `capture_topology` vocabulary; mirrors the cloud
- * SignRequest Literal and the IETF -04 capture-topologies appendix. */
+ * SignRequest Literal and the IETF -04 capture-topologies appendix.
+ * A client-supplied captureTopology is ADVISORY: the server stamps the
+ * authoritative value from the ingress route (for code-authorship that is
+ * `github_sha_pull`, set only after the server re-fetches the commit and
+ * recomputes the diff). */
 export const CAPTURE_TOPOLOGY_NAMESPACE = [
   "in_process_sdk",
   "network_proxy",
   "browser_extension",
-  "ebpf_observer",
   "mcp_proxy",
   "passive_telemetry",
+  "github_sha_pull",
 ] as const;
 export type CaptureTopology = (typeof CAPTURE_TOPOLOGY_NAMESPACE)[number];
 
@@ -503,8 +507,10 @@ export interface SignOptions {
   policyDecision?: PolicyDecision;
 
   /** Producer-side topology. One of `in_process_sdk`, `network_proxy`,
-   * `browser_extension`, `ebpf_observer`, `mcp_proxy`, `passive_telemetry`.
+   * `browser_extension`, `mcp_proxy`, `passive_telemetry`, `github_sha_pull`.
    * Stamped on the audit-pack manifest entry; never on the signed payload.
+   * Client-supplied captureTopology is advisory: the server stamps the
+   * authoritative value from the ingress route.
    * `passive_telemetry` requires `receiptType='protectmcp:observation'`
    * (false-attestation guard). */
   captureTopology?: CaptureTopology;

--- a/typescript/tests/canonicalize.test.ts
+++ b/typescript/tests/canonicalize.test.ts
@@ -26,12 +26,14 @@ const { vectors } = JSON.parse(readFileSync(vectorsPath, "utf8")) as {
 };
 
 // Closed Literal mirrored from the cloud SignRequest and IETF draft -04 appendix.
+// passive_telemetry is observation-only and tested separately. github_sha_pull is
+// the server-stamped authoritative code-authorship capture layer.
 const CAPTURE_TOPOLOGY_VOCABULARY = new Set([
   "in_process_sdk",
   "network_proxy",
   "browser_extension",
-  "ebpf_observer",
   "mcp_proxy",
+  "github_sha_pull",
 ]);
 
 describe("canonicalize() against conformance vectors", () => {

--- a/typescript/tests/captureTopology.test.ts
+++ b/typescript/tests/captureTopology.test.ts
@@ -56,13 +56,18 @@ describe("CAPTURE_TOPOLOGY_NAMESPACE", () => {
     expect([...CAPTURE_TOPOLOGY_NAMESPACE].sort()).toEqual(
       [
         "browser_extension",
-        "ebpf_observer",
+        "github_sha_pull",
         "in_process_sdk",
         "mcp_proxy",
         "network_proxy",
         "passive_telemetry",
       ],
     );
+  });
+
+  it("drops ebpf_observer and adds the github_sha_pull code-authorship layer", () => {
+    expect(CAPTURE_TOPOLOGY_NAMESPACE).not.toContain("ebpf_observer");
+    expect(CAPTURE_TOPOLOGY_NAMESPACE).toContain("github_sha_pull");
   });
 });
 
@@ -178,9 +183,9 @@ describe("agent.sign capture_topology + observation wire fields", () => {
     "in_process_sdk",
     "network_proxy",
     "browser_extension",
-    "ebpf_observer",
     "mcp_proxy",
     "passive_telemetry",
+    "github_sha_pull",
   ] as const)("passes captureTopology=%s through on the outgoing body", async (value) => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       jsonResponse({

--- a/typescript/tests/codeAuthorshipEnvelope.test.ts
+++ b/typescript/tests/codeAuthorshipEnvelope.test.ts
@@ -1,0 +1,267 @@
+/**
+ * SDK half of the authoritative code-authorship path (POST /v1/code-authorship).
+ *
+ * The client supplies an ADVISORY change digest. The server re-fetches the
+ * commit, recomputes the canonical diff, and signs an in-toto Statement whose
+ * `subject[0].digest.sha256` is the SERVER digest. These tests pin the advisory
+ * digest computation, the wire body the submit helper posts, the authoritative
+ * envelope parsing, and the capture-layer observation-decision rule
+ * (`github_sha_pull` is authoritative, `in_process_sdk` / `passive_telemetry`
+ * are observation only and never authoritative).
+ */
+
+import { createHash } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AUTHORITATIVE_CAPTURE_LAYER,
+  CODE_AUTHORSHIP_ASSET_CLASS,
+  CODE_AUTHORSHIP_PATH,
+  CODE_AUTHORSHIP_PREDICATE_TYPE,
+  CODE_AUTHORSHIP_WRITE_SCOPE,
+  INTOTO_STATEMENT_TYPE,
+  OBSERVATION_ONLY_CAPTURE_LAYERS,
+  _resetForTests,
+  computeAdvisoryDigest,
+  init,
+  parseCodeAuthorshipResponse,
+  subjectMatchesServer,
+  submitCodeAuthorship,
+  verifyCodeAuthorshipEnvelope,
+} from "../src/index.js";
+
+const SERVER_HEX = "f".repeat(64);
+const ADVISORY = "sha256:" + "1".repeat(64);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function serverEnvelope(opts: {
+  serverHex: string;
+  captureLayer: string;
+  advisory?: string;
+  digestMatch?: boolean;
+  predicateType?: string;
+  statementType?: string;
+  includeSubjectDigest?: boolean;
+}): Record<string, unknown> {
+  const subject =
+    opts.includeSubjectDigest === false
+      ? []
+      : [{ name: "owner/repo@" + "c".repeat(40), digest: { sha256: opts.serverHex } }];
+  return {
+    _type: opts.statementType ?? INTOTO_STATEMENT_TYPE,
+    subject,
+    predicateType: opts.predicateType ?? CODE_AUTHORSHIP_PREDICATE_TYPE,
+    predicate: {
+      capture_layer: opts.captureLayer,
+      asset_class: CODE_AUTHORSHIP_ASSET_CLASS,
+      advisory_client_digest: opts.advisory ?? ADVISORY,
+      digest_match: opts.digestMatch ?? true,
+    },
+  };
+}
+
+function serverResponse(opts: {
+  serverHex: string;
+  captureLayer?: string;
+  digestMatch?: boolean;
+}): Record<string, unknown> {
+  return {
+    envelope: serverEnvelope({
+      serverHex: opts.serverHex,
+      captureLayer: opts.captureLayer ?? "github_sha_pull",
+    }),
+    receipt: { signature_id: "sig_ca", algorithm: "ML-DSA-65" },
+    kid: "key_ca",
+    jwks_url: "https://api.asqav.com/.well-known/jwks.json",
+    server_digest: "sha256:" + opts.serverHex,
+    digest_match: opts.digestMatch ?? true,
+  };
+}
+
+beforeEach(() => {
+  _resetForTests();
+  init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("code-authorship constants + scope", () => {
+  it("exposes the code_authorship:write scope", () => {
+    expect(CODE_AUTHORSHIP_WRITE_SCOPE).toBe("code_authorship:write");
+  });
+
+  it("matches the contract predicate type, asset class, and capture layers", () => {
+    expect(CODE_AUTHORSHIP_PREDICATE_TYPE).toBe(
+      "https://asqav.com/attestation/code-authorship/v1",
+    );
+    expect(CODE_AUTHORSHIP_ASSET_CLASS).toBe("code");
+    expect(AUTHORITATIVE_CAPTURE_LAYER).toBe("github_sha_pull");
+    expect([...OBSERVATION_ONLY_CAPTURE_LAYERS].sort()).toEqual([
+      "in_process_sdk",
+      "passive_telemetry",
+    ]);
+  });
+});
+
+describe("computeAdvisoryDigest", () => {
+  it("hashes supplied diff text into the sha256 wire form", () => {
+    const diff = "diff --git a/x b/x\n+hello\n";
+    const expected = "sha256:" + createHash("sha256").update(diff, "utf8").digest("hex");
+    expect(computeAdvisoryDigest("head", diff)).toBe(expected);
+  });
+
+  it("falls back to the head sha when no diff is supplied", () => {
+    const head = "a".repeat(40);
+    const expected = "sha256:" + createHash("sha256").update(head, "utf8").digest("hex");
+    expect(computeAdvisoryDigest(head)).toBe(expected);
+  });
+
+  it("always emits a sha256:<64 hex> value", () => {
+    const digest = computeAdvisoryDigest("head", "anything");
+    expect(digest.startsWith("sha256:")).toBe(true);
+    const hex = digest.split(":")[1];
+    expect(hex).toHaveLength(64);
+    expect(/^[0-9a-f]{64}$/.test(hex)).toBe(true);
+  });
+});
+
+describe("submitCodeAuthorship", () => {
+  it("posts the advisory digest to /code-authorship and reads the server subject", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(serverResponse({ serverHex: SERVER_HEX })));
+
+    const result = await submitCodeAuthorship({
+      repo: "owner/repo",
+      commitSha: "c".repeat(40),
+      baseSha: "b".repeat(40),
+      changeDigest: ADVISORY,
+      changeClass: "write",
+      author: "human:alice@example.com",
+      anchor: "https://github.com/owner/repo/pull/7",
+    });
+
+    const url = spy.mock.calls[0][0] as string;
+    expect(url.endsWith(CODE_AUTHORSHIP_PATH)).toBe(true);
+    const body = JSON.parse((spy.mock.calls[0][1] as RequestInit)?.body as string);
+    expect(body.repo).toBe("owner/repo");
+    expect(body.commit_sha).toBe("c".repeat(40));
+    expect(body.base_sha).toBe("b".repeat(40));
+    // The client digest is advisory. It travels so the server can report a match.
+    expect(body.change_digest).toBe(ADVISORY);
+    expect(body.change_class).toBe("write");
+    expect(body.author).toBe("human:alice@example.com");
+    expect(body.anchor).toBe("https://github.com/owner/repo/pull/7");
+
+    // The authoritative subject digest is the SERVER value, not the client's.
+    expect(result.subjectDigest).toBe(SERVER_HEX);
+    expect(result.serverDigest).toBe("sha256:" + SERVER_HEX);
+    expect(result.captureLayer).toBe("github_sha_pull");
+    expect(result.kid).toBe("key_ca");
+    expect(subjectMatchesServer(result)).toBe(true);
+  });
+
+  it("omits absent optional fields", async () => {
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(serverResponse({ serverHex: "e".repeat(64) })));
+
+    await submitCodeAuthorship({ repo: "owner/repo", commitSha: "c".repeat(40) });
+
+    const body = JSON.parse((spy.mock.calls[0][1] as RequestInit)?.body as string);
+    expect(body).toEqual({ repo: "owner/repo", commit_sha: "c".repeat(40) });
+  });
+});
+
+describe("parseCodeAuthorshipResponse digest_match semantics", () => {
+  it("reports advisory-vs-server agreement while binding the server subject", () => {
+    const result = parseCodeAuthorshipResponse({
+      envelope: serverEnvelope({
+        serverHex: "2".repeat(64),
+        captureLayer: "github_sha_pull",
+        advisory: ADVISORY,
+        digestMatch: false,
+      }),
+      receipt: {},
+      kid: "k",
+      jwks_url: "u",
+      server_digest: "sha256:" + "2".repeat(64),
+      digest_match: false,
+    });
+    // Advisory digest disagreed, but the bound subject is still the server digest.
+    expect(result.digestMatch).toBe(false);
+    expect(result.advisoryClientDigest).toBe(ADVISORY);
+    expect(result.subjectDigest).toBe("2".repeat(64));
+    expect(subjectMatchesServer(result)).toBe(true);
+  });
+});
+
+describe("verifyCodeAuthorshipEnvelope capture-layer rule", () => {
+  it("treats a github_sha_pull envelope as authoritative and passing", () => {
+    const envelope = serverEnvelope({ serverHex: "a".repeat(64), captureLayer: "github_sha_pull" });
+    const verification = verifyCodeAuthorshipEnvelope(envelope);
+    expect(verification.verdict).toBe("PASS");
+    expect(verification.authoritative).toBe(true);
+    expect(verification.observationOnly).toBe(false);
+    expect(verification.captureLayer).toBe("github_sha_pull");
+    expect(verification.subjectDigest).toBe("a".repeat(64));
+  });
+
+  it.each([...OBSERVATION_ONLY_CAPTURE_LAYERS])(
+    "treats capture_layer=%s as observation only, never authoritative",
+    (layer) => {
+      const envelope = serverEnvelope({ serverHex: "a".repeat(64), captureLayer: layer });
+      const verification = verifyCodeAuthorshipEnvelope(envelope);
+      expect(verification.verdict).toBe("REJECT");
+      expect(verification.authoritative).toBe(false);
+      expect(verification.observationOnly).toBe(true);
+      expect(verification.reasons).toContain("observation_capture_layer_not_authoritative");
+    },
+  );
+
+  it("rejects an envelope missing the subject digest", () => {
+    const envelope = serverEnvelope({
+      serverHex: "a".repeat(64),
+      captureLayer: "github_sha_pull",
+      includeSubjectDigest: false,
+    });
+    const verification = verifyCodeAuthorshipEnvelope(envelope);
+    expect(verification.verdict).toBe("REJECT");
+    expect(verification.reasons).toContain("code_authorship_missing_subject_digest");
+  });
+
+  it("rejects a wrong predicateType", () => {
+    const envelope = serverEnvelope({
+      serverHex: "a".repeat(64),
+      captureLayer: "github_sha_pull",
+      predicateType: "https://example.com/wrong/v1",
+    });
+    const verification = verifyCodeAuthorshipEnvelope(envelope);
+    expect(verification.verdict).toBe("REJECT");
+    expect(verification.reasons).toContain("code_authorship_wrong_predicate_type");
+  });
+
+  it("treats an unknown capture layer as not authoritative", () => {
+    const envelope = serverEnvelope({ serverHex: "a".repeat(64), captureLayer: "network_proxy" });
+    const verification = verifyCodeAuthorshipEnvelope(envelope);
+    expect(verification.verdict).toBe("REJECT");
+    expect(verification.authoritative).toBe(false);
+    expect(verification.observationOnly).toBe(false);
+    expect(verification.reasons).toContain("code_authorship_capture_layer_not_github_sha_pull");
+  });
+
+  it("rejects a non-object envelope cleanly", () => {
+    const verification = verifyCodeAuthorshipEnvelope(null);
+    expect(verification.verdict).toBe("REJECT");
+    expect(verification.reasons).toContain("envelope_not_an_object");
+  });
+});


### PR DESCRIPTION
## What

SDK half of the authoritative code-authorship path. The client supplies an advisory change digest and the server signs the authoritative envelope.

Matches the backend contract for POST /api/v1/code-authorship (X-API-Key scope code_authorship:write). Body: repo, commit_sha, base_sha, change_digest (advisory), change_class, author, anchor. Response: envelope (DSSE in-toto Statement), receipt, kid, jwks_url, server_digest, digest_match. The Statement subject[0].digest.sha256 is the server-recomputed diff hash. The predicate carries capture_layer=github_sha_pull, asset_class=code, advisory_client_digest, and digest_match. predicateType is https://asqav.com/attestation/code-authorship/v1.

## Commits

1. capture_topology vocabulary: drop ebpf_observer, add github_sha_pull (the server-stamped authoritative code-authorship layer). Client capture_topology is documented as advisory. Mirrored across Python, TypeScript, the conformance vectors, and the parity tests.
2. asqav.code_authorship module: compute_advisory_digest, submit_code_authorship (POST helper), verify_code_authorship_envelope (capture-layer rule), and the code_authorship:write scope constant. Adds an asqav hook code-authorship command.
3. TypeScript mirror: codeAuthorship.ts with the same constants, submit helper, and capture-layer rule.
4. github-action: posts the advisory digest to /v1/code-authorship and writes the server's authoritative in-toto Statement. The README states honestly what the action does and documents third-party verification.

## The observation-decision rule

A code-authorship receipt is authoritative only when capture_layer is github_sha_pull. A receipt with capture_layer in {in_process_sdk, passive_telemetry} is a client self-report and can never be an authoritative decision receipt (observation only). verify_code_authorship_envelope rejects the observation layers and requires subject[0].digest.sha256 to be present.

## THREAT_MODEL

- New attack surface: a forged code-authorship envelope claiming a server digest the producer never earned, or a client self-report (in_process_sdk / passive_telemetry) presented as authoritative.
- Existing guard: the binding subject digest is server-recomputed and the envelope is ML-DSA-65 signed by the server key (verified by the standalone verifier or the hosted /verify). The client digest is advisory only.
- New test: verify_code_authorship_envelope rejects in_process_sdk and passive_telemetry as observation only, rejects a missing subject digest and a wrong predicateType, and passes a github_sha_pull envelope (Python and TypeScript).
- Trust boundary: unchanged for signing (the server still signs). The SDK gains a local structural verifier whose verdict is a convenience. The cloud stays the authoritative verifier.

## Tests

- Python: 1480 passed, 2 skipped (cd python, PYTHONPATH=src, pytest tests).
- TypeScript: tsc clean, 689 passed across 49 files.
- github-action: 5 passed (server call mocked).

## Contract mismatch risk vs the backend

The backend endpoint is being built in parallel and is not in any local repo yet, so this matches the contract as specified in the brief. Open items to confirm against the backend once it lands: (1) the exact DSSE wrapping of the envelope and where the signature lives (this PR treats envelope as the in-toto Statement and reads the signature id from receipt), (2) whether author and anchor are plain strings as assumed, (3) the JWKS resolution for an offline signature check (this PR verifies structure and capture layer locally and defers the cryptographic check to the standalone verifier).

comment hygiene clean
