### PR TITLE
docs(corpus): align CLI docs, genesis pins, JCS dialect, and expected shapes with shipped semantics (criterion 436)

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -12,13 +12,13 @@ These vectors intentionally do NOT pin ML-DSA-65 signature bytes. FIPS 204 suppo
 
 ## Fingerprint format
 
-Asqav uses RFC 8785 (the JSON format spec, also known as JCS):
+Asqav canonicalizes with the Python `json.dumps` dialect, which matches the RFC 8785 (JCS) rules on the domain the corpus exercises:
 
 - UTF-8 encoded.
 - Object keys sorted lexicographically by Unicode code point.
 - No insignificant whitespace between tokens.
-- Numbers serialized per ECMAScript `ToString(ToNumber(x))`.
 - Strings escaped per JSON RFC 8259.
+- Integers serialized bare; floats follow Python's shortest-repr, so float forms outside the corpus domain are out of scope (NaN/Infinity are rejected).
 
 Before signing, the server formats `{"action_type": ..., "context": ...}` (plus server-side metadata) into the standard form and hashes with SHA-256. The hash is what ML-DSA-65 signs.
 

--- a/conformance/vectors.json
+++ b/conformance/vectors.json
@@ -144,8 +144,12 @@
       "description": "Audit Pack manifest entry stamped with capture_topology=in_process_sdk. Producer-side metadata; lives in `manifest`, never in the signed payload.",
       "input": {
         "action_type": "api:call",
-        "context": {"tool": "database.query"},
-        "manifest": {"capture_topology": "in_process_sdk"}
+        "context": {
+          "tool": "database.query"
+        },
+        "manifest": {
+          "capture_topology": "in_process_sdk"
+        }
       },
       "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"in_process_sdk\"}}",
       "sha256": "f4b6da748f7720f15450cf61fa2c4cf8c3e9148fc15ab6b6cd15d8d3f3fd341e",
@@ -158,8 +162,12 @@
       "description": "Audit Pack manifest entry stamped with capture_topology=network_proxy. Producer-side metadata; lives in `manifest`, never in the signed payload.",
       "input": {
         "action_type": "api:call",
-        "context": {"tool": "database.query"},
-        "manifest": {"capture_topology": "network_proxy"}
+        "context": {
+          "tool": "database.query"
+        },
+        "manifest": {
+          "capture_topology": "network_proxy"
+        }
       },
       "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"network_proxy\"}}",
       "sha256": "de100ddcb08a1aadf3ade136a42ce554d38004ba06bbc4f0cecdc2235d46bd9d",
@@ -172,8 +180,12 @@
       "description": "Audit Pack manifest entry stamped with capture_topology=browser_extension. Producer-side metadata; lives in `manifest`, never in the signed payload.",
       "input": {
         "action_type": "api:call",
-        "context": {"tool": "database.query"},
-        "manifest": {"capture_topology": "browser_extension"}
+        "context": {
+          "tool": "database.query"
+        },
+        "manifest": {
+          "capture_topology": "browser_extension"
+        }
       },
       "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"browser_extension\"}}",
       "sha256": "9375a5437440101f386da4f6af0b2b64b1ed1f53fa3bdd5334363f15a173bd15",
@@ -186,8 +198,12 @@
       "description": "Audit Pack manifest entry stamped with capture_topology=github_sha_pull, the server-stamped authoritative code-authorship capture layer. Lives in `manifest`, never in the signed payload.",
       "input": {
         "action_type": "api:call",
-        "context": {"tool": "database.query"},
-        "manifest": {"capture_topology": "github_sha_pull"}
+        "context": {
+          "tool": "database.query"
+        },
+        "manifest": {
+          "capture_topology": "github_sha_pull"
+        }
       },
       "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"github_sha_pull\"}}",
       "sha256": "1a242ac2766e99b3e9bf00d7bb25ff251fdc1a1b59d77bbbe537723755fef4b6",
@@ -200,8 +216,12 @@
       "description": "Audit Pack manifest entry stamped with capture_topology=mcp_proxy. Producer-side metadata; lives in `manifest`, never in the signed payload.",
       "input": {
         "action_type": "api:call",
-        "context": {"tool": "database.query"},
-        "manifest": {"capture_topology": "mcp_proxy"}
+        "context": {
+          "tool": "database.query"
+        },
+        "manifest": {
+          "capture_topology": "mcp_proxy"
+        }
       },
       "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"mcp_proxy\"}}",
       "sha256": "4731cae72f4a30b5c10a688541faf8759873af7d78b8fe999069e112217b82c7",
@@ -214,8 +234,12 @@
       "description": "An unknown capture_topology value MUST be rejected by a conformant SDK before the HTTP roundtrip. Canonical bytes are still defined so implementers can verify rejection without depending on hash drift.",
       "input": {
         "action_type": "api:call",
-        "context": {"tool": "database.query"},
-        "manifest": {"capture_topology": "rootkit"}
+        "context": {
+          "tool": "database.query"
+        },
+        "manifest": {
+          "capture_topology": "rootkit"
+        }
       },
       "canonical": "{\"action_type\":\"api:call\",\"context\":{\"tool\":\"database.query\"},\"manifest\":{\"capture_topology\":\"rootkit\"}}",
       "sha256": "d2a306e1c437b467c431b7d1b4a70c1190aec10642e43ac002c55bb84dd3e617",
@@ -245,14 +269,14 @@
           "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
         },
         "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
-        "previousReceiptHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
         "sandbox_state": "live",
         "tool_name": "database.query",
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0001\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=\",\"expect_ack_from\":\"00000000000000000098\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"transport_label\":\"mcp\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "7857e59e44ee36292a9f23667b8eac0c4461906994669ef286dd0b24365a706b",
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0001\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=\",\"expect_ack_from\":\"00000000000000000098\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"transport_label\":\"mcp\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "b859a5c36c51764957216ae672a036e220c060677d73b4406a1d49679e7d2696",
       "counterparty_binding": {
         "envelope_hash_base64": "DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=",
         "envelope_hash_hex": "0d6c88a16e96fd3429be13e44dc957062f77d417dc0c3ea28e4fa496230de2a9",
@@ -285,7 +309,7 @@
             "value": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
           },
           "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
-          "previousReceiptHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
           "sandbox_state": "live",
           "tool_name": "database.query",
           "type": "protectmcp:action",
@@ -297,8 +321,8 @@
           "sig": "AAAA_synthetic_signature_bytes_base64_placeholder_for_vector_only_AAAA"
         }
       },
-      "canonical": "{\"anchors\":[{\"tsa_url\":\"https://tsa.example/timestamp\",\"type\":\"rfc3161\",\"value\":\"AAAA_synthetic_tsr_base64_placeholder_AAAA\"}],\"payload\":{\"action_id\":\"act_01HVZA_ORIGINATOR_0001\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_originator_A\",\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:00+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:action\",\"v\":1},\"signature\":{\"alg\":\"ML-DSA-65\",\"kid\":\"00000000000000000098\",\"sig\":\"AAAA_synthetic_signature_bytes_base64_placeholder_for_vector_only_AAAA\"}}",
-      "sha256": "0d6c88a16e96fd3429be13e44dc957062f77d417dc0c3ea28e4fa496230de2a9",
+      "canonical": "{\"anchors\":[{\"tsa_url\":\"https://tsa.example/timestamp\",\"type\":\"rfc3161\",\"value\":\"AAAA_synthetic_tsr_base64_placeholder_AAAA\"}],\"payload\":{\"action_id\":\"act_01HVZA_ORIGINATOR_0001\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_originator_A\",\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:00+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:action\",\"v\":1},\"signature\":{\"alg\":\"ML-DSA-65\",\"kid\":\"00000000000000000098\",\"sig\":\"AAAA_synthetic_signature_bytes_base64_placeholder_for_vector_only_AAAA\"}}",
+      "sha256": "e89bf2fe64bd7dab3a606ea265ca14f88f4d161ec0485062a7facee4902c655f",
       "counterparty_binding": {
         "envelope_hash_base64": "DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=",
         "envelope_hash_base64url": "DWyIoW6W_TQpvhPkTclXBi931BfcDD6ijk-kliMN4qk="
@@ -326,14 +350,14 @@
           "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
         },
         "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
-        "previousReceiptHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
         "sandbox_state": "live",
         "tool_name": "database.query",
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0003\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W_TQpvhPkTclXBi931BfcDD6ijk-kliMN4qk=\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "bd1b607e03b63dc6e86097341359fa4d23f4334ec7330fded86aa60aef312993",
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0003\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W_TQpvhPkTclXBi931BfcDD6ijk-kliMN4qk=\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "6754d67d7ced46f9563a00effa57c588105c9b8783e36049518f6f7e3034b266",
       "counterparty_binding": {
         "envelope_hash_base64url": "DWyIoW6W_TQpvhPkTclXBi931BfcDD6ijk-kliMN4qk=",
         "envelope_hash_base64": "DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=",
@@ -362,14 +386,14 @@
           "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
         },
         "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
-        "previousReceiptHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
         "sandbox_state": "live",
         "tool_name": "database.query",
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0004\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=\",\"receipt_ref\":\"urn:uuid:12345678-1234-5678-1234-567812345678#segment[0]\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:02+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "aa96a7ffa667af21b41d6c81ebfc815654bc9e01421c699a662964ce39fd08f6",
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0004\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=\",\"receipt_ref\":\"urn:uuid:12345678-1234-5678-1234-567812345678#segment[0]\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:02+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "76264e84b5743c0a881024db8e86584a6ffa0dde7c76c3679f014adeab78c26c",
       "counterparty_binding": {
         "receipt_ref": "urn:uuid:12345678-1234-5678-1234-567812345678#segment[0]"
       },
@@ -397,14 +421,14 @@
           "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
         },
         "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
-        "previousReceiptHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
         "sandbox_state": "live",
         "tool_name": "database.query",
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0005\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"transport_label\":\"http\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:03+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "bc4d977ee8b17342344211d78f3bef62ee185c4976e80d7e12418834d93affbf",
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0005\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"transport_label\":\"http\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:03+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "c5c45719ebe1eee133ab792e54d7e906c4560607a43f010f292ddf2067ff0468",
       "counterparty_binding": {
         "transport_label_declared": "http",
         "transport_label_actual": "mcp"
@@ -431,14 +455,14 @@
           "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
         },
         "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
-        "previousReceiptHash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
         "sandbox_state": "live",
         "tool_name": "database.query",
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0006\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:04+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "601b05853ff8aee9354e5bbd992dec1a1bc131f971e27ac8e30d58f1e904850b",
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0006\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:04+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "70a004037ffb928a8a4380ee93a1367f75b4ee1b2012d0f84f53891eeebe36c4",
       "counterparty_binding_member_missing": "envelope_hash",
       "expected_verify": false,
       "reason": "envelope_hash is REQUIRED on counterparty_binding; absence breaks the cross-agent byte-equality guarantee and MUST cause the acknowledging receipt to be reported non-conformant."

--- a/docs/fingerprint-spec.md
+++ b/docs/fingerprint-spec.md
@@ -33,7 +33,7 @@ def hash_action(action_type: str, context: dict) -> str:
     return "sha256:" + hashlib.sha256(body).hexdigest()
 ```
 
-This is RFC 8785, the JCS standard, applied to the `{action_type, context}` pair, then SHA-256 over the resulting bytes. Stdlib only, no third-party packages. The output is `sha256:<64 hex chars>`.
+This is the `json.dumps` canonicalization dialect (matching the RFC 8785 JCS rules on the supported value domain) applied to the `{action_type, context}` pair, then SHA-256 over the resulting bytes. Stdlib only, no third-party packages. The output is `sha256:<64 hex chars>`.
 
 ## Inputs
 

--- a/python/docs/CLI.md
+++ b/python/docs/CLI.md
@@ -82,7 +82,7 @@ asqav audit-pack policy a3f6...c91d --output text
 
 ### `asqav replay-verify <agent_id> <session_id> [--strict]`
 
-Re-derives the IETF chain over `sha256(canonical_json(signed_envelope))`. With `--strict` rejects any step that lacks a cloud-emitted `signed_envelope`, since the synthetic fallback shape cannot prove byte-level integrity.
+Re-derives the IETF chain over `sha256(canonical_json(payload))` (the chain hashes the payload member, not the whole envelope). With `--strict` rejects any step that lacks a cloud-emitted `signed_envelope`, since the synthetic fallback shape cannot prove byte-level integrity.
 
 ```bash
 asqav replay-verify agt_x7y8z9 sess_abc --strict --output json

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -2082,10 +2082,11 @@ def replay_verify_cmd(
     ),
     output: str = typer.Option("text", "--output", "-o", help="Output format: text or json."),
 ) -> None:
-    """Re-derive a session's IETF chain (`sha256(canonical_json(signed_envelope))`).
+    """Re-derive a session's IETF chain over `sha256(canonical_json(payload))`.
 
-    Wraps :func:`asqav.replay`. With ``--strict`` the command fails
-    when any step lacks the cloud-emitted ``signed_envelope``.
+    The chain hashes the payload member, not the whole envelope. Wraps
+    :func:`asqav.replay`. With ``--strict`` the command fails when any step
+    lacks the cloud-emitted ``signed_envelope``.
     """
     import json as json_mod
 

--- a/verifier/conformance-vectors/acta-01-genesis/expected.json
+++ b/verifier/conformance-vectors/acta-01-genesis/expected.json
@@ -1,3 +1,6 @@
 {
-  "verdict": "PASS"
+  "format": "acta",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Valid ACTA genesis; Ed25519 over JCS(payload) verifies."
 }

--- a/verifier/conformance-vectors/acta-02-chain-link/expected.json
+++ b/verifier/conformance-vectors/acta-02-chain-link/expected.json
@@ -1,3 +1,6 @@
 {
-  "verdict": "PASS"
+  "format": "acta",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "ACTA successor links via SHA-256 of the JCS of the full predecessor receipt."
 }

--- a/verifier/conformance-vectors/acta-03-tamper-sig/expected.json
+++ b/verifier/conformance-vectors/acta-03-tamper-sig/expected.json
@@ -1,3 +1,6 @@
 {
-  "verdict": "FAIL"
+  "format": "acta",
+  "outcome": "FAIL",
+  "reason_code": "sig_mismatch",
+  "notes": "Flipped signature byte; Ed25519 verify fails."
 }

--- a/verifier/conformance-vectors/acta-05-commitment-mode-unsupported/expected.json
+++ b/verifier/conformance-vectors/acta-05-commitment-mode-unsupported/expected.json
@@ -1,3 +1,6 @@
 {
-  "verdict": "FAIL"
+  "format": "acta",
+  "outcome": "FAIL",
+  "reason_code": "sig_mismatch",
+  "notes": "Commitment-mode receipt (signs SHA-256(JCS)) fails the baseline JCS verifier - honest, never a false pass."
 }

--- a/verifier/conformance-vectors/acta-up-01-a2a-trusted-attestation/expected.json
+++ b/verifier/conformance-vectors/acta-up-01-a2a-trusted-attestation/expected.json
@@ -1,3 +1,6 @@
 {
-  "verdict": "PASS"
+  "format": "acta",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Real ScopeBlind APS issuer attestation (a2a-trust-header/happy-path.json); the upstream Ed25519 signature over JCS(payload) verifies under our adapter. Inbound interop: we verify a producer we did not write."
 }

--- a/verifier/conformance-vectors/acta-up-02-a2a-trajectory-endpoint/expected.json
+++ b/verifier/conformance-vectors/acta-up-02-a2a-trajectory-endpoint/expected.json
@@ -1,3 +1,6 @@
 {
-  "verdict": "PASS"
+  "format": "acta",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Real ScopeBlind trust-level-ascending endpoint attestation (the 'trusted' link); a second upstream payload whose Ed25519 signature verifies, confirming the interop is not a single-receipt fluke."
 }

--- a/verifier/conformance-vectors/acta-up-03-a2a-tampered-sig/expected.json
+++ b/verifier/conformance-vectors/acta-up-03-a2a-tampered-sig/expected.json
@@ -1,3 +1,6 @@
 {
-  "verdict": "FAIL"
+  "format": "acta",
+  "outcome": "FAIL",
+  "reason_code": "sig_mismatch",
+  "notes": "The real happy-path attestation with its first signature nibble flipped; Ed25519 verify fails, proving the oracle rejects a mutated third-party receipt rather than waving it through."
 }

--- a/verifier/conformance-vectors/asqav-10-hash-mode-multikey/expected.json
+++ b/verifier/conformance-vectors/asqav-10-hash-mode-multikey/expected.json
@@ -1,3 +1,6 @@
 {
-  "verdict": "PASS"
+  "format": "asqav-native",
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Hash-mode receipt signed by the LAST of three sibling keys that share issuer_id/org_id; signature.kid is the org id, so a kid-shaped match answers for every sibling and list position would pick the wrong one. The agent bind (agent_id plus the org_id the receipt signs) resolves the actual signer. ANTI-VACUOUS: pre-change kid-first resolution verifies the first sibling and FAILs. Parity vector: both PY and TS oracles must PASS."
 }

--- a/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/expected.json
+++ b/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/expected.json
@@ -1,5 +1,6 @@
 {
-  "verdict": "PASS",
   "format": "pipelock-evidence-v2",
-  "notes": "Valid proxy_decision receipt from the Go reference implementation. Signed with RFC 8032 section 7.1 test-1 key. Verifies Ed25519 preimage (JCS with signature zeroed out) and chain-genesis sentinel sha256:0."
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Valid proxy_decision EvidenceReceipt v2 from Go reference implementation; signed with RFC 8032 section 7.1 test-1 key (d75a98...). Verifies Ed25519 over JCS preimage (signature zeroed out) and chain genesis sha256:0. Source: luckyPipewrench/pipelock-verify-python commit 9eaff72."
 }

--- a/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/expected.json
+++ b/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/expected.json
@@ -1,5 +1,6 @@
 {
-  "verdict": "FAIL",
   "format": "pipelock-evidence-v2",
-  "notes": "Valid proxy_decision receipt with verdict field changed from 'allow' to 'block'. The original signature was computed over the receipt with verdict='allow'; changing the payload shifts the JCS preimage and invalidates the Ed25519 signature."
+  "outcome": "FAIL",
+  "reason_code": "issuer_signature",
+  "notes": "Same receipt with payload.verdict changed from 'allow' to 'block' after signing; JCS preimage diverges, Ed25519 verify fails."
 }


### PR DESCRIPTION
## Criterion 436 (SDK parity audit 2026-08-03, findings 3.6/3.7/10/11.4)

Docs and corpus drifted from the shipped semantics in four places.

## Fixes

- `python/docs/CLI.md` and the `replay-verify` docstring claimed the chain hashes the whole signed envelope; it hashes the payload member (`sha256(canonical_json(payload))`), matching `replay.py`
- `conformance/vectors.json`: six counterparty_binding vectors pinned the genesis link with the sha256-prefixed 64-zero seed; the wire seed is the bare 64-zero hex - fixed in `input` and `canonical`, canonical `sha256` fields recomputed
- `conformance/README.md` and `docs/fingerprint-spec.md` described the canonicalization as strict JCS; it is the `json.dumps` dialect matching the JCS rules on the corpus domain (floats follow Python shortest-repr)
- ten `expected.json` files carried older shapes (`{verdict}` / `{format,notes,verdict}`); all now use the standard `{format, outcome, reason_code, notes}` form from the manifest

## Verification

- Python suite green on branch; oracle corpus 51/51 matched
- TypeScript suite green