### PR TITLE
fix(license): make the packaged LICENSE match the declared Elastic license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ### Fixed
 
+- **The published `@asqav/sdk` LICENSE file did not match the license
+  `package.json` declares.** The relicense to Elastic License 2.0 (#344)
+  updated the root `LICENSE`, `package.json`, and `pyproject.toml`, but left
+  `typescript/LICENSE` on its pre-relicense MIT text. `@asqav/sdk@0.8.2` and
+  `0.8.3` on npm both shipped declaring `LicenseRef-Elastic-License-2.0`
+  while bundling an MIT-worded LICENSE file inside the tarball. Those two
+  published versions are immutable and keep shipping that text.
+  `typescript/LICENSE` now matches the repo's canonical Elastic License 2.0
+  text, so the next publish carries the correct grant. A test
+  (`tests/license-consistency.test.ts`) pins the packaged LICENSE file
+  against the declared license going forward.
+
 - **A forged anchor value cannot report as a present anchor.** The anchors axis
   decoded the value leniently, and a lenient base64 decode drops every character
   outside the alphabet, so an all-punctuation value such as `!!!!` decoded to zero

--- a/typescript/LICENSE
+++ b/typescript/LICENSE
@@ -1,22 +1,95 @@
-MIT License
-
 Copyright (c) 2026 Asqav
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Elastic License 2.0
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+URL: https://www.elastic.co/licensing/elastic-license
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## Acceptance
 
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/typescript/tests/license-consistency.test.ts
+++ b/typescript/tests/license-consistency.test.ts
@@ -1,0 +1,58 @@
+/** Pins the packaged LICENSE text to package.json's declared license. */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PKG_DIR = path.resolve(__dirname, "..");
+const REPO_ROOT = path.resolve(PKG_DIR, "..");
+
+interface PackedFile {
+  path: string;
+}
+interface PackResult {
+  files: PackedFile[];
+}
+
+/** Asks npm which files it would ship, so a fix to the wrong path can't pass */
+function packedFiles(): PackedFile[] {
+  const out = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: PKG_DIR,
+    encoding: "utf8",
+  });
+  const [result] = JSON.parse(out) as PackResult[];
+  return result.files;
+}
+
+describe("license consistency", () => {
+  it("package.json declares the Elastic license and lists LICENSE in files", () => {
+    const pkg = JSON.parse(
+      readFileSync(path.join(PKG_DIR, "package.json"), "utf8"),
+    ) as { license: string; files: string[] };
+    expect(pkg.license).toBe("LicenseRef-Elastic-License-2.0");
+    expect(pkg.files).toContain("LICENSE");
+  });
+
+  it(
+    "the LICENSE file npm actually packs matches the repo's Elastic LICENSE, not MIT",
+    () => {
+      const packed = packedFiles();
+      const licenseEntry = packed.find((f) => f.path.toUpperCase() === "LICENSE");
+      expect(licenseEntry).toBeDefined();
+
+      const packagedLicenseText = readFileSync(path.join(PKG_DIR, "LICENSE"), "utf8");
+      const canonicalLicenseText = readFileSync(path.join(REPO_ROOT, "LICENSE"), "utf8");
+
+      // Pins the exact pre-relicense grant this test guards against
+      expect(packagedLicenseText).not.toMatch(/^MIT License/);
+      expect(packagedLicenseText).not.toMatch(/Permission is hereby granted, free of charge/);
+
+      // Packaged copy must carry the same text as the repo's canonical LICENSE
+      expect(packagedLicenseText).toBe(canonicalLicenseText);
+    },
+    // A real `npm pack` subprocess under a full parallel run can exceed the
+    // 5s default when the CI box is busy running 50+ other test files
+    20000,
+  );
+});


### PR DESCRIPTION
## What shipped wrong

`@asqav/sdk` on npm has shipped a licensing contradiction since the 0.8.2 release. `package.json` declares `LicenseRef-Elastic-License-2.0`, but the bundled `LICENSE` file inside the tarball still carries the pre-relicense MIT text. Verified against the real published tarballs, not just the source tree:

- `npm pack @asqav/sdk@0.8.3` -> `package/LICENSE` starts with `MIT License`
- `npm pack @asqav/sdk@0.8.2` -> same
- `npm view @asqav/sdk@0.8.3 license` -> `LicenseRef-Elastic-License-2.0`

Root cause: the relicense commit (3581729, #344) rewrote the root `LICENSE`, both manifests, README, and CHANGELOG, but never touched `typescript/LICENSE`, a second copy the npm `files` allowlist (`["dist","README.md","LICENSE"]`) packages verbatim. The project's own CHANGELOG says versions after 0.8.0 are Elastic License 2.0; 0.8.2 and 0.8.3 both shipped the opposite grant in the file a buyer actually reads.

Python's `asqav` package is a different, narrower situation: both the 0.8.3 wheel and sdist ship no LICENSE file at all (checked the real downloaded artifacts). No contradiction there, just an absence. Left out of this PR, noted as a follow-up.

## What's immutable

`@asqav/sdk@0.8.2` and `0.8.3` are already published and cannot be changed or withdrawn. Anyone who already installed them keeps whatever the bundled MIT file grants them for those specific versions. This PR only fixes the source so the next publish carries the correct text.

## What this PR does

- Replaces `typescript/LICENSE` with the byte-identical Elastic License 2.0 text from the repo's canonical `LICENSE`. No change to the declared license itself, `package.json`'s `license` field is untouched.
- Adds `typescript/tests/license-consistency.test.ts`, which runs a real `npm pack --dry-run` to find the file npm would actually ship, then checks its content against the declared license. Proven to fail on the unfixed tree first.
- Adds a CHANGELOG entry under `Unreleased`.
- No version bump. This repo bumps version files at release/tag time, and `Unreleased` already carries unrelated changes accumulated since the last tag.

## Proof of work

VERIFY-WITH: `npm pack --dry-run` (from `typescript/`, after `npm run build`)
```
npm notice 3.9kB LICENSE
npm notice Tarball Details
npm notice name: @asqav/sdk
npm notice version: 0.8.3
npm notice shasum: b6e0538cc3b3ab439556581a5b0fc46ede112257
npm notice total files: 54
```
3.9kB is the Elastic text. The pre-fix MIT file was 1.1kB. 54 total files matches the real published 0.8.3 tarball's file count.

Test proven to fail against the unfixed tree, then pass:
```
# before fix
AssertionError: expected 'MIT License\n\nCopyright (c) 2026 Asq...' not to match /^MIT License/
Tests  1 failed | 1 passed (2)

# after fix
Test Files  55 passed (55)
Tests  933 passed (933)
```

CI: the required `ci-ok` check's `typescript` job runs automatically on this PR via the `pull_request` trigger, see the Checks tab. The `python`/`verifier`/`actions` jobs are path-filtered out since this diff touches no `python/**` or `conformance/**` files.

Diff stat:
```
 CHANGELOG.md                                 |  12 +++
 typescript/LICENSE                           | 107 ++++++++++++++++++++++-----
 typescript/tests/license-consistency.test.ts |  58 +++++++++++++++
 3 files changed, 160 insertions(+), 17 deletions(-)
```