### PR TITLE
docs(sdk): state what the nonce wire field does and does not gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,32 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   `cve_inventory_digest` to the CVE inventory digest page, and the air-gapped
   signer pointer to offline and air-gapped verification.
 
+### Security
+
+- **Corrected security claim: the `nonce` wire field carries no replay
+  protection.** The shipped docstrings and both README wire-field tables told
+  readers that the cloud verifier rejects a duplicate nonce per
+  `(agent_id, action_ref)` inside the validity window. No such control exists.
+  The caller-supplied nonce is written to the signature record and read back by
+  nothing: no unique index covers it, no query looks a value up to decide whether
+  it was seen, and it reaches the signed bytes in none of the three signing modes.
+  Re-sending a sign request with the same nonce produces a second accepted
+  signature.
+
+  Anyone who read that sentence and treated the field as a replay control had no
+  such protection, which is why this lands as a corrected security claim rather
+  than a wording tidy. The enforced half of the pair is real and unchanged:
+  `valid_seconds` and `expires_at` set the record's validity horizon, and verify
+  answers `signature_expired` past it. That is the control to bound replay with.
+
+  The nonce bullet also drops its time-bound-receipts pointer. That page repeats
+  the same claim, and a corrected sentence sitting next to a link that asserts the
+  opposite still misleads. The `expires_at` bullet keeps the link.
+
+  The 0.8.3 package descriptions on PyPI and npm are immutable, so a reader
+  landing on either registry page keeps seeing the old sentence until the next
+  release republishes the README.
+
 ## [0.8.3] - 2026-07-20
 
 Patch release with a verifier correctness fix and a docs alignment.

--- a/python/README.md
+++ b/python/README.md
@@ -190,7 +190,7 @@ Six wire fields on `agent.sign(...)` carry the NSA CSI U/OO/6030316-26 alignment
 
 - `result_digest` - `sha256:<hex>` of the tool output, binds the receipt to a specific result. See <https://www.asqav.com/docs/result-digest>.
 - `expires_at` - explicit ISO-8601 or POSIX validity horizon. Converted client-side to `valid_seconds` and sent as a duration, since the cloud owns absolute time-binding. Mutually exclusive with `valid_seconds`. See <https://www.asqav.com/docs/time-bound-receipts>.
-- `nonce` - 12 random bytes auto-generated when omitted. Cloud rejects duplicates inside the validity window. See <https://www.asqav.com/docs/time-bound-receipts>.
+- `nonce` - 12 random bytes auto-generated when omitted, carried as an opaque per-call token. The cloud stores it verbatim and runs no uniqueness check, so re-sending the same value produces a second accepted signature and the field gates no replay. Bound replay with `valid_seconds` or `expires_at`, which the verifier enforces by returning `signature_expired`.
 - `tool_fingerprint` - 32 bare lowercase hex chars, SHA-256[:32], over `{tool_name, schema}`, auto-derived when `tool_name` + `tool_schema` are present. See <https://www.asqav.com/docs/tool-fingerprint>.
 - `config_manifest_digest` - `sha256:<hex>` of the agent's runtime configuration snapshot. Required on configuration_change receipts. See <https://www.asqav.com/docs/configuration-change-receipts>.
 - `cve_inventory_digest` - `sha256:<hex>` over the CVE snapshot at sign time. See <https://www.asqav.com/docs/cve-inventory>.

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1434,10 +1434,12 @@ def _compute_cve_inventory_digest(cve_list: list[Any]) -> str:
 
 
 def _generate_nonce() -> str:
-    """Return a 24-hex-char (12 random bytes) nonce for replay protection.
+    """Return a 24-hex-char (12 random bytes) value for the `nonce` wire field.
 
-    The cloud verifier rejects duplicate nonces per `(agent_id, action_ref)`
-    inside the validity window.
+    The cloud stores the value verbatim and runs no uniqueness check, so
+    re-sending one produces a second accepted signature. The enforced
+    control is the validity window (`valid_seconds` / `expires_at`), which
+    makes verify return `signature_expired` once it passes.
     """
     import secrets as _secrets
 
@@ -1829,6 +1831,13 @@ class Agent:
                 raises ``expiry_collision_guard``. Passing neither falls
                 back to the server-side default
                 (``valid_seconds=86400``).
+            nonce: Opaque per-call token, 24 hex chars auto-generated when
+                omitted. The cloud stores it verbatim and runs no
+                uniqueness check, so re-sending the same value produces a
+                second accepted signature and a caller leaning on it for
+                replay protection has none. The enforced control is the
+                validity window: pass ``valid_seconds`` or ``expires_at``
+                and verify returns ``signature_expired`` once it passes.
             tool_schema: Optional JSON schema describing the tool surface.
                 When provided alongside ``tool_name`` and
                 ``tool_fingerprint`` is omitted, the SDK computes the
@@ -2181,7 +2190,7 @@ class Agent:
         if tool_fingerprint is None and tool_name is not None and tool_schema is not None:
             tool_fingerprint = _compute_tool_fingerprint(tool_name, tool_schema)
 
-        # Auto-generate 24-hex nonce when caller omits; cloud rejects duplicates in-window.
+        # Fill the nonce wire field when omitted. The cloud stores it with no re-use check.
         if nonce is None:
             nonce = _generate_nonce()
 
@@ -2255,7 +2264,7 @@ class Agent:
         # and builds the signed authorized_under_mandate attestation server-side.
         if mandate_id is not None:
             body["mandate_id"] = mandate_id
-        # Replay protection.
+        # Opaque caller token. The cloud stores it and checks no re-use.
         if nonce is not None:
             body["nonce"] = nonce
         if valid_seconds is not None:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -182,7 +182,7 @@ Six wire fields on `agent.sign(...)` carry the NSA CSI U/OO/6030316-26 alignment
 
 - `resultDigest` - `sha256:<hex>` of the tool output, binds the receipt to a specific result. See <https://www.asqav.com/docs/result-digest>.
 - `expiresAt` - explicit ISO-8601 or POSIX validity horizon. Converted client-side to `validSeconds` and sent as a duration, since the cloud owns absolute time-binding. Mutually exclusive with `validSeconds`. See <https://www.asqav.com/docs/time-bound-receipts>.
-- `nonce` - 12 random bytes auto-generated when omitted. Cloud rejects duplicates inside the validity window. See <https://www.asqav.com/docs/time-bound-receipts>.
+- `nonce` - 12 random bytes auto-generated when omitted, carried as an opaque per-call token. The cloud stores it verbatim and runs no uniqueness check, so re-sending the same value produces a second accepted signature and the field gates no replay. Bound replay with `validSeconds` or `expiresAt`, which the verifier enforces by returning `signature_expired`.
 - `toolFingerprint` - 32 bare lowercase hex chars, SHA-256[:32], over `{tool_name, schema}`, auto-derived when `toolName` + `toolSchema` are present. See <https://www.asqav.com/docs/tool-fingerprint>.
 - `configManifestDigest` - `sha256:<hex>` of the agent's runtime configuration snapshot. Required on configuration_change receipts. See <https://www.asqav.com/docs/configuration-change-receipts>.
 - `cveInventoryDigest` - `sha256:<hex>` over the CVE snapshot at sign time. See <https://www.asqav.com/docs/cve-inventory>.

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -457,7 +457,8 @@ export interface SignOptions {
   /** Optional user-intent envelope. The end user signs a digest of the
    * action and the SDK passes it through to the backend verbatim. */
   userIntent?: UserIntent;
-  /** Optional opaque nonce for replay protection. Unique per agent. */
+  /** Optional opaque per-call token. The cloud stores it and checks no re-use, so
+   * it gates no replay. Bound replay with `validSeconds` or `expiresAt`. */
   nonce?: string;
   /** Optional validity window in seconds. Sets `valid_until = signed_at + validSeconds`
    * on the server; verifying the record after expiry returns
@@ -1711,9 +1712,9 @@ export function computeCveInventoryDigest(cveList: unknown[]): string {
   return `sha256:${hex}`;
 }
 
-/** Return a 24-hex-char (12 random bytes) nonce for replay protection.
- * The cloud verifier rejects duplicate nonces per `(agent_id, action_ref)`
- * inside the validity window. */
+/** Return a 24-hex-char (12 random bytes) value for the `nonce` wire field.
+ * The cloud stores it verbatim and runs no uniqueness check, so re-sending one
+ * produces a second accepted signature. Bound replay with `validSeconds`. */
 export function generateNonce(): string {
   // Use Web Crypto (Node >=19 + browsers); avoids require("crypto") CJS shim in the .mjs bundle.
   const buf = new Uint8Array(12);
@@ -1725,8 +1726,8 @@ export function generateNonce(): string {
  * Tack the optional non-IETF wire fields (`co_signers`, `nonce`,
  * `valid_seconds`, `expected_executor_pubkey_b64`) onto the body when
  * the caller supplied them. Mutates `body` in place for parity with the
- * inline original. Auto-generates `nonce` for cloud-side replay
- * protection (NSA CSI alignment) when the caller omits one.
+ * inline original. Fills `nonce` (NSA CSI alignment) when the caller omits
+ * one. The cloud stores that value and checks no re-use.
  */
 function applyOptionalWireFields(
   body: Record<string, unknown>,


### PR DESCRIPTION
The SDK told users the cloud rejects a duplicate nonce. The cloud runs no such check.

## The claim

Six places across both language halves carried the same sentence in some form: the cloud verifier rejects duplicate nonces per `(agent_id, action_ref)` inside the validity window.

| File | Line |
| --- | --- |
| `python/src/asqav/client.py` | `_generate_nonce` docstring |
| `python/src/asqav/client.py` | inline comment at the auto-generate branch |
| `python/src/asqav/client.py` | inline comment at the body write |
| `typescript/src/index.ts` | `SignOptions.nonce` JSDoc |
| `typescript/src/index.ts` | `generateNonce` JSDoc |
| `typescript/src/index.ts` | `applyOptionalWireFields` JSDoc |
| `python/README.md` | wire-field table |
| `typescript/README.md` | wire-field table |

## What the API actually does

Measured against the API repo at its main head:

- `SignRequest.nonce` is written to `signature_records.nonce` on the sign route and read back by nothing. Grepping the whole API source for a read of that attribute returns a single hit, and the hit is the column's own description string.
- No unique index covers it. The three indexes naming a nonce are plain `CREATE INDEX`. The `(agent_id, action_ref, nonce)` index the claim implies is absent.
- No query filters on a nonce to decide whether a value was seen before.
- It reaches the signed bytes in none of the three signing modes. Only the server-generated `receipt_nonce` is signed, and only under `compliance_mode`.

Re-sending a sign request with the same nonce produces a second accepted signature. The SDK retries a failed sign with the identical body, so it repeats its own nonce by design, which is why constraining that column would reject well-behaved clients rather than attackers.

## What is enforced

`valid_seconds` and `expires_at` set the record's validity horizon, and the verify ladder answers `signature_expired` once it passes. That half is real. Every corrected sentence points at it, so a reader who came for replay bounding leaves with the control that works.

The `sign()` docstring gains the `nonce` entry it was missing. That Args block documents `expires_at` in detail while the field the README bullets was absent from it, which is the first place a Python reader looks.

The nonce README bullet drops its time-bound-receipts pointer. That page repeats the same claim, and a corrected sentence next to a link asserting the opposite still misleads. The `expires_at` bullet keeps the link.

## Version

No bump. PyPI and npm both publish 0.8.3, the version files read 0.8.3, and the CHANGELOG carries an Unreleased block, so this repo bumps at release rather than per change. Package descriptions are immutable once published, so the old sentence stays live on both registry pages until the next release republishes the README.

## Proof of work

```
$ ruff check python/src
All checks passed!
CI_RUFF_EXIT=0

$ npx tsc --noEmit
TSC_EXIT=0

$ PYTHONPATH=python/src python3 -m pytest python/tests/test_client_nsa_aligned_fields.py -q
..................................................                       [100%]
50 passed in 0.57s

$ PYTHONPATH=python/src python3 -m pytest python/tests/test_scope_tokens.py python/tests/test_conformance_vectors.py -q
.......................................                                  [100%]
39 passed in 0.37s

$ npx vitest run tests/nsaAlignedFields.test.ts tests/generateNonce.test.ts tests/sdk.test.ts
 Test Files  3 passed (3)
      Tests  55 passed (55)

$ PYTHONPATH=python/src python3 -c "import asqav; print(asqav.__file__)"
/Users/jagmarques/asqav-repos/.company/.asondy/worktrees/asqav-sdk/c382-nonce-claim/python/src/asqav/__init__.py

$ git diff --stat origin/main
 CHANGELOG.md               | 26 ++++++++++++++++++++++++++
 python/README.md           |  2 +-
 python/src/asqav/client.py | 19 ++++++++++++++-----
 typescript/README.md       |  2 +-
 typescript/src/index.ts    | 13 +++++++------
 5 files changed, 49 insertions(+), 13 deletions(-)
```

comment hygiene clean
