### PR TITLE
fix(verifier): resolve the actual signer when an org kid spans sibling keys

### DIFF
--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -144,6 +144,7 @@ class AsqavNativeAdapter(FormatAdapter):
             self.extract_signature(doc).kid,
             payload.get("agent_id") or doc.get("agent_id"),
             payload.get("issuer_id"),
+            payload.get("org_id") or doc.get("org_id"),
         )
 
     def resolve_key(self, doc: dict, key_provider: Any) -> tuple[bytes | None, str]:

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -368,13 +368,16 @@ def _match_key_by_id(jwks: dict, kid: str):
     return None
 
 
-def _match_key_by_agent(jwks: dict, agent_id, issuer_id):
+def _match_key_by_agent(jwks: dict, agent_id, issuer_id, org_id=None):
     """Return the first usable jwks entry for an agent key bound to a claimed issuer.
 
     The single agent-side matcher, so the entry a signature verifies against is the
     same entry every published field is read from. agent_id is attacker-controlled,
-    so a match also requires the key's published issuer_id to equal the issuer the
-    receipt claims inside its signed bytes.
+    so a match also requires the key's published issuer_id (or org_id) to equal the
+    issuer the receipt claims inside its signed bytes. A hash-mode receipt signs the
+    raw org_id rather than issuer_id, so the org binding answers for that shape: an
+    org publishes issuer_id == org_id on every key it owns, and agent_id is unique
+    per key, so agent_id plus the org binding names exactly one signer.
     """
     keys = jwks.get("keys") if isinstance(jwks, dict) else None
     if not isinstance(keys, list):
@@ -382,19 +385,18 @@ def _match_key_by_agent(jwks: dict, agent_id, issuer_id):
     for k in keys:
         if not isinstance(k, dict):
             continue
-        if (
-            agent_id
-            and agent_id == k.get("agent_id")
-            and issuer_id
-            and issuer_id == k.get("issuer_id")
-        ):
+        if not (agent_id and agent_id == k.get("agent_id")):
+            continue
+        issuer_bound = issuer_id and issuer_id == k.get("issuer_id")
+        org_bound = org_id and org_id == k.get("org_id")
+        if issuer_bound or org_bound:
             if not isinstance(k.get("public_key"), str):
                 continue
             return k
     return None
 
 
-def match_signing_key(jwks: dict, kid: str, agent_id=None, issuer_id=None):
+def match_signing_key(jwks: dict, kid: str, agent_id=None, issuer_id=None, org_id=None):
     """Return the one jwks entry a receipt's signature is checked against.
 
     Exact key id, then the agent bind, then the bare-kid issuer match. Every caller
@@ -408,12 +410,13 @@ def match_signing_key(jwks: dict, kid: str, agent_id=None, issuer_id=None):
     owns, so an org-shaped kid matches each sibling alike and list position picks one.
     Position binds nothing: agent_id and issuer_id both sit inside the signed bytes,
     so the pair names the signer, while the sibling it lands on holds other key bytes,
-    another revocation status and another agent.
+    another revocation status and another agent. The agent bind carries the org_id a
+    hash-mode receipt signs, so the correct sibling resolves before the loose match.
     """
     entry = _match_key_by_id(jwks, kid)
     if entry is not None:
         return entry
-    entry = _match_key_by_agent(jwks, agent_id, issuer_id)
+    entry = _match_key_by_agent(jwks, agent_id, issuer_id, org_id)
     if entry is not None:
         return entry
     return _match_key(jwks, kid)
@@ -457,17 +460,17 @@ def resolve_key_issuer(jwks: dict, kid: str):
     return key_issuer_of(_match_key(jwks, kid))
 
 
-def resolve_key_by_agent_id(jwks: dict, agent_id: str, issuer_id: str):
+def resolve_key_by_agent_id(jwks: dict, agent_id: str, issuer_id: str, org_id: str | None = None):
     """Return (public_key_bytes, status, alg, kid, key_issuer_id) for an agent key.
 
     Cloud receipts set signature.kid to the issuer (org) id but sign with the
     agent's own key; the JWKS publishes agent_id per key, so the signing key is
     resolvable by the receipt's agent_id. agent_id is attacker-controlled, so a
-    match also requires the key's published issuer_id to equal the receipt's
-    claimed issuer_id: without that bind a valid key from any org would verify a
-    receipt claiming a different issuer. Same defensive shape as resolve_key.
+    match also requires the key's published issuer_id (or org_id) to equal the
+    receipt's claimed issuer: without that bind a valid key from any org would
+    verify a receipt claiming a different issuer. Same defensive shape as resolve_key.
     """
-    k = _match_key_by_agent(jwks, agent_id, issuer_id)
+    k = _match_key_by_agent(jwks, agent_id, issuer_id, org_id)
     if k is None:
         return None, None, None, None, None
     return (
@@ -845,8 +848,9 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
         # agent_id is attacker-controlled, so trust only a key whose issuer_id matches.
         if sig_res[0] != "PASS":
             agent_id = payload.get("agent_id") or envelope.get("agent_id")
+            org_bind = payload.get("org_id") or envelope.get("org_id")
             pk_a, status_a, alg_a, kid_a, issuer_a = resolve_key_by_agent_id(
-                jwks, agent_id, payload.get("issuer_id")
+                jwks, agent_id, payload.get("issuer_id"), org_bind
             )
             if pk_a is not None:
                 sig_res_a = verify_signature(pk_a, msg, sig, alg_a or alg or jwks_alg)
@@ -1017,8 +1021,9 @@ def run_structured(
         # key whose published issuer_id matches the claimed issuer.
         if sig_res[0] != "PASS":
             agent_id = payload.get("agent_id") or envelope.get("agent_id")
+            org_bind = payload.get("org_id") or envelope.get("org_id")
             pk_a, status_a, alg_a, kid_a, issuer_a = resolve_key_by_agent_id(
-                jwks, agent_id, payload.get("issuer_id")
+                jwks, agent_id, payload.get("issuer_id"), org_bind
             )
             if pk_a is not None:
                 sig_res_a = verify_signature(pk_a, msg, sig_bytes, alg_a or alg or jwks_alg)

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -215,7 +215,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 50
+    assert len(results) == 51
     # asqav-05 (INCOMPLETE) upgrades to PASS when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/python/tests/test_oracle_multikey_org_resolution.py
+++ b/python/tests/test_oracle_multikey_org_resolution.py
@@ -1,0 +1,149 @@
+"""A multi-agent org's receipts resolve the actual signer, not the first sibling.
+
+Criterion 232. A cloud hash-mode receipt sets signature.kid to the ORG id and signs
+with the agent's own key, while the directory publishes every key the org owns under
+that same issuer_id/org_id. A kid-shaped match therefore answers for the whole sibling
+set and list position picks one, so a receipt signed by any sibling but the first used
+to verify against the wrong key and read as a false FAIL. These gates pin the agent
+bind (agent_id plus the org_id the receipt signs) that resolves the correct signer.
+
+ANTI-VACUOUS: the signer here is the LAST of three siblings; against the pre-change
+kid-first resolution the signature axis checks the FIRST sibling and FAILs, so the
+PASS assertions only hold once the org-bound agent match resolves the real signer.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from asqav.verifier import verify_receipt as v
+from asqav.verifier.oracle import crypto
+from asqav.verifier.oracle.adapters.asqav_native import AsqavNativeAdapter
+from asqav.verifier.oracle.canonical import asqav_jcs
+from asqav.verifier.oracle.core import verify
+
+_ED25519_AVAILABLE = crypto.verify_ed25519(b"\x00" * 32, b"m", b"\x00" * 64)[0] != crypto.SKIPPED
+
+requires_ed25519 = pytest.mark.skipif(
+    not _ED25519_AVAILABLE, reason="cryptography not installed; Ed25519 verify SKIPs"
+)
+
+ORG = "org_multikey_shared"
+
+
+def _flat(agent_id: str) -> dict:
+    """A hash-mode signing payload naming its agent and org inside the signed bytes."""
+    return {
+        "v": 1,
+        "mode": "hash",
+        "hash": "c" * 64,
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-01-01T00:00:00Z",
+        "action_id": "act_1",
+        "agent_id": agent_id,
+        "org_id": ORG,
+        "policy_digest": "d" * 64,
+        "policy_decision": "allow",
+    }
+
+
+def _sign(flat: dict, sk) -> dict:
+    """Build the hash-mode receipt envelope signed by sk over the canonical flat bytes."""
+    sig = base64.b64encode(sk.sign(asqav_jcs(flat))).decode()
+    doc = dict(flat)
+    doc["payload"] = None
+    doc["algorithm"] = "Ed25519"
+    doc["key_id"] = ORG
+    doc["signature_b64"] = sig
+    return doc
+
+
+def _sibling_jwks(signer_index: int, public_keys: list[bytes]) -> dict:
+    """Three sibling keys sharing issuer_id/org_id; agent_id uniquely names each."""
+    keys = []
+    for i, pk in enumerate(public_keys):
+        keys.append(
+            {
+                "kid": f"crypto_kid_{i}",
+                "agent_id": f"agt_{i}",
+                "issuer_id": ORG,
+                "org_id": ORG,
+                "alg": "Ed25519",
+                "public_key": base64.b64encode(pk).decode(),
+                "status": "active",
+            }
+        )
+    return {"keys": keys}
+
+
+@requires_ed25519
+def test_last_sibling_receipt_resolves_the_actual_signer() -> None:
+    """A receipt signed by the last of three siblings verifies to PASS, not a false FAIL."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    sks = [Ed25519PrivateKey.generate() for _ in range(3)]
+    pks = [sk.public_key().public_bytes_raw() for sk in sks]
+    flat = _flat("agt_2")
+    receipt = _sign(flat, sks[2])
+    jwks = _sibling_jwks(2, pks)
+
+    result = verify(receipt, [AsqavNativeAdapter()], key_provider=jwks)
+    assert result.axis("signature").result == "PASS", result.axes
+    assert result.verdict == "PASS", result.axes
+
+
+@requires_ed25519
+def test_each_sibling_resolves_to_its_own_key() -> None:
+    """Whichever sibling signs, the agent bind resolves that sibling's key, never another."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    sks = [Ed25519PrivateKey.generate() for _ in range(3)]
+    pks = [sk.public_key().public_bytes_raw() for sk in sks]
+    jwks = _sibling_jwks(0, pks)
+    ad = AsqavNativeAdapter()
+    for i, sk in enumerate(sks):
+        receipt = _sign(_flat(f"agt_{i}"), sk)
+        pk, note = ad.resolve_key(receipt, jwks)
+        assert pk == pks[i], (i, note)
+        assert verify(receipt, [ad], key_provider=jwks).verdict == "PASS"
+
+
+@requires_ed25519
+def test_forged_signature_against_the_org_still_fails() -> None:
+    """A signature from a key the directory does not publish fails, never a false PASS."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    sks = [Ed25519PrivateKey.generate() for _ in range(3)]
+    pks = [sk.public_key().public_bytes_raw() for sk in sks]
+    attacker = Ed25519PrivateKey.generate()
+    receipt = _sign(_flat("agt_2"), attacker)
+    jwks = _sibling_jwks(2, pks)
+
+    result = verify(receipt, [AsqavNativeAdapter()], key_provider=jwks)
+    assert result.verdict != "PASS", result.axes
+
+
+@requires_ed25519
+def test_cross_org_agent_bind_does_not_match() -> None:
+    """agent_id is attacker-controlled: a key from another org never resolves the claim."""
+    entry = v._match_key_by_agent(
+        {
+            "keys": [
+                {
+                    "kid": "foreign",
+                    "agent_id": "agt_2",
+                    "issuer_id": "some-other-org",
+                    "org_id": "some-other-org",
+                    "public_key": "QUFBQQ==",
+                    "status": "active",
+                }
+            ]
+        },
+        "agt_2",
+        None,
+        ORG,
+    )
+    assert entry is None, "a foreign-org key must not satisfy the org binding"

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -145,6 +145,7 @@ export class AsqavNativeAdapter extends FormatAdapter {
       this.extractSignature(doc).kid,
       payload.agent_id ?? doc.agent_id,
       payload.issuer_id,
+      payload.org_id ?? doc.org_id,
     );
   }
 

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -134,18 +134,23 @@ function matchKeyById(
 }
 
 // An agent key bound to the issuer the receipt claims (mirrors `_match_key_by_agent`).
-// agent_id is attacker-controlled, so the key's published issuer must equal the one
-// the receipt names inside its signed bytes.
+// agent_id is attacker-controlled, so the key's published issuer (or org) must equal
+// the one the receipt names inside its signed bytes; a hash-mode receipt signs the raw
+// org_id, so the org binding answers for that shape and names exactly one sibling.
 function matchKeyByAgent(
   jwks: Record<string, unknown> | null,
   agentId: unknown,
   issuerId: unknown,
+  orgId?: unknown,
 ): Record<string, unknown> | null {
   const keys = jwks?.keys;
   if (!Array.isArray(keys)) return null;
   for (const k of keys as Array<Record<string, unknown>>) {
     if (k === null || typeof k !== "object") continue;
-    if (agentId && agentId === k.agent_id && issuerId && issuerId === k.issuer_id) {
+    if (!(agentId && agentId === k.agent_id)) continue;
+    const issuerBound = issuerId && issuerId === k.issuer_id;
+    const orgBound = orgId && orgId === k.org_id;
+    if (issuerBound || orgBound) {
       if (typeof k.public_key !== "string") continue;
       return k;
     }
@@ -161,16 +166,20 @@ function matchKeyByAgent(
  * publishes issuer_id on every key that org owns, so an org-shaped kid matches each
  * sibling alike and list position picks one. Position binds nothing: agent_id and
  * issuer_id both sit inside the signed bytes, so the pair names the signer, while the
- * sibling it lands on holds other key bytes and another revocation status.
+ * sibling it lands on holds other key bytes and another revocation status. The agent
+ * bind carries the org_id a hash-mode receipt signs, so the right sibling resolves.
  */
 export function matchSigningKey(
   jwks: Record<string, unknown> | null,
   kid: string,
   agentId?: unknown,
   issuerId?: unknown,
+  orgId?: unknown,
 ): Record<string, unknown> | null {
   return (
-    matchKeyById(jwks, kid) ?? matchKeyByAgent(jwks, agentId, issuerId) ?? matchKey(jwks, kid)
+    matchKeyById(jwks, kid) ??
+    matchKeyByAgent(jwks, agentId, issuerId, orgId) ??
+    matchKey(jwks, kid)
   );
 }
 

--- a/typescript/tests/signing-key-sibling-hashmode.test.ts
+++ b/typescript/tests/signing-key-sibling-hashmode.test.ts
@@ -1,0 +1,95 @@
+// A multi-agent org's hash-mode receipts resolve the actual signer, not the first
+// sibling. The TypeScript half of python/tests/test_oracle_multikey_org_resolution.py:
+// a hash-mode receipt sets signature.kid to the org id and signs with the agent's own
+// key, so the agent bind (agent_id plus the org_id the receipt signs) must pick the
+// signer. ANTI-VACUOUS: the signer is the LAST of three siblings, so the pre-change
+// kid-first resolution checks the first sibling and FAILs the signature axis.
+
+import { describe, expect, it } from "vitest";
+import { ml_dsa65 } from "@noble/post-quantum/ml-dsa.js";
+
+import { AsqavNativeAdapter } from "../src/verifier/adapters/asqavNative.js";
+import { asqavJcs } from "../src/verifier/canonical.js";
+import { verify } from "../src/verifier/core.js";
+
+const ORG = "org_multikey_shared";
+
+function flat(agentId: string): Record<string, unknown> {
+  return {
+    v: 1,
+    mode: "hash",
+    hash: "c".repeat(64),
+    hash_algo: "sha256",
+    metadata: {},
+    server_timestamp: "2026-01-01T00:00:00Z",
+    action_id: "act_1",
+    agent_id: agentId,
+    org_id: ORG,
+    policy_digest: "d".repeat(64),
+    policy_decision: "allow",
+  };
+}
+
+function hashReceipt(f: Record<string, unknown>, sig: string): Record<string, unknown> {
+  return {
+    ...f,
+    payload: null,
+    algorithm: "ML-DSA-65",
+    key_id: ORG,
+    signature_b64: sig,
+  };
+}
+
+function siblingKey(i: number, publicKey: Uint8Array): Record<string, unknown> {
+  return {
+    kid: `crypto_kid_${i}`,
+    agent_id: `agt_${i}`,
+    issuer_id: ORG,
+    org_id: ORG,
+    alg: "ML-DSA-65",
+    public_key: Buffer.from(publicKey).toString("base64"),
+    status: "active",
+  };
+}
+
+function axesOf(res: ReturnType<typeof verify>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const a of res.axes) out[a.axis] = a.result;
+  return out;
+}
+
+describe("hash-mode resolution across three org siblings", () => {
+  it("passes a receipt signed by the last sibling", () => {
+    const sks = [ml_dsa65.keygen(), ml_dsa65.keygen(), ml_dsa65.keygen()];
+    const f = flat("agt_2");
+    const sig = Buffer.from(ml_dsa65.sign(asqavJcs(f), sks[2].secretKey)).toString("base64");
+    const jwks = { keys: sks.map((kp, i) => siblingKey(i, kp.publicKey)) };
+    const res = verify(hashReceipt(f, sig), [new AsqavNativeAdapter()], jwks);
+    const axes = axesOf(res);
+    expect(axes.signature, JSON.stringify(axes)).toBe("PASS");
+    expect(res.verdict, JSON.stringify(axes)).toBe("PASS");
+  });
+
+  it("resolves each sibling to its own key", () => {
+    const sks = [ml_dsa65.keygen(), ml_dsa65.keygen(), ml_dsa65.keygen()];
+    const jwks = { keys: sks.map((kp, i) => siblingKey(i, kp.publicKey)) };
+    const ad = new AsqavNativeAdapter();
+    sks.forEach((kp, i) => {
+      const f = flat(`agt_${i}`);
+      const sig = Buffer.from(ml_dsa65.sign(asqavJcs(f), kp.secretKey)).toString("base64");
+      const [pk] = ad.resolveKey(hashReceipt(f, sig), jwks);
+      expect(pk).not.toBeNull();
+      expect(Buffer.from(pk as Uint8Array).equals(Buffer.from(kp.publicKey))).toBe(true);
+    });
+  });
+
+  it("rejects a signature from an unpublished key", () => {
+    const sks = [ml_dsa65.keygen(), ml_dsa65.keygen(), ml_dsa65.keygen()];
+    const forger = ml_dsa65.keygen();
+    const f = flat("agt_2");
+    const sig = Buffer.from(ml_dsa65.sign(asqavJcs(f), forger.secretKey)).toString("base64");
+    const jwks = { keys: sks.map((kp, i) => siblingKey(i, kp.publicKey)) };
+    const res = verify(hashReceipt(f, sig), [new AsqavNativeAdapter()], jwks);
+    expect(res.verdict).not.toBe("PASS");
+  });
+});

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -27,7 +27,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 50 corpus vectors", () => {
+  it("matches every manifest outcome across all 51 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -43,9 +43,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(50);
+    expect(results.length).toBe(51);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(50);
+    expect(passed).toBe(51);
   });
 });
 

--- a/verifier/conformance-vectors/asqav-10-hash-mode-multikey/expected.json
+++ b/verifier/conformance-vectors/asqav-10-hash-mode-multikey/expected.json
@@ -1,0 +1,3 @@
+{
+  "verdict": "PASS"
+}

--- a/verifier/conformance-vectors/asqav-10-hash-mode-multikey/jwks.json
+++ b/verifier/conformance-vectors/asqav-10-hash-mode-multikey/jwks.json
@@ -1,0 +1,31 @@
+{
+  "keys": [
+    {
+      "kid": "vec_kid_0",
+      "agent_id": "agt_0",
+      "issuer_id": "org_multikey_vec",
+      "org_id": "org_multikey_vec",
+      "alg": "Ed25519",
+      "public_key": "iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w=",
+      "status": "active"
+    },
+    {
+      "kid": "vec_kid_1",
+      "agent_id": "agt_1",
+      "issuer_id": "org_multikey_vec",
+      "org_id": "org_multikey_vec",
+      "alg": "Ed25519",
+      "public_key": "gTl3Dqh9F19Wo1Rmw0x+zMuNipG07jeiXfYPW4/Js5Q=",
+      "status": "active"
+    },
+    {
+      "kid": "vec_kid_2",
+      "agent_id": "agt_2",
+      "issuer_id": "org_multikey_vec",
+      "org_id": "org_multikey_vec",
+      "alg": "Ed25519",
+      "public_key": "7UkoxijRwsbq6QM4kFmVYSlZJzpcY/k2NsFGFKyHN9E=",
+      "status": "active"
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-10-hash-mode-multikey/receipt.json
+++ b/verifier/conformance-vectors/asqav-10-hash-mode-multikey/receipt.json
@@ -1,0 +1,18 @@
+{
+  "v": 1,
+  "mode": "hash",
+  "hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "hash_algo": "sha256",
+  "metadata": {},
+  "server_timestamp": "2026-01-01T00:00:00Z",
+  "action_id": "act_vec",
+  "agent_id": "agt_2",
+  "org_id": "org_multikey_vec",
+  "policy_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "policy_decision": "allow",
+  "payload": null,
+  "algorithm": "Ed25519",
+  "key_id": "org_multikey_vec",
+  "signature_b64": "E7mmk0lw7mzAjFkdfMfLg04BAnnIybu60r/AaCGtm/imVyZINRtvjyCQXXFT6Rmqb+hrQszXMpuVHDZGDo5FAA==",
+  "anchors": null
+}

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -348,5 +348,12 @@
     "outcome": "FAIL",
     "reason_code": "issuer_signature",
     "notes": "The v:2 receipt with signer flipped after signing; because signer sits inside the signed body the canonical bytes diverge and Ed25519 verify FAILs. Parity vector: both PY and TS must FAIL, proving signer is inside the signed coverage, not loose metadata."
+  },
+  {
+    "dir": "asqav-10-hash-mode-multikey",
+    "format": "asqav-native",
+    "outcome": "PASS",
+    "reason_code": "",
+    "notes": "Hash-mode receipt signed by the LAST of three sibling keys that share issuer_id/org_id; signature.kid is the org id, so a kid-shaped match answers for every sibling and list position would pick the wrong one. The agent bind (agent_id plus the org_id the receipt signs) resolves the actual signer. ANTI-VACUOUS: pre-change kid-first resolution verifies the first sibling and FAILs. Parity vector: both PY and TS oracles must PASS."
   }
 ]


### PR DESCRIPTION
Criterion 232. A cloud hash-mode receipt sets signature.kid to the org id and signs with the agent's own key, while the public directory publishes every key the org owns under that same issuer_id and org_id (the live directory has an org with 46 sibling keys sharing one issuer_id). The kid-shaped match answered for the whole sibling set and list position picked one, so a receipt signed by any sibling but the first verified against the wrong key and read as a FALSE FAIL on every offline surface.

The agent bind already names the signer by agent_id, but it required an issuer_id that hash-mode receipts do not carry (they sign the raw org_id). This extends the bind to also match the org_id the hash-mode receipt signs, and threads the org binding through match_signing_key, the asqav-native oracle adapter, the run/run_structured fallback, and the TypeScript vrShim mirror. agent_id is unique per key and both agent_id and org_id sit inside the signed bytes, so the pair still names exactly one signer; a foreign-org key never satisfies the bind.

Verification (reproduced):
- Live directory re-derived: 129 keys, one org with 46 siblings all sharing issuer_id == org_id, each kid a distinct crypto key id (not the org id); integrity.py:91 sets signature.kid = issuer_id, confirming the org-kid shape.
- New three-sibling conformance vector asqav-10-hash-mode-multikey (signed by the LAST sibling) verifies to PASS; corpus is 51/51 in both Python and TypeScript.
- ANTI-VACUOUS: the new vector and the Python/TypeScript multi-key tests FAIL against the pre-change kid-first resolution (stash-verified: 50/51 corpus + 3 failing unit tests pre-change).
- Adversarial negatives: a signature from an unpublished key FAILs; a key published under another org does not resolve.
- Full Python SDK suite 2697 passed; full TypeScript suite 936 passed; tsc and ruff clean.

THREAT_MODEL:
- attack surface: key resolution for receipts whose kid is shared across sibling keys
- existing guard: agent_id is attacker-controlled, so the bind still requires the key's published issuer_id OR org_id to equal the claim; the signature itself is the cryptographic gate and is checked against the resolved key
- new test: multi-key tests + conformance vector assert the correct sibling resolves and that forgery and cross-org keys FAIL
- trust boundary changed: no; resolution only selects which published key to verify against, and a foreign-org key never matches the bind

comment hygiene clean