### PR TITLE
fix(verifier): accept the canonical envelope and decision vocabulary in verify_compliance_receipt (criterion 434)

### DIFF
--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -413,8 +413,10 @@ def _resolve_previous_receipt_hash(data: dict[str, Any]) -> str | None:
     )
 
 
-#: REQUIRED fields on a Compliance Receipt envelope (wire form); top-level
-#: discriminator is ``type``. Used by `verify_compliance_receipt`.
+#: REQUIRED fields on a Compliance Receipt envelope (wire form); the wire
+#: discriminator is ``type`` and the wire verdict field is ``decision``
+#: (matches the standalone verifier's REQUIRED_FIELDS). Used by
+#: `verify_compliance_receipt`.
 _COMPLIANCE_REQUIRED_FIELDS: tuple[str, ...] = (
     "type",
     "issuer_id",
@@ -423,7 +425,7 @@ _COMPLIANCE_REQUIRED_FIELDS: tuple[str, ...] = (
     "payload_digest",
     "policy_digest",
     "previousReceiptHash",
-    "policy_decision",
+    "decision",
     "issued_at",
 )
 
@@ -3527,20 +3529,28 @@ def verify_compliance_receipt(
 
     errors: list[str] = []
 
+    # Canonical wire envelope {payload, signature, anchors}: the signed fields
+    # live inside the payload member; flat bundles keep them top-level.
+    _inner = envelope.get("payload")
+    if isinstance(_inner, dict) and ("signature" in envelope or "anchors" in envelope):
+        signed = _inner
+    else:
+        signed = envelope
+
     # 1. REQUIRED fields present.
-    missing = [f for f in _COMPLIANCE_REQUIRED_FIELDS if f not in envelope]
+    missing = [f for f in _COMPLIANCE_REQUIRED_FIELDS if f not in signed]
     fields_present = not missing
     if missing:
         errors.append(f"missing_fields:{','.join(missing)}")
 
     # 2. ``type`` namespace. Wire field is ``type``; ``receipt_type`` accepted too.
-    rt = envelope.get("type") or envelope.get("receipt_type")
+    rt = signed.get("type") or signed.get("receipt_type")
     receipt_type_in_namespace = rt in RECEIPT_TYPE_NAMESPACE
     if not receipt_type_in_namespace:
         errors.append("invalid_receipt_type")
 
     # 3. 300-second skew bound.
-    issued_at = envelope.get("issued_at") or envelope.get("signed_at")
+    issued_at = signed.get("issued_at") or signed.get("signed_at")
     skew_within_bound = False
     if issued_at is None:
         errors.append("missing_issued_at")
@@ -3564,7 +3574,7 @@ def verify_compliance_receipt(
     # 4. Chain link rederives. Only checked when caller supplies the
     # predecessor envelope; first-record seeds skip this.
     chain_link_rederives = True
-    expected_prev = envelope.get("previousReceiptHash")
+    expected_prev = _resolve_previous_receipt_hash(envelope)
     if expected_prev == FIRST_RECEIPT_SEED:
         # First record on the chain; nothing to rederive.
         pass
@@ -3584,7 +3594,7 @@ def verify_compliance_receipt(
     # No predecessor supplied: leave chain_link_rederives=True (unchecked is not failed).
 
     # 5. Conditional MUSTs: sandbox_state, reason on deny/rate_limit, anchors[].value.
-    _payload = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else envelope
+    _payload = signed
     if isinstance(_payload, dict):
         _sandbox = _payload.get("sandbox_state")
         if _sandbox is not None and _sandbox not in SANDBOX_STATE_NAMESPACE:

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -24,8 +24,9 @@ from asqav.replay import FIRST_RECEIPT_SEED
 def _good_envelope(**overrides) -> dict:
     """A receipt envelope that passes every check by default.
 
-    Uses the spec wire form ``type`` (draft-marques-asqav-compliance-receipts
-    Section 2.1) rather than the SDK-internal ``receipt_type`` attribute.
+    Uses the spec wire forms ``type`` and ``decision``
+    (draft-marques-asqav-compliance-receipts) rather than the SDK-internal
+    ``receipt_type`` / ``policy_decision`` attributes.
     """
     base = {
         "type": "protectmcp:decision",
@@ -36,7 +37,7 @@ def _good_envelope(**overrides) -> dict:
         "payload_digest": "sha256:" + "b" * 64,
         "policy_digest": "sha256:" + "c" * 64,
         "previousReceiptHash": FIRST_RECEIPT_SEED,
-        "policy_decision": "permit",
+        "decision": "allow",
     }
     base.update(overrides)
     return base
@@ -478,5 +479,61 @@ def test_valid_mandate_and_controls_together_pass() -> None:
         },
     )
     result = verify_compliance_receipt(env)
+    assert result.valid is True
+    assert result.errors == []
+
+
+# === Canonical {payload, signature, anchors} wire envelope (criterion 434) ===
+
+
+def _canonical_envelope(**payload_overrides) -> dict:
+    """The canonical wire shape: signed fields nested under ``payload``."""
+    return {
+        "payload": _good_envelope(**payload_overrides),
+        "signature": {"alg": "Ed25519", "kid": "k", "sig": "s"},
+        "anchors": [],
+    }
+
+
+def test_canonical_envelope_passes_required_field_check() -> None:
+    result = verify_compliance_receipt(_canonical_envelope())
+    assert result.fields_present is True
+    assert result.valid is True
+    assert result.errors == []
+
+
+def test_canonical_envelope_flags_payload_field_missing() -> None:
+    env = _canonical_envelope()
+    del env["payload"]["issuer_id"]
+    result = verify_compliance_receipt(env)
+    assert result.fields_present is False
+    assert "issuer_id" in next(
+        e for e in result.errors if e.startswith("missing_fields:")
+    )
+
+
+def test_canonical_envelope_reason_conditional_on_payload_decision() -> None:
+    result = verify_compliance_receipt(_canonical_envelope(decision="deny"))
+    assert "missing_reason_on_deny_or_rate_limit" in result.errors
+
+
+def test_asqav_01_genesis_permit_vector_passes() -> None:
+    """The published asqav-01 conformance vector passes this surface."""
+    import json as _json
+
+    vector_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "verifier",
+        "conformance-vectors",
+        "asqav-01-genesis-permit",
+        "receipt.json",
+    )
+    with open(vector_path, encoding="utf-8") as f:
+        envelope = _json.load(f)
+    fixed_now = datetime(2026, 5, 4, 12, 5, 0, tzinfo=timezone.utc).timestamp()
+    result = verify_compliance_receipt(envelope, now=fixed_now)
+    assert result.fields_present is True
     assert result.valid is True
     assert result.errors == []


### PR DESCRIPTION
## Criterion 434 (SDK parity audit 2026-08-03)

The SDK's two Python verifier surfaces disagreed on the wire:
- `verify_compliance_receipt` (client.py) read REQUIRED fields, `type`, `issued_at`, and `previousReceiptHash` from the top level only, so every canonical `{payload, signature, anchors}` receipt was reported with all signed fields missing (audit finding 1.4, reproduced on the asqav-01 vector)
- it required the SDK-internal `policy_decision` name where the wire vocabulary is `decision`, diverging from the standalone verifier's `REQUIRED_FIELDS` (finding 1.5)

## Fix

- resolve the signed fields from the `payload` member when the envelope is in canonical shape (same discriminator as the existing chain-link logic)
- `_resolve_previous_receipt_hash` now serves both shapes
- required vocabulary switched to `decision`, matching `verifier/verify_receipt.py`

## Verification

- New tests: canonical envelope passes, payload-missing negative fires, `asqav-01-genesis-permit` vector passes this surface
- Standalone surface re-checked on the same vector: `[ok] structure required fields present; type protectmcp:decision`
- Full Python suite: 2705 passed, 1 skipped (pre-existing)