### PR TITLE
fix(sdk): validate env-controlled paths before file I/O (Trustabl #375)

### DIFF
--- a/python/src/asqav/credentials.py
+++ b/python/src/asqav/credentials.py
@@ -25,11 +25,32 @@ _DEFAULT_API_BASE = "https://api.asqav.com/api/v1"
 CREDENTIALS_PATH = Path(os.path.expanduser("~")) / ".asqav" / "credentials"
 
 
+def _validated_fs_path(raw: str, source: str) -> Path:
+    """Sanitize a caller-supplied path before any file I/O.
+
+    Expands a leading ``~`` and rejects the two classic path-injection vectors,
+    null bytes and traversal (``..``) components, so an attacker-influenced
+    value cannot redirect a read, write, or chmod to an arbitrary location.
+    Raises ``ValueError`` on a rejected path.
+    """
+    if "\x00" in raw:
+        raise ValueError(f"{source} must not contain null bytes")
+    expanded = os.path.expanduser(raw)
+    if ".." in Path(expanded).parts:
+        raise ValueError(f"{source} must not contain path traversal ('..')")
+    return Path(expanded)
+
+
 def credentials_path() -> Path:
-    """Resolve the credentials file location (env override, else ~/.asqav/credentials)."""
+    """Resolve the credentials file location (env override, else ~/.asqav/credentials).
+
+    The ``ASQAV_CREDENTIALS_PATH`` override is validated (see
+    :func:`_validated_fs_path`) before it is used for I/O, so a traversal value
+    such as ``../../etc/passwd`` is rejected rather than read or written.
+    """
     override = os.environ.get("ASQAV_CREDENTIALS_PATH")
     if override:
-        return Path(override)
+        return _validated_fs_path(override, "ASQAV_CREDENTIALS_PATH")
     return Path(os.path.expanduser("~")) / ".asqav" / "credentials"
 
 

--- a/python/src/asqav/local.py
+++ b/python/src/asqav/local.py
@@ -14,6 +14,21 @@ __all__ = ["LocalQueue", "local_sign"]
 _DEFAULT_QUEUE_DIR = os.path.join(os.path.expanduser("~"), ".asqav", "queue")
 
 
+def _validated_queue_dir(raw: str) -> Path:
+    """Sanitize the queue directory before mkdir/write I/O.
+
+    Expands a leading ``~`` and rejects null bytes and traversal (``..``)
+    components so an attacker-influenced ``ASQAV_QUEUE_DIR`` (or ``queue_dir``)
+    cannot point the queue's mkdir and item writes at an arbitrary location.
+    """
+    if "\x00" in raw:
+        raise ValueError("queue dir must not contain null bytes")
+    expanded = os.path.expanduser(raw)
+    if ".." in Path(expanded).parts:
+        raise ValueError("queue dir must not contain path traversal ('..')")
+    return Path(expanded)
+
+
 class LocalQueue:
     """Queue for offline action signing with later sync to the Asqav API."""
 
@@ -23,7 +38,7 @@ class LocalQueue:
             or os.environ.get("ASQAV_QUEUE_DIR")
             or _DEFAULT_QUEUE_DIR
         )
-        self.queue_dir = Path(resolved)
+        self.queue_dir = _validated_queue_dir(resolved)
         self.queue_dir.mkdir(parents=True, exist_ok=True)
 
     def enqueue(

--- a/python/tests/test_credentials.py
+++ b/python/tests/test_credentials.py
@@ -103,6 +103,47 @@ def test_credentials_path_env_override(home, monkeypatch) -> None:
     assert creds.resolve_api_key() == "sk_override"
 
 
+# === path-injection regression (Trustabl #375) ===
+
+
+def test_credentials_path_rejects_traversal(home, monkeypatch) -> None:
+    monkeypatch.setenv("ASQAV_CREDENTIALS_PATH", str(home / ".." / "escaped.json"))
+    with pytest.raises(ValueError, match="path traversal"):
+        creds.credentials_path()
+
+
+def test_save_credentials_traversal_does_not_write_outside(home, monkeypatch) -> None:
+    target = home.parent / "escaped_creds.json"
+    monkeypatch.setenv("ASQAV_CREDENTIALS_PATH", str(home / ".." / "escaped_creds.json"))
+    with pytest.raises(ValueError):
+        creds.save_credentials("sk_evil")
+    assert not target.exists()
+
+
+def test_load_credentials_traversal_does_not_leak(home, monkeypatch) -> None:
+    secret = home.parent / "secret.json"
+    secret.write_text(json.dumps({"api_key": "sk_leaked"}), encoding="utf-8")
+    monkeypatch.setenv("ASQAV_CREDENTIALS_PATH", str(home / ".." / "secret.json"))
+    assert creds.load_credentials() == {}
+    assert creds.resolve_api_key() is None
+
+
+def test_validated_fs_path_rejects_null_byte(home) -> None:
+    with pytest.raises(ValueError, match="null bytes"):
+        creds._validated_fs_path(str(home / "creds") + "\x00.json", "ASQAV_CREDENTIALS_PATH")
+
+
+def test_validated_fs_path_rejects_traversal(home) -> None:
+    with pytest.raises(ValueError, match="path traversal"):
+        creds._validated_fs_path(str(home / ".." / "x"), "ASQAV_CREDENTIALS_PATH")
+
+
+def test_validated_fs_path_expands_user_and_allows_legit(home) -> None:
+    assert creds._validated_fs_path("~/creds.json", "X") == home / "creds.json"
+    legit = home / "custom" / "creds.json"
+    assert creds._validated_fs_path(str(legit), "X") == legit
+
+
 # === login command ===
 
 

--- a/python/tests/test_local.py
+++ b/python/tests/test_local.py
@@ -8,6 +8,8 @@ import sys
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
@@ -217,3 +219,26 @@ def test_enqueue_is_atomic_no_tmp_residue(tmp_path) -> None:
     assert len(items) == 1
     assert items[0]["id"] == item_id
     assert items[0]["context"] == {"k": "v"}
+
+
+# === path-injection regression (Trustabl #375) ===
+
+
+def test_queue_dir_arg_traversal_rejected(tmp_path) -> None:
+    """A traversal queue_dir is rejected before any mkdir/write escapes."""
+    target = tmp_path.parent / "escaped_queue"
+    with pytest.raises(ValueError, match="path traversal"):
+        LocalQueue(queue_dir=str(tmp_path / ".." / "escaped_queue"))
+    assert not target.exists()
+
+
+def test_queue_dir_env_traversal_rejected(tmp_path, monkeypatch) -> None:
+    """ASQAV_QUEUE_DIR with '..' is rejected, mirroring the credentials fix."""
+    monkeypatch.setenv("ASQAV_QUEUE_DIR", str(tmp_path / ".." / "evil_queue"))
+    with pytest.raises(ValueError, match="path traversal"):
+        LocalQueue()
+
+
+def test_queue_dir_null_byte_rejected(tmp_path) -> None:
+    with pytest.raises(ValueError, match="null bytes"):
+        LocalQueue(queue_dir=str(tmp_path) + "\x00sub")

--- a/typescript/src/credentials.ts
+++ b/typescript/src/credentials.ts
@@ -14,10 +14,39 @@ const DEFAULT_API_BASE = "https://api.asqav.com/api/v1";
 
 export const CREDENTIALS_PATH = path.join(os.homedir(), ".asqav", "credentials");
 
-/** Resolve the credentials file location (env override, else ~/.asqav/credentials). */
+function expandHome(raw: string): string {
+  if (raw === "~") return os.homedir();
+  if (raw.startsWith("~/") || raw.startsWith("~\\")) {
+    return path.join(os.homedir(), raw.slice(2));
+  }
+  return raw;
+}
+
+/**
+ * Sanitize a caller-supplied path before any file I/O. Expands a leading "~"
+ * and rejects the two classic path-injection vectors, null bytes and traversal
+ * ("..") components, so an attacker-influenced value cannot redirect a read,
+ * write, or chmod to an arbitrary location. Throws on a rejected path.
+ */
+export function validatedPath(raw: string, source: string): string {
+  if (raw.includes("\0")) {
+    throw new Error(`${source} must not contain null bytes`);
+  }
+  const expanded = expandHome(raw);
+  if (expanded.split(/[\\/]+/).includes("..")) {
+    throw new Error(`${source} must not contain path traversal ('..')`);
+  }
+  return expanded;
+}
+
+/**
+ * Resolve the credentials file location (env override, else ~/.asqav/credentials).
+ * The ASQAV_CREDENTIALS_PATH override is validated before it is used for I/O, so
+ * a traversal value such as ../../etc/passwd is rejected rather than read or written.
+ */
 export function credentialsPath(): string {
   const override = process.env.ASQAV_CREDENTIALS_PATH;
-  if (override) return override;
+  if (override) return validatedPath(override, "ASQAV_CREDENTIALS_PATH");
   return path.join(os.homedir(), ".asqav", "credentials");
 }
 

--- a/typescript/tests/credentials.test.ts
+++ b/typescript/tests/credentials.test.ts
@@ -12,6 +12,7 @@ import {
   resolveApiBase,
   resolveApiKey,
   saveCredentials,
+  validatedPath,
 } from "../src/credentials.js";
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -189,6 +190,43 @@ describe("credentials layer + onboarding CLI (TypeScript)", () => {
     saveCredentials("sk_override");
     expect(fs.existsSync(override)).toBe(true);
     expect(resolveApiKey()).toBe("sk_override");
+  });
+
+  // === path-injection regression (Trustabl #375) ===
+
+  it("rejects a traversal ASQAV_CREDENTIALS_PATH and writes nothing outside", () => {
+    const home = useDefaultPath();
+    // String concat (not path.join) so the literal ".." survives into the env value.
+    const traversal = `${home}/../escaped_creds.json`;
+    process.env.ASQAV_CREDENTIALS_PATH = traversal;
+    expect(() => credentialsPath()).toThrow(/path traversal/);
+    expect(() => saveCredentials("sk_evil")).toThrow(/path traversal/);
+    expect(fs.existsSync(path.resolve(traversal))).toBe(false);
+  });
+
+  it("load on a traversal path returns {} and leaks nothing", () => {
+    const home = useDefaultPath();
+    const secret = path.resolve(`${home}/../secret.json`);
+    fs.writeFileSync(secret, JSON.stringify({ api_key: "sk_leaked" }));
+    process.env.ASQAV_CREDENTIALS_PATH = `${home}/../secret.json`;
+    expect(loadCredentials()).toEqual({});
+    expect(resolveApiKey()).toBeNull();
+  });
+
+  it("validatedPath rejects null bytes", () => {
+    expect(() => validatedPath("creds\x00.json", "X")).toThrow(/null bytes/);
+  });
+
+  it("validatedPath rejects traversal components", () => {
+    expect(() => validatedPath("/a/../b", "X")).toThrow(/path traversal/);
+    expect(() => validatedPath("../creds", "X")).toThrow(/path traversal/);
+  });
+
+  it("validatedPath expands ~ and allows legit absolute paths", () => {
+    const home = useDefaultPath();
+    expect(validatedPath("~/creds.json", "X")).toBe(path.join(home, "creds.json"));
+    const abs = path.join(home, "custom", "creds.json");
+    expect(validatedPath(abs, "X")).toBe(abs);
   });
 
   // === login command ===


### PR DESCRIPTION
## Finding (Trustabl #375, high severity: path parameter in I/O without validation)

Env-controlled paths flowed raw into file I/O with no validation:

- `python/src/asqav/credentials.py`: `credentials_path()` returned `Path(ASQAV_CREDENTIALS_PATH)` unchecked. `save_credentials()` then ran `os.open(O_WRONLY|O_CREAT|O_TRUNC)` at credentials.py:76, wrote the key, and chmod 0600 the file plus chmod 0700 the parent dir. An attacker who can set `ASQAV_CREDENTIALS_PATH=../../etc/cron.d/x` could write an arbitrary file and chmod an arbitrary directory. `load_credentials()` (credentials.py:60) could be pointed at a sensitive file to read it.
- `typescript/src/credentials.ts`: identical pattern. `saveCredentials()` ran `fs.writeFileSync` plus `fs.chmodSync` at credentials.ts:76 on the raw env path, and `loadCredentials()` (credentials.ts:56) read it.
- `python/src/asqav/local.py`: `ASQAV_QUEUE_DIR` (or `queue_dir`) went straight into `Path(...).mkdir(parents=True)` at local.py:42 and the per-item writes, the same class of bug one level down.

## Fix

Validate every env-controlled path before any I/O. Expand a leading `~`, reject null bytes, reject traversal (`..`) components, and raise on a bad value:

- Python: new `_validated_fs_path()` at credentials.py:28, wired into `credentials_path()` at credentials.py:53. New `_validated_queue_dir()` at local.py:17, wired into `LocalQueue.__init__` at local.py:41.
- TypeScript: new `validatedPath()` (plus `expandHome()`) at credentials.ts:31, wired into `credentialsPath()` at credentials.ts:49.

A traversal value now raises before any read, write, mkdir, or chmod runs. `load_credentials` and `loadCredentials` fail safe to `{}`. Legitimate absolute and `~` paths behave exactly as before, so existing resolution and the 0600/0700 modes are unchanged.

## Regression tests

- `python/tests/test_credentials.py`: a traversal env path raises and writes nothing outside the home dir, a traversal read leaks nothing, a null byte is rejected, and `~` expansion plus legit paths still pass.
- `python/tests/test_local.py`: a traversal `queue_dir` and `ASQAV_QUEUE_DIR` are rejected before any mkdir escapes, and a null byte is rejected.
- `typescript/tests/credentials.test.ts`: the same coverage for the TS layer.

## Verification

- Python: `cd python && PYTHONPATH=src python -m pytest tests -q` gives 1489 passed, 2 skipped. `ruff check` is clean.
- TypeScript: `cd typescript && npm run lint` (tsc --noEmit) is clean and `npm test` gives 711 passed.

Fixes #375
