### PR TITLE
refactor(verifier): name the claim-bind predicate in the Python signing-key resolver (criterion 339)

### DIFF
--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -368,16 +368,26 @@ def _match_key_by_id(jwks: dict, kid: str):
     return None
 
 
+def _key_bound_to_claimant(k: dict, issuer_id, org_id=None):
+    """Return True when a key's published issuer or org equals the claimed one.
+
+    agent_id is attacker-controlled, so this claim bind, not the agent match alone,
+    decides which sibling a receipt verifies against. A hash-mode receipt signs the
+    raw org_id rather than issuer_id, so the org binding answers for that shape and
+    names exactly one signer.
+    """
+    issuer_bound = issuer_id and issuer_id == k.get("issuer_id")
+    org_bound = org_id and org_id == k.get("org_id")
+    return bool(issuer_bound or org_bound)
+
+
 def _match_key_by_agent(jwks: dict, agent_id, issuer_id, org_id=None):
     """Return the first usable jwks entry for an agent key bound to a claimed issuer.
 
     The single agent-side matcher, so the entry a signature verifies against is the
-    same entry every published field is read from. agent_id is attacker-controlled,
-    so a match also requires the key's published issuer_id (or org_id) to equal the
-    issuer the receipt claims inside its signed bytes. A hash-mode receipt signs the
-    raw org_id rather than issuer_id, so the org binding answers for that shape: an
-    org publishes issuer_id == org_id on every key it owns, and agent_id is unique
-    per key, so agent_id plus the org binding names exactly one signer.
+    same entry every published field is read from. An org publishes issuer_id ==
+    org_id on every key it owns, and agent_id is unique per key, so agent_id plus
+    the claim bind names exactly one signer.
     """
     keys = jwks.get("keys") if isinstance(jwks, dict) else None
     if not isinstance(keys, list):
@@ -387,9 +397,7 @@ def _match_key_by_agent(jwks: dict, agent_id, issuer_id, org_id=None):
             continue
         if not (agent_id and agent_id == k.get("agent_id")):
             continue
-        issuer_bound = issuer_id and issuer_id == k.get("issuer_id")
-        org_bound = org_id and org_id == k.get("org_id")
-        if issuer_bound or org_bound:
+        if _key_bound_to_claimant(k, issuer_id, org_id):
             if not isinstance(k.get("public_key"), str):
                 continue
             return k

--- a/python/tests/test_signing_key_sibling.py
+++ b/python/tests/test_signing_key_sibling.py
@@ -122,6 +122,29 @@ def test_org_kid_answers_for_an_agent_the_directory_omits() -> None:
     assert entry["kid"] == "key-agent-one"
 
 
+def test_three_key_org_resolves_its_middle_signer() -> None:
+    """A directory of three siblings answers for the middle one, not the first."""
+    jwks = {"keys": [_key("key-agent-one", "agt_one"), _key("key-agent-two", "agt_two"),
+                     _key("key-agent-three", "agt_three")]}
+    entry = v.match_signing_key(jwks, ORG, "agt_two", ORG)
+    assert entry is not None
+    assert entry["kid"] == "key-agent-two"
+    last = v.match_signing_key(jwks, ORG, "agt_three", ORG)
+    assert last is not None
+    assert last["kid"] == "key-agent-three"
+
+
+def test_three_key_org_binds_the_middle_signer_by_org() -> None:
+    """A hash-mode receipt signs the raw org_id, so the org bind names the signer."""
+    def org_key(kid: str, agent_id: str) -> dict:
+        return {**_key(kid, agent_id), "org_id": ORG}
+    jwks = {"keys": [org_key("key-agent-one", "agt_one"), org_key("key-agent-two", "agt_two"),
+                     org_key("key-agent-three", "agt_three")]}
+    entry = v.match_signing_key(jwks, "kid-absent", "agt_two", None, ORG)
+    assert entry is not None
+    assert entry["kid"] == "key-agent-two"
+
+
 # --- adversarial: agent_id is attacker-controlled ---
 
 


### PR DESCRIPTION
Extract `_key_bound_to_claimant` from `_match_key_by_agent` so the issuer-or-org bind that picks a sibling key is one named predicate, and pin a three-key org resolving its middle signer by both issuer and org bindings.

Behaviour-preserving: `match_signing_key` still resolves the signing agent rather than a kid matched against issuer_id. The sibling-resolution and multi-key parity suites stay green (18 passed in tests/test_signing_key_sibling.py + tests/test_oracle_multikey_org_resolution.py), and ruff is clean.