### PR TITLE
refactor(verifier): name the expiry-lapsed verdict in the TS offline expiry axis (criterion 381)

### DIFF
--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -392,6 +392,13 @@ export function checkSkew(issuedAt: unknown): readonly [VerifyState, string] {
   return ["PASS", `skew ${skew.toFixed(0)}s within bound`];
 }
 
+// True once the signed expiry sits in the past (mirrors the hosted signature_expired
+// verdict). The window is a negative delta from the wall clock, so the verdict does
+// not depend on which verifier the reader runs
+function expiryLapsed(deltaSeconds: number): boolean {
+  return deltaSeconds < 0;
+}
+
 /**
  * Refuse a receipt past the expiry its own signer committed to (mirrors `check_expiry`).
  *
@@ -409,7 +416,7 @@ export function checkExpiry(payload: unknown): readonly [VerifyState, string] {
     return ["FAIL", `unreadable expires_at ${pyRepr(raw)}; refused rather than read as no expiry`];
   }
   const delta = (ms - Date.now()) / 1000;
-  if (delta < 0) {
+  if (expiryLapsed(delta)) {
     return ["FAIL", `expires_at ${pyStr(raw)} lapsed ${(-delta).toFixed(0)}s ago`];
   }
   return ["PASS", `expires_at ${pyStr(raw)} is ${delta.toFixed(0)}s ahead`];

--- a/typescript/tests/verifier-expiry-offline.test.ts
+++ b/typescript/tests/verifier-expiry-offline.test.ts
@@ -1,0 +1,35 @@
+// The offline verifier refuses a receipt whose signed expires_at is in the past, so
+// the verdict does not depend on which verifier the reader runs. The window is read
+// from inside the signed bytes; the TypeScript half of the Python control lives in
+// python/tests/test_expiry_offline.py
+
+import { describe, expect, it } from "vitest";
+
+import { checkExpiry } from "../src/verifier/index.js";
+
+function stampAt(offsetSeconds: number): string {
+  return new Date(Date.now() + offsetSeconds * 1000).toISOString();
+}
+
+describe("the offline expiry axis", () => {
+  it("fails a receipt whose signed expires_at lapsed", () => {
+    const [result, note] = checkExpiry({ expires_at: stampAt(-3600) });
+    expect(result).toBe("FAIL");
+    expect(note).toContain("lapsed");
+  });
+
+  it("passes a non-expired control", () => {
+    const [result] = checkExpiry({ expires_at: stampAt(3600) });
+    expect(result).toBe("PASS");
+  });
+
+  it("passes a receipt that declares no expiry", () => {
+    const [result] = checkExpiry({});
+    expect(result).toBe("PASS");
+  });
+
+  it("fails closed on an unreadable expires_at", () => {
+    const [result] = checkExpiry({ expires_at: "not-a-stamp" });
+    expect(result).toBe("FAIL");
+  });
+});


### PR DESCRIPTION
Extract `expiryLapsed` from `checkExpiry` so the rule that a negative signed window fails is one named predicate, and pin the offline control with an expired receipt that fails, a non-expired one that passes, a no-expiry pass and an unreadable fail-closed.

Behaviour-preserving: the offline verifier still refuses a receipt whose signed expires_at is in the past in both language halves. The shared expiry parity table and the offline-verify suite stay green (120 py + 170 ts passed). tsc and npm run build are clean.