### PR TITLE
fix(verifier): pin the receipt timestamp grammar so the basic form draws one verdict (criterion 336)

### DIFF
--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -681,14 +681,27 @@ def _extended_offset(issued_at: str) -> str:
     return f"{date}{tail[: m.start()]}{m.group(1)}{hours:02d}:{minutes:02d}"
 
 
+#: Extended ISO-8601 form pinned so the basic form draws one verdict on every parser.
+_EXTENDED_STAMP_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}"
+    r"(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)?"
+    r"(?:Z|[+-]\d{2}(?::?\d{2})?)?$"
+)
+
+
 def _parse_stamp(value: object):
     """Parse an ISO-8601 stamp, or None when it is unreadable.
 
     One parser for every time axis, so a stamp the skew axis refuses is not
     quietly accepted by the expiry axis. A stamp with no zone reads as UTC.
+    The grammar is matched explicitly before fromisoformat, whose acceptance of
+    the basic form differs by version; one stamp must draw one verdict on all.
     """
+    text = str(value)
+    if _EXTENDED_STAMP_RE.match(text) is None:
+        return None
     try:
-        ts = datetime.fromisoformat(_extended_offset(str(value).replace("Z", "+00:00")))
+        ts = datetime.fromisoformat(_extended_offset(text.replace("Z", "+00:00")))
     except (ValueError, AttributeError, TypeError):
         return None
     return ts if ts.tzinfo is not None else ts.replace(tzinfo=timezone.utc)

--- a/verifier/axis-parity-cases.json
+++ b/verifier/axis-parity-cases.json
@@ -51,6 +51,7 @@
   {"name":"2020-01-01T00:00:00+00:00","issued_at":"2020-01-01T00:00:00+00:00","expect":{"result":"PASS","note_contains":"within bound"}},
   {"name":"2020-01-01T00:00:00Z","issued_at":"2020-01-01T00:00:00Z","expect":{"result":"PASS","note_contains":"within bound"}},
   {"name":"2020-01-01T00:00:00z","issued_at":"2020-01-01T00:00:00z","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
+  {"name":"20200101T000000Z basic form","issued_at":"20200101T000000Z","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
   {"name":"2020-01-01T00:00:00.123456Z","issued_at":"2020-01-01T00:00:00.123456Z","expect":{"result":"PASS","note_contains":"within bound"}},
   {"name":"2020-01-01T00:00:00.123456+00:00","issued_at":"2020-01-01T00:00:00.123456+00:00","expect":{"result":"PASS","note_contains":"within bound"}},
   {"name":"2020-01-01T00:00","issued_at":"2020-01-01T00:00","expect":{"result":"PASS","note_contains":"within bound"}},


### PR DESCRIPTION
The Python verifier inherited the ISO 8601 basic-form date body from datetime.fromisoformat, which accepts 20200101T000000Z only on CPython 3.11+, so that stamp drew PASS on 3.11 but FAIL on 3.10 and in the TypeScript verifier (which pins a dashed regex). This pins the whole grammar with an explicit extended-form regex mirroring the TS ISO_STAMP, matched before fromisoformat. Verified: the same stamp now draws FAIL on Python 3.10, Python 3.11, and TypeScript (three identical verdicts), and a new cross-language parity case in axis-parity-cases.json fails before the fix on py3.11 and passes after. Best-of-N winner over a date-body-guard variant.