### PR TITLE
fix(sdk): label TS keyed hash-only digest as hmac-sha256, not sha256 (criterion 433)

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1984,6 +1984,8 @@ async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, un
     const hex = salt
       ? createHmac("sha256", Buffer.from(salt)).update(canonical).digest("hex")
       : createHash("sha256").update(canonical).digest("hex");
+    // Wire digest keeps the sha256:<32-byte hex> shape; hash_algo names the keyedness
+    const hashAlgo = salt ? "hmac-sha256" : "sha256";
     const digest = `sha256:${hex}`;
     const metadata: Record<string, unknown> = {
       agent_id: args.agentId,
@@ -2001,7 +2003,7 @@ async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, un
     const hashBody: Record<string, unknown> = {
       action_type: args.actionType,
       hash: digest,
-      hash_algo: "sha256",
+      hash_algo: hashAlgo,
       payload_size: payloadSize,
       metadata,
       session_id: args.sessionId,

--- a/typescript/tests/clientHashMode.test.ts
+++ b/typescript/tests/clientHashMode.test.ts
@@ -292,6 +292,34 @@ describe("Agent.sign body shape across modes", () => {
     expect(plain.startsWith("sha256:")).toBe(true);
     expect(salted.startsWith("sha256:")).toBe(true);
   });
+
+  it("hash-only labels a keyed digest hmac-sha256, not sha256", async () => {
+    const agent = await makeAgent();
+
+    _setModeForTests("hash-only");
+    let fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+    await agent.sign({ actionType: "api:call", context: { k: 3 } });
+    const plainBody = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    fetchSpy.mockRestore();
+
+    _setModeForTests("hash-only", new Uint8Array(32).fill(1));
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
+    await agent.sign({ actionType: "api:call", context: { k: 3 } });
+    const saltedBody = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+
+    // A keyed digest must never be labelled plain sha256 on the wire.
+    expect(plainBody.hash_algo).toBe("sha256");
+    expect(saltedBody.hash_algo).toBe("hmac-sha256");
+    expect(saltedBody.hash.startsWith("sha256:")).toBe(true);
+  });
 });
 
 describe("init() resolves mode from baseUrl", () => {


### PR DESCRIPTION
## Criterion 433 (SDK parity audit 2026-08-03, HIGH)

The TypeScript producer computed HMAC-SHA256 over the canonical action bytes when `orgSalt` was set, but hardcoded `hash_algo: "sha256"` in the sign body (`typescript/src/index.ts:2004`). Keyed digests were therefore mislabelled on the wire; the criterion-225 fix (#412) had landed in the Python client only.

## Fix

Mirror the Python client semantics exactly:
- `hash_algo` is `hmac-sha256` exactly when a salt is present, `sha256` otherwise
- the wire digest keeps the `sha256:<64 hex>` shape in both cases (the algorithm label names the keyedness)

## Verification

- New test `hash-only labels a keyed digest hmac-sha256, not sha256` in `tests/clientHashMode.test.ts` (mirrors `python/tests/test_client_hash_mode.py::test_hash_only_uses_hmac_when_org_salt_set`)
- Full TypeScript suite: 58 files / 946 tests pass
- `tsc --noEmit` clean