### PR TITLE
fix(verifier): resolve one signing key for the signature and status axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A rewritten `signature.kid` cannot buy a PASS for a revoked key.** `kid` sits
+  outside the signed payload bytes, so a receipt holder can change it without
+  disturbing the signature. The signature axis resolved its key through an
+  agent-id fallback that the `key_status` and `issuer_bind` axes did not share, so
+  a kid the directory answers for nothing left those two axes emitting nothing at
+  all. The verdict aggregate can block on an axis reporting SKIPPED but not on one
+  that was never emitted, so a receipt signed by a REVOKED key read PASS offline.
+  Both surfaces now resolve through one shared entry, so every axis weighs the key
+  that actually signed. A revoked-key receipt reports FAIL whichever route
+  resolves it.
+
 ## [0.8.3] - 2026-07-20
 
 Patch release with a verifier correctness fix and a docs alignment.

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -123,31 +123,40 @@ class AsqavNativeAdapter(FormatAdapter):
             kid=sig_obj.get("kid", ""),
         )
 
+    def _signing_key_entry(self, doc: dict, jwks: dict) -> dict | None:
+        """The one jwks entry this receipt's signature is checked against.
+
+        Cloud receipts set kid to the issuer id; when that resolves nothing, the
+        agent's own key answers, mirroring run(). agent_id is attacker-controlled,
+        so the agent match trusts only a key whose published issuer_id equals the
+        one the receipt claims inside its signed bytes.
+
+        Every axis resolves through here. kid lives OUTSIDE the signed bytes, so a
+        second independent lookup on it is attacker-steerable: a receipt could
+        verify against a key found by the agent route while the revocation and
+        issuer axes read a kid that resolves nothing and emit no axis at all. An
+        axis that never exists cannot be blocked on, unlike one that reports
+        SKIPPED, so the verdict would read PASS for a key the directory revoked.
+        """
+        payload = _payload(doc)
+        return _vr.match_signing_key(
+            jwks,
+            self.extract_signature(doc).kid,
+            payload.get("agent_id") or doc.get("agent_id"),
+            payload.get("issuer_id"),
+        )
+
     def resolve_key(self, doc: dict, key_provider: Any) -> tuple[bytes | None, str]:
         jwks = key_provider or {"keys": []}
         kid = self.extract_signature(doc).kid
-        pk, status, _alg = _vr.resolve_key(jwks, kid)
-        if pk is None:
-            # Cloud receipts set kid to the issuer id; when that resolves nothing,
-            # fall back to the agent's own key, mirroring run(). agent_id is
-            # attacker-controlled, so resolve_key_by_agent_id trusts only a key
-            # whose published issuer_id matches the one the receipt claims.
-            fallback = self._resolve_key_by_agent(doc, jwks)
-            if fallback is not None:
-                return fallback
+        entry = self._signing_key_entry(doc, jwks)
+        if entry is None:
             return None, f"kid {kid!r} not in jwks directory"
-        return pk, f"resolved kid {kid} (status={status})"
-
-    def _resolve_key_by_agent(self, doc: dict, jwks: dict) -> tuple[bytes, str] | None:
-        """Resolve the signing key by the receipt's agent_id when the kid is absent."""
-        payload = _payload(doc)
-        agent_id = payload.get("agent_id") or doc.get("agent_id")
-        pk, status, _alg, kid, _issuer = _vr.resolve_key_by_agent_id(
-            jwks, agent_id, payload.get("issuer_id")
-        )
-        if pk is None:
-            return None
-        return pk, f"resolved agent key {kid} (status={status})"
+        pk = _vr._b64decode(entry["public_key"])
+        status = entry.get("status")
+        if kid and kid in (entry.get("issuer_id"), entry.get("kid")):
+            return pk, f"resolved kid {kid} (status={status})"
+        return pk, f"resolved agent key {entry.get('kid')} (status={status})"
 
     def signing_input(self, doc: dict) -> bytes:
         if _is_hash_mode(doc):
@@ -209,29 +218,33 @@ class AsqavNativeAdapter(FormatAdapter):
 
         A receipt signed by a revoked key, or by a key the directory publishes
         under a different issuer, must not PASS offline, matching the hosted
-        /verify. No key resolved means the signature axis already FAILs, so these
-        axes only weigh in once a key is found. Both wire shapes name their issuer
-        inside the signed bytes: issuer_id in compliance mode, org_id in hash mode.
+        /verify. No key resolved at all means the signature axis already reports no
+        key, so these axes only weigh in once a key is found. Both wire shapes name
+        their issuer inside the signed bytes: issuer_id in compliance mode, org_id
+        in hash mode.
+
+        Resolution goes through the same entry the signature axis verifies
+        against, so these axes weigh the key that actually signed rather than
+        whatever the unsigned kid happens to name.
         """
         jwks = key_provider or {"keys": []}
-        kid = self.extract_signature(doc).kid
-        pk, status, _alg = _vr.resolve_key(jwks, kid)
-        if pk is None:
+        entry = self._signing_key_entry(doc, jwks)
+        if entry is None:
             return []
-        key_issuer = _vr.resolve_key_issuer(jwks, kid)
-        # kid selects the key and the receipt selects the kid, so bind the
-        # resolved key back to the issuer the signed bytes name.
+        key_issuer = _vr.key_issuer_of(entry)
+        # The resolved key is bound back to the issuer the signed bytes name.
         if _is_hash_mode(doc):
             issued_at = doc.get("server_timestamp", "")
-            bind = _vr.check_org_binding(key_issuer, _vr.resolve_key_org(jwks, kid), doc.get("org_id"))
+            bind = _vr.check_org_binding(key_issuer, _vr.key_org_of(entry), doc.get("org_id"))
         else:
             payload = _payload(doc)
             issued_at = payload.get("issued_at", "")
             bind = _vr.check_issuer_binding(key_issuer, payload.get("issuer_id"))
-        revoked_at = _vr.resolve_revoked_at(jwks, kid)
         # Offline anchor presence is unverifiable (anchors are unsigned); pass
         # False so a forged anchor never rides a revoked key to PASS.
-        res, note = _vr.check_key_status(status, issued_at, revoked_at, False)
+        res, note = _vr.check_key_status(
+            entry.get("status"), issued_at, _vr.revoked_at_of(entry), False
+        )
         return [("key_status", res, note), ("issuer_bind", *bind)]
 
     def attestation(self, doc: dict) -> dict[str, Any]:

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -332,6 +332,64 @@ def _match_key(jwks: dict, kid: str):
     return None
 
 
+def _match_key_by_agent(jwks: dict, agent_id, issuer_id):
+    """Return the first usable jwks entry for an agent key bound to a claimed issuer.
+
+    The single agent-side matcher, so the entry a signature verifies against is the
+    same entry every published field is read from. agent_id is attacker-controlled,
+    so a match also requires the key's published issuer_id to equal the issuer the
+    receipt claims inside its signed bytes.
+    """
+    keys = jwks.get("keys") if isinstance(jwks, dict) else None
+    if not isinstance(keys, list):
+        return None
+    for k in keys:
+        if not isinstance(k, dict):
+            continue
+        if (
+            agent_id
+            and agent_id == k.get("agent_id")
+            and issuer_id
+            and issuer_id == k.get("issuer_id")
+        ):
+            if not isinstance(k.get("public_key"), str):
+                continue
+            return k
+    return None
+
+
+def match_signing_key(jwks: dict, kid: str, agent_id=None, issuer_id=None):
+    """Return the one jwks entry a receipt's signature is checked against.
+
+    kid first, then the agent-id bind. Every caller resolves through here, so the
+    key that verifies a signature and the key whose status and issuer the axes weigh
+    are one entry rather than two independent lookups. Resolving them separately lets
+    a receipt verify against a key found one way while the revocation and issuer axes
+    read a key found the other way, or vanish because the second lookup missed.
+    """
+    entry = _match_key(jwks, kid)
+    if entry is not None:
+        return entry
+    return _match_key_by_agent(jwks, agent_id, issuer_id)
+
+
+def key_issuer_of(entry):
+    """Return the issuer id a jwks entry publishes, or None when it names no string."""
+    issuer = entry.get("issuer_id") if entry else None
+    return issuer if isinstance(issuer, str) else None
+
+
+def key_org_of(entry):
+    """Return the org id a jwks entry publishes, or None when the value is not one."""
+    org = entry.get("org_id") if entry else None
+    return org if _is_org_id(org) else None
+
+
+def revoked_at_of(entry):
+    """Return the revoked_at a jwks entry publishes, if any."""
+    return entry.get("revoked_at") if entry else None
+
+
 def resolve_key(jwks: dict, kid: str):
     """Return (public_key_bytes, status, alg) for the receipt's signature.kid.
 
@@ -350,9 +408,7 @@ def resolve_key_issuer(jwks: dict, kid: str):
     Reads the same entry resolve_key returns, so the bind weighs the key that
     actually verified. None when kid resolves nothing or publishes no string issuer.
     """
-    k = _match_key(jwks, kid)
-    issuer = k.get("issuer_id") if k else None
-    return issuer if isinstance(issuer, str) else None
+    return key_issuer_of(_match_key(jwks, kid))
 
 
 def resolve_key_by_agent_id(jwks: dict, agent_id: str, issuer_id: str):
@@ -365,29 +421,16 @@ def resolve_key_by_agent_id(jwks: dict, agent_id: str, issuer_id: str):
     claimed issuer_id: without that bind a valid key from any org would verify a
     receipt claiming a different issuer. Same defensive shape as resolve_key.
     """
-    keys = jwks.get("keys") if isinstance(jwks, dict) else None
-    if not isinstance(keys, list):
+    k = _match_key_by_agent(jwks, agent_id, issuer_id)
+    if k is None:
         return None, None, None, None, None
-    for k in keys:
-        if not isinstance(k, dict):
-            continue
-        if (
-            agent_id
-            and agent_id == k.get("agent_id")
-            and issuer_id
-            and issuer_id == k.get("issuer_id")
-        ):
-            pub = k.get("public_key")
-            if not isinstance(pub, str):
-                continue
-            return (
-                _b64decode(pub),
-                k.get("status"),
-                k.get("alg"),
-                k.get("kid"),
-                k.get("issuer_id"),
-            )
-    return None, None, None, None, None
+    return (
+        _b64decode(k["public_key"]),
+        k.get("status"),
+        k.get("alg"),
+        k.get("kid"),
+        k.get("issuer_id"),
+    )
 
 
 def resolve_revoked_at(jwks: dict, kid: str):
@@ -397,8 +440,7 @@ def resolve_revoked_at(jwks: dict, kid: str):
     timestamp, so the key-status axis falls back to a bare status gate. Reads the
     same entry resolve_key returns, so every axis weighs one key, not two.
     """
-    k = _match_key(jwks, kid)
-    return k.get("revoked_at") if k else None
+    return revoked_at_of(_match_key(jwks, kid))
 
 
 def check_issuer_binding(key_issuer_id, claimed_issuer_id):
@@ -422,9 +464,7 @@ def resolve_key_org(jwks: dict, kid: str):
     A value that is not an org id cannot serve as one, so it reads as unpublished
     and the issuer branch decides, rather than counting as a mismatch.
     """
-    k = _match_key(jwks, kid)
-    org = k.get("org_id") if k else None
-    return org if _is_org_id(org) else None
+    return key_org_of(_match_key(jwks, kid))
 
 
 #: Same body text as the TypeScript ORG_ID_RE. Anchored by fullmatch, not by $,

--- a/python/tests/test_oracle_kid_shared_resolution.py
+++ b/python/tests/test_oracle_kid_shared_resolution.py
@@ -1,0 +1,192 @@
+"""One key resolution serves the signature axis and the key-status axes alike.
+
+``signature.kid`` sits OUTSIDE the signed payload bytes, so a holder of a receipt can
+rewrite it without disturbing the signature. When the signature axis resolves its key
+through a fallback the gating axes do not share, a rewritten kid makes ``key_status``
+and ``issuer_bind`` resolve nothing and emit no axis at all. The aggregate in
+``oracle/core.py`` weighs the axes that exist, and it can block on an axis reporting
+SKIPPED but not on one that was never emitted, so a receipt signed by a REVOKED key
+reads PASS.
+
+Every gate here pins the invariant that closes that: the entry the signature verifies
+against is the entry every axis reads its published fields from.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+
+import pytest
+
+from asqav.verifier import verify_receipt as v
+from asqav.verifier.oracle import crypto
+from asqav.verifier.oracle.adapters.asqav_native import AsqavNativeAdapter
+from asqav.verifier.oracle.canonical import asqav_jcs
+from asqav.verifier.oracle.core import verify
+
+_ED25519_AVAILABLE = crypto.verify_ed25519(b"\x00" * 32, b"m", b"\x00" * 64)[0] != crypto.SKIPPED
+
+requires_ed25519 = pytest.mark.skipif(
+    not _ED25519_AVAILABLE, reason="cryptography not installed; Ed25519 verify SKIPs"
+)
+
+ISSUER = "acme-legal-entity"
+AGENT = "agt_shared_resolution"
+REAL_KID = "key-shared-resolution"
+#: A kid the directory answers for nothing, which is what a rewritten kid looks like.
+ABSENT_KID = "kid-that-resolves-nothing"
+
+
+def _payload() -> dict:
+    """A compliance payload naming its issuer and agent inside the signed bytes."""
+    return {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-06-01T19:26:44.289388Z",
+        "issuer_id": ISSUER,
+        "agent_id": AGENT,
+        "action_ref": "sha256:" + "8" * 64,
+        "payload_digest": {"hash": "8" * 64, "size": 512},
+        "policy_digest": "sha256:" + "3" * 64,
+        "previousReceiptHash": "0" * 64,
+        "decision": "allow",
+    }
+
+
+def _jwks(status: str = "revoked", public_key: str = "QUFBQQ==") -> dict:
+    """A directory publishing one key, resolvable by kid AND by agent_id."""
+    return {
+        "keys": [
+            {
+                "kid": REAL_KID,
+                "issuer_id": ISSUER,
+                "agent_id": AGENT,
+                "alg": "Ed25519",
+                "public_key": public_key,
+                "status": status,
+            }
+        ]
+    }
+
+
+def _receipt(kid: str, sig: str = "AAAA") -> dict:
+    return {
+        "payload": _payload(),
+        "signature": {"alg": "Ed25519", "kid": kid, "sig": sig},
+        "anchors": [],
+    }
+
+
+def _axes(doc: dict, jwks: dict) -> dict[str, str]:
+    return {name: res for name, res, _note in AsqavNativeAdapter().extra_axes(doc, jwks)}
+
+
+# --- the axes must exist whichever route resolved the key ---
+
+
+def test_absent_kid_still_emits_the_gating_axes() -> None:
+    """A kid the directory does not answer for still yields both gating axes."""
+    axes = _axes(_receipt(ABSENT_KID), _jwks())
+    assert "key_status" in axes, "a rewritten kid must not make the axis vanish"
+    assert "issuer_bind" in axes
+
+
+def test_absent_kid_reports_the_revoked_status_of_the_signing_key() -> None:
+    """The status read is the one published for the key the agent route resolves."""
+    assert _axes(_receipt(ABSENT_KID), _jwks(status="revoked"))["key_status"] == "FAIL"
+
+
+def test_absent_kid_agrees_with_the_real_kid_on_every_axis() -> None:
+    """Rewriting the kid changes no axis outcome, since one entry answers both."""
+    assert _axes(_receipt(ABSENT_KID), _jwks()) == _axes(_receipt(REAL_KID), _jwks())
+
+
+def test_active_key_passes_the_status_axis_through_the_agent_route() -> None:
+    """The shared resolution does not turn an active key into a failure."""
+    axes = _axes(_receipt(ABSENT_KID), _jwks(status="active"))
+    assert axes["key_status"] == "PASS"
+    assert axes["issuer_bind"] == "PASS"
+
+
+def test_no_key_at_all_emits_no_axis() -> None:
+    """With nothing resolvable the signature axis carries the verdict on its own."""
+    assert _axes(_receipt(ABSENT_KID), {"keys": []}) == {}
+
+
+def test_agent_route_needs_the_claimed_issuer_to_match() -> None:
+    """agent_id is attacker-controlled, so the issuer bind still gates the match."""
+    jwks = _jwks()
+    jwks["keys"][0]["issuer_id"] = "some-other-entity"
+    assert _axes(_receipt(ABSENT_KID), jwks) == {}
+
+
+# --- the shared entry is the one the signature verifies against ---
+
+
+def test_resolve_key_and_extra_axes_resolve_the_same_entry() -> None:
+    """Both surfaces answer for the absent kid, rather than one answering alone."""
+    ad = AsqavNativeAdapter()
+    doc, jwks = _receipt(ABSENT_KID), _jwks()
+    pk, note = ad.resolve_key(doc, jwks)
+    assert pk is not None, note
+    assert ad.extra_axes(doc, jwks) != []
+
+
+def test_match_signing_key_prefers_the_kid_entry() -> None:
+    """kid wins when it resolves, so the agent route only fills a genuine gap."""
+    jwks = {
+        "keys": [
+            {"kid": REAL_KID, "issuer_id": ISSUER, "public_key": "QUFBQQ==", "status": "active"},
+            {
+                "kid": "other",
+                "issuer_id": ISSUER,
+                "agent_id": AGENT,
+                "public_key": "QkJCQg==",
+                "status": "revoked",
+            },
+        ]
+    }
+    entry = v.match_signing_key(jwks, REAL_KID, AGENT, ISSUER)
+    assert entry is not None
+    assert entry["kid"] == REAL_KID
+
+
+# --- end to end over a real signature ---
+
+
+@requires_ed25519
+def test_rewritten_kid_cannot_flip_a_revoked_receipt_to_pass() -> None:
+    """The whole point: one unsigned byte field cannot buy a PASS.
+
+    The payload bytes and the signature are identical across both documents, so the
+    only difference an attacker introduces is the kid the directory resolves by.
+    """
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    sk = Ed25519PrivateKey.generate()
+    pub = base64.b64encode(sk.public_key().public_bytes_raw()).decode()
+    payload = _payload()
+    sig = base64.b64encode(sk.sign(asqav_jcs(payload))).decode()
+
+    honest = {
+        "payload": payload,
+        "signature": {"alg": "Ed25519", "kid": REAL_KID, "sig": sig},
+        "anchors": [],
+    }
+    rewritten = copy.deepcopy(honest)
+    rewritten["signature"]["kid"] = ABSENT_KID
+
+    jwks = _jwks(status="revoked", public_key=pub)
+    ad = [AsqavNativeAdapter()]
+
+    honest_res = verify(honest, ad, key_provider=jwks)
+    rewritten_res = verify(rewritten, ad, key_provider=jwks)
+
+    # The signature really does check out against the published key in both cases.
+    assert honest_res.axis("signature").result == "PASS"
+    assert rewritten_res.axis("signature").result == "PASS"
+    # And the revoked status carries the verdict in both cases.
+    assert honest_res.verdict == "FAIL"
+    assert rewritten_res.verdict == "FAIL"
+    assert rewritten_res.axis("key_status") is not None
+    assert rewritten_res.axis("key_status").result == "FAIL"


### PR DESCRIPTION
## The defect

`signature.kid` sits OUTSIDE the signed payload bytes, so a receipt holder can rewrite
it without disturbing the signature.

Two independent key resolutions read that field:

- `resolve_key` (the signature axis) resolves by `kid`, then falls back to the receipt's
  `agent_id` when the kid answers nothing.
- `extra_axes` (`key_status` and `issuer_bind`) resolves by `kid` alone and returns an
  empty axis list when that misses.

So a kid the directory answers for nothing leaves the signature verifying through the
agent route while both gating axes emit **nothing at all**. The aggregate in
`oracle/core.py` computes `has_fail` and `blocking_skip` over the axes present in its
list, so it can block on an axis reporting SKIPPED but not on one that was never
emitted.

A receipt signed by a key the directory marks REVOKED therefore reads PASS offline,
which is the one verdict the product promises it can never give.

## Reproduced

An Ed25519 receipt signed by a revoked key, verified twice. The payload bytes and the
signature are byte-identical across both documents. Only the kid differs.

```
A. honest receipt, real kid (revoked key)          VERDICT: FAIL
     structure    PASS
     signature    PASS
     chain        PASS
     key_status   FAIL     signing key status 'revoked'
     issuer_bind  PASS

B. same bytes, only the UNSIGNED kid changed       VERDICT: PASS
     structure    PASS
     signature    PASS
     chain        PASS
     key_status   <NEVER EMITTED>
     issuer_bind  <NEVER EMITTED>
```

## The fix

`match_signing_key` is the one resolution both surfaces call: kid first, then the
agent-id bind. The adapter reads `status`, `issuer_id`, `org_id` and `revoked_at` from
that same entry, so the key a signature verifies against and the key the axes weigh
cannot be two keys. This restores the invariant `_match_key` already states in its own
docstring, that key material and the key's published fields come from one entry.

`_match_key_by_agent` becomes the single agent-side predicate and
`resolve_key_by_agent_id` delegates to it, so the entry-returning and tuple-returning
forms cannot drift. `resolve_key_issuer`, `resolve_key_org` and `resolve_revoked_at`
delegate to small entry readers for the same reason.

The agent route keeps its bind. `agent_id` is attacker-controlled, so a match still
requires the key's published `issuer_id` to equal the issuer the receipt claims inside
its signed bytes. A gate covers that: pointing the directory at a different issuer makes
the agent route resolve nothing.

When nothing resolves at all the axis list stays empty, which is correct. The signature
axis reports no key and carries the verdict to INCOMPLETE on its own.

## Verification

Gates in `python/tests/test_oracle_kid_shared_resolution.py`. Against the split
resolution, seven of the nine fail:

```
FAILED test_absent_kid_still_emits_the_gating_axes
FAILED test_absent_kid_reports_the_revoked_status_of_the_signing_key
FAILED test_absent_kid_agrees_with_the_real_kid_on_every_axis
FAILED test_active_key_passes_the_status_axis_through_the_agent_route
FAILED test_resolve_key_and_extra_axes_resolve_the_same_entry
FAILED test_match_signing_key_prefers_the_kid_entry
FAILED test_rewritten_kid_cannot_flip_a_revoked_receipt_to_pass
7 failed, 2 passed
```

The last is the end-to-end gate over a real signature. With the shared resolution the
file reports 9 passed, the full python suite reports 1500 passed (which includes the
50-vector conformance corpus), and `ruff check src/` is clean.

## Scope note on the TypeScript half

The TypeScript `resolveKey` carries no agent-id fallback at all, so a rewritten kid
resolves nothing there, the signature axis reports no key, and the verdict lands on
INCOMPLETE. TypeScript is therefore NOT exposed to this PASS, and this change leaves it
untouched.

That does leave the two halves disagreeing on one receipt, FAIL against INCOMPLETE.
Closing that divergence means giving TypeScript the same fallback plus the same shared
resolution, which is a behaviour change to the TypeScript verdict and wants its own
change and its own gates rather than riding along with a security fix.

https://claude.ai/code/session_01GYGMd7NYh8cCXxUF1zAJ1Q
