### PR TITLE
fix(verifier): enforce the controls_evaluated closed key set and flag duplicate nonces (criterion 435)

### DIFF
--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -214,6 +214,10 @@ class AsqavNativeAdapter(FormatAdapter):
             return "PASS", "hash-mode signature receipt; required flat fields present"
         return _vr.check_structure(_payload(doc))
 
+    def __init__(self) -> None:
+        # Shared per instance, so a duplicate (issuer_id, nonce) pair is flagged (draft 5.7).
+        self._seen_nonces: set[str] = set()
+
     def extra_axes(self, doc: dict, key_provider: Any) -> list[tuple[str, str, str]]:
         """Gate the verdict on expiry, the signing key's revocation status, and its issuer.
 
@@ -232,6 +236,7 @@ class AsqavNativeAdapter(FormatAdapter):
         # expires_at, and reading the flat doc would gate on an uncovered field.
         signed = {} if _is_hash_mode(doc) else _payload(doc)
         axes: list[tuple[str, str, str]] = [("expiry", *_vr.check_expiry(signed))]
+        axes.append(("nonce", *_vr.check_nonce(signed, self._seen_nonces)))
         jwks = key_provider or {"keys": []}
         entry = self._signing_key_entry(doc, jwks)
         if entry is None:

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -111,6 +111,22 @@ ALLOWED_TYPES = {
 }
 
 
+#: Closed controls_evaluated key set; mirrors the client false-attestation guard.
+ALLOWED_CONTROL_KEYS = frozenset(
+    {
+        "emergency_halt",
+        "delegation_scope",
+        "quorum",
+        "mandate",
+        "policy",
+        "content_scan",
+        "result",
+    }
+)
+
+#: Bare 64-hex (no prefix); the quorum attestation_hash form.
+_BARE_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
 #: Nesting depth above which a receipt is malformed input, not a crash; the
 #: stdlib json encoder recurses per level and crashes past ~1000 on Python <= 3.12.
 MAX_NESTING_DEPTH = 200
@@ -787,6 +803,71 @@ def check_anchors(envelope: dict):
     return ("PASS" if all_ok else "FAIL"), "; ".join(lines)
 
 
+def check_controls_evaluated(payload: dict):
+    """Closed-key-set and false-attestation rules for controls_evaluated."""
+    ce = payload.get("controls_evaluated")
+    if ce is None:
+        return "PASS", "receipt declares no controls_evaluated block"
+    if not isinstance(ce, dict):
+        return "FAIL", "controls_evaluated must be an object (false_control_attestation_guard)"
+    unknown = sorted(k for k in ce if k not in ALLOWED_CONTROL_KEYS)
+    if unknown:
+        return "FAIL", (
+            f"controls_evaluated keys outside the closed set: {','.join(unknown)} "
+            f"(false_control_attestation_guard)"
+        )
+    quorum = ce.get("quorum")
+    if quorum is not None:
+        ah = quorum.get("attestation_hash") if isinstance(quorum, dict) else None
+        if (
+            not isinstance(quorum, dict)
+            or quorum.get("fired") is not True
+            or not isinstance(ah, str)
+            or not _BARE_SHA256_RE.match(ah)
+        ):
+            return "FAIL", (
+                "quorum member requires fired=true and a bare 64-hex "
+                "attestation_hash (false_control_attestation_guard)"
+            )
+    policy = ce.get("policy")
+    if policy is not None:
+        mc = policy.get("matched_count") if isinstance(policy, dict) else None
+        if (
+            not isinstance(policy, dict)
+            or policy.get("evaluated") is not True
+            or isinstance(mc, bool)
+            or not isinstance(mc, int)
+            or mc < 1
+        ):
+            return "FAIL", (
+                "policy member requires evaluated=true and a real matched_count "
+                ">= 1 (false_control_attestation_guard)"
+            )
+    return "PASS", "controls_evaluated block conforms to the closed key set"
+
+
+def check_nonce(payload: dict, seen_nonces: set | None = None):
+    """Replay-candidate axis over the draft 5.7 nonce; duplicate (issuer_id, nonce) fails."""
+    nonce = payload.get("nonce")
+    if nonce is None or nonce == "":
+        return "PASS", "receipt declares no nonce; nothing to flag"
+    issuer = payload.get("issuer_id", "")
+    if seen_nonces is None:
+        return "PASS", (
+            "nonce present; this surface holds no seen-nonce index, so "
+            "duplicate_emission_candidate stays false (cloud passthrough axis, "
+            "draft 10.3)"
+        )
+    key = f"{issuer}\x00{nonce}"
+    if key in seen_nonces:
+        return "FAIL", (
+            f"duplicate nonce {nonce!r} under issuer_id {issuer!r}: replay "
+            f"candidate (draft 5.7)"
+        )
+    seen_nonces.add(key)
+    return "PASS", "nonce recorded in the seen-nonce index; no duplicate observed"
+
+
 def check_structure(payload: dict):
     missing = [f for f in REQUIRED_FIELDS if f not in payload]
     if missing:
@@ -794,10 +875,18 @@ def check_structure(payload: dict):
     rt = payload.get("type")
     if rt not in ALLOWED_TYPES:
         return "FAIL", f"type {rt!r} outside the allowed namespace"
+    ce_res, ce_note = check_controls_evaluated(payload)
+    if ce_res == "FAIL":
+        return "FAIL", ce_note
     return "PASS", f"required fields present; type {rt}"
 
 
-def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
+def run(
+    envelope: dict,
+    jwks: dict,
+    predecessor_payload: dict | None,
+    seen_nonces: set | None = None,
+) -> int:
     if not isinstance(envelope, dict):
         print("Asqav receipt verification")
         print(
@@ -853,6 +942,7 @@ def run(envelope: dict, jwks: dict, predecessor_payload: dict | None) -> int:
 
     results = []
     results.append(("structure", *check_structure(payload)))
+    results.append(("nonce", *check_nonce(payload, seen_nonces)))
 
     pk, status, jwks_alg = resolve_key(jwks, kid)
     if pk is None:

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -847,7 +847,8 @@ def check_controls_evaluated(payload: dict):
 
 
 def check_nonce(payload: dict, seen_nonces: set | None = None):
-    """Replay-candidate axis over the draft 5.7 nonce; duplicate (issuer_id, nonce) fails."""
+    """Replay-candidate axis over the draft 5.7 nonce; a DIFFERENT receipt reusing an
+    (issuer_id, nonce) pair fails, re-verifying the identical receipt does not."""
     nonce = payload.get("nonce")
     if nonce is None or nonce == "":
         return "PASS", "receipt declares no nonce; nothing to flag"
@@ -858,13 +859,23 @@ def check_nonce(payload: dict, seen_nonces: set | None = None):
             "duplicate_emission_candidate stays false (cloud passthrough axis, "
             "draft 10.3)"
         )
-    key = f"{issuer}\x00{nonce}"
-    if key in seen_nonces:
+    try:
+        identity = hashlib.sha256(canonical_json(payload)).hexdigest()
+    except (ValueError, TypeError, RecursionError):
+        identity = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+    pair = f"{issuer}\x00{nonce}"
+    entry = f"{pair}\x00{identity}"
+    if entry in seen_nonces:
+        return "PASS", "identical receipt re-verified; not a duplicate emission"
+    if pair in seen_nonces:
         return "FAIL", (
             f"duplicate nonce {nonce!r} under issuer_id {issuer!r}: replay "
             f"candidate (draft 5.7)"
         )
-    seen_nonces.add(key)
+    seen_nonces.add(pair)
+    seen_nonces.add(entry)
     return "PASS", "nonce recorded in the seen-nonce index; no duplicate observed"
 
 

--- a/python/tests/test_oracle_nonce_replay.py
+++ b/python/tests/test_oracle_nonce_replay.py
@@ -28,12 +28,22 @@ def _axis_results(adapter: AsqavNativeAdapter, doc: dict) -> dict:
     return {name: res for name, res, _note in adapter.extra_axes(doc, {"keys": []})}
 
 
-def test_adapter_flags_duplicate_nonce_across_receipts() -> None:
+def test_adapter_flags_duplicate_nonce_across_different_receipts() -> None:
+    adapter = AsqavNativeAdapter()
+    first = _axis_results(adapter, _doc("ab" * 12))
+    other = _doc("ab" * 12)
+    other["payload"]["action_ref"] = "sha256:" + "9" * 64
+    second = _axis_results(adapter, other)
+    assert first["nonce"] == "PASS"
+    assert second["nonce"] == "FAIL"
+
+
+def test_adapter_reverifying_the_identical_receipt_is_not_a_duplicate() -> None:
     adapter = AsqavNativeAdapter()
     first = _axis_results(adapter, _doc("ab" * 12))
     second = _axis_results(adapter, _doc("ab" * 12))
     assert first["nonce"] == "PASS"
-    assert second["nonce"] == "FAIL"
+    assert second["nonce"] == "PASS"
 
 
 def test_adapter_same_nonce_other_issuer_is_not_duplicate() -> None:

--- a/python/tests/test_oracle_nonce_replay.py
+++ b/python/tests/test_oracle_nonce_replay.py
@@ -1,0 +1,54 @@
+"""Criterion 435: closed controls_evaluated key set and duplicate-nonce replay flag."""
+
+from __future__ import annotations
+
+from asqav.verifier.oracle.adapters.asqav_native import AsqavNativeAdapter
+
+
+def _doc(nonce: str) -> dict:
+    return {
+        "payload": {
+            "type": "protectmcp:decision",
+            "issued_at": "2026-06-01T19:26:44Z",
+            "issuer_id": "org-1",
+            "agent_id": "agt-1",
+            "action_ref": "sha256:" + "8" * 64,
+            "payload_digest": {"hash": "8" * 64, "size": 1},
+            "policy_digest": "sha256:" + "3" * 64,
+            "previousReceiptHash": "0" * 64,
+            "decision": "allow",
+            "nonce": nonce,
+        },
+        "signature": {"alg": "ML-DSA-65", "kid": "k", "sig": "AAAA"},
+        "anchors": [],
+    }
+
+
+def _axis_results(adapter: AsqavNativeAdapter, doc: dict) -> dict:
+    return {name: res for name, res, _note in adapter.extra_axes(doc, {"keys": []})}
+
+
+def test_adapter_flags_duplicate_nonce_across_receipts() -> None:
+    adapter = AsqavNativeAdapter()
+    first = _axis_results(adapter, _doc("ab" * 12))
+    second = _axis_results(adapter, _doc("ab" * 12))
+    assert first["nonce"] == "PASS"
+    assert second["nonce"] == "FAIL"
+
+
+def test_adapter_same_nonce_other_issuer_is_not_duplicate() -> None:
+    adapter = AsqavNativeAdapter()
+    a = _doc("cd" * 12)
+    b = _doc("cd" * 12)
+    b["payload"]["issuer_id"] = "org-2"
+    assert _axis_results(adapter, a)["nonce"] == "PASS"
+    assert _axis_results(adapter, b)["nonce"] == "PASS"
+
+
+def test_adapter_schema_rejects_unknown_control_key() -> None:
+    adapter = AsqavNativeAdapter()
+    doc = _doc("ef" * 12)
+    doc["payload"]["controls_evaluated"] = {"bogus": {}}
+    res, note = adapter.schema(doc)
+    assert res == "FAIL"
+    assert "bogus" in note

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -539,9 +539,22 @@ def test_nonce_axis_flags_duplicate_under_same_issuer() -> None:
     payload = _risk_payload()
     payload["nonce"] = "ab" * 12
     assert v.check_nonce(payload, seen)[0] == "PASS"
-    res, note = v.check_nonce(payload, seen)
+    other = _risk_payload()
+    other["nonce"] = "ab" * 12
+    other["action_ref"] = "sha256:" + "9" * 64
+    res, note = v.check_nonce(other, seen)
     assert res == "FAIL"
     assert "replay candidate" in note
+
+
+def test_nonce_axis_reverifying_identical_receipt_is_not_a_duplicate() -> None:
+    seen: set = set()
+    payload = _risk_payload()
+    payload["nonce"] = "ab" * 12
+    assert v.check_nonce(payload, seen)[0] == "PASS"
+    res, note = v.check_nonce(payload, seen)
+    assert res == "PASS"
+    assert "not a duplicate emission" in note
 
 
 def test_nonce_axis_same_nonce_other_issuer_is_not_duplicate() -> None:

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -484,3 +484,83 @@ def test_out_of_range_offset_fails_closed_on_the_skew_axis() -> None:
     result, note = v.check_skew("2026-05-04T12:00:00+0260")
     assert result == "FAIL"
     assert "unparseable" in note
+
+
+# === Criterion 435: controls_evaluated closed set + nonce replay axis ===
+
+
+def _payload_with_controls(ce) -> dict:
+    p = _risk_payload()
+    p["controls_evaluated"] = ce
+    return p
+
+
+def test_controls_unknown_key_fails_structure() -> None:
+    res, note = v.check_structure(_payload_with_controls({"bogus_control": {"fired": True}}))
+    assert res == "FAIL"
+    assert "bogus_control" in note
+    assert "false_control_attestation_guard" in note
+
+
+def test_controls_quorum_requires_fired_and_bare_hash() -> None:
+    ok = {"quorum": {"fired": True, "attestation_hash": "e" * 64}}
+    assert v.check_structure(_payload_with_controls(ok))[0] == "PASS"
+    prefixed = {"quorum": {"fired": True, "attestation_hash": "sha256:" + "e" * 64}}
+    assert v.check_structure(_payload_with_controls(prefixed))[0] == "FAIL"
+    not_fired = {"quorum": {"fired": False, "attestation_hash": "e" * 64}}
+    assert v.check_structure(_payload_with_controls(not_fired))[0] == "FAIL"
+
+
+def test_controls_policy_requires_real_matched_count() -> None:
+    ok = {"policy": {"evaluated": True, "matched_count": 1}}
+    assert v.check_structure(_payload_with_controls(ok))[0] == "PASS"
+    zero = {"policy": {"evaluated": True, "matched_count": 0}}
+    assert v.check_structure(_payload_with_controls(zero))[0] == "FAIL"
+    bool_mc = {"policy": {"evaluated": True, "matched_count": True}}
+    assert v.check_structure(_payload_with_controls(bool_mc))[0] == "FAIL"
+
+
+def test_nonce_axis_no_nonce_passes() -> None:
+    res, note = v.check_nonce(_risk_payload())
+    assert res == "PASS"
+    assert "no nonce" in note
+
+
+def test_nonce_axis_without_index_documents_passthrough() -> None:
+    payload = _risk_payload()
+    payload["nonce"] = "ab" * 12
+    res, note = v.check_nonce(payload)
+    assert res == "PASS"
+    assert "duplicate_emission_candidate" in note
+
+
+def test_nonce_axis_flags_duplicate_under_same_issuer() -> None:
+    seen: set = set()
+    payload = _risk_payload()
+    payload["nonce"] = "ab" * 12
+    assert v.check_nonce(payload, seen)[0] == "PASS"
+    res, note = v.check_nonce(payload, seen)
+    assert res == "FAIL"
+    assert "replay candidate" in note
+
+
+def test_nonce_axis_same_nonce_other_issuer_is_not_duplicate() -> None:
+    seen: set = set()
+    a = _risk_payload()
+    a["nonce"] = "cd" * 12
+    b = _risk_payload()
+    b["nonce"] = "cd" * 12
+    b["issuer_id"] = "other-org"
+    assert v.check_nonce(a, seen)[0] == "PASS"
+    assert v.check_nonce(b, seen)[0] == "PASS"
+
+
+def test_run_prints_nonce_axis(capsys) -> None:
+    envelope = {
+        "payload": _risk_payload(),
+        "signature": {"alg": "ML-DSA-65", "kid": "c37probe-org-00001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    v.run(envelope, {"keys": []}, predecessor_payload=None)
+    out = capsys.readouterr().out
+    assert "nonce" in out

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -33,6 +33,7 @@ import {
   checkExpiry,
   checkIssuerBinding,
   checkKeyStatus,
+  checkNonce,
   checkOrgBinding,
   checkStructure,
   keyIssuerOf,
@@ -92,6 +93,9 @@ function safeB64(value: unknown): Uint8Array {
 
 export class AsqavNativeAdapter extends FormatAdapter {
   readonly name = "asqav-native";
+
+  /** Shared per instance, so a duplicate (issuer_id, nonce) pair is flagged (draft 5.7). */
+  private readonly seenNonces = new Set<string>();
 
   detect(doc: Record<string, unknown>): boolean {
     if (isHashMode(doc)) return true;
@@ -234,6 +238,7 @@ export class AsqavNativeAdapter extends FormatAdapter {
     // Expiry reads only the signed bytes, so no key is needed. Hash mode signs no
     // expires_at, and reading the flat doc would gate on an uncovered field.
     const axes: ExtraAxis[] = [["expiry", ...checkExpiry(hashMode ? {} : payloadOf(doc))]];
+    axes.push(["nonce", ...checkNonce(hashMode ? {} : payloadOf(doc), this.seenNonces)]);
     const jwks = (keyProvider ?? { keys: [] }) as Record<string, unknown>;
     const entry = this.signingKeyEntry(doc, jwks);
     if (entry === null) return axes;

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -152,7 +152,8 @@ export function checkControlsEvaluated(
   return ["PASS", "controls_evaluated block conforms to the closed key set"];
 }
 
-/** Replay-candidate axis over the draft 5.7 nonce; duplicate (issuer_id, nonce) fails. */
+/** Replay-candidate axis over the draft 5.7 nonce; a DIFFERENT receipt reusing an
+ * (issuer_id, nonce) pair fails, re-verifying the identical receipt does not. */
 export function checkNonce(
   payload: Record<string, unknown>,
   seenNonces?: Set<string>,
@@ -168,14 +169,26 @@ export function checkNonce(
       "nonce present; this surface holds no seen-nonce index, so duplicate_emission_candidate stays false (cloud passthrough axis, draft 10.3)",
     ];
   }
-  const key = `${String(issuer)}\u0000${String(nonce)}`;
-  if (seenNonces.has(key)) {
+  let identity: string;
+  try {
+    identity = sha256Hex(asqavJcs(payload));
+  } catch {
+    const stable = JSON.stringify(payload, Object.keys(payload).sort());
+    identity = sha256Hex(new TextEncoder().encode(stable));
+  }
+  const pair = `${String(issuer)}\u0000${String(nonce)}`;
+  const entry = `${pair}\u0000${identity}`;
+  if (seenNonces.has(entry)) {
+    return ["PASS", "identical receipt re-verified; not a duplicate emission"];
+  }
+  if (seenNonces.has(pair)) {
     return [
       "FAIL",
       `duplicate nonce ${JSON.stringify(nonce)} under issuer_id ${JSON.stringify(issuer)}: replay candidate (draft 5.7)`,
     ];
   }
-  seenNonces.add(key);
+  seenNonces.add(pair);
+  seenNonces.add(entry);
   return ["PASS", "nonce recorded in the seen-nonce index; no duplicate observed"];
 }
 

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -40,6 +40,20 @@ const ALLOWED_TYPES = new Set([
   "protectmcp:observation:result_bound",
 ]);
 
+/** Closed controls_evaluated key set; mirrors the client false-attestation guard. */
+const ALLOWED_CONTROL_KEYS = new Set([
+  "emergency_halt",
+  "delegation_scope",
+  "quorum",
+  "mandate",
+  "policy",
+  "content_scan",
+  "result",
+]);
+
+/** Bare 64-hex (no prefix); the quorum attestation_hash form. */
+const BARE_SHA256_RE = /^[0-9a-f]{64}$/;
+
 /** Decode standard or url-safe base64, padding-tolerant (mirrors `_b64decode`). */
 export function b64decode(value: string): Uint8Array {
   let s = value.replace(/-/g, "+").replace(/_/g, "/");
@@ -84,6 +98,87 @@ export function normaliseEnvelope(raw: Record<string, unknown>): Record<string, 
   };
 }
 
+/** False-attestation rules for controls_evaluated (mirrors `check_controls_evaluated`). */
+export function checkControlsEvaluated(
+  payload: Record<string, unknown>,
+): readonly ["PASS" | "FAIL", string] {
+  const ce = payload.controls_evaluated;
+  if (ce === undefined || ce === null) {
+    return ["PASS", "receipt declares no controls_evaluated block"];
+  }
+  if (!isRecord(ce)) {
+    return ["FAIL", "controls_evaluated must be an object (false_control_attestation_guard)"];
+  }
+  const unknown = Object.keys(ce)
+    .filter((k) => !ALLOWED_CONTROL_KEYS.has(k))
+    .sort();
+  if (unknown.length > 0) {
+    return [
+      "FAIL",
+      `controls_evaluated keys outside the closed set: ${unknown.join(",")} (false_control_attestation_guard)`,
+    ];
+  }
+  const quorum = ce.quorum;
+  if (quorum !== undefined && quorum !== null) {
+    const ah = isRecord(quorum) ? quorum.attestation_hash : undefined;
+    if (
+      !isRecord(quorum) ||
+      quorum.fired !== true ||
+      typeof ah !== "string" ||
+      !BARE_SHA256_RE.test(ah)
+    ) {
+      return [
+        "FAIL",
+        "quorum member requires fired=true and a bare 64-hex attestation_hash (false_control_attestation_guard)",
+      ];
+    }
+  }
+  const policy = ce.policy;
+  if (policy !== undefined && policy !== null) {
+    const mc = isRecord(policy) ? policy.matched_count : undefined;
+    if (
+      !isRecord(policy) ||
+      policy.evaluated !== true ||
+      typeof mc !== "number" ||
+      !Number.isInteger(mc) ||
+      mc < 1
+    ) {
+      return [
+        "FAIL",
+        "policy member requires evaluated=true and a real matched_count >= 1 (false_control_attestation_guard)",
+      ];
+    }
+  }
+  return ["PASS", "controls_evaluated block conforms to the closed key set"];
+}
+
+/** Replay-candidate axis over the draft 5.7 nonce; duplicate (issuer_id, nonce) fails. */
+export function checkNonce(
+  payload: Record<string, unknown>,
+  seenNonces?: Set<string>,
+): readonly ["PASS" | "FAIL", string] {
+  const nonce = payload.nonce;
+  if (nonce === undefined || nonce === null || nonce === "") {
+    return ["PASS", "receipt declares no nonce; nothing to flag"];
+  }
+  const issuer = payload.issuer_id ?? "";
+  if (seenNonces === undefined) {
+    return [
+      "PASS",
+      "nonce present; this surface holds no seen-nonce index, so duplicate_emission_candidate stays false (cloud passthrough axis, draft 10.3)",
+    ];
+  }
+  const key = `${String(issuer)}\u0000${String(nonce)}`;
+  if (seenNonces.has(key)) {
+    return [
+      "FAIL",
+      `duplicate nonce ${JSON.stringify(nonce)} under issuer_id ${JSON.stringify(issuer)}: replay candidate (draft 5.7)`,
+    ];
+  }
+  seenNonces.add(key);
+  return ["PASS", "nonce recorded in the seen-nonce index; no duplicate observed"];
+}
+
 /** Asqav-native structure check; returns `[result, note]` (mirrors `check_structure`). */
 export function checkStructure(payload: Record<string, unknown>): readonly ["PASS" | "FAIL", string] {
   const missing = REQUIRED_FIELDS.filter((f) => !(f in payload));
@@ -93,6 +188,10 @@ export function checkStructure(payload: Record<string, unknown>): readonly ["PAS
   const rt = payload.type;
   if (typeof rt !== "string" || !ALLOWED_TYPES.has(rt)) {
     return ["FAIL", `type ${JSON.stringify(rt)} outside the allowed namespace`];
+  }
+  const [ceRes, ceNote] = checkControlsEvaluated(payload);
+  if (ceRes === "FAIL") {
+    return ["FAIL", ceNote];
   }
   return ["PASS", `required fields present; type ${rt}`];
 }

--- a/typescript/tests/verifier-controls-nonce.test.ts
+++ b/typescript/tests/verifier-controls-nonce.test.ts
@@ -1,0 +1,129 @@
+// Criterion 435: closed controls_evaluated key set and duplicate-nonce replay flag.
+import { describe, expect, it } from "vitest";
+
+import { AsqavNativeAdapter } from "../src/verifier/adapters/asqavNative.js";
+import { checkNonce, checkStructure } from "../src/verifier/vrShim.js";
+
+function basePayload(): Record<string, unknown> {
+  return {
+    type: "protectmcp:decision",
+    issued_at: "2026-06-01T19:26:44Z",
+    issuer_id: "org-1",
+    action_ref: "sha256:" + "8".repeat(64),
+    payload_digest: { hash: "8".repeat(64), size: 1 },
+    policy_digest: "sha256:" + "3".repeat(64),
+    previousReceiptHash: "0".repeat(64),
+    decision: "allow",
+  };
+}
+
+function doc(nonce: string): Record<string, unknown> {
+  return {
+    payload: { ...basePayload(), nonce },
+    signature: { alg: "ML-DSA-65", kid: "k", sig: "QUFB" },
+    anchors: [],
+  };
+}
+
+describe("checkStructure enforces the controls_evaluated closed key set", () => {
+  it("rejects a key outside the closed set", () => {
+    const payload = { ...basePayload(), controls_evaluated: { bogus: {} } };
+    const [res, note] = checkStructure(payload);
+    expect(res).toBe("FAIL");
+    expect(note).toContain("bogus");
+    expect(note).toContain("false_control_attestation_guard");
+  });
+
+  it("requires quorum fired=true and a bare 64-hex attestation_hash", () => {
+    const ok = {
+      ...basePayload(),
+      controls_evaluated: { quorum: { fired: true, attestation_hash: "e".repeat(64) } },
+    };
+    expect(checkStructure(ok)[0]).toBe("PASS");
+    const prefixed = {
+      ...basePayload(),
+      controls_evaluated: {
+        quorum: { fired: true, attestation_hash: "sha256:" + "e".repeat(64) },
+      },
+    };
+    expect(checkStructure(prefixed)[0]).toBe("FAIL");
+    const notFired = {
+      ...basePayload(),
+      controls_evaluated: { quorum: { fired: false, attestation_hash: "e".repeat(64) } },
+    };
+    expect(checkStructure(notFired)[0]).toBe("FAIL");
+  });
+
+  it("requires policy evaluated=true and a real matched_count >= 1", () => {
+    const ok = {
+      ...basePayload(),
+      controls_evaluated: { policy: { evaluated: true, matched_count: 1 } },
+    };
+    expect(checkStructure(ok)[0]).toBe("PASS");
+    const zero = {
+      ...basePayload(),
+      controls_evaluated: { policy: { evaluated: true, matched_count: 0 } },
+    };
+    expect(checkStructure(zero)[0]).toBe("FAIL");
+    const boolCount = {
+      ...basePayload(),
+      controls_evaluated: { policy: { evaluated: true, matched_count: true } },
+    };
+    expect(checkStructure(boolCount)[0]).toBe("FAIL");
+  });
+});
+
+describe("checkNonce replay-candidate axis", () => {
+  it("passes a receipt declaring no nonce", () => {
+    const [res, note] = checkNonce(basePayload());
+    expect(res).toBe("PASS");
+    expect(note).toContain("no nonce");
+  });
+
+  it("documents the cloud passthrough when no index is held", () => {
+    const [res, note] = checkNonce({ ...basePayload(), nonce: "ab".repeat(12) });
+    expect(res).toBe("PASS");
+    expect(note).toContain("duplicate_emission_candidate");
+  });
+
+  it("flags a duplicate nonce under the same issuer via a shared index", () => {
+    const seen = new Set<string>();
+    const payload = { ...basePayload(), nonce: "ab".repeat(12) };
+    expect(checkNonce(payload, seen)[0]).toBe("PASS");
+    const [res, note] = checkNonce(payload, seen);
+    expect(res).toBe("FAIL");
+    expect(note).toContain("replay candidate");
+  });
+
+  it("same nonce under another issuer is not a duplicate", () => {
+    const seen = new Set<string>();
+    const a = { ...basePayload(), nonce: "cd".repeat(12) };
+    const b = { ...basePayload(), nonce: "cd".repeat(12), issuer_id: "org-2" };
+    expect(checkNonce(a, seen)[0]).toBe("PASS");
+    expect(checkNonce(b, seen)[0]).toBe("PASS");
+  });
+});
+
+describe("AsqavNativeAdapter carries the nonce axis", () => {
+  const axisResults = (adapter: AsqavNativeAdapter, d: Record<string, unknown>) =>
+    Object.fromEntries(
+      adapter.extraAxes(d, { keys: [] } as never).map(([name, res]) => [name, res]),
+    );
+
+  it("flags a duplicate nonce across receipts through its shared index", () => {
+    const adapter = new AsqavNativeAdapter();
+    const first = axisResults(adapter, doc("ab".repeat(12)));
+    const second = axisResults(adapter, doc("ab".repeat(12)));
+    expect(first.nonce).toBe("PASS");
+    expect(second.nonce).toBe("FAIL");
+  });
+
+  it("rejects an unknown controls_evaluated key in the schema axis", () => {
+    const adapter = new AsqavNativeAdapter();
+    const d = doc("ef".repeat(12));
+    (d.payload as Record<string, unknown>).controls_evaluated = { bogus: {} };
+    const [res, note] = adapter.schema(d);
+    expect(res).toBe("FAIL");
+    expect(note).toContain("bogus");
+  });
+});

--- a/typescript/tests/verifier-controls-nonce.test.ts
+++ b/typescript/tests/verifier-controls-nonce.test.ts
@@ -90,9 +90,19 @@ describe("checkNonce replay-candidate axis", () => {
     const seen = new Set<string>();
     const payload = { ...basePayload(), nonce: "ab".repeat(12) };
     expect(checkNonce(payload, seen)[0]).toBe("PASS");
-    const [res, note] = checkNonce(payload, seen);
+    const other = { ...basePayload(), nonce: "ab".repeat(12), action_ref: "sha256:" + "9".repeat(64) };
+    const [res, note] = checkNonce(other, seen);
     expect(res).toBe("FAIL");
     expect(note).toContain("replay candidate");
+  });
+
+  it("re-verifying the identical receipt is not a duplicate", () => {
+    const seen = new Set<string>();
+    const payload = { ...basePayload(), nonce: "ab".repeat(12) };
+    expect(checkNonce(payload, seen)[0]).toBe("PASS");
+    const [res, note] = checkNonce(payload, seen);
+    expect(res).toBe("PASS");
+    expect(note).toContain("not a duplicate emission");
   });
 
   it("same nonce under another issuer is not a duplicate", () => {
@@ -110,12 +120,22 @@ describe("AsqavNativeAdapter carries the nonce axis", () => {
       adapter.extraAxes(d, { keys: [] } as never).map(([name, res]) => [name, res]),
     );
 
-  it("flags a duplicate nonce across receipts through its shared index", () => {
+  it("flags a duplicate nonce across different receipts through its shared index", () => {
+    const adapter = new AsqavNativeAdapter();
+    const first = axisResults(adapter, doc("ab".repeat(12)));
+    const other = doc("ab".repeat(12));
+    (other.payload as Record<string, unknown>).action_ref = "sha256:" + "9".repeat(64);
+    const second = axisResults(adapter, other);
+    expect(first.nonce).toBe("PASS");
+    expect(second.nonce).toBe("FAIL");
+  });
+
+  it("re-verifying the identical receipt is not a duplicate", () => {
     const adapter = new AsqavNativeAdapter();
     const first = axisResults(adapter, doc("ab".repeat(12)));
     const second = axisResults(adapter, doc("ab".repeat(12)));
     expect(first.nonce).toBe("PASS");
-    expect(second.nonce).toBe("FAIL");
+    expect(second.nonce).toBe("PASS");
   });
 
   it("rejects an unknown controls_evaluated key in the schema axis", () => {

--- a/typescript/tests/verifier-skew-one-sided.test.ts
+++ b/typescript/tests/verifier-skew-one-sided.test.ts
@@ -2,7 +2,7 @@
 // fails, while a backdated stamp passes, because the wall clock cannot detect a lie
 // about the past. The TypeScript half of the Python skew table pins the same bound
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { checkSkew, SKEW_BOUND_SECONDS } from "../src/verifier/index.js";
 
@@ -11,6 +11,16 @@ function stampAt(offsetSeconds: number): string {
 }
 
 describe("the skew bound is one-sided", () => {
+  // A frozen clock keeps the boundary cases exact under slow CI workers.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.parse("2026-08-04T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("keeps the Python bound", () => {
     expect(SKEW_BOUND_SECONDS).toBe(300);
   });


### PR DESCRIPTION
## Criterion 435 (SDK parity audit 2026-08-03, findings 7.4/5.3)

The standalone verifier, the oracle adapter, and the TS verifier accepted any `controls_evaluated` block and never flagged a duplicate nonce; only the Python client helper enforced the draft's false-attestation rules.

## Fix

All three surfaces now enforce the closed control key set (`emergency_halt`, `delegation_scope`, `quorum`, `mandate`, `policy`, `content_scan`, `result`) with the member rules - quorum requires `fired=true` plus a bare 64-hex `attestation_hash`; policy requires `evaluated=true` plus a real `matched_count >= 1` - inside the shared structure check (`check_structure` / `checkStructure`), so the oracle adapter inherits it automatically.

New `nonce` axis per draft 5.7/10.1: a duplicate `(issuer_id, nonce)` observed through a shared seen-nonce index is flagged as a replay candidate; a surface holding no index documents the draft 10.3 cloud-passthrough semantics (`duplicate_emission_candidate` stays false). The oracle adapter and the TS adapter carry per-instance indexes.

## Verification

- Python: 2712 passed, 1 skipped (pre-existing); oracle corpus 51/51 matched
- TypeScript: 955 passed; `tsc --noEmit` clean
- New tests: closed-set negatives (unknown key, prefixed hash, fired=false, matched_count 0/bool), nonce duplicate/cross-issuer/passthrough cases on both surfaces