### PR TITLE
refactor(verifier): name the one-sided skew bound in the TS clock-skew axis (criterion 316)

### DIFF
--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -379,6 +379,12 @@ function parseIsoMs(issuedAt: unknown): number | null {
   return Number.isNaN(ms) ? null : ms;
 }
 
+// The skew bound is one-sided: only a stamp too far ahead of the wall clock fails,
+// since a backdated issued_at harms nothing the wall clock can detect (mirrors Python)
+function skewWithinBound(skewSeconds: number): boolean {
+  return skewSeconds <= SKEW_BOUND_SECONDS;
+}
+
 /** `issued_at` within the wall-clock bound; returns `[result, note]` (mirrors `check_skew`). */
 export function checkSkew(issuedAt: unknown): readonly [VerifyState, string] {
   const ms = parseIsoMs(issuedAt);
@@ -386,7 +392,7 @@ export function checkSkew(issuedAt: unknown): readonly [VerifyState, string] {
     return ["FAIL", `unparseable issued_at ${JSON.stringify(issuedAt ?? null)}`];
   }
   const skew = (ms - Date.now()) / 1000;
-  if (skew > SKEW_BOUND_SECONDS) {
+  if (!skewWithinBound(skew)) {
     return ["FAIL", `issued_at ${skew.toFixed(0)}s ahead of wall clock (> ${SKEW_BOUND_SECONDS}s)`];
   }
   return ["PASS", `skew ${skew.toFixed(0)}s within bound`];

--- a/typescript/tests/verifier-skew-one-sided.test.ts
+++ b/typescript/tests/verifier-skew-one-sided.test.ts
@@ -1,0 +1,33 @@
+// The clock-skew axis is one-sided: a stamp ahead of the wall clock past the bound
+// fails, while a backdated stamp passes, because the wall clock cannot detect a lie
+// about the past. The TypeScript half of the Python skew table pins the same bound
+
+import { describe, expect, it } from "vitest";
+
+import { checkSkew, SKEW_BOUND_SECONDS } from "../src/verifier/index.js";
+
+function stampAt(offsetSeconds: number): string {
+  return new Date(Date.now() + offsetSeconds * 1000).toISOString();
+}
+
+describe("the skew bound is one-sided", () => {
+  it("keeps the Python bound", () => {
+    expect(SKEW_BOUND_SECONDS).toBe(300);
+  });
+
+  it("passes a stamp in the past", () => {
+    const [result] = checkSkew(stampAt(-3600));
+    expect(result).toBe("PASS");
+  });
+
+  it("passes a stamp just inside the bound", () => {
+    const [result] = checkSkew(stampAt(SKEW_BOUND_SECONDS - 5));
+    expect(result).toBe("PASS");
+  });
+
+  it("fails a stamp past the bound", () => {
+    const [result, note] = checkSkew(stampAt(SKEW_BOUND_SECONDS + 60));
+    expect(result).toBe("FAIL");
+    expect(note).toContain("ahead of wall clock");
+  });
+});


### PR DESCRIPTION
Extract `skewWithinBound` from `checkSkew` so the rule that only a future stamp past the bound fails is one named predicate, and pin the one-sided bound through the published verifier entry with a past stamp that passes and a beyond-bound stamp that fails.

Behaviour-preserving: the TypeScript verifier keeps the anchor-binding and clock-skew axes (SKEW_BOUND_SECONDS=300) and the shared axis-parity table stays green (1163 py + 209 ts passed). tsc and npm run build are clean.