### PR TITLE
fix(client): label keyed hash-only digest as hmac-sha256 (criterion 225)

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -1467,8 +1467,11 @@ def _build_sign_body(
         payload_size = len(canonical_bytes)
         if _org_salt is not None:
             digest_hex = hmac.new(_org_salt, canonical_bytes, hashlib.sha256).hexdigest()
+            hash_algo = "hmac-sha256"
         else:
             digest_hex = hashlib.sha256(canonical_bytes).hexdigest()
+            hash_algo = "sha256"
+        # Wire digest keeps the sha256:<32-byte hex> shape; hash_algo names the keyedness
         digest = f"sha256:{digest_hex}"
         metadata: dict[str, Any] = {
             "agent_id": agent_id,
@@ -1490,7 +1493,7 @@ def _build_sign_body(
         body: dict[str, Any] = {
             "action_type": action_type,
             "hash": digest,
-            "hash_algo": "sha256",
+            "hash_algo": hash_algo,
             "payload_size": payload_size,
             "metadata": metadata,
             "session_id": session_id,

--- a/python/tests/test_client_hash_mode.py
+++ b/python/tests/test_client_hash_mode.py
@@ -235,20 +235,27 @@ def test_hash_only_uses_hmac_when_org_salt_set() -> None:
     agent = _make_agent()
     plain_hash = None
     salted_hash = None
+    plain_algo = None
+    salted_algo = None
 
     client_mod._mode = "hash-only"
     client_mod._org_salt = None
     with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
         agent.sign("api:call", {"k": 3})
         plain_hash = mock_post.call_args[0][1]["hash"]
+        plain_algo = mock_post.call_args[0][1]["hash_algo"]
 
     client_mod._org_salt = b"\x01" * 32
     with patch("asqav.client._post", return_value=MOCK_SIGN_RESPONSE) as mock_post:
         agent.sign("api:call", {"k": 3})
         salted_hash = mock_post.call_args[0][1]["hash"]
+        salted_algo = mock_post.call_args[0][1]["hash_algo"]
 
     assert plain_hash != salted_hash
     assert plain_hash.startswith("sha256:") and salted_hash.startswith("sha256:")
+    # The keyed digest must not be labelled plain sha256 on the wire
+    assert plain_algo == "sha256"
+    assert salted_algo == "hmac-sha256"
 
 
 def test_init_resolves_mode_from_url() -> None:


### PR DESCRIPTION
When an org_salt is set, hash-only mode computes an HMAC-SHA256 digest but labelled it hash_algo=sha256 on the wire. It now emits hash_algo=hmac-sha256 so the cloud and verifier can report the distinct verified_keyed verdict. The wire digest keeps the sha256:<32-byte hex> shape the server validates; hash_algo carries the keyedness. Companion to asqav PR #1366. Revert control: stashing the client.py fix fails test_hash_only_uses_hmac_when_org_salt_set; restored, all 12 pass.

Generated with Qwen Code (9-shotted by Qwen-Coder)