### PR TITLE
fix(verifier): expiry reports on its own axis and never folds the verdict (criterion 426); one-line docstring sweep

### DIFF
--- a/python/src/asqav/_detectors.py
+++ b/python/src/asqav/_detectors.py
@@ -129,8 +129,8 @@ def register_detector(detector: DetectorPlugin, *, fail_open: bool = False) -> N
     _registry.append((detector, fail_open))
 
 
+    # Remove all registered detectors (useful in tests).
 def clear_detectors() -> None:
-    """Remove all registered detectors (useful in tests)."""
     _registry.clear()
 
 

--- a/python/src/asqav/_jcs.py
+++ b/python/src/asqav/_jcs.py
@@ -13,8 +13,8 @@ from typing import Any
 __all__ = ["canonical_json"]
 
 
+    # Return canonical JCS bytes for ``obj``, byte-identical to the cloud.
 def canonical_json(obj: Any) -> bytes:
-    """Return canonical JCS bytes for ``obj``, byte-identical to the cloud."""
     return json.dumps(
         obj,
         sort_keys=True,

--- a/python/src/asqav/_mode.py
+++ b/python/src/asqav/_mode.py
@@ -14,8 +14,8 @@ _VALID_EXPLICIT = {"auto", "hash-only", "full-payload"}
 _VALID_ENV = {"hash-only", "full-payload"}
 
 
+    # True if ``hostname`` is ``api.asqav.com`` or any ``*.asqav.com`` subdomain.
 def _is_asqav_cloud_host(hostname: str | None) -> bool:
-    """True if ``hostname`` is ``api.asqav.com`` or any ``*.asqav.com`` subdomain."""
     if not hostname:
         return False
     h = hostname.lower().strip().rstrip(".")
@@ -24,12 +24,12 @@ def _is_asqav_cloud_host(hostname: str | None) -> bool:
     return h == "api.asqav.com" or h.endswith(".asqav.com")
 
 
+    # Resolve the wire mode; ``explicit`` wins, then ``env``, then host auto-detection.
 def _resolve_mode(
     api_base_url: str | None,
     env: str | None,
     explicit: str | None = "auto",
 ) -> Mode:
-    """Resolve the wire mode; ``explicit`` wins, then ``env``, then host auto-detection."""
     if explicit is None:
         explicit = "auto"
     if explicit not in _VALID_EXPLICIT:

--- a/python/src/asqav/_useragent.py
+++ b/python/src/asqav/_useragent.py
@@ -8,8 +8,8 @@ so every request must identify itself with a real product token.
 from __future__ import annotations
 
 
+    # Resolve the installed package version without importing the package.
 def _sdk_version() -> str:
-    """Resolve the installed package version without importing the package."""
     try:
         from importlib.metadata import version
 

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -36,31 +36,31 @@ except ImportError:
     httpx = None  # type: ignore
 
 
+    # Ensure httpx is available for async operations.
 def _ensure_httpx() -> None:
-    """Ensure httpx is available for async operations."""
     if not _HTTPX_AVAILABLE:
         raise AsqavError(
             "httpx is required for async operations. Install with: pip install asqav[httpx]"
         )
 
 
+    # Ensure the SDK is initialized.
 def _ensure_initialized() -> None:
-    """Ensure the SDK is initialized."""
 
     if not _api_key:
         raise AuthenticationError("Call asqav.init() first. Get your API key at asqav.com")
 
 
+    # Get the current ``(api_base, api_key)`` tuple from the client module.
 def _get_config() -> tuple[str, str]:
-    """Get the current ``(api_base, api_key)`` tuple from the client module."""
 
     if not _api_key:
         raise AuthenticationError("Call asqav.init() first. Get your API key at asqav.com")
     return _api_base, _api_key
 
 
+    # Handle API response errors (async version).
 async def _handle_response(response: Any) -> None:
-    """Handle API response errors (async version)."""
     if response.status_code == 401:
         raise AuthenticationError("Invalid API key")
     elif response.status_code == 429:
@@ -73,9 +73,9 @@ async def _handle_response(response: Any) -> None:
         raise APIError(error, response.status_code)
 
 
+    # Make an async GET request to the API.
 @with_async_retry()
 async def _async_get(path: str) -> dict[str, Any]:
-    """Make an async GET request to the API."""
     _ensure_httpx()
     _ensure_initialized()
     api_base, api_key = _get_config()
@@ -91,9 +91,9 @@ async def _async_get(path: str) -> dict[str, Any]:
         return result
 
 
+    # Make an async POST request to the API.
 @with_async_retry()
 async def _async_post(path: str, data: dict[str, Any]) -> dict[str, Any]:
-    """Make an async POST request to the API."""
     _ensure_httpx()
     _ensure_initialized()
     api_base, api_key = _get_config()
@@ -109,9 +109,9 @@ async def _async_post(path: str, data: dict[str, Any]) -> dict[str, Any]:
         return result
 
 
+    # Make an async PATCH request to the API.
 @with_async_retry()
 async def _async_patch(path: str, data: dict[str, Any]) -> dict[str, Any]:
-    """Make an async PATCH request to the API."""
     _ensure_httpx()
     _ensure_initialized()
     api_base, api_key = _get_config()
@@ -127,9 +127,9 @@ async def _async_patch(path: str, data: dict[str, Any]) -> dict[str, Any]:
         return result
 
 
+    # Async agent representation; mirrors the sync :class:`Agent` over async HTTP.
 @dataclass
 class AsyncAgent:
-    """Async agent representation; mirrors the sync :class:`Agent` over async HTTP."""
 
     agent_id: str
     name: str
@@ -140,6 +140,7 @@ class AsyncAgent:
     created_at: float
     _session_id: str | None = field(default=None, repr=False)
 
+        # Create a new agent via Asqav Cloud; ``algorithm`` is ml-dsa-44/65/87.
     @classmethod
     async def create(
         cls,
@@ -147,7 +148,6 @@ class AsyncAgent:
         algorithm: str = "ml-dsa-65",
         capabilities: list[str] | None = None,
     ) -> AsyncAgent:
-        """Create a new agent via Asqav Cloud; ``algorithm`` is ml-dsa-44/65/87."""
         data = await _async_post(
             "/agents/create",
             {
@@ -167,9 +167,9 @@ class AsyncAgent:
             created_at=_parse_timestamp(require_field(data, "created_at")),
         )
 
+        # Get an existing agent by ID.
     @classmethod
     async def get(cls, agent_id: str) -> AsyncAgent:
-        """Get an existing agent by ID."""
         data = await _async_get(f"/agents/{agent_id}")
 
         return cls(
@@ -182,6 +182,7 @@ class AsyncAgent:
             created_at=_parse_timestamp(require_field(data, "created_at")),
         )
 
+        # Sign an action cryptographically (async); ``co_signers`` lists countersigner agents.
     async def sign(
         self,
         action_type: str,
@@ -193,7 +194,6 @@ class AsyncAgent:
         co_signers: list[str] | None = None,
         user_intent: dict[str, Any] | None = None,
     ) -> SignatureResponse:
-        """Sign an action cryptographically (async); ``co_signers`` lists countersigner agents."""
         from .client import _build_sign_body
 
         if tool_name or model_name or parent_id:
@@ -239,8 +239,8 @@ class AsyncAgent:
             previous_receipt_hash=_resolve_previous_receipt_hash(data),
         )
 
+        # Countersign an existing signature record (async); appends to ``co_signatures``.
     async def countersign(self, signature_id: str) -> SignatureResponse:
-        """Countersign an existing signature record (async); appends to ``co_signatures``."""
         data = await _async_post(
             f"/agents/{self.agent_id}/countersign/{signature_id}",
             {},
@@ -265,8 +265,8 @@ class AsyncAgent:
             user_intent_verified=data.get("user_intent_verified"),
         )
 
+        # Start a new session (async).
     async def start_session(self) -> SessionResponse:
-        """Start a new session (async)."""
         data = await _async_post("/sessions/", {"agent_id": self.agent_id})
 
         self._session_id = data["session_id"]
@@ -278,8 +278,8 @@ class AsyncAgent:
             started_at=data["started_at"],
         )
 
+        # End the current session (async); ``status`` is completed/error/timeout.
     async def end_session(self, status: str = "completed") -> SessionResponse:
-        """End the current session (async); ``status`` is completed/error/timeout."""
         if not self._session_id:
             raise AsqavError("No active session")
 
@@ -379,8 +379,8 @@ class AsyncAgent:
             checks_complete=checks_complete,
         )
 
+        # Publicly verify a signature by ID (async).
     async def verify(self, signature_id: str) -> VerificationResponse:
-        """Publicly verify a signature by ID (async)."""
         _ensure_httpx()
         api_base, _ = _get_config()
         url = f"{api_base}/verify/{signature_id}"

--- a/python/src/asqav/attestation.py
+++ b/python/src/asqav/attestation.py
@@ -120,26 +120,26 @@ def reconstruct_signed_message(
 # === Pure Merkle helpers (certificate-transparency 6962-style) ===
 
 
+    # SHA256(0x00 || entry). Mirrors the cloud's leaf domain separation.
 def merkle_leaf_hash(entry: bytes) -> bytes:
-    """SHA256(0x00 || entry). Mirrors the cloud's leaf domain separation."""
     return hashlib.sha256(_LEAF_PREFIX + entry).digest()
 
 
+    # SHA256(0x01 || left || right). Mirrors the cloud's internal node hash.
 def merkle_node_hash(left: bytes, right: bytes) -> bytes:
-    """SHA256(0x01 || left || right). Mirrors the cloud's internal node hash."""
     return hashlib.sha256(_NODE_PREFIX + left + right).digest()
 
 
+    # Largest power of two strictly less than n (n > 1). The 6962 split point.
 def _largest_power_of_two_below(n: int) -> int:
-    """Largest power of two strictly less than n (n > 1). The 6962 split point."""
     k = 1
     while k << 1 < n:
         k <<= 1
     return k
 
 
+    # Merkle tree hash over already-hashed leaves. Empty tree hashes SHA256(b"").
 def merkle_root(leaves: list[bytes]) -> bytes:
-    """Merkle tree hash over already-hashed leaves. Empty tree hashes SHA256(b"")."""
     n = len(leaves)
     if n == 0:
         return hashlib.sha256(b"").digest()
@@ -149,8 +149,8 @@ def merkle_root(leaves: list[bytes]) -> bytes:
     return merkle_node_hash(merkle_root(leaves[:k]), merkle_root(leaves[k:]))
 
 
+    # Audit path (sibling hashes, leaf-up) for the leaf at ``index``.
 def merkle_inclusion_proof(leaves: list[bytes], index: int) -> list[bytes]:
-    """Audit path (sibling hashes, leaf-up) for the leaf at ``index``."""
     n = len(leaves)
     if index < 0 or index >= n:
         raise IndexError(f"index {index} out of range for tree size {n}")
@@ -162,6 +162,7 @@ def merkle_inclusion_proof(leaves: list[bytes], index: int) -> list[bytes]:
     return merkle_inclusion_proof(leaves[k:], index - k) + [merkle_root(leaves[:k])]
 
 
+    # Verify an inclusion proof offline (6962 algorithm). False on any mismatch.
 def verify_merkle_inclusion(
     leaf: bytes,
     index: int,
@@ -169,7 +170,6 @@ def verify_merkle_inclusion(
     proof: list[bytes],
     root: bytes,
 ) -> bool:
-    """Verify an inclusion proof offline (6962 algorithm). False on any mismatch."""
     if index < 0 or index >= tree_size or tree_size <= 0:
         return False
     if tree_size == 1:
@@ -291,13 +291,13 @@ def verify_attestation_offline(
     }
 
 
+    # Verify the receipt signature over the signed message and bind it to the claim.
 def _check_signature(
     signed_message: bytes,
     receipt: dict[str, Any],
     recomputed_hash: str,
     verify_signature: Callable[[bytes, bytes], bool],
 ) -> tuple[str, str]:
-    """Verify the receipt signature over the signed message and bind it to the claim."""
     try:
         message_obj = json.loads(signed_message)
     except (ValueError, TypeError):
@@ -313,8 +313,8 @@ def _check_signature(
     return _AXIS_FAIL, "signature does not verify over the signed message"
 
 
+    # Map per-axis results to a verdict. A good receipt is never a plain PASS.
 def _verdict(axes: list[dict[str, str]]) -> str:
-    """Map per-axis results to a verdict. A good receipt is never a plain PASS."""
     results = {a["name"]: a["result"] for a in axes}
     if any(r == _AXIS_FAIL for r in results.values()):
         return VERDICT_FAIL

--- a/python/src/asqav/canonicalize.py
+++ b/python/src/asqav/canonicalize.py
@@ -19,16 +19,16 @@ __all__ = [
 ]
 
 
+    # Canonical bytes of ``{action_type, context}`` for hashing or signing.
 def canonicalize_action(
     action_type: str,
     context: "dict[str, Any] | None" = None,
 ) -> bytes:
-    """Canonical bytes of ``{action_type, context}`` for hashing or signing."""
     return canonicalize({"action_type": action_type, "context": context or {}})
 
 
+    # Return JCS-subset JSON bytes for ``obj``; matches the conformance vectors byte-for-byte.
 def canonicalize(obj: Any) -> bytes:
-    """Return JCS-subset JSON bytes for ``obj``; matches the conformance vectors byte-for-byte."""
     return json.dumps(
         obj,
         sort_keys=True,
@@ -38,8 +38,8 @@ def canonicalize(obj: Any) -> bytes:
     ).encode("utf-8")
 
 
+    # Return JSON pointer to the first float in ``value`` (depth-first); ``bool`` is JCS-safe.
 def _find_float_pointer(value: Any, pointer: str) -> str | None:
-    """Return JSON pointer to the first float in ``value`` (depth-first); ``bool`` is JCS-safe."""
     if isinstance(value, bool):
         return None
     if isinstance(value, float):

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -103,7 +103,8 @@ def main(
         is_eager=True,
     ),
 ) -> None:
-    """AI agent governance - audit trails, policy enforcement, compliance."""
+    # AI agent governance - audit trails, policy enforcement, compliance.
+    pass
 
 
 @app.command()
@@ -351,7 +352,7 @@ def _build_sign_context(
 
 
 def _print_sign_result_json(sig: Any) -> None:
-    """Render the Signature as the documented JSON payload."""
+    # Render the Signature as the documented JSON payload.
     import json as json_mod
 
     payload = {
@@ -377,7 +378,7 @@ def _print_sign_result_json(sig: Any) -> None:
 
 
 def _print_sign_result_text(sig: Any) -> None:
-    """Render the Signature as human-readable text lines."""
+    # Render the Signature as human-readable text lines.
     print(f"signature_id: {sig.signature_id}")
     print(f"action_id:    {sig.action_id}")
     print(f"algorithm:    {sig.algorithm}")
@@ -604,7 +605,7 @@ def replay(
 
 @agents_app.command("list")
 def agents_list() -> None:
-    """List all agents for your organization."""
+    # List all agents for your organization.
     api_key = resolve_api_key()
     if not api_key:
         print("Error: API key required. Run `asqav login` or set ASQAV_API_KEY.")
@@ -636,7 +637,7 @@ def agents_list() -> None:
 
 @agents_app.command("create")
 def agents_create(name: str = typer.Argument(help="Name for the new agent.")) -> None:
-    """Create a new agent."""
+    # Create a new agent.
     api_key = resolve_api_key()
     if not api_key:
         print("Error: API key required. Run `asqav login` or set ASQAV_API_KEY.")
@@ -662,7 +663,7 @@ def agents_revoke(
     agent_id: str = typer.Argument(help="Agent ID to revoke."),
     reason: str = typer.Option("manual", "--reason", help="Reason recorded in the audit trail."),
 ) -> None:
-    """Revoke an agent's credentials. Irreversible."""
+    # Revoke an agent's credentials. Irreversible.
     _init_sdk()
     from asqav import Agent, APIError
 
@@ -692,7 +693,7 @@ def sessions_list(
     status: str = typer.Option("", "--status", help="Filter by session status."),
     agent_id: str = typer.Option("", "--agent", help="Filter by agent_id."),
 ) -> None:
-    """List sessions for the current org."""
+    # List sessions for the current org.
     _init_sdk()
     from asqav import APIError, list_sessions
 
@@ -722,7 +723,7 @@ def sessions_end(
     session_id: str = typer.Argument(help="Session to end."),
     status: str = typer.Option("completed", "--status", help="Final status."),
 ) -> None:
-    """End a session by setting its status."""
+    # End a session by setting its status.
     _init_sdk()
     from asqav.client import _patch
 
@@ -747,7 +748,7 @@ app.add_typer(policies_app, name="policies")
 
 @policies_app.command("list")
 def policies_list() -> None:
-    """List all org policies."""
+    # List all org policies.
     _init_sdk()
     from asqav.client import _get
 
@@ -777,7 +778,7 @@ def policies_create(
         "block", "--action", help="One of: log, block, block_and_alert."
     ),
 ) -> None:
-    """Create a new policy."""
+    # Create a new policy.
     _init_sdk()
     from asqav.client import _post
 
@@ -794,7 +795,7 @@ def policies_create(
 
 @policies_app.command("delete")
 def policies_delete(policy_id: str = typer.Argument(help="Policy ID to delete.")) -> None:
-    """Delete a policy."""
+    # Delete a policy.
     _init_sdk()
     from asqav.client import _delete
 
@@ -819,7 +820,7 @@ app.add_typer(webhooks_app, name="webhooks")
 
 @webhooks_app.command("list")
 def webhooks_list() -> None:
-    """List configured webhooks."""
+    # List configured webhooks.
     _init_sdk()
     from asqav.client import _get
 
@@ -844,7 +845,7 @@ def webhooks_create(
         "signature.created", "--events", help="Comma-separated event names."
     ),
 ) -> None:
-    """Create a webhook subscription."""
+    # Create a webhook subscription.
     _init_sdk()
     from asqav.client import _post
 
@@ -859,7 +860,7 @@ def webhooks_create(
 
 @webhooks_app.command("delete")
 def webhooks_delete(webhook_id: str = typer.Argument(help="Webhook ID.")) -> None:
-    """Delete a webhook."""
+    # Delete a webhook.
     _init_sdk()
     from asqav.client import _delete
 
@@ -875,7 +876,7 @@ def webhooks_delete(webhook_id: str = typer.Argument(help="Webhook ID.")) -> Non
 
 
 def _init_sdk() -> None:
-    """Initialize SDK with an API key from the credential chain."""
+    # Initialize SDK with an API key from the credential chain.
     import asqav
 
     api_key = resolve_api_key()
@@ -887,7 +888,7 @@ def _init_sdk() -> None:
 
 @app.command()
 def sync() -> None:
-    """Sync local queue to the Asqav API."""
+    # Sync local queue to the Asqav API.
     _init_sdk()
 
     from asqav.local import LocalQueue
@@ -924,7 +925,7 @@ def sync() -> None:
 
 @queue_app.command("list")
 def queue_list() -> None:
-    """List pending items in the local queue."""
+    # List pending items in the local queue.
     from asqav.local import LocalQueue
 
     queue = LocalQueue()
@@ -944,7 +945,7 @@ def queue_list() -> None:
 
 @queue_app.command("count")
 def queue_count() -> None:
-    """Show number of pending items in the local queue."""
+    # Show number of pending items in the local queue.
     from asqav.local import LocalQueue
 
     queue = LocalQueue()
@@ -973,7 +974,7 @@ def demo(
 
 @app.command()
 def quickstart() -> None:
-    """Get started with asqav in 60 seconds."""
+    # Get started with asqav in 60 seconds.
     api_key = resolve_api_key()
     if api_key:
         typer.echo(
@@ -1020,7 +1021,7 @@ def quickstart() -> None:
 
 
 def _detect_framework() -> str:
-    """Detect the project framework from dependency manifests in the cwd."""
+    # Detect the project framework from dependency manifests in the cwd.
     from pathlib import Path
 
     for fname in ("requirements.txt", "pyproject.toml"):
@@ -1035,7 +1036,7 @@ def _detect_framework() -> str:
 
 
 def _onboarding_snippet(framework: str) -> str:
-    """Return a short govern() + @asqav.secure snippet flavoured for the framework."""
+    # Return a short govern() + @asqav.secure snippet flavoured for the framework.
     action = {
         "openai": "api:openai:chat",
         "anthropic": "api:anthropic:messages",
@@ -1058,7 +1059,7 @@ def _onboarding_snippet(framework: str) -> str:
 
 
 def _resolve_key_source(explicit: str | None) -> tuple[str | None, str]:
-    """Resolve an API key and report which source supplied it (arg/env/file/none)."""
+    # Resolve an API key and report which source supplied it (arg/env/file/none).
     import os
 
     from asqav.credentials import load_credentials
@@ -1080,7 +1081,7 @@ def login(
     api_base: str = typer.Option("", "--api-base", help="Override the API base URL."),
     force: bool = typer.Option(False, "--force", help="Overwrite an existing credentials file."),
 ) -> None:
-    """Validate an API key and save it to ~/.asqav/credentials."""
+    # Validate an API key and save it to ~/.asqav/credentials.
     from asqav.credentials import credentials_path, save_credentials
 
     if not api_key:
@@ -1141,7 +1142,7 @@ def whoami(
         "", "--api-key", help="API key (else ASQAV_API_KEY env, else ~/.asqav/credentials)."
     ),
 ) -> None:
-    """Show which API key source is active and validate it against the API."""
+    # Show which API key source is active and validate it against the API.
     _whoami_impl(api_key)
 
 
@@ -1151,7 +1152,7 @@ def status(
         "", "--api-key", help="API key (else ASQAV_API_KEY env, else ~/.asqav/credentials)."
     ),
 ) -> None:
-    """Alias for `asqav whoami`."""
+    # Alias for `asqav whoami`.
     _whoami_impl(api_key)
 
 
@@ -1160,7 +1161,7 @@ def init_cmd(
     write: bool = typer.Option(False, "--write", help="Write the snippet to asqav_governance.py."),
     demo: bool = typer.Option(False, "--demo", help="Run one labelled demo sign."),
 ) -> None:
-    """Print a ready-to-paste governance snippet for this project (non-invasive)."""
+    # Print a ready-to-paste governance snippet for this project (non-invasive).
     from pathlib import Path
 
     framework = _detect_framework()
@@ -1202,7 +1203,7 @@ def init_cmd(
 
 @app.command()
 def doctor() -> None:
-    """Validate your governance setup."""
+    # Validate your governance setup.
     all_ok = True
 
     # Check 1: API key
@@ -1342,7 +1343,7 @@ def doctor() -> None:
 def queue_clear(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation."),
 ) -> None:
-    """Clear all pending items from the local queue."""
+    # Clear all pending items from the local queue.
     from asqav.local import LocalQueue
 
     queue = LocalQueue()
@@ -1503,7 +1504,7 @@ def approve(
     entity_id: str = typer.Argument(help="Entity providing approval."),
     json_out: bool = typer.Option(False, "--json", help="Print result as JSON."),
 ) -> None:
-    """Approve a pending signing-action session. Wraps asqav.approve_action()."""
+    # Approve a pending signing-action session. Wraps asqav.approve_action().
     import json as json_mod
 
     _init_sdk()
@@ -2231,7 +2232,7 @@ def migrate_run(
 
 @compliance_app.command("frameworks")
 def compliance_frameworks() -> None:
-    """List the compliance frameworks the bundle exporter recognizes."""
+    # List the compliance frameworks the bundle exporter recognizes.
     from asqav.compliance import FRAMEWORKS
 
     for key, meta in sorted(FRAMEWORKS.items()):
@@ -2542,14 +2543,14 @@ _SHADOW_AI_REQUIRED_ENV_VARS = ("ASQAV_API_KEY", "ASQAV_AGENT_ID", "POSTGRES_PAS
 
 
 def _shadow_ai_template_dir() -> "object":
-    """Resolve the shipped templates directory as an importlib.resources Traversable."""
+    # Resolve the shipped templates directory as an importlib.resources Traversable.
     from importlib.resources import files
 
     return files("asqav").joinpath("templates", "shadow-ai")
 
 
 def _shadow_ai_copy_templates(dest: "object", force: bool) -> list[str]:
-    """Copy the three template files into dest, returning the written paths."""
+    # Copy the three template files into dest, returning the written paths.
     from pathlib import Path
 
     dest_path = Path(str(dest))
@@ -2567,7 +2568,7 @@ def _shadow_ai_copy_templates(dest: "object", force: bool) -> list[str]:
 
 
 def _shadow_ai_parse_env(env_path: "object") -> dict[str, str]:
-    """Return a dict of KEY=VALUE pairs from a dotenv-style file."""
+    # Return a dict of KEY=VALUE pairs from a dotenv-style file.
     from pathlib import Path
 
     out: dict[str, str] = {}
@@ -2581,7 +2582,7 @@ def _shadow_ai_parse_env(env_path: "object") -> dict[str, str]:
 
 
 def _shadow_ai_validate_env(dir_path: "object") -> "object":
-    """Return the .env path if present and required vars are non-empty, else raise."""
+    # Return the .env path if present and required vars are non-empty, else raise.
     from pathlib import Path
 
     base = Path(str(dir_path))
@@ -2617,7 +2618,7 @@ def shadow_ai_init(
         help="Overwrite existing files in the target directory.",
     ),
 ) -> None:
-    """Scaffold docker-compose.yml, .env.template, and README.md into the target directory."""
+    # Scaffold docker-compose.yml, .env.template, and README.md into the target directory.
     from pathlib import Path
 
     target = Path(dir)
@@ -2714,7 +2715,7 @@ def shadow_ai_up(
         help="Directory holding docker-compose.yml and .env.",
     ),
 ) -> None:
-    """Start the shim + signer stack via docker compose up -d --build."""
+    # Start the shim + signer stack via docker compose up -d --build.
     import subprocess
     from pathlib import Path
 
@@ -2748,7 +2749,7 @@ def shadow_ai_down(
         help="Directory holding docker-compose.yml.",
     ),
 ) -> None:
-    """Stop the shim + signer stack via docker compose down."""
+    # Stop the shim + signer stack via docker compose down.
     import subprocess
     from pathlib import Path
 
@@ -2785,7 +2786,7 @@ def shadow_ai_status(
         help="Base URL of the local signer.",
     ),
 ) -> None:
-    """Probe shim /_healthz and signer /api/v1/health/; exit 0 only if both are healthy."""
+    # Probe shim /_healthz and signer /api/v1/health/; exit 0 only if both are healthy.
     from pathlib import Path
 
     compose = Path(dir) / "docker-compose.yml"
@@ -2839,7 +2840,7 @@ def shadow_ai_logs(
         help="Show only the last N log lines (0 = all).",
     ),
 ) -> None:
-    """Tail docker compose logs for the shim + signer stack."""
+    # Tail docker compose logs for the shim + signer stack.
     import subprocess
     from pathlib import Path
 

--- a/python/src/asqav/cli_hook.py
+++ b/python/src/asqav/cli_hook.py
@@ -63,14 +63,15 @@ def _read_event(*, fail_code: int = 1) -> dict[str, Any]:
     return event
 
 
+    # sha256:<hex> over the JCS-canonical bytes of the tool response.
 def _result_digest(tool_response: Any) -> str:
-    """sha256:<hex> over the JCS-canonical bytes of the tool response."""
     from asqav.canonicalize import canonicalize
 
     digest = hashlib.sha256(canonicalize(tool_response)).hexdigest()
     return f"sha256:{digest}"
 
 
+    # Build the same body sign() POSTs, reusing the SDK builder (no re-impl).
 def _build_body(
     *,
     action_type: str,
@@ -79,7 +80,6 @@ def _build_body(
     agent_id: str,
     compliance_fields: dict[str, Any],
 ) -> dict[str, Any]:
-    """Build the same body sign() POSTs, reusing the SDK builder (no re-impl)."""
     from asqav.client import _build_sign_body
 
     return _build_sign_body(
@@ -123,8 +123,8 @@ def _map_event(
     return action_type, context, session_id, compliance_fields
 
 
+    # Return (api_key, agent_id) from the credential chain + env, or error clearly.
 def _require_identity() -> tuple[str, str]:
-    """Return (api_key, agent_id) from the credential chain + env, or error clearly."""
     api_key = resolve_api_key()
     agent_id = os.environ.get("ASQAV_AGENT_ID")
     missing = [
@@ -142,6 +142,7 @@ def _require_identity() -> tuple[str, str]:
     return api_key, agent_id  # type: ignore[return-value]
 
 
+    # Init the SDK, fetch the agent, and sign. Raises on any failure.
 def _sign_event(
     *,
     action_type: str,
@@ -151,7 +152,6 @@ def _sign_event(
     api_key: str,
     agent_id: str,
 ) -> Any:
-    """Init the SDK, fetch the agent, and sign. Raises on any failure."""
     import asqav
 
     asqav.init(api_key=api_key)

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -55,8 +55,8 @@ _MAX_RETRIES = 5
 _RETRY_DELAYS = [0.5, 1.0, 2.0, 4.0, 8.0]  # Exponential backoff
 
 
+    # Execute function with exponential backoff retry on rate limit/network errors.
 def _with_retry(func: Callable[[], Any]) -> Any:
-    """Execute function with exponential backoff retry on rate limit/network errors."""
     last_error: Exception | None = None
     for attempt, delay in enumerate(_RETRY_DELAYS):
         try:
@@ -68,8 +68,8 @@ def _with_retry(func: Callable[[], Any]) -> Any:
     raise last_error
 
 
+    # Hash an arbitrary value with SHA-256 for output verification.
 def _hash_value(value: Any) -> str:
-    """Hash an arbitrary value with SHA-256 for output verification."""
     if isinstance(value, str):
         raw = value.encode("utf-8")
     elif isinstance(value, bytes):
@@ -79,8 +79,8 @@ def _hash_value(value: Any) -> str:
     return hashlib.sha256(raw).hexdigest()
 
 
+    # Parse a timestamp from API response (ISO string or float).
 def _parse_timestamp(value: Any) -> float:
-    """Parse a timestamp from API response (ISO string or float)."""
     if isinstance(value, (int, float)):
         return float(value)
     if isinstance(value, str):
@@ -132,26 +132,26 @@ _HASH_ONLY_METADATA_WHITELIST: frozenset[str] = frozenset(
 )
 
 
+    # Base exception for asqav errors.
 class AsqavError(Exception):
-    """Base exception for asqav errors."""
 
     pass
 
 
+    # Raised when API key is missing or invalid.
 class AuthenticationError(AsqavError):
-    """Raised when API key is missing or invalid."""
 
     pass
 
 
+    # Raised when rate limit is exceeded.
 class RateLimitError(AsqavError):
-    """Raised when rate limit is exceeded."""
 
     pass
 
 
+    # Raised for general API errors.
 class APIError(AsqavError):
-    """Raised for general API errors."""
 
     def __init__(self, message: str, status_code: int | None = None) -> None:
         super().__init__(message)
@@ -204,9 +204,9 @@ def require_field(data: dict[str, Any], name: str) -> Any:
     return data[name]
 
 
+    # Response from agent creation.
 @dataclass
 class AgentResponse:
-    """Response from agent creation."""
 
     agent_id: str
     name: str
@@ -217,17 +217,17 @@ class AgentResponse:
     created_at: float
 
 
+    # Response from token issuance.
 @dataclass
 class TokenResponse:
-    """Response from token issuance."""
 
     token: str
     expires_at: float
     algorithm: str
 
 
+    # Turn the JSON bitcoin_anchor block from the API into a typed value.
 def _parse_bitcoin_anchor(raw: dict[str, Any] | None) -> "BitcoinAnchor | None":
-    """Turn the JSON bitcoin_anchor block from the API into a typed value."""
     if not raw:
         return None
     return BitcoinAnchor(
@@ -386,8 +386,8 @@ def _map_policy_decision_to_decision(policy_decision: str | None) -> str:
     return DECISION_MAP.get((policy_decision or "").lower(), "deny")
 
 
+    # Read a string ``key`` from the sign response ``payload`` object, else None.
 def _payload_field(data: dict[str, Any], key: str) -> str | None:
-    """Read a string ``key`` from the sign response ``payload`` object, else None."""
     payload = data.get("payload")
     if not isinstance(payload, dict):
         return None
@@ -395,16 +395,16 @@ def _payload_field(data: dict[str, Any], key: str) -> str | None:
     return value if isinstance(value, str) else None
 
 
+    # Top-level ``action_ref`` wins; compliance-mode clouds nest it under payload.
 def _resolve_action_ref(data: dict[str, Any]) -> str | None:
-    """Top-level ``action_ref`` wins; compliance-mode clouds nest it under payload."""
     top = data.get("action_ref")
     if top is not None:
         return top
     return _payload_field(data, "action_ref")
 
 
+    # Either casing at top level wins; fall back to the copy nested under payload.
 def _resolve_previous_receipt_hash(data: dict[str, Any]) -> str | None:
-    """Either casing at top level wins; fall back to the copy nested under payload."""
     return (
         data.get("previousReceiptHash")
         or data.get("previous_receipt_hash")
@@ -502,9 +502,9 @@ class SignatureResponse:
         return self.anchors
 
 
+    # Response from session operations.
 @dataclass
 class SessionResponse:
-    """Response from session operations."""
 
     session_id: str
     agent_id: str
@@ -546,14 +546,14 @@ class SDTokenResponse:
                 parts.append(self.disclosures[claim_name])
         return "~".join(parts) + "~"
 
+        # Return full SD-JWT with all disclosures.
     def full(self) -> str:
-        """Return full SD-JWT with all disclosures."""
         return self.token
 
 
+    # Agent identity certificate.
 @dataclass
 class CertificateResponse:
-    """Agent identity certificate."""
 
     agent_id: str
     agent_name: str
@@ -671,9 +671,9 @@ class VerificationResponse:
     algorithm_registry_version: str | None = None
 
 
+    # Signed action from a session.
 @dataclass
 class SignedActionResponse:
-    """Signed action from a session."""
 
     signature_id: str
     agent_id: str
@@ -686,9 +686,9 @@ class SignedActionResponse:
     verification_url: str
 
 
+    # Details of a single entity signature within a signing session.
 @dataclass
 class SignatureDetail:
-    """Details of a single entity signature within a signing session."""
 
     entity_id: str
     entity_name: str
@@ -696,9 +696,9 @@ class SignatureDetail:
     signed_at: str
 
 
+    # Response from signing session operations.
 @dataclass
 class SigningSessionResponse:
-    """Response from signing session operations."""
 
     session_id: str
     config_id: str
@@ -715,9 +715,9 @@ class SigningSessionResponse:
     resolved_at: str | None = None
 
 
+    # Response from signing approval operation.
 @dataclass
 class ApprovalResponse:
-    """Response from signing approval operation."""
 
     session_id: str
     entity_id: str
@@ -727,9 +727,9 @@ class ApprovalResponse:
     approved: bool
 
 
+    # Response from signing group operations.
 @dataclass
 class SigningGroupResponse:
-    """Response from signing group operations."""
 
     id: str
     agent_id: str
@@ -740,9 +740,9 @@ class SigningGroupResponse:
     updated_at: str | None = None
 
 
+    # Response from signing entity operations.
 @dataclass
 class SigningEntityResponse:
-    """Response from signing entity operations."""
 
     id: str
     config_id: str
@@ -752,9 +752,9 @@ class SigningEntityResponse:
     created_at: str
 
 
+    # Response from group keypair operations.
 @dataclass
 class GroupKeypairResponse:
-    """Response from group keypair operations."""
 
     id: str
     config_id: str
@@ -765,9 +765,9 @@ class GroupKeypairResponse:
     status: str = "active"
 
 
+    # Response from group signing operation.
 @dataclass
 class GroupSignResponse:
-    """Response from group signing operation."""
 
     signature_hex: str
     message_hex: str
@@ -776,9 +776,9 @@ class GroupSignResponse:
     audit_record_id: str | None = None
 
 
+    # Response from risk rule operations.
 @dataclass
 class RiskRuleResponse:
-    """Response from risk rule operations."""
 
     id: str
     name: str
@@ -791,9 +791,9 @@ class RiskRuleResponse:
     created_at: str = ""
 
 
+    # Response from delegation operations.
 @dataclass
 class DelegationResponse:
-    """Response from delegation operations."""
 
     id: str
     config_id: str
@@ -804,18 +804,18 @@ class DelegationResponse:
     created_at: str
 
 
+    # Response from key share refresh operation.
 @dataclass
 class KeyRefreshResponse:
-    """Response from key share refresh operation."""
 
     keypair_id: str
     refreshed_at: str
     delegations_invalidated: int
 
 
+    # Response from key share recovery operation.
 @dataclass
 class ShareRecoveryResponse:
-    """Response from key share recovery operation."""
 
     keypair_id: str
     recovered_entity_id: str
@@ -861,12 +861,12 @@ class Span:
     status: str = "ok"
     signature: str | None = None
 
+        # Add an attribute to the span.
     def set_attribute(self, key: str, value: Any) -> None:
-        """Add an attribute to the span."""
         self.attributes[key] = value
 
+        # Set span status (ok, error).
     def set_status(self, status: str) -> None:
-        """Set span status (ok, error)."""
         self.status = status
 
 
@@ -938,8 +938,8 @@ def span(
         _completed_spans.append(span_obj)
 
 
+    # Get the active span, if any.
 def get_current_span() -> Span | None:
-    """Get the active span, if any."""
     return _current_span
 
 
@@ -957,8 +957,8 @@ def configure_otel(endpoint: str | None = None) -> None:
     _otel_endpoint = endpoint
 
 
+    # Convert a Span to OTEL format.
 def span_to_otel(s: Span) -> dict[str, Any]:
-    """Convert a Span to OTEL format."""
     return {
         "traceId": s.span_id.replace("-", "")[:32].ljust(32, "0"),
         "spanId": s.span_id.replace("-", "")[:16],
@@ -991,8 +991,8 @@ def export_spans() -> list[dict[str, Any]]:
     return spans
 
 
+    # Flush spans to configured OTEL endpoint.
 def flush_spans() -> None:
-    """Flush spans to configured OTEL endpoint."""
     global _otel_endpoint, _completed_spans
 
     if not _otel_endpoint or not _completed_spans:
@@ -2595,23 +2595,23 @@ class Agent:
             payload["note"] = note
         return _post(f"/agents/{self.agent_id}/suspend", payload)
 
+        # Remove suspension from this agent.
     def unsuspend(self) -> dict[str, Any]:
-        """Remove suspension from this agent."""
         return _post(f"/agents/{self.agent_id}/unsuspend", {})
 
+        # Permanently retire this agent (keys archived, no further activity).
     def decommission(self, reason: str = "manual") -> dict[str, Any]:
-        """Permanently retire this agent (keys archived, no further activity)."""
         return _post(
             f"/agents/{self.agent_id}/decommission",
             {"reason": reason},
         )
 
+        # Block signing and token issuance, keep read + verify. Enterprise.
     def quarantine(self) -> dict[str, Any]:
-        """Block signing and token issuance, keep read + verify. Enterprise."""
         return _post(f"/agents/{self.agent_id}/quarantine", {})
 
+        # Restore normal signing and token issuance after quarantine.
     def unquarantine(self) -> dict[str, Any]:
-        """Restore normal signing and token issuance after quarantine."""
         return _post(f"/agents/{self.agent_id}/unquarantine", {})
 
     def delegate(
@@ -2649,15 +2649,15 @@ class Agent:
             created_at=_parse_timestamp(data["created_at"]),
         )
 
+        # Check if this agent is revoked.
     @property
     def is_revoked(self) -> bool:
-        """Check if this agent is revoked."""
         data = _get(f"/agents/{self.agent_id}/status")
         return bool(data.get("revoked", False))
 
+        # Check if this agent is suspended.
     @property
     def is_suspended(self) -> bool:
-        """Check if this agent is suspended."""
         data = _get(f"/agents/{self.agent_id}/status")
         return bool(data.get("suspended", False))
 
@@ -2836,8 +2836,8 @@ def health_check() -> dict[str, Any]:
     return _get("/health")
 
 
+    # Generate a unique trace ID for correlating actions across a workflow.
 def generate_trace_id() -> str:
-    """Generate a unique trace ID for correlating actions across a workflow."""
     return uuid.uuid4().hex
 
 
@@ -2970,9 +2970,9 @@ def govern(
     return Agent.create(agent_name, algorithm=algorithm, capabilities=capabilities)
 
 
+    # Make a GET request to the API.
 @with_retry()
 def _get(path: str) -> dict[str, Any]:
-    """Make a GET request to the API."""
     _ensure_initialized()
 
     if _HTTPX_AVAILABLE and _client:
@@ -2985,9 +2985,9 @@ def _get(path: str) -> dict[str, Any]:
         return _urllib_request("GET", path)
 
 
+    # Make a POST request to the API.
 @with_retry()
 def _post(path: str, data: dict[str, Any]) -> dict[str, Any]:
-    """Make a POST request to the API."""
     _ensure_initialized()
 
     if _HTTPX_AVAILABLE and _client:
@@ -2999,9 +2999,9 @@ def _post(path: str, data: dict[str, Any]) -> dict[str, Any]:
         return _urllib_request("POST", path, data)
 
 
+    # Make a PATCH request to the API.
 @with_retry()
 def _patch(path: str, data: dict[str, Any]) -> dict[str, Any]:
-    """Make a PATCH request to the API."""
     _ensure_initialized()
 
     if _HTTPX_AVAILABLE and _client:
@@ -3013,9 +3013,9 @@ def _patch(path: str, data: dict[str, Any]) -> dict[str, Any]:
         return _urllib_request("PATCH", path, data)
 
 
+    # Make a PUT request to the API.
 @with_retry()
 def _put(path: str, data: dict[str, Any]) -> dict[str, Any]:
-    """Make a PUT request to the API."""
     _ensure_initialized()
 
     if _HTTPX_AVAILABLE and _client:
@@ -3027,9 +3027,9 @@ def _put(path: str, data: dict[str, Any]) -> dict[str, Any]:
         return _urllib_request("PUT", path, data)
 
 
+    # Make a DELETE request to the API.
 @with_retry()
 def _delete(path: str) -> dict[str, Any]:
-    """Make a DELETE request to the API."""
     _ensure_initialized()
 
     if _HTTPX_AVAILABLE and _client:
@@ -3041,14 +3041,14 @@ def _delete(path: str) -> dict[str, Any]:
         return _urllib_request("DELETE", path)
 
 
+    # Ensure the SDK is initialized.
 def _ensure_initialized() -> None:
-    """Ensure the SDK is initialized."""
     if not _api_key:
         raise AuthenticationError("Call asqav.init() first. Get your API key at asqav.com")
 
 
+    # Handle API response errors.
 def _handle_response(response: Any) -> None:
-    """Handle API response errors."""
     if response.status_code == 401:
         raise AuthenticationError("Invalid API key")
     elif response.status_code == 429:
@@ -3070,12 +3070,12 @@ def _handle_response(response: Any) -> None:
         raise APIError(error, response.status_code)
 
 
+    # HTTP client using stdlib urllib (used when httpx not installed).
 def _urllib_request(
     method: str,
     path: str,
     data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """HTTP client using stdlib urllib (used when httpx not installed)."""
     import json
     import urllib.error
     import urllib.request
@@ -3155,8 +3155,8 @@ def list_agents() -> list[Agent]:
     return out
 
 
+    # Generate an agent name from environment.
 def _auto_generate_name() -> str:
-    """Generate an agent name from environment."""
     env_name = os.environ.get("ASQAV_AGENT_NAME")
     if env_name:
         return env_name
@@ -3927,8 +3927,8 @@ def get_action_status(session_id: str) -> SigningSessionResponse:
     return _parse_signing_session(data)
 
 
+    # Parse API response into a SigningSessionResponse.
 def _parse_signing_session(data: dict[str, Any]) -> SigningSessionResponse:
-    """Parse API response into a SigningSessionResponse."""
     signatures = [
         SignatureDetail(
             entity_id=s["entity_id"],
@@ -4024,8 +4024,8 @@ def update_signing_group(
     return _parse_signing_group(data)
 
 
+    # Parse API response into a SigningGroupResponse.
 def _parse_signing_group(data: dict[str, Any]) -> SigningGroupResponse:
-    """Parse API response into a SigningGroupResponse."""
     return SigningGroupResponse(
         id=data["id"],
         agent_id=data["agent_id"],
@@ -4235,8 +4235,8 @@ def recover_share(
     )
 
 
+    # Parse API response into a GroupKeypairResponse.
 def _parse_group_keypair(data: dict[str, Any]) -> GroupKeypairResponse:
-    """Parse API response into a GroupKeypairResponse."""
     return GroupKeypairResponse(
         id=data["id"],
         config_id=data["config_id"],
@@ -4354,8 +4354,8 @@ def delete_risk_rule(rule_id: str) -> dict[str, Any]:
     return _delete(f"/risk-rules/{rule_id}")
 
 
+    # Parse API response into RiskRuleResponse.
 def _parse_risk_rule(data: dict[str, Any]) -> RiskRuleResponse:
-    """Parse API response into RiskRuleResponse."""
     return RiskRuleResponse(
         id=data["id"],
         name=data["name"],
@@ -4447,8 +4447,8 @@ def revoke_delegation(delegation_id: str) -> dict[str, Any]:
     return _delete(f"/signing-groups/delegations/{delegation_id}")
 
 
+    # Parse API response into a DelegationResponse.
 def _parse_delegation(data: dict[str, Any]) -> DelegationResponse:
-    """Parse API response into a DelegationResponse."""
     return DelegationResponse(
         id=data["id"],
         config_id=data["config_id"],
@@ -4741,9 +4741,9 @@ def verify_attestation(attestation: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+    # Result of a budget pre-check for an agent action.
 @dataclass
 class BudgetCheckResult:
-    """Result of a budget pre-check for an agent action."""
 
     allowed: bool
     current_spend: float
@@ -4878,8 +4878,8 @@ class BudgetTracker:
         self._records.append(sig.signature_id)
         return sig
 
+        # Get current budget status.
     def status(self) -> dict[str, Any]:
-        """Get current budget status."""
         return {
             "limit": self.limit,
             "currency": self.currency,

--- a/python/src/asqav/code_authorship.py
+++ b/python/src/asqav/code_authorship.py
@@ -79,8 +79,8 @@ def compute_advisory_digest(
     return "sha256:" + hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
 
 
+    # Strip a ``sha256:`` prefix to the bare hex, or None when absent.
 def _bare_hex(digest: str | None) -> str | None:
-    """Strip a ``sha256:`` prefix to the bare hex, or None when absent."""
     if not isinstance(digest, str) or not digest:
         return None
     return digest.split(":", 1)[-1]
@@ -107,9 +107,9 @@ class CodeAuthorshipResult:
     advisory_client_digest: str | None
     raw: dict[str, Any] = field(default_factory=dict)
 
+        # Project the wire response into a result, reading the Statement fields.
     @classmethod
     def from_response(cls, data: dict[str, Any]) -> "CodeAuthorshipResult":
-        """Project the wire response into a result, reading the Statement fields."""
         envelope = data.get("envelope") if isinstance(data.get("envelope"), dict) else {}
         receipt = data.get("receipt") if isinstance(data.get("receipt"), dict) else {}
 
@@ -142,9 +142,9 @@ class CodeAuthorshipResult:
             raw=data,
         )
 
+        # True when the bound subject digest equals the server-recomputed digest.
     @property
     def subject_matches_server(self) -> bool:
-        """True when the bound subject digest equals the server-recomputed digest."""
         if self.subject_digest is None or self.server_digest is None:
             return False
         return self.subject_digest == _bare_hex(self.server_digest)

--- a/python/src/asqav/compliance.py
+++ b/python/src/asqav/compliance.py
@@ -63,8 +63,8 @@ FRAMEWORKS = {
     },
 }
 
+    # Compute Merkle root from hex hashes (binary tree, odd levels duplicate the tail).
 def _compute_merkle_root(hashes: list[str]) -> str:
-    """Compute Merkle root from hex hashes (binary tree, odd levels duplicate the tail)."""
     if not hashes:
         return hashlib.sha256(b"").hexdigest()
 
@@ -83,14 +83,14 @@ def _compute_merkle_root(hashes: list[str]) -> str:
     return level[0]
 
 
+    # Deterministic hash for a single receipt.
 def _receipt_hash(receipt: dict) -> str:
-    """Deterministic hash for a single receipt."""
     canonical = json.dumps(receipt, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 
+    # Convert a SignatureResponse, SignedActionResponse, or dict to a receipt dict.
 def _normalize_signature(sig: Any) -> dict:
-    """Convert a SignatureResponse, SignedActionResponse, or dict to a receipt dict."""
     if isinstance(sig, dict):
         return sig
 
@@ -114,9 +114,9 @@ def _normalize_signature(sig: Any) -> dict:
     return result
 
 
+    # Self-contained compliance bundle for offline audit verification.
 @dataclass
 class ComplianceBundle:
-    """Self-contained compliance bundle for offline audit verification."""
 
     framework: str
     framework_metadata: dict = field(default_factory=dict)
@@ -126,8 +126,8 @@ class ComplianceBundle:
     receipts: list[dict] = field(default_factory=list)
     verification: dict = field(default_factory=dict)
 
+        # Serialize bundle to a plain dictionary.
     def to_dict(self) -> dict[str, Any]:
-        """Serialize bundle to a plain dictionary."""
         return {
             "framework": self.framework,
             "framework_metadata": self.framework_metadata,
@@ -138,12 +138,12 @@ class ComplianceBundle:
             "verification": self.verification,
         }
 
+        # Serialize bundle to a JSON string.
     def to_json(self) -> str:
-        """Serialize bundle to a JSON string."""
         return json.dumps(self.to_dict(), indent=2)
 
+        # Write bundle JSON to a file.
     def to_file(self, path: str) -> None:
-        """Write bundle JSON to a file."""
         with open(path, "w") as f:
             f.write(self.to_json())
 

--- a/python/src/asqav/counterparty.py
+++ b/python/src/asqav/counterparty.py
@@ -48,8 +48,8 @@ class CounterpartyBinding:
         metadata={"description": "Operational transport hint (mcp|bus|http)."},
     )
 
+        # Return the wire-shape dict; drops ``None`` keys to match cloud JCS.
     def to_wire(self) -> dict[str, Any]:
-        """Return the wire-shape dict; drops ``None`` keys to match cloud JCS."""
         out: dict[str, Any] = {
             "envelope_hash": self.envelope_hash,
             "receipt_ref": self.receipt_ref,
@@ -61,8 +61,8 @@ class CounterpartyBinding:
         return out
 
 
+    # Base64 SHA-256 over the envelope's JCS bytes.
 def compute_envelope_hash(envelope: dict[str, Any]) -> str:
-    """Base64 SHA-256 over the envelope's JCS bytes."""
     return base64.b64encode(hashlib.sha256(canonical_json(envelope)).digest()).decode()
 
 
@@ -97,9 +97,9 @@ def compute_counterparty_binding(
     )
 
 
+    # Outcome of the counterparty-binding sanity check; ``valid`` ANDs all populated booleans.
 @dataclass
 class CounterpartyBindingVerification:
-    """Outcome of the counterparty-binding sanity check; ``valid`` ANDs all populated booleans."""
 
     valid: bool
     envelope_hash_matches: bool

--- a/python/src/asqav/credentials.py
+++ b/python/src/asqav/credentials.py
@@ -54,8 +54,8 @@ def credentials_path() -> Path:
     return Path(os.path.expanduser("~")) / ".asqav" / "credentials"
 
 
+    # Read the credentials file. Missing or corrupt file returns {} (never raises).
 def load_credentials() -> dict[str, object]:
-    """Read the credentials file. Missing or corrupt file returns {} (never raises)."""
     try:
         data = json.loads(credentials_path().read_text(encoding="utf-8"))
     except (OSError, ValueError):
@@ -63,8 +63,8 @@ def load_credentials() -> dict[str, object]:
     return data if isinstance(data, dict) else {}
 
 
+    # Write the credentials file with mode 0600 under a mode 0700 ~/.asqav dir.
 def save_credentials(api_key: str, api_base: str | None = None) -> Path:
-    """Write the credentials file with mode 0600 under a mode 0700 ~/.asqav dir."""
     path = credentials_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.parent.chmod(0o700)
@@ -80,8 +80,8 @@ def save_credentials(api_key: str, api_base: str | None = None) -> Path:
     return path
 
 
+    # Resolve an API key: explicit arg, then ASQAV_API_KEY env, then credentials file.
 def resolve_api_key(explicit: str | None = None) -> str | None:
-    """Resolve an API key: explicit arg, then ASQAV_API_KEY env, then credentials file."""
     if explicit:
         return explicit
     env_key = os.environ.get("ASQAV_API_KEY")
@@ -93,8 +93,8 @@ def resolve_api_key(explicit: str | None = None) -> str | None:
     return None
 
 
+    # Resolve an API base: explicit arg, then ASQAV_API_BASE env, then file, then default.
 def resolve_api_base(explicit: str | None = None) -> str:
-    """Resolve an API base: explicit arg, then ASQAV_API_BASE env, then file, then default."""
     if explicit:
         return explicit
     env_base = os.environ.get("ASQAV_API_BASE")

--- a/python/src/asqav/decorators.py
+++ b/python/src/asqav/decorators.py
@@ -16,8 +16,8 @@ F = TypeVar("F")
 # === Session context manager ===
 
 
+    # Groups sign calls under a single session; created by :func:`session`.
 class Session:
-    """Groups sign calls under a single session; created by :func:`session`."""
 
     def __init__(self, agent: Agent, session_response: SessionResponse) -> None:
         self._agent = agent
@@ -27,14 +27,14 @@ class Session:
     def session_id(self) -> str:
         return self._session_response.session_id
 
+        # Sign an action within this session.
     def sign(self, action_type: str, context: dict[str, Any] | None = None) -> SignatureResponse:
-        """Sign an action within this session."""
         return self._agent.sign(action_type, context)
 
 
+    # Context manager that groups sign calls; signs ``session:error`` on exception.
 @contextmanager
 def session() -> Generator[Session, None, None]:
-    """Context manager that groups sign calls; signs ``session:error`` on exception."""
     agent = get_agent()
     session_resp = agent.start_session()
     sess = Session(agent, session_resp)
@@ -53,9 +53,9 @@ def session() -> Generator[Session, None, None]:
         agent.end_session(status="completed")
 
 
+    # Async counterpart of :func:`session`; signs ``session:error`` on exception.
 @asynccontextmanager
 async def async_session() -> AsyncGenerator[Session, None]:
-    """Async counterpart of :func:`session`; signs ``session:error`` on exception."""
     agent = get_agent()
     session_resp = agent.start_session()
     sess = Session(agent, session_resp)

--- a/python/src/asqav/demo.py
+++ b/python/src/asqav/demo.py
@@ -134,9 +134,9 @@ SCENARIOS: list[dict[str, Any]] = [
 
 # === Local HMAC-signed receipt (no ML-DSA dep, keeps demo zero-install) ===
 
+    # In-memory demo state: approvals + secret key.
 @dataclass
 class DemoState:
-    """In-memory demo state: approvals + secret key."""
 
     secret: bytes = field(default_factory=lambda: secrets.token_bytes(32))
     approvals: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -425,8 +425,8 @@ class DemoHandler(http.server.BaseHTTPRequestHandler):
         self._json(404, {"error": "not found"})
 
 
+    # Return `preferred` if free, otherwise scan upward for an open port.
 def _find_free_port(preferred: int = 3030) -> int:
-    """Return `preferred` if free, otherwise scan upward for an open port."""
     import socket
     for port in range(preferred, preferred + 20):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -438,8 +438,8 @@ def _find_free_port(preferred: int = 3030) -> int:
     return preferred
 
 
+    # Start the demo server. Blocks until Ctrl-C.
 def serve(port: int = 3030, open_browser: bool = True) -> None:
-    """Start the demo server. Blocks until Ctrl-C."""
     state = DemoState()
     DemoHandler.state = state
     port = _find_free_port(port)

--- a/python/src/asqav/doors.py
+++ b/python/src/asqav/doors.py
@@ -68,13 +68,13 @@ OTEL_SIGNATURE_ATTR = "asqav.signature"
 ERC8004_ZERO_ADDRESS = "0x" + "00" * 20
 
 
+    # Return the JCS canonical bytes of ``receipt``; the same bytes both SDKs hash.
 def canonical_receipt_bytes(receipt: dict) -> bytes:
-    """Return the JCS canonical bytes of ``receipt``; the same bytes both SDKs hash."""
     return canonical_json(receipt)
 
 
+    # ``sha256:<hex>`` over the raw canonical receipt bytes (the C2PA raw-bytes rule).
 def receipt_digest(receipt: dict) -> str:
-    """``sha256:<hex>`` over the raw canonical receipt bytes (the C2PA raw-bytes rule)."""
     return "sha256:" + hashlib.sha256(canonical_receipt_bytes(receipt)).hexdigest()
 
 
@@ -89,8 +89,8 @@ def _payload(receipt: dict) -> dict:
     return payload if isinstance(payload, dict) else receipt
 
 
+    # Return ``(sig, alg, kid)`` for compliance-mode or flat hash-mode receipts.
 def _signature_bits(receipt: dict) -> tuple[Any, Any, Any]:
-    """Return ``(sig, alg, kid)`` for compliance-mode or flat hash-mode receipts."""
     sig = receipt.get("signature")
     if isinstance(sig, dict):
         return sig.get("sig"), sig.get("alg"), sig.get("kid")
@@ -129,8 +129,8 @@ def _timestamp(receipt: dict) -> Any:
     return _field(receipt, "issued_at", "server_timestamp")
 
 
+    # A deterministic offline pointer to the receipt by digest. Not a live endpoint.
 def _verify_urn(receipt: dict) -> str:
-    """A deterministic offline pointer to the receipt by digest. Not a live endpoint."""
     return "urn:asqav:receipt:" + receipt_digest(receipt).split(":", 1)[1]
 
 
@@ -271,8 +271,8 @@ def to_erc8004_validation_request(
     }
 
 
+    # Return every door for ``receipt`` keyed by standard name; one inner object, N skins.
 def wrap_all(receipt: dict) -> dict:
-    """Return every door for ``receipt`` keyed by standard name; one inner object, N skins."""
     _require_dict(receipt)
     return {
         "w3c_vc": to_w3c_vc(receipt),
@@ -283,33 +283,33 @@ def wrap_all(receipt: dict) -> dict:
     }
 
 
+    # Recover the inner receipt from a VC door.
 def receipt_from_vc(vc: dict) -> dict:
-    """Recover the inner receipt from a VC door."""
     return vc["credentialSubject"]
 
 
+    # Recover the inner receipt from a CloudEvents door.
 def receipt_from_cloudevent(event: dict) -> dict:
-    """Recover the inner receipt from a CloudEvents door."""
     return event["data"]
 
 
+    # Recover the inner receipt from an OTel GenAI attribute map.
 def receipt_from_otel_genai_attributes(attrs: dict) -> dict:
-    """Recover the inner receipt from an OTel GenAI attribute map."""
     return json.loads(attrs[OTEL_RECEIPT_ATTR])
 
 
+    # Recover the inner receipt from a C2PA door.
 def receipt_from_c2pa_assertion(assertion: dict) -> dict:
-    """Recover the inner receipt from a C2PA door."""
     return assertion["data"]["receipt"]
 
 
+    # Recover the inner receipt from an ERC-8004 door.
 def receipt_from_erc8004_validation_request(request: dict) -> dict:
-    """Recover the inner receipt from an ERC-8004 door."""
     return request["receipt"]
 
 
+    # Recover the inner receipt from any door envelope, detected by shape.
 def extract_receipt(envelope: dict) -> dict:
-    """Recover the inner receipt from any door envelope, detected by shape."""
     if not isinstance(envelope, dict):
         raise TypeError("envelope must be a dict")
     if "credentialSubject" in envelope:

--- a/python/src/asqav/extras/_base.py
+++ b/python/src/asqav/extras/_base.py
@@ -19,8 +19,8 @@ logger = logging.getLogger("asqav")
 __all__ = ["AsqavAdapter"]
 
 
+    # Convert CamelCase class name to kebab-case (e.g. AsqavCrewHook -> asqav-crew-hook).
 def _class_name_to_agent_name(cls_name: str) -> str:
-    """Convert CamelCase class name to kebab-case (e.g. AsqavCrewHook -> asqav-crew-hook)."""
     # Insert hyphen before uppercase letters, then lowercase
     s = re.sub(r"(?<=[a-z0-9])([A-Z])", r"-\1", cls_name)
     s = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1-\2", s)
@@ -108,8 +108,8 @@ class AsqavAdapter:
             self._sign_action, action_type, context, **compliance_kwargs
         )
 
+        # Config-only repr: agent identity and mode, never the API key.
     def __repr__(self) -> str:
-        """Config-only repr: agent identity and mode, never the API key."""
         return (
             f"{type(self).__name__}("
             f"agent_id={self._agent.agent_id!r}, "
@@ -117,13 +117,13 @@ class AsqavAdapter:
             f"observe={self._observe!r})"
         )
 
+        # Start a session to group related signatures.
     def _start_session(self) -> None:
-        """Start a session to group related signatures."""
         self._session_id = uuid.uuid4().hex
         self._agent.start_session()
 
+        # End the current session.
     def _end_session(self, status: str = "completed") -> None:
-        """End the current session."""
         if self._agent._session_id is not None:
             try:
                 self._agent.end_session(status)

--- a/python/src/asqav/extras/anthropic.py
+++ b/python/src/asqav/extras/anthropic.py
@@ -66,8 +66,8 @@ class _SignedClient:
         return getattr(self._real, name)
 
 
+    # Drop-in replacement for anthropic.Anthropic that signs every call.
 class AsqavAnthropic:
-    """Drop-in replacement for anthropic.Anthropic that signs every call."""
 
     def __init__(
         self,

--- a/python/src/asqav/extras/crewai.py
+++ b/python/src/asqav/extras/crewai.py
@@ -219,11 +219,11 @@ class AsqavGuardrailProvider(AsqavAdapter):
 # -- Default-on entrypoint -----------------------------------------------------
 
 
+    # Chain an existing callback with the asqav one, preserving existing behavior.
 def _compose(
     existing: Callable[[Any], Any] | None,
     added: Callable[[Any], Any],
 ) -> Callable[[Any], Any]:
-    """Chain an existing callback with the asqav one, preserving existing behavior."""
     if existing is None:
         return added
 

--- a/python/src/asqav/extras/dspy.py
+++ b/python/src/asqav/extras/dspy.py
@@ -29,8 +29,8 @@ except ImportError as err:
 from ._base import AsqavAdapter
 
 
+    # Best-effort class name extraction for audit context.
 def _safe_class_name(instance: Any) -> str:
-    """Best-effort class name extraction for audit context."""
     try:
         return type(instance).__name__
     except Exception:
@@ -74,13 +74,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
 
     # === Module handlers ===
 
+        # Sign a dspy.module.start event.
     def on_module_start(
         self,
         call_id: str,
         instance: Any,
         inputs: dict[str, Any],
     ) -> None:
-        """Sign a dspy.module.start event."""
         self._sign_action(
             "dspy.module.start",
             {
@@ -90,13 +90,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
             },
         )
 
+        # Sign a dspy.module.end event.
     def on_module_end(
         self,
         call_id: str,
         outputs: Any | None,
         exception: Exception | None = None,
     ) -> None:
-        """Sign a dspy.module.end event."""
         self._sign_action(
             "dspy.module.end",
             {
@@ -108,13 +108,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
 
     # === LM handlers ===
 
+        # Sign a dspy.lm.start event with model name if available.
     def on_lm_start(
         self,
         call_id: str,
         instance: Any,
         inputs: dict[str, Any],
     ) -> None:
-        """Sign a dspy.lm.start event with model name if available."""
         self._sign_action(
             "dspy.lm.start",
             {
@@ -125,13 +125,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
             },
         )
 
+        # Sign a dspy.lm.end event.
     def on_lm_end(
         self,
         call_id: str,
         outputs: dict[str, Any] | None,
         exception: Exception | None = None,
     ) -> None:
-        """Sign a dspy.lm.end event."""
         self._sign_action(
             "dspy.lm.end",
             {
@@ -143,13 +143,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
 
     # === Tool handlers ===
 
+        # Sign a dspy.tool.start event.
     def on_tool_start(
         self,
         call_id: str,
         instance: Any,
         inputs: dict[str, Any],
     ) -> None:
-        """Sign a dspy.tool.start event."""
         tool_name = getattr(instance, "name", None) or _safe_class_name(instance)
         self._sign_action(
             "dspy.tool.start",
@@ -160,13 +160,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
             },
         )
 
+        # Sign a dspy.tool.end event.
     def on_tool_end(
         self,
         call_id: str,
         outputs: dict[str, Any] | None,
         exception: Exception | None = None,
     ) -> None:
-        """Sign a dspy.tool.end event."""
         self._sign_action(
             "dspy.tool.end",
             {
@@ -178,13 +178,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
 
     # === Evaluate handlers ===
 
+        # Sign a dspy.evaluate.start event.
     def on_evaluate_start(
         self,
         call_id: str,
         instance: Any,
         inputs: dict[str, Any],
     ) -> None:
-        """Sign a dspy.evaluate.start event."""
         self._sign_action(
             "dspy.evaluate.start",
             {
@@ -194,13 +194,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
             },
         )
 
+        # Sign a dspy.evaluate.end event.
     def on_evaluate_end(
         self,
         call_id: str,
         outputs: Any | None,
         exception: Exception | None = None,
     ) -> None:
-        """Sign a dspy.evaluate.end event."""
         self._sign_action(
             "dspy.evaluate.end",
             {
@@ -212,13 +212,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
 
     # === Adapter format handlers ===
 
+        # Sign a dspy.adapter.format.start event.
     def on_adapter_format_start(
         self,
         call_id: str,
         instance: Any,
         inputs: dict[str, Any],
     ) -> None:
-        """Sign a dspy.adapter.format.start event."""
         self._sign_action(
             "dspy.adapter.format.start",
             {
@@ -228,13 +228,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
             },
         )
 
+        # Sign a dspy.adapter.format.end event.
     def on_adapter_format_end(
         self,
         call_id: str,
         outputs: dict[str, Any] | None,
         exception: Exception | None = None,
     ) -> None:
-        """Sign a dspy.adapter.format.end event."""
         self._sign_action(
             "dspy.adapter.format.end",
             {
@@ -246,13 +246,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
 
     # === Adapter parse handlers ===
 
+        # Sign a dspy.adapter.parse.start event.
     def on_adapter_parse_start(
         self,
         call_id: str,
         instance: Any,
         inputs: dict[str, Any],
     ) -> None:
-        """Sign a dspy.adapter.parse.start event."""
         self._sign_action(
             "dspy.adapter.parse.start",
             {
@@ -262,13 +262,13 @@ class AsqavDSPyCallback(AsqavAdapter, BaseCallback):  # type: ignore[misc]
             },
         )
 
+        # Sign a dspy.adapter.parse.end event.
     def on_adapter_parse_end(
         self,
         call_id: str,
         outputs: dict[str, Any] | None,
         exception: Exception | None = None,
     ) -> None:
-        """Sign a dspy.adapter.parse.end event."""
         self._sign_action(
             "dspy.adapter.parse.end",
             {

--- a/python/src/asqav/extras/instructor.py
+++ b/python/src/asqav/extras/instructor.py
@@ -20,16 +20,16 @@ except ImportError as exc:  # pragma: no cover - import guard
 from ._base import AsqavAdapter
 
 
+    # Best-effort extraction of the model id from completion kwargs.
 def _model_name(kwargs: dict[str, Any]) -> str:
-    """Best-effort extraction of the model id from completion kwargs."""
     model = kwargs.get("model")
     if isinstance(model, str):
         return model
     return "unknown"
 
 
+    # Best-effort name of the Pydantic schema instructor is targeting.
 def _response_model_name(kwargs: dict[str, Any]) -> str | None:
-    """Best-effort name of the Pydantic schema instructor is targeting."""
     rm = kwargs.get("response_model")
     if rm is None:
         return None
@@ -51,8 +51,8 @@ def _exception_name(exc: BaseException | None) -> str | None:
         return "Exception"
 
 
+    # Asqav adapter for instructor clients; fail-open (extraction runs even if Asqav is down).
 class AsqavInstructorHook(AsqavAdapter):
-    """Asqav adapter for instructor clients; fail-open (extraction runs even if Asqav is down)."""
 
     def __init__(
         self,
@@ -65,8 +65,8 @@ class AsqavInstructorHook(AsqavAdapter):
 
     # === Public attachment surface ===
 
+        # Register this hook on an instructor client (sync or async; both expose ``.on()``).
     def attach(self, client: Any) -> None:
-        """Register this hook on an instructor client (sync or async; both expose ``.on()``)."""
         if not hasattr(client, "on"):
             raise TypeError(
                 "client does not look like an instructor client; "
@@ -80,8 +80,8 @@ class AsqavInstructorHook(AsqavAdapter):
 
     # === Event handlers ===
 
+        # instructor emits the LLM kwargs right before the call.
     def _on_kwargs(self, *args: Any, **kwargs: Any) -> None:
-        """instructor emits the LLM kwargs right before the call."""
         self._sign_action(
             "instructor.completion.start",
             {
@@ -91,8 +91,8 @@ class AsqavInstructorHook(AsqavAdapter):
             },
         )
 
+        # Successful completion. We only persist hashable, low-PII fields.
     def _on_response(self, response: Any) -> None:
-        """Successful completion. We only persist hashable, low-PII fields."""
         usage = getattr(response, "usage", None)
         ctx: dict[str, Any] = {"id": getattr(response, "id", None)}
         if usage is not None:
@@ -113,8 +113,8 @@ class AsqavInstructorHook(AsqavAdapter):
             {"error_type": _exception_name(error), "message": str(error)[:500]},
         )
 
+        # Pydantic validation failed against response_model.
     def _on_parse_error(self, error: Exception) -> None:
-        """Pydantic validation failed against response_model."""
         self._sign_action(
             "instructor.parse.error",
             {"error_type": _exception_name(error), "message": str(error)[:500]},

--- a/python/src/asqav/extras/langchain.py
+++ b/python/src/asqav/extras/langchain.py
@@ -93,12 +93,12 @@ class AsqavCallbackHandler(BaseCallbackHandler, AsqavAdapter):  # type: ignore[m
             {"chain": str(name), "input_keys": input_keys},
         )
 
+        # Sign chain:end with output keys.
     def on_chain_end(self, outputs: dict[str, Any], **kwargs: Any) -> None:
-        """Sign chain:end with output keys."""
         self._sign_action("chain:end", {"output_keys": list(outputs.keys())})
 
+        # Sign chain:error with error type and message.
     def on_chain_error(self, error: BaseException, **kwargs: Any) -> None:
-        """Sign chain:error with error type and message."""
         self._sign_action(
             "chain:error",
             {"error_type": type(error).__name__, "error": str(error)[:200]},
@@ -106,29 +106,29 @@ class AsqavCallbackHandler(BaseCallbackHandler, AsqavAdapter):  # type: ignore[m
 
     # -- Tool callbacks --------------------------------------------------------
 
+        # Sign tool:start with tool name and truncated input.
     def on_tool_start(
         self,
         serialized: dict[str, Any],
         input_str: str,
         **kwargs: Any,
     ) -> None:
-        """Sign tool:start with tool name and truncated input."""
         name = serialized.get("name") or serialized.get("id", ["unknown"])[-1]
         self._sign_action(
             "tool:start",
             {"tool": str(name), "input": str(input_str)[:200]},
         )
 
+        # Sign tool:end with output type and length.
     def on_tool_end(self, output: Any, **kwargs: Any) -> None:
-        """Sign tool:end with output type and length."""
         output_str = str(output)
         self._sign_action(
             "tool:end",
             {"output_type": type(output).__name__, "output_length": len(output_str)},
         )
 
+        # Sign tool:error with error details.
     def on_tool_error(self, error: BaseException, **kwargs: Any) -> None:
-        """Sign tool:error with error details."""
         self._sign_action(
             "tool:error",
             {"error_type": type(error).__name__, "error": str(error)[:200]},
@@ -136,21 +136,21 @@ class AsqavCallbackHandler(BaseCallbackHandler, AsqavAdapter):  # type: ignore[m
 
     # -- LLM callbacks ---------------------------------------------------------
 
+        # Sign llm:start with model name and prompt count.
     def on_llm_start(
         self,
         serialized: dict[str, Any],
         prompts: list[str],
         **kwargs: Any,
     ) -> None:
-        """Sign llm:start with model name and prompt count."""
         model = serialized.get("name") or serialized.get("id", ["unknown"])[-1]
         self._sign_action(
             "llm:start",
             {"model": str(model), "prompt_count": len(prompts)},
         )
 
+        # Sign llm:end with generation count and token usage if available.
     def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
-        """Sign llm:end with generation count and token usage if available."""
         generation_count = sum(len(g) for g in response.generations)
         context: dict[str, Any] = {"generation_count": generation_count}
 
@@ -163,8 +163,8 @@ class AsqavCallbackHandler(BaseCallbackHandler, AsqavAdapter):  # type: ignore[m
 
         self._sign_action("llm:end", context)
 
+        # Sign llm:error with error details.
     def on_llm_error(self, error: BaseException, **kwargs: Any) -> None:
-        """Sign llm:error with error details."""
         self._sign_action(
             "llm:error",
             {"error_type": type(error).__name__, "error": str(error)[:200]},

--- a/python/src/asqav/extras/litellm.py
+++ b/python/src/asqav/extras/litellm.py
@@ -77,6 +77,7 @@ class AsqavGuardrail(AsqavAdapter):
 
     # -- LiteLLM guardrail callback interface --
 
+        # Sign before an LLM call is made.
     async def async_pre_call_hook(
         self,
         user_api_key_dict: dict,
@@ -84,7 +85,6 @@ class AsqavGuardrail(AsqavAdapter):
         data: dict,
         call_type: str,
     ) -> None:
-        """Sign before an LLM call is made."""
         messages = data.get("messages", [])
         await self._sign_action_async(
             "llm:pre_call",
@@ -95,13 +95,13 @@ class AsqavGuardrail(AsqavAdapter):
             },
         )
 
+        # Sign after a successful LLM call.
     async def async_post_call_success_hook(
         self,
         data: dict,
         user_api_key_dict: dict,
         response: Any,
     ) -> None:
-        """Sign after a successful LLM call."""
         context: dict[str, Any] = {
             "model": data.get("model"),
             "response_type": type(response).__name__,
@@ -139,13 +139,13 @@ class AsqavGuardrail(AsqavAdapter):
             risk_class="medium",
         )
 
+        # Sign moderation events.
     async def async_moderation_hook(
         self,
         data: dict,
         user_api_key_dict: dict,
         call_type: str,
     ) -> None:
-        """Sign moderation events."""
         await self._sign_action_async(
             "llm:moderation",
             {
@@ -166,8 +166,8 @@ def _content_digest(value: Any) -> str | None:
     return hashlib.sha256(raw).hexdigest()
 
 
+    # Read the ASQAV_REDACT_CONTENT env default (digest-only unless 'false').
 def _redact_content_default() -> bool:
-    """Read the ASQAV_REDACT_CONTENT env default (digest-only unless 'false')."""
     return os.environ.get("ASQAV_REDACT_CONTENT", "true").lower() != "false"
 
 
@@ -327,8 +327,8 @@ class AsqavSigningLogger(CustomLogger):
             )
             self._adapter = None
 
+        # Warn once that signing is off so the logger never looks like enforcement.
     def _warn_no_key(self) -> None:
-        """Warn once that signing is off so the logger never looks like enforcement."""
         if not self._warned:
             logger.warning(
                 "AsqavSigningLogger: ASQAV_API_KEY not set. No receipts are "
@@ -337,8 +337,8 @@ class AsqavSigningLogger(CustomLogger):
             )
             self._warned = True
 
+        # Map a call to an action_type like ``llm:gpt-4``.
     def _action_type(self, model: str) -> str:
-        """Map a call to an action_type like ``llm:gpt-4``."""
         return f"llm:{model}" if model else "llm:call"
 
     def _sign_and_index(
@@ -369,8 +369,8 @@ class AsqavSigningLogger(CustomLogger):
                 "AsqavSigningLogger sign/index failed (fail-soft): %s", exc
             )
 
+        # Append one JSONL index line stitching local digests to the cloud receipt.
     def _append_index(self, fields: dict[str, Any], sig: Any) -> None:
-        """Append one JSONL index line stitching local digests to the cloud receipt."""
         record = {
             "ts": time.time(),
             "model": fields.get("model"),
@@ -391,14 +391,14 @@ class AsqavSigningLogger(CustomLogger):
 
     # -- LiteLLM CustomLogger interface --
 
+        # Sync success hook: sign + index the completed call.
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
-        """Sync success hook: sign + index the completed call."""
         self._sign_and_index(kwargs, response_obj, start_time, end_time)
 
+        # Async success hook: sign off the event loop so calls keep flowing.
     async def async_log_success_event(
         self, kwargs, response_obj, start_time, end_time
     ):
-        """Async success hook: sign off the event loop so calls keep flowing."""
         import asyncio
 
         await asyncio.to_thread(

--- a/python/src/asqav/extras/llamaindex.py
+++ b/python/src/asqav/extras/llamaindex.py
@@ -52,8 +52,8 @@ _SIGNED_EVENT_TYPES = frozenset(
 _MAX_LEN = 200
 
 
+    # Extract sorted payload keys, or empty list if payload is not a dict.
 def _safe_payload_keys(payload: Optional[Dict[str, Any]]) -> list[str]:
-    """Extract sorted payload keys, or empty list if payload is not a dict."""
     if isinstance(payload, dict):
         return sorted(payload.keys())
     return []
@@ -97,6 +97,7 @@ class AsqavLlamaIndexHandler(AsqavAdapter, BaseCallbackHandler):  # type: ignore
 
     # === BaseCallbackHandler interface ===
 
+        # Sign a llamaindex.<event_type>.start governance event.
     def on_event_start(
         self,
         event_type: CBEventType,
@@ -105,7 +106,6 @@ class AsqavLlamaIndexHandler(AsqavAdapter, BaseCallbackHandler):  # type: ignore
         parent_id: str = "",
         **kwargs: Any,
     ) -> str:
-        """Sign a llamaindex.<event_type>.start governance event."""
         if event_type not in self.event_starts_to_ignore and event_type in _SIGNED_EVENT_TYPES:
             context: dict[str, Any] = {
                 "event_id": event_id,
@@ -117,6 +117,7 @@ class AsqavLlamaIndexHandler(AsqavAdapter, BaseCallbackHandler):  # type: ignore
             self._sign_action(f"llamaindex.{event_type.value}.start", context)
         return event_id
 
+        # Sign a llamaindex.<event_type>.end governance event.
     def on_event_end(
         self,
         event_type: CBEventType,
@@ -124,7 +125,6 @@ class AsqavLlamaIndexHandler(AsqavAdapter, BaseCallbackHandler):  # type: ignore
         event_id: str = "",
         **kwargs: Any,
     ) -> None:
-        """Sign a llamaindex.<event_type>.end governance event."""
         if event_type not in self.event_ends_to_ignore and event_type in _SIGNED_EVENT_TYPES:
             context: dict[str, Any] = {
                 "event_id": event_id,
@@ -133,16 +133,16 @@ class AsqavLlamaIndexHandler(AsqavAdapter, BaseCallbackHandler):  # type: ignore
             }
             self._sign_action(f"llamaindex.{event_type.value}.end", context)
 
+        # Start a trace - begins an Asqav session for grouped signing.
     def start_trace(self, trace_id: Optional[str] = None) -> None:
-        """Start a trace - begins an Asqav session for grouped signing."""
         if trace_id:
             self._start_session()
 
+        # End a trace - closes the Asqav session.
     def end_trace(
         self,
         trace_id: Optional[str] = None,
         trace_map: Optional[Dict[str, List[str]]] = None,
     ) -> None:
-        """End a trace - closes the Asqav session."""
         if self._session_id is not None:
             self._end_session("completed")

--- a/python/src/asqav/extras/opa_detector.py
+++ b/python/src/asqav/extras/opa_detector.py
@@ -64,8 +64,8 @@ class OpaDetector:
     def _endpoint(self) -> str:
         return f"{self._opa_url}/v1/data/{self._policy_path}"
 
+        # POST payload as JSON; return parsed JSON response dict.
     def _post_json(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """POST payload as JSON; return parsed JSON response dict."""
         endpoint = self._endpoint()
         body = json.dumps(payload).encode("utf-8")
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
@@ -92,8 +92,8 @@ class OpaDetector:
         with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310
             return json.loads(resp.read().decode("utf-8"))
 
+        # POST to OPA; map the boolean result to allow/deny.
     def inspect(self, action_type: str, context: dict[str, Any]) -> DetectorResult:
-        """POST to OPA; map the boolean result to allow/deny."""
         payload = {"input": {"action_type": action_type, "context": context}}
         try:
             data = self._post_json(payload)

--- a/python/src/asqav/extras/openai.py
+++ b/python/src/asqav/extras/openai.py
@@ -33,8 +33,8 @@ import asqav
 logger = logging.getLogger("asqav.extras.openai")
 
 
+    # Wraps openai.Chat.Completions to sign every create() call.
 class _SignedCompletions:
-    """Wraps openai.Chat.Completions to sign every create() call."""
 
     def __init__(self, real_completions: Any, agent: Any, agent_name: str) -> None:
         self._real = real_completions
@@ -65,8 +65,8 @@ class _SignedCompletions:
         return response
 
 
+    # Wraps openai.Chat to inject signed completions.
 class _SignedChat:
-    """Wraps openai.Chat to inject signed completions."""
 
     def __init__(self, real_chat: Any, agent: Any, agent_name: str) -> None:
         self._real = real_chat

--- a/python/src/asqav/extras/openai_agents.py
+++ b/python/src/asqav/extras/openai_agents.py
@@ -66,8 +66,8 @@ class AsqavGuardrail(AsqavAdapter):
         agent_id: ID of an existing Asqav agent (calls ``Agent.get``).
     """
 
+        # Extract agent name from the OpenAI Agent object.
     def _resolve_agent_name(self, agent: Any) -> str:
-        """Extract agent name from the OpenAI Agent object."""
         name = getattr(agent, "name", None)
         if name:
             return str(name)
@@ -149,8 +149,8 @@ class AsqavTracingProcessor(AsqavAdapter, TracingProcessor):
         agent_id: ID of an existing Asqav agent (calls ``Agent.get``).
     """
 
+        # Sign a trace:start governance event.
     def on_trace_start(self, trace: Trace) -> None:
-        """Sign a trace:start governance event."""
         try:
             self._sign_action(
                 "trace:start",
@@ -162,8 +162,8 @@ class AsqavTracingProcessor(AsqavAdapter, TracingProcessor):
         except Exception as exc:
             logger.warning("asqav trace:start signing failed (fail-open): %s", exc)
 
+        # Sign a trace:end governance event.
     def on_trace_end(self, trace: Trace) -> None:
-        """Sign a trace:end governance event."""
         try:
             self._sign_action(
                 "trace:end",
@@ -175,8 +175,8 @@ class AsqavTracingProcessor(AsqavAdapter, TracingProcessor):
         except Exception as exc:
             logger.warning("asqav trace:end signing failed (fail-open): %s", exc)
 
+        # Sign a span:start governance event.
     def on_span_start(self, span: Span[Any]) -> None:
-        """Sign a span:start governance event."""
         try:
             span_data = span.span_data
             self._sign_action(
@@ -190,8 +190,8 @@ class AsqavTracingProcessor(AsqavAdapter, TracingProcessor):
         except Exception as exc:
             logger.warning("asqav span:start signing failed (fail-open): %s", exc)
 
+        # Sign a span:end governance event.
     def on_span_end(self, span: Span[Any]) -> None:
-        """Sign a span:end governance event."""
         try:
             span_data = span.span_data
             exported = span.export() if hasattr(span, "export") else None
@@ -212,10 +212,10 @@ class AsqavTracingProcessor(AsqavAdapter, TracingProcessor):
         except Exception as exc:
             logger.warning("asqav span:end signing failed (fail-open): %s", exc)
 
+        # End the Asqav session on processor shutdown.
     def shutdown(self) -> None:
-        """End the Asqav session on processor shutdown."""
         self._end_session(status="completed")
 
+        # No-op - Asqav signs events synchronously.
     def force_flush(self) -> None:
-        """No-op - Asqav signs events synchronously."""
         pass

--- a/python/src/asqav/extras/presidio_detector.py
+++ b/python/src/asqav/extras/presidio_detector.py
@@ -27,8 +27,8 @@ logger = logging.getLogger("asqav")
 _PRESIDIO_DOCS = "https://microsoft.github.io/presidio/"
 
 
+    # Lazy-load presidio_analyzer.AnalyzerEngine; raise ImportError if missing.
 def _load_analyzer() -> Any:
-    """Lazy-load presidio_analyzer.AnalyzerEngine; raise ImportError if missing."""
     try:
         from presidio_analyzer import AnalyzerEngine  # type: ignore[import]
 

--- a/python/src/asqav/extras/strands.py
+++ b/python/src/asqav/extras/strands.py
@@ -71,8 +71,8 @@ def _hash_repr(value: Any) -> str:
     return hashlib.sha256(data).hexdigest()[:16]
 
 
+    # Best-effort extraction of the model identifier from a hook event.
 def _extract_model_name(event: Any) -> str:
-    """Best-effort extraction of the model identifier from a hook event."""
     agent = getattr(event, "agent", None)
     if agent is None:
         return "unknown"
@@ -86,8 +86,8 @@ def _extract_model_name(event: Any) -> str:
     return type(model).__name__
 
 
+    # Pull the current message list from the agent if available.
 def _extract_messages(event: Any) -> Any:
-    """Pull the current message list from the agent if available."""
     agent = getattr(event, "agent", None)
     if agent is None:
         return None
@@ -108,8 +108,8 @@ def _strands_before_hook(action_type: str, context: dict) -> dict:
     return context
 
 
+    # Register the strands before-hook exactly once per process.
 def _ensure_hook_registered() -> None:
-    """Register the strands before-hook exactly once per process."""
     global _HOOK_REGISTERED
     if _HOOK_REGISTERED:
         return
@@ -155,13 +155,13 @@ class AsqavStrandsHooks(AsqavAdapter, HookProvider):
         self._model_name: str = "unknown"
         _ensure_hook_registered()
 
+        # Register Before/AfterModelCall callbacks with the Strands registry.
     def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
-        """Register Before/AfterModelCall callbacks with the Strands registry."""
         registry.add_callback(BeforeModelCallEvent, self._on_before_model_call)
         registry.add_callback(AfterModelCallEvent, self._on_after_model_call)
 
+        # Capture pre-call state used by the after-call signature.
     def _on_before_model_call(self, event: BeforeModelCallEvent) -> None:
-        """Capture pre-call state used by the after-call signature."""
         try:
             self._call_start = time.perf_counter()
             self._model_name = _extract_model_name(event)
@@ -171,8 +171,8 @@ class AsqavStrandsHooks(AsqavAdapter, HookProvider):
                 "asqav strands before-model-call capture failed (fail-open): %s", exc
             )
 
+        # Sign the strands:model_call governance event.
     def _on_after_model_call(self, event: AfterModelCallEvent) -> None:
-        """Sign the strands:model_call governance event."""
         try:
             latency_ms: float | None = None
             if self._call_start is not None:

--- a/python/src/asqav/hooks.py
+++ b/python/src/asqav/hooks.py
@@ -23,8 +23,8 @@ _before_hooks: list[tuple[PatternType, BeforeHook]] = []
 _after_hooks: list[tuple[PatternType, AfterHook]] = []
 
 
+    # Return True if ``pattern`` matches ``action_type``.
 def _matches(pattern: PatternType, action_type: str) -> bool:
-    """Return True if ``pattern`` matches ``action_type``."""
     if isinstance(pattern, re.Pattern):
         return pattern.search(action_type) is not None
     if pattern == "*":
@@ -44,21 +44,21 @@ def register_before(pattern: PatternType, fn: BeforeHook) -> None:
         _before_hooks.append((pattern, fn))
 
 
+    # Register ``fn(response)`` to observe signing for matching actions.
 def register_after(pattern: PatternType, fn: AfterHook) -> None:
-    """Register ``fn(response)`` to observe signing for matching actions."""
     with _lock:
         _after_hooks.append((pattern, fn))
 
 
+    # Remove every registered before/after hook. Intended for tests.
 def clear_hooks() -> None:
-    """Remove every registered before/after hook. Intended for tests."""
     with _lock:
         _before_hooks.clear()
         _after_hooks.clear()
 
 
+    # Invoke matching before-hooks. Returns the (possibly mutated) context.
 def _dispatch_before(action_type: str, context: dict) -> dict:
-    """Invoke matching before-hooks. Returns the (possibly mutated) context."""
     with _lock:
         snapshot = list(_before_hooks)
     current = context if context is not None else {}
@@ -76,8 +76,8 @@ def _dispatch_before(action_type: str, context: dict) -> dict:
     return current
 
 
+    # Invoke matching after-hooks. Failures are logged and swallowed.
 def _dispatch_after(action_type: str, response: Any) -> None:
-    """Invoke matching after-hooks. Failures are logged and swallowed."""
     with _lock:
         snapshot = list(_after_hooks)
     for pattern, fn in snapshot:

--- a/python/src/asqav/ietf_projection.py
+++ b/python/src/asqav/ietf_projection.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 
+    # Return ``{alg, kid, sig}`` for compliance-mode receipts, else ``None`` (flat shape).
 def signature_envelope_from_response(response: Any) -> dict[str, str] | None:
-    """Return ``{alg, kid, sig}`` for compliance-mode receipts, else ``None`` (flat shape)."""
     sig = _get(response, "signature")
     if isinstance(sig, dict):
         keys = set(sig.keys())
@@ -15,16 +15,16 @@ def signature_envelope_from_response(response: Any) -> dict[str, str] | None:
     return None
 
 
+    # Return the ``anchors[]`` array when present, else ``None``.
 def anchors_from_response(response: Any) -> list[dict[str, Any]] | None:
-    """Return the ``anchors[]`` array when present, else ``None``."""
     anchors = _get(response, "anchors")
     if isinstance(anchors, list):
         return [dict(e) for e in anchors]
     return None
 
 
+    # Helper for callers that hold raw anchor bytes locally.
 def encode_anchor_value(raw: bytes) -> str:
-    """Helper for callers that hold raw anchor bytes locally."""
     import base64
 
     return base64.b64encode(raw).decode()

--- a/python/src/asqav/keys.py
+++ b/python/src/asqav/keys.py
@@ -36,8 +36,8 @@ class LocalKeypair:
     public_key_pem: bytes
 
 
+    # Normalise + validate the requested algorithm string.
 def _check_algorithm(algorithm: str) -> str:
-    """Normalise + validate the requested algorithm string."""
     norm = algorithm.lower()
     if norm not in SUPPORTED_ALGORITHMS:
         raise ValueError(
@@ -89,8 +89,8 @@ def _generate_ed25519() -> LocalKeypair:
     )
 
 
+    # Generate an ECDSA P-256 keypair (alg=ES256 in JOSE).
 def _generate_es256() -> LocalKeypair:
-    """Generate an ECDSA P-256 keypair (alg=ES256 in JOSE)."""
     try:
         from cryptography.hazmat.primitives import serialization
         from cryptography.hazmat.primitives.asymmetric import ec

--- a/python/src/asqav/local.py
+++ b/python/src/asqav/local.py
@@ -29,8 +29,8 @@ def _validated_queue_dir(raw: str) -> Path:
     return Path(expanded)
 
 
+    # Queue for offline action signing with later sync to the Asqav API.
 class LocalQueue:
-    """Queue for offline action signing with later sync to the Asqav API."""
 
     def __init__(self, queue_dir: str | None = None) -> None:
         resolved = (
@@ -41,13 +41,13 @@ class LocalQueue:
         self.queue_dir = _validated_queue_dir(resolved)
         self.queue_dir.mkdir(parents=True, exist_ok=True)
 
+        # Queue an action for later sync. Returns the queue item ID.
     def enqueue(
         self,
         agent_id: str,
         action_type: str,
         context: dict[str, Any] | None = None,
     ) -> str:
-        """Queue an action for later sync. Returns the queue item ID."""
         now = datetime.now(timezone.utc)
         timestamp = now.strftime("%Y%m%d%H%M%S")
         short_id = uuid4().hex[:8]
@@ -68,8 +68,8 @@ class LocalQueue:
         os.replace(tmp_path, filepath)
         return item_id
 
+        # List all pending queue items, sorted oldest first.
     def list_pending(self) -> list[dict[str, Any]]:
-        """List all pending queue items, sorted oldest first."""
         items: list[dict[str, Any]] = []
         for filepath in self.queue_dir.glob("*.json"):
             try:
@@ -81,10 +81,10 @@ class LocalQueue:
         items.sort(key=lambda x: x.get("queued_at", ""))
         return items
 
+        # Sync pending items to API. Returns summary with synced/failed counts.
     def sync(
         self, on_progress: Callable[[str, bool, str | None], Any] | None = None
     ) -> dict[str, Any]:
-        """Sync pending items to API. Returns summary with synced/failed counts."""
         from .client import _post
 
         items = self.list_pending()
@@ -123,12 +123,12 @@ class LocalQueue:
             "errors": errors,
         }
 
+        # Return number of pending items in the queue.
     def count(self) -> int:
-        """Return number of pending items in the queue."""
         return len(list(self.queue_dir.glob("*.json")))
 
+        # Delete all pending items. Returns number deleted.
     def clear(self) -> int:
-        """Delete all pending items. Returns number deleted."""
         files = list(self.queue_dir.glob("*.json"))
         for filepath in files:
             filepath.unlink(missing_ok=True)

--- a/python/src/asqav/patterns.py
+++ b/python/src/asqav/patterns.py
@@ -28,6 +28,6 @@ def resolve_pattern(pattern: str) -> str:
     return PATTERNS.get(key, key)
 
 
+    # Return all available semantic action patterns.
 def list_patterns() -> dict[str, str]:
-    """Return all available semantic action patterns."""
     return dict(PATTERNS)

--- a/python/src/asqav/phases.py
+++ b/python/src/asqav/phases.py
@@ -11,22 +11,22 @@ from dataclasses import dataclass
 from typing import Any
 
 
+    # Three linked receipts covering an action's full lifecycle.
 @dataclass
 class PhaseChain:
-    """Three linked receipts covering an action's full lifecycle."""
 
     intent: Any  # SignatureResponse from intent phase
     decision: Any  # PreflightResult from decision phase
     execution: Any  # SignatureResponse from execution phase
     trace_id: str
 
+        # Whether the decision phase approved the action.
     @property
     def approved(self) -> bool:
-        """Whether the decision phase approved the action."""
         return self.decision.cleared if self.decision else False
 
+        # Serialize the chain to a plain dict.
     def to_dict(self) -> dict:
-        """Serialize the chain to a plain dict."""
 
         def _sig_dict(sig: Any) -> dict | None:
             if sig is None:
@@ -57,8 +57,8 @@ class PhaseChain:
             "approved": self.approved,
         }
 
+        # Serialize the chain to a JSON string.
     def to_json(self) -> str:
-        """Serialize the chain to a JSON string."""
         return json.dumps(self.to_dict())
 
 

--- a/python/src/asqav/pytest_plugin.py
+++ b/python/src/asqav/pytest_plugin.py
@@ -12,9 +12,9 @@ from typing import Any
 import pytest
 
 
+    # One test outcome captured for the bundle.
 @dataclass
 class CapturedOutcome:
-    """One test outcome captured for the bundle."""
 
     nodeid: str
     outcome: str  # "passed" | "failed" | "skipped"
@@ -22,9 +22,9 @@ class CapturedOutcome:
     longrepr: str | None = None
 
 
+    # In-memory state for one pytest invocation.
 @dataclass
 class _PluginState:
-    """In-memory state for one pytest invocation."""
 
     enabled: bool = False
     agent_name: str = "test-runner"
@@ -93,9 +93,9 @@ def pytest_configure(config: pytest.Config) -> None:
     _state.signatures = []
 
 
+    # Capture each test phase outcome. We only sign the 'call' phase.
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):  # type: ignore[no-untyped-def]
-    """Capture each test phase outcome. We only sign the 'call' phase."""
     outcome = yield
     if not _state.enabled:
         return
@@ -152,10 +152,10 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
 # === Programmatic API ===
 
 
+    # Build a :class:`ComplianceBundle` from pre-signed test results.
 def make_bundle_from_report(
     signatures: list[Any], *, framework: str = "eu_ai_act"
 ) -> Any:
-    """Build a :class:`ComplianceBundle` from pre-signed test results."""
     from asqav.compliance import export_bundle
 
     return export_bundle(signatures, framework=framework)

--- a/python/src/asqav/reasoning.py
+++ b/python/src/asqav/reasoning.py
@@ -13,8 +13,8 @@ from dataclasses import dataclass
 from typing import Any
 
 
+    # Return hex SHA-256 of ``data`` (dicts/lists JSON-serialized; bytes pass through).
 def _sha256(data: Any) -> str:
-    """Return hex SHA-256 of ``data`` (dicts/lists JSON-serialized; bytes pass through)."""
     if isinstance(data, bytes):
         payload = data
     elif isinstance(data, str):
@@ -24,9 +24,9 @@ def _sha256(data: Any) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
+    # Wrapper around ``SignatureResponse`` plus the three captured hashes.
 @dataclass
 class ReasoningReceipt:
-    """Wrapper around ``SignatureResponse`` plus the three captured hashes."""
 
     signature: Any  # SignatureResponse
     prompt_hash: str

--- a/python/src/asqav/replay.py
+++ b/python/src/asqav/replay.py
@@ -33,14 +33,14 @@ def _payload_bytes_for_chain(envelope: dict[str, Any]) -> bytes:
     return canonical_json(envelope)
 
 
+    # SHA-256 of the cloud's chain input for one envelope.
 def _chain_hash_for_envelope(envelope: dict[str, Any]) -> str:
-    """SHA-256 of the cloud's chain input for one envelope."""
     return hashlib.sha256(_payload_bytes_for_chain(envelope)).hexdigest()
 
 
+    # Single step in an audit trail replay.
 @dataclass
 class ReplayStep:
-    """Single step in an audit trail replay."""
 
     index: int
     action_type: str
@@ -56,9 +56,9 @@ class ReplayStep:
     signed_envelope: dict[str, Any] | None = None
 
 
+    # Complete audit trail timeline for a session.
 @dataclass
 class ReplayTimeline:
-    """Complete audit trail timeline for a session."""
 
     agent_id: str
     session_id: str
@@ -70,8 +70,8 @@ class ReplayTimeline:
     end_time: float | None = None
     total_actions: int = 0
 
+        # Serialize timeline to a plain dictionary.
     def to_dict(self) -> dict[str, Any]:
-        """Serialize timeline to a plain dictionary."""
         return {
             "agent_id": self.agent_id,
             "session_id": self.session_id,
@@ -97,17 +97,17 @@ class ReplayTimeline:
             "total_actions": self.total_actions,
         }
 
+        # Serialize timeline to a JSON string.
     def to_json(self) -> str:
-        """Serialize timeline to a JSON string."""
         return json.dumps(self.to_dict(), indent=2)
 
+        # Write timeline JSON to a file.
     def to_file(self, path: str) -> None:
-        """Write timeline JSON to a file."""
         with open(path, "w") as f:
             f.write(self.to_json())
 
+        # Human-readable multi-line summary of the timeline.
     def summary(self) -> str:
-        """Human-readable multi-line summary of the timeline."""
         lines = [
             "Audit Trail Replay",
             f"  Agent: {self.agent_id}",
@@ -228,8 +228,8 @@ def _verify_hash_chain(signatures: list[dict]) -> list[bool]:
     return results
 
 
+    # Generate a human-readable description for a replay step.
 def _build_explanation(action_type: str, context: dict[str, Any] | None) -> str:
-    """Generate a human-readable description for a replay step."""
     parts = action_type.split(":")
 
     if len(parts) == 2:
@@ -259,14 +259,14 @@ def _build_explanation(action_type: str, context: dict[str, Any] | None) -> str:
     return base
 
 
+    # Fetch signatures for a session and reconstruct a :class:`ReplayTimeline`.
 def replay(agent_id: str, session_id: str) -> ReplayTimeline:
-    """Fetch signatures for a session and reconstruct a :class:`ReplayTimeline`."""
     raw_sigs = get_session_signatures(session_id)
     return _build_timeline(agent_id, session_id, raw_sigs)
 
 
+    # Reconstruct a :class:`ReplayTimeline` from a :class:`ComplianceBundle` export offline.
 def replay_from_bundle(bundle: ComplianceBundle) -> ReplayTimeline:
-    """Reconstruct a :class:`ReplayTimeline` from a :class:`ComplianceBundle` export offline."""
     agent_id = ""
     session_id = ""
     if bundle.receipts:
@@ -300,6 +300,7 @@ def replay_from_bundle(bundle: ComplianceBundle) -> ReplayTimeline:
     )
 
 
+    # Shared logic to build a ReplayTimeline from a list of signatures.
 def _build_timeline(
     agent_id: str,
     session_id: str,
@@ -307,7 +308,6 @@ def _build_timeline(
     *,
     signed_envelopes: list[dict[str, Any] | None] | None = None,
 ) -> ReplayTimeline:
-    """Shared logic to build a ReplayTimeline from a list of signatures."""
     indexed = list(enumerate(signatures))
     indexed.sort(key=lambda pair: pair[1].signed_at)
     sorted_sigs = [s for _, s in indexed]

--- a/python/src/asqav/retry.py
+++ b/python/src/asqav/retry.py
@@ -16,8 +16,8 @@ from typing import Any, TypeVar
 F = TypeVar("F", bound=Callable[..., Any])
 
 
+    # Return True for retryable exceptions: rate-limit, 5xx, connection, timeout.
 def _is_retryable(exc: Exception) -> bool:
-    """Return True for retryable exceptions: rate-limit, 5xx, connection, timeout."""
     from .client import APIError, AuthenticationError, RateLimitError
 
     if isinstance(exc, AuthenticationError):
@@ -37,26 +37,26 @@ def _is_retryable(exc: Exception) -> bool:
     return False
 
 
+    # Exponential backoff delay in seconds for ``attempt`` (zero-based).
 def _calculate_delay(
     attempt: int,
     base_delay: float,
     max_delay: float,
     jitter: bool,
 ) -> float:
-    """Exponential backoff delay in seconds for ``attempt`` (zero-based)."""
     delay = min(base_delay * (2 ** attempt), max_delay)
     if jitter:
         delay = random.uniform(0, delay)
     return delay
 
 
+    # Decorator that retries sync functions with exponential backoff + optional jitter.
 def with_retry(
     max_retries: int = 3,
     base_delay: float = 0.5,
     max_delay: float = 30.0,
     jitter: bool = True,
 ) -> Callable[[F], F]:
-    """Decorator that retries sync functions with exponential backoff + optional jitter."""
 
     def decorator(func: F) -> F:
         @functools.wraps(func)
@@ -78,13 +78,13 @@ def with_retry(
     return decorator
 
 
+    # Decorator that retries async functions with exponential backoff + optional jitter.
 def with_async_retry(
     max_retries: int = 3,
     base_delay: float = 0.5,
     max_delay: float = 30.0,
     jitter: bool = True,
 ) -> Callable[[F], F]:
-    """Decorator that retries async functions with exponential backoff + optional jitter."""
 
     def decorator(func: F) -> F:
         @functools.wraps(func)

--- a/python/src/asqav/scope.py
+++ b/python/src/asqav/scope.py
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
     from .client import Agent, SDTokenResponse
 
 
+    # A portable proof of agent permissions; wraps an SDTokenResponse.
 @dataclass
 class ScopeToken:
-    """A portable proof of agent permissions; wraps an SDTokenResponse."""
 
     token: str
     jwt: str
@@ -32,8 +32,8 @@ class ScopeToken:
 
     # -- helpers --------------------------------------------------------------
 
+        # Return an ``Authorization`` header dict; ``disclose=None`` includes all disclosures.
     def to_header(self, disclose: list[str] | None = None) -> dict[str, str]:
-        """Return an ``Authorization`` header dict; ``disclose=None`` includes all disclosures."""
         if disclose is not None:
             parts = [self.jwt]
             for name in disclose:
@@ -44,20 +44,20 @@ class ScopeToken:
             value = self.token
         return {"Authorization": f"Bearer {value}"}
 
+        # Return an SD-JWT string with only the listed disclosures revealed.
     def present(self, disclose: list[str]) -> str:
-        """Return an SD-JWT string with only the listed disclosures revealed."""
         parts = [self.jwt]
         for name in disclose:
             if name in self.disclosures:
                 parts.append(self.disclosures[name])
         return "~".join(parts) + "~"
 
+        # Check if the token has expired.
     def is_expired(self) -> bool:
-        """Check if the token has expired."""
         return time.time() >= self.expires_at
 
+        # Serialize to a plain dict for storage or transport.
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to a plain dict for storage or transport."""
         return {
             "token": self.token,
             "jwt": self.jwt,
@@ -69,9 +69,9 @@ class ScopeToken:
             "metadata": self.metadata,
         }
 
+        # Reconstruct a :class:`ScopeToken` from a dict.
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ScopeToken:
-        """Reconstruct a :class:`ScopeToken` from a dict."""
         return cls(
             token=data["token"],
             jwt=data["jwt"],
@@ -87,13 +87,13 @@ class ScopeToken:
 # -- factory ----------------------------------------------------------------
 
 
+    # Issue a portable :class:`ScopeToken` for an agent over the given action patterns.
 def create_scope_token(
     agent: Agent,
     actions: list[str],
     ttl: int = 3600,
     metadata: dict[str, Any] | None = None,
 ) -> ScopeToken:
-    """Issue a portable :class:`ScopeToken` for an agent over the given action patterns."""
     resolved = [resolve_pattern(a) for a in actions]
     nonce = uuid.uuid4().hex
 
@@ -128,8 +128,8 @@ def create_scope_token(
     )
 
 
+    # Verify a scope token via :func:`verify_signature`; returns a result dict.
 def verify_scope_token(signature_id: str) -> dict[str, Any]:
-    """Verify a scope token via :func:`verify_signature`; returns a result dict."""
     from .client import verify_signature
 
     resp = verify_signature(signature_id)
@@ -143,6 +143,6 @@ def verify_scope_token(signature_id: str) -> dict[str, Any]:
     }
 
 
+    # Check if a nonce was already used. Returns True if replay detected.
 def is_replay(nonce: str, seen_nonces: set[str]) -> bool:
-    """Check if a nonce was already used. Returns True if replay detected."""
     return nonce in seen_nonces

--- a/python/src/asqav/verifier/oracle/__main__.py
+++ b/python/src/asqav/verifier/oracle/__main__.py
@@ -48,8 +48,8 @@ def _load(path: str | None) -> dict | None:
         raise SystemExit(2) from None
 
 
+    # Verify one receipt file and print the verdict + per-axis result as JSON.
 def run(receipt_path: str, keys_path: str | None, predecessor_path: str | None) -> int:
-    """Verify one receipt file and print the verdict + per-axis result as JSON."""
     receipt = _load(receipt_path)
     key_provider = _load(keys_path)
     predecessor = _load(predecessor_path)

--- a/python/src/asqav/verifier/oracle/adapter.py
+++ b/python/src/asqav/verifier/oracle/adapter.py
@@ -62,11 +62,13 @@ class FormatAdapter(ABC):
 
     @abstractmethod
     def detect(self, doc: dict) -> bool:
-        """Cheap structural test: does this adapter own ``doc``? No crypto."""
+        # Cheap structural test: does this adapter own ``doc``? No crypto.
+        pass
 
     @abstractmethod
     def extract_signature(self, doc: dict) -> SignatureMaterial:
-        """Pull the issuer signature bytes plus alg and kid out of ``doc``."""
+        # Pull the issuer signature bytes plus alg and kid out of ``doc``.
+        pass
 
     @abstractmethod
     def resolve_key(self, doc: dict, key_provider: Any) -> tuple[bytes | None, str]:
@@ -86,11 +88,13 @@ class FormatAdapter(ABC):
 
     @abstractmethod
     def chain_step(self, doc: dict) -> ChainStep:
-        """Describe how this receipt links to its predecessor."""
+        # Describe how this receipt links to its predecessor.
+        pass
 
     @abstractmethod
     def schema(self, doc: dict) -> tuple[str, str]:
-        """Structural check; returns ``(result, note)`` with PASS / FAIL."""
+        # Structural check; returns ``(result, note)`` with PASS / FAIL.
+        pass
 
     def extra_axes(self, doc: dict, key_provider: Any) -> list[tuple[str, str, str]]:
         """Format-specific axes beyond structure / issuer-signature / chain.

--- a/python/src/asqav/verifier/oracle/adapters/acta.py
+++ b/python/src/asqav/verifier/oracle/adapters/acta.py
@@ -40,8 +40,8 @@ from ..canonical import jcs
 from ..core import sha256_hex
 
 
+    # Decode a hex string; b'' on any malformed input so verify FAILs, never crashes.
 def _safe_hex(value: Any) -> bytes:
-    """Decode a hex string; b'' on any malformed input so verify FAILs, never crashes."""
     if not isinstance(value, str):
         return b""
     try:
@@ -64,8 +64,8 @@ def _is_lower_hex(s: Any) -> bool:
     )
 
 
+    # ACTA signed receipt - Ed25519 over JCS(payload), hex sig, chain incl sig.
 class ActaAdapter(FormatAdapter):
-    """ACTA signed receipt - Ed25519 over JCS(payload), hex sig, chain incl sig."""
 
     name = "acta"
 

--- a/python/src/asqav/verifier/oracle/adapters/aerf.py
+++ b/python/src/asqav/verifier/oracle/adapters/aerf.py
@@ -44,8 +44,8 @@ _STRIP = ("signature", "timestamp", "parent_signature", "parent_key_id", "log_in
 _SPKI_PREFIX = bytes.fromhex("302a300506032b6570032100")
 
 
+    # Decode a hex string; b'' on any malformed input so verify FAILs, never crashes.
 def _safe_hex(value: Any) -> bytes:
-    """Decode a hex string; b'' on any malformed input so verify FAILs, never crashes."""
     if not isinstance(value, str):
         return b""
     try:
@@ -58,23 +58,23 @@ def _signable(doc: dict) -> dict:
     return {k: v for k, v in doc.items() if k not in _STRIP}
 
 
+    # Return the raw 32-byte key from raw input or an RFC 8410 SPKI value.
 def _raw_ed25519(key: bytes) -> bytes:
-    """Return the raw 32-byte key from raw input or an RFC 8410 SPKI value."""
     if len(key) == 44 and key.startswith(_SPKI_PREFIX):
         return key[12:]
     return key
 
 
+    # Return the raw 32-byte Ed25519 key for ``kid`` from the provider, or None.
 def _resolve_raw(key_provider: Any, kid: str) -> bytes | None:
-    """Return the raw 32-byte Ed25519 key for ``kid`` from the provider, or None."""
     material = (key_provider or {}).get(kid)
     if material is None:
         return None
     return _raw_ed25519(material if isinstance(material, bytes) else _safe_hex(material))
 
 
+    # AERF notarised-evidence receipt - Ed25519 over JCS, sig excluded from chain.
 class AerfAdapter(FormatAdapter):
-    """AERF notarised-evidence receipt - Ed25519 over JCS, sig excluded from chain."""
 
     name = "aerf"
 
@@ -130,8 +130,8 @@ class AerfAdapter(FormatAdapter):
             return "FAIL", "genesis must omit previous_receipt_hash, not set it null"
         return "PASS", "required fields present; type notarised_evidence"
 
+        # Parent counter-signature and PDP binding per the AERF procedure.
     def extra_axes(self, doc: dict, key_provider: Any) -> list[tuple[str, str, str]]:
-        """Parent counter-signature and PDP binding per the AERF procedure."""
         axes: list[tuple[str, str, str]] = []
         has_impact = bool(doc.get("impact_tags"))
         if has_impact or doc.get("parent_signature"):

--- a/python/src/asqav/verifier/oracle/adapters/agentreceipts.py
+++ b/python/src/asqav/verifier/oracle/adapters/agentreceipts.py
@@ -33,13 +33,13 @@ from ..did import resolve_ed25519_key
 _SHA256_PREFIX = "sha256:"
 
 
+    # The receipt with ``proof`` removed - the exact object the signature covers.
 def _signable(doc: dict) -> dict:
-    """The receipt with ``proof`` removed - the exact object the signature covers."""
     return {k: v for k, v in doc.items() if k != "proof"}
 
 
+    # Decode a multibase ``u`` (base64url, no padding) proofValue to raw bytes.
 def _multibase_u_decode(value: str) -> bytes:
-    """Decode a multibase ``u`` (base64url, no padding) proofValue to raw bytes."""
     if not value or value[0] != "u":
         raise ValueError("proofValue is not multibase 'u' (base64url) encoded")
     body = value[1:]
@@ -51,8 +51,8 @@ def _chain(doc: dict) -> dict:
     return sub.get("chain", {}) if isinstance(sub, dict) else {}
 
 
+    # agent-receipts AgentReceipt - Ed25519 over strict RFC 8785 JCS, proof excluded.
 class AgentReceiptsAdapter(FormatAdapter):
-    """agent-receipts AgentReceipt - Ed25519 over strict RFC 8785 JCS, proof excluded."""
 
     name = "agentreceipts"
 

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -78,8 +78,8 @@ def _payload(doc: dict) -> dict:
     return payload if isinstance(payload, dict) else env
 
 
+    # Decode signature material; b'' on any malformed input so verify FAILs, never crashes.
 def _safe_b64(value: Any) -> bytes:
-    """Decode signature material; b'' on any malformed input so verify FAILs, never crashes."""
     if not isinstance(value, str):
         return b""
     try:
@@ -88,8 +88,8 @@ def _safe_b64(value: Any) -> bytes:
         return b""
 
 
+    # Asqav Compliance Receipt - ML-DSA-65 over canonical bytes (compliance or hash mode).
 class AsqavNativeAdapter(FormatAdapter):
-    """Asqav Compliance Receipt - ML-DSA-65 over canonical bytes (compliance or hash mode)."""
 
     name = "asqav-native"
 

--- a/python/src/asqav/verifier/oracle/adapters/authproof.py
+++ b/python/src/asqav/verifier/oracle/adapters/authproof.py
@@ -48,8 +48,8 @@ _REQUIRED = (
 )
 
 
+    # Decode a hex string; b'' on any malformed input so verify FAILs, never crashes.
 def _safe_hex(value: Any) -> bytes:
-    """Decode a hex string; b'' on any malformed input so verify FAILs, never crashes."""
     if not isinstance(value, str):
         return b""
     try:
@@ -58,8 +58,8 @@ def _safe_hex(value: Any) -> bytes:
         return b""
 
 
+    # Decode a base64url JWK coordinate; b'' on malformed input.
 def _b64url(value: Any) -> bytes:
-    """Decode a base64url JWK coordinate; b'' on malformed input."""
     if not isinstance(value, str):
         return b""
     try:
@@ -72,8 +72,8 @@ def _is_p256_jwk(jwk: Any) -> bool:
     return isinstance(jwk, dict) and jwk.get("kty") == "EC" and jwk.get("crv") == "P-256"
 
 
+    # Authproof delegation receipt - ES256 over insertion-order JSON.stringify.
 class AuthproofAdapter(FormatAdapter):
-    """Authproof delegation receipt - ES256 over insertion-order JSON.stringify."""
 
     name = "authproof"
 
@@ -91,8 +91,8 @@ class AuthproofAdapter(FormatAdapter):
     def extract_signature(self, doc: dict) -> SignatureMaterial:
         return SignatureMaterial(sig=_safe_hex(doc.get("signature", "")), alg="ES256", kid="")
 
+        # Return the 65-byte uncompressed P-256 point from the embedded JWK (key is in-band).
     def resolve_key(self, doc: dict, _key_provider: Any) -> tuple[bytes | None, str]:
-        """Return the 65-byte uncompressed P-256 point from the embedded JWK (key is in-band)."""
         jwk = doc.get("signerPublicKey")
         if not _is_p256_jwk(jwk):
             return None, "signerPublicKey is not a P-256 JWK"

--- a/python/src/asqav/verifier/oracle/adapters/pipelock.py
+++ b/python/src/asqav/verifier/oracle/adapters/pipelock.py
@@ -108,8 +108,8 @@ _PAYLOAD_AUTHORITY: dict[str, str] = {
 _SIGNATURE_FIELDS = frozenset({"signer_key_id", "key_purpose", "algorithm", "signature"})
 
 
+    # Decode a hex string; b'' on any malformed input so verify FAILs, never crashes.
 def _safe_hex(value: Any) -> bytes:
-    """Decode a hex string; b'' on any malformed input so verify FAILs, never crashes."""
     if not isinstance(value, str):
         return b""
     try:
@@ -135,18 +135,18 @@ def _signable_preimage(doc: dict) -> bytes:
     return jcs_rfc8785(clone)
 
 
+    # SHA-256 of JCS(full receipt including its signature) - the chain primitive.
 def _full_receipt_hash(doc: dict) -> str:
-    """SHA-256 of JCS(full receipt including its signature) - the chain primitive."""
     return sha256_hex(jcs_rfc8785(doc))
 
 
+    # Pipelock EvidenceReceipt v2 - Ed25519 over JCS, chain covers full receipt.
 class PipelockEvidenceAdapter(FormatAdapter):
-    """Pipelock EvidenceReceipt v2 - Ed25519 over JCS, chain covers full receipt."""
 
     name = "pipelock-evidence-v2"
 
+        # Cheap structural fingerprint: record_type + receipt_version, no crypto.
     def detect(self, doc: dict) -> bool:
-        """Cheap structural fingerprint: record_type + receipt_version, no crypto."""
         return (
             doc.get("record_type") == _RECORD_TYPE
             and doc.get("receipt_version") == _RECEIPT_VERSION
@@ -186,8 +186,8 @@ class PipelockEvidenceAdapter(FormatAdapter):
             return None, f"signer_key_id {kid!r} key is {len(raw)} bytes, expected 32"
         return raw, f"resolved signer_key_id {kid!r}"
 
+        # JCS preimage: full receipt with signature object zeroed out.
     def signing_input(self, doc: dict) -> bytes:
-        """JCS preimage: full receipt with signature object zeroed out."""
         return _signable_preimage(doc)
 
     def chain_step(self, doc: dict) -> ChainStep:

--- a/python/src/asqav/verifier/oracle/canonical.py
+++ b/python/src/asqav/verifier/oracle/canonical.py
@@ -36,8 +36,8 @@ import unicodedata
 from typing import Any
 
 
+    # Recursively NFC-normalise every string key and value.
 def _nfc(obj: Any) -> Any:
-    """Recursively NFC-normalise every string key and value."""
     if isinstance(obj, str):
         return unicodedata.normalize("NFC", obj)
     if isinstance(obj, dict):
@@ -47,33 +47,33 @@ def _nfc(obj: Any) -> Any:
     return obj
 
 
+    # AERF/ACTA-dialect JCS: NFC, code-point key sort, numbers as Python emits them.
 def jcs(obj: Any) -> bytes:
-    """AERF/ACTA-dialect JCS: NFC, code-point key sort, numbers as Python emits them."""
     return json.dumps(
         _nfc(obj), sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
     ).encode("utf-8")
 
 
+    # Asqav cloud JCS bytes (no NFC); byte-identical to the cloud signer.
 def asqav_jcs(obj: Any) -> bytes:
-    """Asqav cloud JCS bytes (no NFC); byte-identical to the cloud signer."""
     return json.dumps(
         obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
     ).encode("utf-8")
 
 
+    # Strict RFC 8785 JCS bytes (UTF-16 key sort, ECMAScript numbers) with NFC.
 def jcs_rfc8785(obj: Any) -> bytes:
-    """Strict RFC 8785 JCS bytes (UTF-16 key sort, ECMAScript numbers) with NFC."""
     return _serialize_8785(_nfc(obj)).encode("utf-8")
 
 
+    # UTF-16 BE code-unit sequence for ``key`` - the RFC 8785 key-ordering key.
 def _utf16_key(key: str) -> tuple[int, ...]:
-    """UTF-16 BE code-unit sequence for ``key`` - the RFC 8785 key-ordering key."""
     raw = key.encode("utf-16-be")
     return tuple(int.from_bytes(raw[i : i + 2], "big") for i in range(0, len(raw), 2))
 
 
+    # ECMAScript ``Number.prototype.toString`` form of a JSON number (RFC 8785).
 def _number_8785(value: float) -> str:
-    """ECMAScript ``Number.prototype.toString`` form of a JSON number (RFC 8785)."""
     if value != value or value in (float("inf"), float("-inf")):
         raise ValueError(f"non-finite number not allowed in JCS: {value!r}")
     if isinstance(value, int):
@@ -83,8 +83,8 @@ def _number_8785(value: float) -> str:
     return _ecma_float(float(value))
 
 
+    # Non-integral float as ECMA-262 6.1.6.1.20 Number-to-String (shortest round-trip).
 def _ecma_float(value: float) -> str:
-    """Non-integral float as ECMA-262 6.1.6.1.20 Number-to-String (shortest round-trip)."""
     sign = "-" if value < 0 else ""
     s, exp = _shortest_digits(abs(value))
     k = len(s)
@@ -99,8 +99,8 @@ def _ecma_float(value: float) -> str:
     return f"{sign}{tail}e{'+' if n - 1 >= 0 else '-'}{abs(n - 1)}"
 
 
+    # Return (digit string with no trailing zeros, base-10 exponent) for a positive float.
 def _shortest_digits(value: float) -> tuple[str, int]:
-    """Return (digit string with no trailing zeros, base-10 exponent) for a positive float."""
     mantissa, _, exp = repr(value).partition("e")
     exponent = int(exp) if exp else 0
     if "." in mantissa:
@@ -115,8 +115,8 @@ def _shortest_digits(value: float) -> tuple[str, int]:
     return digits, exponent
 
 
+    # RFC 8785 serialisation: UTF-16 sorted keys, ECMAScript numbers, minimal strings.
 def _serialize_8785(obj: Any) -> str:
-    """RFC 8785 serialisation: UTF-16 sorted keys, ECMAScript numbers, minimal strings."""
     if obj is None or isinstance(obj, bool):
         return json.dumps(obj)
     if isinstance(obj, (int, float)):

--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -37,7 +37,7 @@ class VerifyResult:
 
     ``verdict`` is PASS only when every non-skipped axis passed AND the signature
     was actually checked; a skipped signature downgrades to INCOMPLETE, never a
-    PASS, mirroring the standalone verifier.
+    PASS, mirroring the standalone verifier. The expiry axis never folds it (426).
     """
 
     fmt: str
@@ -47,13 +47,13 @@ class VerifyResult:
     #: payload. None when the receipt carries none (v:1). Never gates the verdict.
     signer: str | None = None
 
+        # Return the result for one axis, or None if it was not run.
     def axis(self, name: str) -> AxisResult | None:
-        """Return the result for one axis, or None if it was not run."""
         return next((a for a in self.axes if a.axis == name), None)
 
 
+    # Return the first adapter whose structural fingerprint matches ``doc``.
 def detect(doc: dict, adapters: list[FormatAdapter]) -> FormatAdapter | None:
-    """Return the first adapter whose structural fingerprint matches ``doc``."""
     if not isinstance(doc, dict):
         # A non-object receipt (array, string, number, null) matches no format;
         # the adapters assume a dict, so guard here rather than crash in detect().
@@ -114,13 +114,13 @@ def _exceeds_depth(obj: Any, max_depth: int) -> bool:
     return False
 
 
+    # Verify one parsed receipt and return a structured ``VerifyResult``.
 def verify(
     doc: dict,
     adapters: list[FormatAdapter],
     key_provider: Any = None,
     predecessor: dict | None = None,
 ) -> VerifyResult:
-    """Verify one parsed receipt and return a structured ``VerifyResult``."""
     ad = detect(doc, adapters)
     if ad is None:
         return VerifyResult(
@@ -146,7 +146,8 @@ def verify(
     ]
     axes.extend(AxisResult(name, res, note) for name, res, note in ad.extra_axes(doc, key_provider))
 
-    has_fail = any(a.result == crypto.FAIL for a in axes)
+    # Expiry reports on its own axis and never folds the verdict (criterion 426)
+    has_fail = any(a.result == crypto.FAIL and a.axis != "expiry" for a in axes)
     # Any skipped axis except a missing-predecessor chain blocks PASS: an unchecked
     # signature / counter-sign / PDP layer means INCOMPLETE, never a hiding PASS.
     blocking_skip = any(a.result == crypto.SKIPPED and a.axis != "chain" for a in axes)
@@ -160,6 +161,6 @@ def verify(
     return VerifyResult(fmt=ad.name, axes=axes, verdict=verdict, signer=signer)
 
 
+    # Lowercase hex SHA-256 - the chain primitive every format shares.
 def sha256_hex(data: bytes) -> str:
-    """Lowercase hex SHA-256 - the chain primitive every format shares."""
     return hashlib.sha256(data).hexdigest()

--- a/python/src/asqav/verifier/oracle/crypto.py
+++ b/python/src/asqav/verifier/oracle/crypto.py
@@ -25,8 +25,8 @@ FAIL = "FAIL"
 SKIPPED = "SKIPPED"
 
 
+    # ML-DSA-65 verify via the standalone tool's dilithium-py path.
 def verify_ml_dsa_65(pk: bytes, msg: bytes, sig: bytes) -> tuple[str, str]:
-    """ML-DSA-65 verify via the standalone tool's dilithium-py path."""
     return _vr.verify_signature(pk, msg, sig, "ML-DSA-65")
 
 
@@ -97,8 +97,8 @@ _DISPATCH = {
 }
 
 
+    # Dispatch to the algorithm's verifier; SKIP an unsupported alg.
 def verify_signature(alg: object, pk: bytes, msg: bytes, sig: bytes) -> tuple[str, str]:
-    """Dispatch to the algorithm's verifier; SKIP an unsupported alg."""
     fn = _DISPATCH.get((alg if isinstance(alg, str) else "").upper())
     if fn is None:
         return SKIPPED, f"unsupported alg {alg!r} (oracle checks {sorted(_DISPATCH)})"

--- a/python/src/asqav/verifier/oracle/did.py
+++ b/python/src/asqav/verifier/oracle/did.py
@@ -26,8 +26,8 @@ _B58_INDEX = {ch: i for i, ch in enumerate(_B58_ALPHABET)}
 _ED25519_MULTICODEC = b"\xed\x01"
 
 
+    # Decode a base58btc string to bytes, preserving leading-zero bytes as '1's.
 def b58btc_decode(text: str) -> bytes:
-    """Decode a base58btc string to bytes, preserving leading-zero bytes as '1's."""
     num = 0
     for ch in text:
         if ch not in _B58_INDEX:
@@ -38,8 +38,8 @@ def b58btc_decode(text: str) -> bytes:
     return b"\x00" * pad + body
 
 
+    # Return the raw 32-byte Ed25519 key from a ``did:key`` 'z...' identifier.
 def _decode_did_key(identifier: str) -> bytes | None:
-    """Return the raw 32-byte Ed25519 key from a ``did:key`` 'z...' identifier."""
     if not identifier.startswith("z"):
         return None  # multibase base58btc is the only did:key form this resolver decodes
     try:
@@ -52,8 +52,8 @@ def _decode_did_key(identifier: str) -> bytes | None:
     return key if len(key) == 32 else None
 
 
+    # Coerce injected key material (raw bytes or hex string) to raw 32-byte form.
 def _coerce_raw(material: object) -> bytes | None:
-    """Coerce injected key material (raw bytes or hex string) to raw 32-byte form."""
     if isinstance(material, bytes):
         raw = material
     elif isinstance(material, str):

--- a/python/src/asqav/verifier/oracle/runner.py
+++ b/python/src/asqav/verifier/oracle/runner.py
@@ -67,8 +67,8 @@ def _key_provider(vec_dir: Path, fmt: str):
     return None
 
 
+    # Run a single vector directory and compare against its expected outcome.
 def run_one(vec_dir: Path, fmt: str, expected_outcome: str, reason_code: str = "") -> VectorOutcome:
-    """Run a single vector directory and compare against its expected outcome."""
     receipt = _load(vec_dir / "receipt.json")
     predecessor = _load(vec_dir / "predecessor.json")
     key_provider = _key_provider(vec_dir, fmt)
@@ -80,8 +80,8 @@ def run_one(vec_dir: Path, fmt: str, expected_outcome: str, reason_code: str = "
     return VectorOutcome(vec_dir.name, expected_outcome, result.verdict, ok, reason_code, detail)
 
 
+    # Run every vector named in ``corpus_root/manifest.json``.
 def run_corpus(corpus_root: Path) -> list[VectorOutcome]:
-    """Run every vector named in ``corpus_root/manifest.json``."""
     manifest = json.loads((corpus_root / "manifest.json").read_text())
     out = []
     for entry in manifest:
@@ -91,8 +91,8 @@ def run_corpus(corpus_root: Path) -> list[VectorOutcome]:
     return out
 
 
+    # Accept the stronger PASS only for the optional-dep ML-DSA skip vector, never broadly.
 def _tolerated(outcome: VectorOutcome) -> bool:
-    """Accept the stronger PASS only for the optional-dep ML-DSA skip vector, never broadly."""
     return outcome.ok or (
         outcome.expected_outcome == "INCOMPLETE"
         and outcome.actual_verdict == "PASS"
@@ -116,8 +116,8 @@ def _default_corpus_root() -> Path:
     return here.parents[5] / "verifier" / "conformance-vectors"
 
 
+    # Run the bundled corpus and print a per-vector report; nonzero on mismatch.
 def main() -> int:
-    """Run the bundled corpus and print a per-vector report; nonzero on mismatch."""
     root = _default_corpus_root()
     results = run_corpus(root)
     for r in results:

--- a/python/src/asqav/verifier/vc_export.py
+++ b/python/src/asqav/verifier/vc_export.py
@@ -55,8 +55,8 @@ STANDARD_VC_PROOF_TYPES = frozenset(
 )
 
 
+    # Reuse the oracle's detection to label the source format, or ``unknown``.
 def _detect_format(receipt: dict) -> str:
-    """Reuse the oracle's detection to label the source format, or ``unknown``."""
     for adapter in ADAPTERS:
         try:
             if adapter.detect(receipt):
@@ -233,8 +233,8 @@ def to_vc_envelope(receipt: dict, *, format: str | None = None) -> dict:
     return envelope
 
 
+    # Best-effort issuance timestamp from the mapped action or source payload, or ``None``.
 def _valid_from(subject: dict) -> str | None:
-    """Best-effort issuance timestamp from the mapped action or source payload, or ``None``."""
     action = subject.get("action")
     if isinstance(action, dict) and action.get("timestamp"):
         return action.get("timestamp")

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -162,8 +162,8 @@ def _describe_value(value) -> str:
     return type(value).__name__
 
 
+    # JCS bytes of the envelope with ``anchors`` removed (the anchored bytes).
 def envelope_minus_anchors_jcs(env: dict) -> bytes:
-    """JCS bytes of the envelope with ``anchors`` removed (the anchored bytes)."""
     e = dict(env)
     e.pop("anchors", None)
     return canonical_json(e)
@@ -276,8 +276,8 @@ def fetch_jwks(url: str = JWKS_URL, *, timeout: int = 30) -> dict:
     return _get_json(url, timeout=timeout)
 
 
+    # Decode standard or url-safe base64, padding-tolerant.
 def _b64decode(value: str) -> bytes:
-    """Decode standard or url-safe base64, padding-tolerant."""
     s = value.replace("-", "+").replace("_", "/")
     s += "=" * ((-len(s)) % 4)
     return base64.b64decode(s, validate=False)
@@ -446,20 +446,20 @@ def match_signing_key(jwks: dict, kid: str, agent_id=None, issuer_id=None, org_i
     return _match_key(jwks, kid)
 
 
+    # Return the issuer id a jwks entry publishes, or None when it names no string.
 def key_issuer_of(entry):
-    """Return the issuer id a jwks entry publishes, or None when it names no string."""
     issuer = entry.get("issuer_id") if entry else None
     return issuer if isinstance(issuer, str) else None
 
 
+    # Return the org id a jwks entry publishes, or None when the value is not one.
 def key_org_of(entry):
-    """Return the org id a jwks entry publishes, or None when the value is not one."""
     org = entry.get("org_id") if entry else None
     return org if _is_org_id(org) else None
 
 
+    # Return the revoked_at a jwks entry publishes, if any.
 def revoked_at_of(entry):
-    """Return the revoked_at a jwks entry publishes, if any."""
     return entry.get("revoked_at") if entry else None
 
 
@@ -639,8 +639,8 @@ def check_key_status(status, issued_at: str, revoked_at=None, has_trusted_anchor
     return "FAIL", f"signing key status {status!r}; receipt cannot be trusted"
 
 
+    # ML-DSA-65 verify. Returns (result, note); result in PASS/FAIL/SKIPPED.
 def verify_signature(pk: bytes, msg: bytes, sig: bytes, alg: object):
-    """ML-DSA-65 verify. Returns (result, note); result in PASS/FAIL/SKIPPED."""
     if (alg if isinstance(alg, str) else "").upper() != "ML-DSA-65":
         return "SKIPPED", f"unsupported alg {alg!r} (this tool checks ML-DSA-65)"
     try:
@@ -736,13 +736,8 @@ def check_skew(issued_at: str):
     return "PASS", f"skew {skew:.0f}s within bound"
 
 
+    # Axis-only expiry flag, mirrors the hosted signature_expired label; never folds the verdict (426).
 def check_expiry(payload: dict):
-    """Refuse a receipt past the expiry its own signer committed to.
-
-    Mirrors the hosted signature_expired verdict. The window is read from inside
-    the signed bytes, so an unsigned envelope field can never move it, and an
-    unreadable value fails closed instead of reading as no window at all.
-    """
     if not isinstance(payload, dict) or "expires_at" not in payload:
         return "PASS", "receipt declares no expiry"
     raw = payload["expires_at"]
@@ -803,8 +798,8 @@ def check_anchors(envelope: dict):
     return ("PASS" if all_ok else "FAIL"), "; ".join(lines)
 
 
+    # Closed-key-set and false-attestation rules for controls_evaluated.
 def check_controls_evaluated(payload: dict):
-    """Closed-key-set and false-attestation rules for controls_evaluated."""
     ce = payload.get("controls_evaluated")
     if ce is None:
         return "PASS", "receipt declares no controls_evaluated block"
@@ -1006,7 +1001,8 @@ def run(
         mark = {"PASS": "ok", "FAIL": "FAIL", "SKIPPED": "skip"}[res]
         print(f"  [{mark:>4}] {name:<11} {note}")
 
-    has_fail = any(r == "FAIL" for _, r, _ in results)
+    # Expiry reports on its own axis and never folds the verdict (criterion 426)
+    has_fail = any(r == "FAIL" for n, r, _ in results if n != "expiry")
     # A skipped chain (no predecessor supplied) is expected and does not block a
     # PASS; any other skip - notably the signature - downgrades to INCOMPLETE.
     has_blocking_skip = any(r == "SKIPPED" and n != "chain" for n, r, _ in results)
@@ -1182,7 +1178,8 @@ def run_structured(
     exp_r, exp_n = check_expiry(payload)
     axes.append({"name": "expiry", "result": exp_r, "note": exp_n})
 
-    has_fail = any(a["result"] == "FAIL" for a in axes)
+    # Expiry reports on its own axis and never folds the verdict (criterion 426)
+    has_fail = any(a["result"] == "FAIL" and a["name"] != "expiry" for a in axes)
     has_blocking_skip = any(
         a["result"] == "SKIPPED" and a["name"] != "chain" for a in axes
     )

--- a/python/tests/test_adapter_base.py
+++ b/python/tests/test_adapter_base.py
@@ -27,14 +27,14 @@ MOCK_SIGN_RESPONSE: dict = {
 # === Helper: concrete subclass for testing ===
 
 
+    # Concrete subclass to test the base.
 class _TestAdapter(AsqavAdapter):
-    """Concrete subclass to test the base."""
 
     pass
 
 
+    # Named to test auto-name generation.
 class AsqavCallbackHandler(AsqavAdapter):
-    """Named to test auto-name generation."""
 
     pass
 
@@ -57,16 +57,16 @@ def test_class_name_to_agent_name_simple():
 # === Initialization ===
 
 
+    # AsqavAdapter raises AsqavError when asqav.init() was not called.
 def test_init_raises_without_asqav_init():
-    """AsqavAdapter raises AsqavError when asqav.init() was not called."""
     with patch("asqav.client._api_key", None):
         with pytest.raises(AsqavError, match="Call asqav.init"):
             _TestAdapter()
 
 
+    # Passing agent_name calls Agent.create with that name.
 @patch("asqav.extras._base.Agent")
 def test_init_with_agent_name(mock_agent_cls):
-    """Passing agent_name calls Agent.create with that name."""
     mock_agent_cls.create.return_value = MagicMock()
     with patch("asqav.client._api_key", "sk_test"):
         adapter = _TestAdapter(agent_name="my-agent")
@@ -74,9 +74,9 @@ def test_init_with_agent_name(mock_agent_cls):
     assert adapter._agent is mock_agent_cls.create.return_value
 
 
+    # Passing agent_id calls Agent.get with that ID.
 @patch("asqav.extras._base.Agent")
 def test_init_with_agent_id(mock_agent_cls):
-    """Passing agent_id calls Agent.get with that ID."""
     mock_agent_cls.get.return_value = MagicMock()
     with patch("asqav.client._api_key", "sk_test"):
         adapter = _TestAdapter(agent_id="agent_abc")
@@ -84,9 +84,9 @@ def test_init_with_agent_id(mock_agent_cls):
     assert adapter._agent is mock_agent_cls.get.return_value
 
 
+    # Without agent_name or agent_id, auto-generates name from class.
 @patch("asqav.extras._base.Agent")
 def test_init_auto_name_from_subclass(mock_agent_cls):
-    """Without agent_name or agent_id, auto-generates name from class."""
     mock_agent_cls.create.return_value = MagicMock()
     with patch("asqav.client._api_key", "sk_test"):
         AsqavCallbackHandler()
@@ -96,9 +96,9 @@ def test_init_auto_name_from_subclass(mock_agent_cls):
 # === _sign_action ===
 
 
+    # _sign_action returns SignatureResponse on success.
 @patch("asqav.extras._base.Agent")
 def test_sign_action_success(mock_agent_cls):
-    """_sign_action returns SignatureResponse on success."""
     mock_agent = MagicMock()
     mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
     mock_agent.sign.return_value = mock_sig
@@ -112,9 +112,9 @@ def test_sign_action_success(mock_agent_cls):
     mock_agent.sign.assert_called_once_with("llm:call", {"model": "gpt-4"})
 
 
+    # Successful signatures accumulate in _signatures list.
 @patch("asqav.extras._base.Agent")
 def test_sign_action_accumulates_signatures(mock_agent_cls):
-    """Successful signatures accumulate in _signatures list."""
     mock_agent = MagicMock()
     mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
     mock_agent.sign.return_value = mock_sig
@@ -129,9 +129,9 @@ def test_sign_action_accumulates_signatures(mock_agent_cls):
     assert all(s is mock_sig for s in adapter._signatures)
 
 
+    # _sign_action returns None on AsqavError (fail-open).
 @patch("asqav.extras._base.Agent")
 def test_sign_action_fail_open(mock_agent_cls):
-    """_sign_action returns None on AsqavError (fail-open)."""
     mock_agent = MagicMock()
     mock_agent.sign.side_effect = AsqavError("network timeout")
     mock_agent_cls.create.return_value = mock_agent
@@ -147,9 +147,9 @@ def test_sign_action_fail_open(mock_agent_cls):
 # === Session lifecycle ===
 
 
+    # _start_session delegates to agent.start_session.
 @patch("asqav.extras._base.Agent")
 def test_start_session(mock_agent_cls):
-    """_start_session delegates to agent.start_session."""
     mock_agent = MagicMock()
     mock_agent_cls.create.return_value = mock_agent
 
@@ -161,9 +161,9 @@ def test_start_session(mock_agent_cls):
     assert adapter._session_id is not None
 
 
+    # _end_session delegates to agent.end_session and clears session_id.
 @patch("asqav.extras._base.Agent")
 def test_end_session(mock_agent_cls):
-    """_end_session delegates to agent.end_session and clears session_id."""
     mock_agent = MagicMock()
     mock_agent._session_id = "sess_123"
     mock_agent_cls.create.return_value = mock_agent
@@ -177,9 +177,9 @@ def test_end_session(mock_agent_cls):
     assert adapter._session_id is None
 
 
+    # _end_session passes custom status to agent.
 @patch("asqav.extras._base.Agent")
 def test_end_session_with_status(mock_agent_cls):
-    """_end_session passes custom status to agent."""
     mock_agent = MagicMock()
     mock_agent._session_id = "sess_123"
     mock_agent_cls.create.return_value = mock_agent
@@ -192,9 +192,9 @@ def test_end_session_with_status(mock_agent_cls):
     mock_agent.end_session.assert_called_once_with("error")
 
 
+    # _end_session does not raise on AsqavError.
 @patch("asqav.extras._base.Agent")
 def test_end_session_fail_open(mock_agent_cls):
-    """_end_session does not raise on AsqavError."""
     mock_agent = MagicMock()
     mock_agent._session_id = "sess_123"
     mock_agent.end_session.side_effect = AsqavError("timeout")
@@ -208,9 +208,9 @@ def test_end_session_fail_open(mock_agent_cls):
     assert adapter._session_id is None
 
 
+    # _end_session skips agent.end_session when agent has no active session.
 @patch("asqav.extras._base.Agent")
 def test_end_session_skips_when_no_agent_session(mock_agent_cls):
-    """_end_session skips agent.end_session when agent has no active session."""
     mock_agent = MagicMock()
     mock_agent._session_id = None
     mock_agent_cls.create.return_value = mock_agent
@@ -261,9 +261,9 @@ def test_sign_action_forwards_compliance_kwargs(mock_agent_cls):
     )
 
 
+    # _sign_action without compliance kwargs calls Agent.sign as before.
 @patch("asqav.extras._base.Agent")
 def test_sign_action_no_compliance_kwargs_unchanged(mock_agent_cls):
-    """_sign_action without compliance kwargs calls Agent.sign as before."""
     mock_agent = MagicMock()
     mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
     mock_agent.sign.return_value = mock_sig
@@ -279,9 +279,9 @@ def test_sign_action_no_compliance_kwargs_unchanged(mock_agent_cls):
 # === c3-lessons regressions: async offload, api_key override, repr ===
 
 
+    # _sign_action_async runs the sync sign off the event loop thread.
 @patch("asqav.extras._base.Agent")
 def test_sign_action_async_offloads_to_thread(mock_agent_cls):
-    """_sign_action_async runs the sync sign off the event loop thread."""
     import asyncio
     import threading
 
@@ -309,9 +309,9 @@ def test_sign_action_async_offloads_to_thread(mock_agent_cls):
     assert sign_thread[0] != loop_thread, "sync sign blocked the event loop thread"
 
 
+    # Observe mode returns None without touching Agent.sign.
 @patch("asqav.extras._base.Agent")
 def test_sign_action_async_observe_skips_network(mock_agent_cls):
-    """Observe mode returns None without touching Agent.sign."""
     import asyncio
 
     mock_agent_cls.create.return_value = MagicMock()
@@ -323,19 +323,19 @@ def test_sign_action_async_observe_skips_network(mock_agent_cls):
     adapter._agent.sign.assert_not_called()
 
 
+    # An explicit api_key= actually initialises the client (was silently ignored).
 @patch("asqav.extras._base._client.init")
 @patch("asqav.extras._base.Agent")
 def test_api_key_argument_initialises_client(mock_agent_cls, mock_init):
-    """An explicit api_key= actually initialises the client (was silently ignored)."""
     mock_agent_cls.create.return_value = MagicMock()
     with patch("asqav.client._api_key", None):
         _TestAdapter(api_key="sk_adapter", agent_name="test")
     mock_init.assert_called_once_with("sk_adapter")
 
 
+    # __repr__ surfaces agent identity and observe flag, never the key.
 @patch("asqav.extras._base.Agent")
 def test_repr_reports_config_and_omits_api_key(mock_agent_cls):
-    """__repr__ surfaces agent identity and observe flag, never the key."""
     mock_agent = MagicMock()
     mock_agent.agent_id = "agent_123"
     mock_agent.name = "my-agent"

--- a/python/tests/test_anchor_forged_value.py
+++ b/python/tests/test_anchor_forged_value.py
@@ -100,8 +100,8 @@ def _axis(value: object) -> tuple[str, str]:
     return check_anchors(env)
 
 
+    # The reported case: an all-punctuation value decoded to nothing and passed.
 def test_reported_forged_punctuation_anchor_fails() -> None:
-    """The reported case: an all-punctuation value decoded to nothing and passed."""
     state, note = _axis("!!!!")
     assert state == "FAIL"
     assert "base64-ok" not in note
@@ -155,15 +155,15 @@ def test_surplus_padding_is_refused_on_every_interpreter(value: str) -> None:
     assert _axis(value)[0] == "FAIL", repr(value)
 
 
+    # Documented behaviour change: an anchor value is one unwrapped token.
 @pytest.mark.parametrize("value", MIME_WRAPPED, ids=repr)
 def test_mime_line_wrapped_base64_is_refused(value: str) -> None:
-    """Documented behaviour change: an anchor value is one unwrapped token."""
     assert _safe_b64(value) is False, repr(value)
     assert _axis(value)[0] == "FAIL", repr(value)
 
 
+    # Every encoding a real signer emits keeps passing, padded or not.
 def test_legitimate_anchor_values_still_pass() -> None:
-    """Every encoding a real signer emits keeps passing, padded or not."""
     rng = random.Random(358)
     for n in range(1, 129):
         raw = bytes(rng.randrange(256) for _ in range(n))

--- a/python/tests/test_anchor_value_cases.py
+++ b/python/tests/test_anchor_value_cases.py
@@ -25,8 +25,8 @@ ENVELOPE = {
 }
 
 
+    # A corpus that silently empties would make every case below vacuous.
 def test_corpus_is_populated() -> None:
-    """A corpus that silently empties would make every case below vacuous."""
     assert len(VALUES) >= 900, f"corpus has only {len(VALUES)} values"
     wide = [c for c in VALUES if any(ord(ch) > 127 for ch in c["value"])]
     assert len(wide) >= 350, f"only {len(wide)} values carry a non-ASCII codepoint"

--- a/python/tests/test_async_preflight_fail_closed.py
+++ b/python/tests/test_async_preflight_fail_closed.py
@@ -29,10 +29,10 @@ AGENT = AsyncAgent(
 )
 
 
+    # A status fetch error blocks rather than silently clearing the agent.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_status_fetch_error_does_not_clear(mock_get: AsyncMock) -> None:
-    """A status fetch error blocks rather than silently clearing the agent."""
     mock_get.side_effect = [
         ConnectionError("network down"),  # status check
         [],  # policies check
@@ -44,10 +44,10 @@ async def test_status_fetch_error_does_not_clear(mock_get: AsyncMock) -> None:
     assert "could not verify" in result.explanation.lower()
 
 
+    # A policy fetch error blocks rather than silently clearing the agent.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_policy_fetch_error_does_not_clear(mock_get: AsyncMock) -> None:
-    """A policy fetch error blocks rather than silently clearing the agent."""
     mock_get.side_effect = [
         {"revoked": False, "suspended": False},  # status check
         ConnectionError("network down"),  # policies check
@@ -58,10 +58,10 @@ async def test_policy_fetch_error_does_not_clear(mock_get: AsyncMock) -> None:
     assert result.checks_complete is False
 
 
+    # A non-list /policies response fails closed instead of silently clearing.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_non_list_policies_does_not_clear(mock_get: AsyncMock) -> None:
-    """A non-list /policies response fails closed instead of silently clearing."""
     mock_get.side_effect = [
         {"revoked": False, "suspended": False},  # status check
         {"policies": []},  # anomalous non-list policies response
@@ -73,11 +73,11 @@ async def test_non_list_policies_does_not_clear(mock_get: AsyncMock) -> None:
     assert any("unexpected response" in r for r in result.reasons)
 
 
+    # A non-dict /status body fails closed (parity pin for the TS fix).
 @pytest.mark.asyncio
 @pytest.mark.parametrize("status_body", [["x"], "revoked", 5, []])
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_non_dict_status_does_not_clear(mock_get: AsyncMock, status_body) -> None:
-    """A non-dict /status body fails closed (parity pin for the TS fix)."""
     mock_get.side_effect = [
         status_body,  # anomalous non-dict status response
         [],  # policies check
@@ -89,10 +89,10 @@ async def test_non_dict_status_does_not_clear(mock_get: AsyncMock, status_body) 
     assert "could not verify" in result.explanation.lower()
 
 
+    # An active agent with no blocking policy clears, checks_complete True.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_happy_path_still_clears(mock_get: AsyncMock) -> None:
-    """An active agent with no blocking policy clears, checks_complete True."""
     mock_get.side_effect = [
         {"revoked": False, "suspended": False},  # status check
         [],  # policies check
@@ -103,10 +103,10 @@ async def test_happy_path_still_clears(mock_get: AsyncMock) -> None:
     assert result.checks_complete is True
 
 
+    # A revoked agent blocks with checks_complete True, distinct from an error.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_revoked_agent_is_a_real_verdict(mock_get: AsyncMock) -> None:
-    """A revoked agent blocks with checks_complete True, distinct from an error."""
     mock_get.side_effect = [
         {"revoked": True, "suspended": False},  # status check
         [],  # policies check

--- a/python/tests/test_async_preflight_resolve_pattern.py
+++ b/python/tests/test_async_preflight_resolve_pattern.py
@@ -38,10 +38,10 @@ _SQL_READ_BLOCK_POLICY = [
 ]
 
 
+    # Passing the semantic alias 'sql-read' triggers a glob policy on the resolved form.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_preflight_resolves_pattern_before_policy_check(mock_get: AsyncMock) -> None:
-    """Passing the semantic alias 'sql-read' triggers a glob policy on the resolved form."""
     mock_get.side_effect = [
         {"revoked": False, "suspended": False},
         _SQL_READ_BLOCK_POLICY,
@@ -55,10 +55,10 @@ async def test_preflight_resolves_pattern_before_policy_check(mock_get: AsyncMoc
     assert any("no-sql-reads" in r for r in result.reasons)
 
 
+    # Already-expanded glob bypasses resolve_pattern transparently.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_preflight_glob_passthrough_still_matches(mock_get: AsyncMock) -> None:
-    """Already-expanded glob bypasses resolve_pattern transparently."""
     mock_get.side_effect = [
         {"revoked": False, "suspended": False},
         _SQL_READ_BLOCK_POLICY,

--- a/python/tests/test_attestation_offline.py
+++ b/python/tests/test_attestation_offline.py
@@ -45,8 +45,8 @@ _AGENT_ID = "agt_test"
 _ORG_ID = "org_test"
 
 
+    # Return (sign(message) -> bytes, verify(message, sig) -> bool) for a fresh key.
 def _ed25519_signer():
-    """Return (sign(message) -> bytes, verify(message, sig) -> bool) for a fresh key."""
     from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.primitives.asymmetric import ed25519
 
@@ -78,8 +78,8 @@ def _signed_message(claim: dict = _CLAIM) -> bytes:
     )
 
 
+    # Build a small Merkle tree and return (root, inclusionProof dict) for index.
 def _tree_head_and_proof(index: int = 2, size: int = 4):
-    """Build a small Merkle tree and return (root, inclusionProof dict) for index."""
     leaves = [merkle_leaf_hash(f"entry-{i}".encode()) for i in range(size)]
     proof = merkle_inclusion_proof(leaves, index)
     return merkle_root(leaves), {
@@ -112,14 +112,14 @@ def _good_receipt():
     return receipt, message, verify, tree_head
 
 
+    # (b) The SDK re-derives the exact statementHash the backend returned.
 def test_compute_statement_hash_matches_cloud_fixture() -> None:
-    """(b) The SDK re-derives the exact statementHash the backend returned."""
     got = compute_statement_hash(_CLAIM, _COMMITMENT, _KEY_ID, _TIMESTAMP)
     assert got == _GOLDEN_HASH
 
 
+    # The signed message carries the exact 11 fields the cloud signs.
 def test_reconstruct_signed_message_mirrors_cloud_shape() -> None:
-    """The signed message carries the exact 11 fields the cloud signs."""
     message = json.loads(_signed_message())
     assert message.keys() == {
         "v", "mode", "statement_hash", "commitment", "commitment_alg",
@@ -131,8 +131,8 @@ def test_reconstruct_signed_message_mirrors_cloud_shape() -> None:
     assert message["statement_hash"] == _GOLDEN_HASH
 
 
+    # (c) A tampered claim re-derives a different hash and fails verification.
 def test_tampered_claim_changes_hash_and_does_not_pass() -> None:
-    """(c) A tampered claim re-derives a different hash and fails verification."""
     tampered = dict(_CLAIM)
     tampered["subject"] = "agt-EVIL"
     assert compute_statement_hash(tampered, _COMMITMENT, _KEY_ID, _TIMESTAMP) != _GOLDEN_HASH
@@ -151,8 +151,8 @@ def test_tampered_claim_changes_hash_and_does_not_pass() -> None:
     assert by_name["statement_hash"] == "FAIL"
 
 
+    # (d) A good receipt yields the distinct outcome, never a plain PASS.
 def test_good_receipt_is_not_rederivable_never_plain_pass() -> None:
-    """(d) A good receipt yields the distinct outcome, never a plain PASS."""
     receipt, message, verify, tree_head = _good_receipt()
     result = verify_attestation_offline(
         _CLAIM,
@@ -170,8 +170,8 @@ def test_good_receipt_is_not_rederivable_never_plain_pass() -> None:
     assert by_name["commitment"] == "NOT_REDERIVABLE"
 
 
+    # Flipping the signature bytes fails the signature axis and the verdict.
 def test_tampered_signature_fails() -> None:
-    """Flipping the signature bytes fails the signature axis and the verdict."""
     receipt, message, verify, tree_head = _good_receipt()
     raw = base64.b64decode(receipt["signature"])
     flipped = bytes([raw[0] ^ 0xFF]) + raw[1:]
@@ -190,8 +190,8 @@ def test_tampered_signature_fails() -> None:
     assert by_name["statement_hash"] == "PASS"
 
 
+    # A proof cut against the wrong tree head fails the inclusion axis.
 def test_tampered_inclusion_proof_fails() -> None:
-    """A proof cut against the wrong tree head fails the inclusion axis."""
     receipt, message, verify, _ = _good_receipt()
     wrong_head = merkle_root([merkle_leaf_hash(b"other-leaf")])
     result = verify_attestation_offline(
@@ -207,8 +207,8 @@ def test_tampered_inclusion_proof_fails() -> None:
     assert by_name["signature"] == "PASS"
 
 
+    # Without a key or tree head the verdict is INCOMPLETE, still never PASS.
 def test_missing_optional_inputs_is_incomplete_not_pass() -> None:
-    """Without a key or tree head the verdict is INCOMPLETE, still never PASS."""
     receipt, _message, _verify, _tree_head = _good_receipt()
     result = verify_attestation_offline(_CLAIM, receipt)
     assert result["verdict"] == "INCOMPLETE"

--- a/python/tests/test_axis_parity_cases.py
+++ b/python/tests/test_axis_parity_cases.py
@@ -32,8 +32,8 @@ PIPELOCK_VECTOR = (
 )
 
 
+    # A table that silently empties would make every case below vacuous.
 def test_table_is_populated() -> None:
-    """A table that silently empties would make every case below vacuous."""
     assert len(TABLE["anchors"]) >= 25, f"only {len(TABLE['anchors'])} anchor cases"
     assert len(TABLE["skew"]) >= 15, f"only {len(TABLE['skew'])} skew cases"
     assert len(TABLE["expiry"]) >= 15, f"only {len(TABLE['expiry'])} expiry cases"
@@ -43,8 +43,8 @@ def test_table_is_populated() -> None:
     assert outcomes == {"PASS", "FAIL"}, outcomes
 
 
+    # The limits are part of the contract the other language mirrors.
 def test_bounds_match_the_table() -> None:
-    """The limits are part of the contract the other language mirrors."""
     assert SKEW_BOUND_SECONDS == 300
     assert ORACLE_MAX_NESTING_DEPTH == 200
 
@@ -90,8 +90,8 @@ def test_expiry_reads_only_the_signed_bytes() -> None:
     assert axes["expiry"]["result"] == "FAIL", axes["expiry"]
 
 
+    # The reference pipelock receipt with this case's chain_prev_hash substituted.
 def _pipelock_receipt(case: dict) -> dict:
-    """The reference pipelock receipt with this case's chain_prev_hash substituted."""
     doc = json.loads((PIPELOCK_VECTOR / "receipt.json").read_text())
     if case.get("omit"):
         doc.pop("chain_prev_hash", None)

--- a/python/tests/test_canonicalize.py
+++ b/python/tests/test_canonicalize.py
@@ -28,24 +28,24 @@ def _load_vectors() -> list[dict]:
     return json.loads(VECTORS_PATH.read_text())["vectors"]
 
 
+    # The SDK's canonicalize() must produce the same bytes as vectors.json.
 @pytest.mark.parametrize("vector", _load_vectors(), ids=lambda v: v["name"])
 def test_canonicalize_matches_vector(vector: dict) -> None:
-    """The SDK's canonicalize() must produce the same bytes as vectors.json."""
     expected = vector["canonical"]
     actual = canonicalize(vector["input"]).decode("utf-8")
     assert actual == expected, f"{vector['name']}: canonical drift"
 
 
+    # SHA-256 of the SDK's canonical bytes must match vectors.json.
 @pytest.mark.parametrize("vector", _load_vectors(), ids=lambda v: v["name"])
 def test_sha256_matches_vector(vector: dict) -> None:
-    """SHA-256 of the SDK's canonical bytes must match vectors.json."""
     canonical_bytes = canonicalize(vector["input"])
     actual = hashlib.sha256(canonical_bytes).hexdigest()
     assert actual == vector["sha256"], f"{vector['name']}: sha256 drift"
 
 
+    # For vectors shaped {action_type, context}, hash_action() must agree.
 def test_hash_action_no_salt_matches_action_context_vector() -> None:
-    """For vectors shaped {action_type, context}, hash_action() must agree."""
     vectors = _load_vectors()
     happy = [
         v for v in vectors
@@ -57,8 +57,8 @@ def test_hash_action_no_salt_matches_action_context_vector() -> None:
         assert result == f"sha256:{v['sha256']}", f"{v['name']}: hash_action drift"
 
 
+    # With a salt, hash_action returns HMAC-SHA-256 not plain SHA-256.
 def test_hash_action_with_salt_uses_hmac() -> None:
-    """With a salt, hash_action returns HMAC-SHA-256 not plain SHA-256."""
     salt = bytes.fromhex(
         "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
     )
@@ -70,21 +70,21 @@ def test_hash_action_with_salt_uses_hmac() -> None:
     assert len(keyed) == len("sha256:") + 64
 
 
+    # Inserting keys in a different order yields the same canonical bytes.
 def test_canonicalize_is_deterministic_across_key_order() -> None:
-    """Inserting keys in a different order yields the same canonical bytes."""
     a = {"b": 1, "a": 2, "c": [{"y": 1, "x": 2}]}
     b = {"a": 2, "c": [{"x": 2, "y": 1}], "b": 1}
     assert canonicalize(a) == canonicalize(b)
 
 
+    # Non-ASCII chars are emitted as raw UTF-8, not \uXXXX escapes.
 def test_canonicalize_preserves_unicode_raw() -> None:
-    """Non-ASCII chars are emitted as raw UTF-8, not \\uXXXX escapes."""
     out = canonicalize({"name": "café"})
     assert "café".encode("utf-8") in out
     assert b"\\u" not in out
 
 
+    # NaN/Infinity are not valid JSON and must raise.
 def test_canonicalize_rejects_nan() -> None:
-    """NaN/Infinity are not valid JSON and must raise."""
     with pytest.raises(ValueError):
         canonicalize({"x": float("nan")})

--- a/python/tests/test_canonicalize_tool_args.py
+++ b/python/tests/test_canonicalize_tool_args.py
@@ -112,8 +112,8 @@ def test_receipt_fixture_float_in_tool_args_is_rejected() -> None:
     assert "RFC 8785 section 3.2.2" in msg
 
 
+    # Same fixture with the float stringified produces stable bytes.
 def test_receipt_fixture_stringified_float_canonicalizes_cleanly() -> None:
-    """Same fixture with the float stringified produces stable bytes."""
     receipt = {
         "payload": {
             "action_type": "tool:call",

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -19,8 +19,8 @@ runner = CliRunner()
 # === Version ===
 
 
+    # --version prints the SDK version.
 def test_version() -> None:
-    """--version prints the SDK version."""
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
     assert "asqav" in result.output
@@ -30,9 +30,9 @@ def test_version() -> None:
 # === verify command ===
 
 
+    # verify prints details for a valid signature.
 @patch("asqav.verify_signature")
 def test_verify_valid(mock_verify: MagicMock) -> None:
-    """verify prints details for a valid signature."""
     mock_verify.return_value = MagicMock(
         verified=True,
         agent_name="test-agent",
@@ -49,9 +49,9 @@ def test_verify_valid(mock_verify: MagicMock) -> None:
     mock_verify.assert_called_once_with("sig_abc")
 
 
+    # verify prints 'invalid' when signature is not verified.
 @patch("asqav.verify_signature")
 def test_verify_invalid(mock_verify: MagicMock) -> None:
-    """verify prints 'invalid' when signature is not verified."""
     mock_verify.return_value = MagicMock(
         verified=False,
         agent_name="bad-agent",
@@ -65,9 +65,9 @@ def test_verify_invalid(mock_verify: MagicMock) -> None:
     assert "bad-agent" in result.output
 
 
+    # verify exits with code 1 for non-existent signature.
 @patch("asqav.verify_signature")
 def test_verify_not_found(mock_verify: MagicMock) -> None:
-    """verify exits with code 1 for non-existent signature."""
     from asqav import APIError
 
     mock_verify.side_effect = APIError("Signature not found", 404)
@@ -91,12 +91,12 @@ def test_verify_network_failure_readable(mock_verify: MagicMock) -> None:
 # === sign command (IETF Compliance Receipts profile) ===
 
 
+    # sign --compliance-mode threads every IETF flag into Agent.sign().
 @patch("asqav.Agent.get")
 @patch("asqav.init")
 def test_sign_compliance_mode_calls_sdk(
     mock_init: MagicMock, mock_get: MagicMock, tmp_path
 ) -> None:
-    """sign --compliance-mode threads every IETF flag into Agent.sign()."""
     fake_agent = MagicMock()
     fake_agent.agent_id = "agent_x"
     fake_agent.algorithm = "ml-dsa-65"
@@ -152,12 +152,12 @@ def test_sign_compliance_mode_calls_sdk(
     assert call_kwargs["sandbox_state"] == "enabled"
 
 
+    # sign --policy-decision deny without --reason exits non-zero.
 @patch("asqav.Agent.get")
 @patch("asqav.init")
 def test_sign_deny_without_reason_rejects(
     mock_init: MagicMock, mock_get: MagicMock
 ) -> None:
-    """sign --policy-decision deny without --reason exits non-zero."""
     result = runner.invoke(
         app,
         [
@@ -175,11 +175,11 @@ def test_sign_deny_without_reason_rejects(
 # === sign command: edge-case branches ===
 
 
+    # A malformed --action-json file is reported with a clear error.
 @patch("asqav.init")
 def test_sign_action_json_invalid_exits_1(
     mock_init: MagicMock, tmp_path
 ) -> None:
-    """A malformed --action-json file is reported with a clear error."""
     bad = tmp_path / "bad.json"
     bad.write_text("{not json")
     result = runner.invoke(
@@ -196,12 +196,12 @@ def test_sign_action_json_invalid_exits_1(
     assert "Error reading action JSON" in result.output
 
 
+    # Agent.get APIError surfaces as 'Error fetching agent' and exit 1.
 @patch("asqav.Agent.get")
 @patch("asqav.init")
 def test_sign_agent_get_api_error_exits_1(
     mock_init: MagicMock, mock_get: MagicMock
 ) -> None:
-    """Agent.get APIError surfaces as 'Error fetching agent' and exit 1."""
     from asqav import APIError
 
     mock_get.side_effect = APIError("agent revoked", 404)
@@ -358,16 +358,16 @@ def test_build_sign_context_returns_none_when_empty() -> None:
     assert _build_sign_context({}, "", None) is None
 
 
+    # `--action-id` without --action-json produces a context with just the id.
 def test_build_sign_context_only_action_id() -> None:
-    """`--action-id` without --action-json produces a context with just the id."""
     from asqav.cli import _build_sign_context
 
     assert _build_sign_context({}, "act_only", None) == {"_action_id": "act_only"}
 
 
+    # verify --output text surfaces IETF profile sub-axes when present.
 @patch("asqav.verify_signature")
 def test_verify_text_shows_ietf_axes(mock_verify: MagicMock) -> None:
-    """verify --output text surfaces IETF profile sub-axes when present."""
     from asqav import VerificationDetail
 
     mock_verify.return_value = MagicMock(
@@ -397,9 +397,9 @@ def test_verify_text_shows_ietf_axes(mock_verify: MagicMock) -> None:
     assert "skew: 1.234" in result.output
 
 
+    # verify --output json returns the full VerificationResponse.
 @patch("asqav.verify_signature")
 def test_verify_json_emits_full_detail(mock_verify: MagicMock) -> None:
-    """verify --output json returns the full VerificationResponse."""
     import json
 
     from asqav import VerificationDetail
@@ -439,10 +439,10 @@ def test_verify_json_emits_full_detail(mock_verify: MagicMock) -> None:
 # === agents list command ===
 
 
+    # agents list prints agents when present.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_agents_list(mock_init: MagicMock, mock_get: MagicMock) -> None:
-    """agents list prints agents when present."""
     mock_get.return_value = {
         "agents": [
             {"name": "alpha", "agent_id": "agent_001", "algorithm": "ml-dsa-65"},
@@ -457,22 +457,22 @@ def test_agents_list(mock_init: MagicMock, mock_get: MagicMock) -> None:
     mock_init.assert_called_once_with(api_key="sk_test")
 
 
+    # agents list prints message when no agents exist.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_agents_list_empty(mock_init: MagicMock, mock_get: MagicMock) -> None:
-    """agents list prints message when no agents exist."""
     mock_get.return_value = {"agents": []}
     result = runner.invoke(app, ["agents", "list"], env={"ASQAV_API_KEY": "sk_test"})
     assert result.exit_code == 0
     assert "No agents found" in result.output
 
 
+    # The cloud returns a bare JSON array; the CLI must render it directly.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_agents_list_handles_array_response(
     mock_init: MagicMock, mock_get: MagicMock
 ) -> None:
-    """The cloud returns a bare JSON array; the CLI must render it directly."""
     mock_get.return_value = [
         {"name": "alpha", "agent_id": "agent_001", "algorithm": "ml-dsa-65"},
         {"name": "beta", "agent_id": "agent_002", "algorithm": "ed25519"},
@@ -485,18 +485,18 @@ def test_agents_list_handles_array_response(
     assert "agent_002" in result.output
 
 
+    # An empty array response must produce the friendly empty message.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_agents_list_empty_array(mock_init: MagicMock, mock_get: MagicMock) -> None:
-    """An empty array response must produce the friendly empty message."""
     mock_get.return_value = []
     result = runner.invoke(app, ["agents", "list"], env={"ASQAV_API_KEY": "sk_test"})
     assert result.exit_code == 0
     assert "No agents found" in result.output
 
 
+    # agents list exits with error when ASQAV_API_KEY is not set.
 def test_agents_list_no_api_key() -> None:
-    """agents list exits with error when ASQAV_API_KEY is not set."""
     result = runner.invoke(app, ["agents", "list"], env={"ASQAV_API_KEY": ""})
     assert result.exit_code == 1
     assert "ASQAV_API_KEY" in result.output
@@ -505,10 +505,10 @@ def test_agents_list_no_api_key() -> None:
 # === agents create command ===
 
 
+    # agents create prints the new agent details.
 @patch("asqav.Agent.create")
 @patch("asqav.init")
 def test_agents_create(mock_init: MagicMock, mock_create: MagicMock) -> None:
-    """agents create prints the new agent details."""
     mock_agent = MagicMock(
         name="my-agent",
         agent_id="agent_new",
@@ -530,8 +530,8 @@ def test_agents_create(mock_init: MagicMock, mock_create: MagicMock) -> None:
 # === quickstart command ===
 
 
+    # quickstart shows success when API key is set.
 def test_quickstart_with_api_key() -> None:
-    """quickstart shows success when API key is set."""
     result = runner.invoke(app, ["quickstart"], env={"ASQAV_API_KEY": "sk_test"})
     assert result.exit_code == 0
     assert "API key detected" in result.output
@@ -540,8 +540,8 @@ def test_quickstart_with_api_key() -> None:
     assert "Next steps" in result.output
 
 
+    # quickstart warns when API key is missing.
 def test_quickstart_without_api_key() -> None:
-    """quickstart warns when API key is missing."""
     result = runner.invoke(app, ["quickstart"], env={"ASQAV_API_KEY": ""})
     assert result.exit_code == 0
     assert "ASQAV_API_KEY not set" in result.output
@@ -551,9 +551,9 @@ def test_quickstart_without_api_key() -> None:
 # === doctor command ===
 
 
+    # doctor reports failure when API key is missing.
 @patch("urllib.request.urlopen")
 def test_doctor_no_api_key(mock_urlopen: MagicMock) -> None:
-    """doctor reports failure when API key is missing."""
     result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": ""})
     assert result.exit_code == 1
     assert "FAIL" in result.output
@@ -561,6 +561,7 @@ def test_doctor_no_api_key(mock_urlopen: MagicMock) -> None:
     assert "SKIP" in result.output
 
 
+    # doctor passes all checks when API key is set and API is reachable.
 @patch("asqav.client._urllib_request")
 @patch("urllib.request.urlopen")
 @patch("asqav.client.health_check")
@@ -571,7 +572,6 @@ def test_doctor_all_pass(
     mock_urlopen: MagicMock,
     mock_urllib_req: MagicMock,
 ) -> None:
-    """doctor passes all checks when API key is set and API is reachable."""
     mock_health.return_value = {"status": "ok"}
     mock_urllib_req.return_value = []
     result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": "sk_test"})
@@ -610,6 +610,7 @@ def test_doctor_url_join_broken_fails(
     assert "All checks passed" not in result.output
 
 
+    # doctor reports failure when API is unreachable.
 @patch("asqav.client._urllib_request", return_value=[])
 @patch("urllib.request.urlopen")
 @patch("asqav.client.health_check")
@@ -620,7 +621,6 @@ def test_doctor_api_unreachable(
     mock_urlopen: MagicMock,
     mock_urllib_req: MagicMock,
 ) -> None:
-    """doctor reports failure when API is unreachable."""
     mock_health.side_effect = Exception("Connection refused")
     result = runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": "sk_test"})
     assert result.exit_code == 1
@@ -657,6 +657,7 @@ def test_doctor_edge_blocked_403(
     assert "All checks passed" not in result.output
 
 
+    # doctor reports a clear failure when the edge probe cannot connect.
 @patch("asqav.client._urllib_request", return_value=[])
 @patch("urllib.request.urlopen")
 @patch("asqav.client.health_check")
@@ -667,7 +668,6 @@ def test_doctor_edge_unreachable(
     mock_urlopen: MagicMock,
     mock_urllib_req: MagicMock,
 ) -> None:
-    """doctor reports a clear failure when the edge probe cannot connect."""
     import urllib.error
 
     mock_health.return_value = {"status": "ok"}
@@ -678,9 +678,9 @@ def test_doctor_edge_unreachable(
     assert "All checks passed" not in result.output
 
 
+    # The edge probe identifies itself with the SDK User-Agent.
 @patch("urllib.request.urlopen")
 def test_doctor_edge_probe_sends_user_agent(mock_urlopen: MagicMock) -> None:
-    """The edge probe identifies itself with the SDK User-Agent."""
     from asqav._useragent import USER_AGENT
 
     runner.invoke(app, ["doctor"], env={"ASQAV_API_KEY": ""})
@@ -692,8 +692,8 @@ def test_doctor_edge_probe_sends_user_agent(mock_urlopen: MagicMock) -> None:
 # === replay command ===
 
 
+    # Build a ReplayTimeline-like double for CLI tests.
 def _fake_timeline(*, chain_integrity: bool = True) -> MagicMock:
-    """Build a ReplayTimeline-like double for CLI tests."""
     tl = MagicMock()
     tl.agent_id = "agt_test"
     tl.session_id = "sess_test"
@@ -703,17 +703,17 @@ def _fake_timeline(*, chain_integrity: bool = True) -> MagicMock:
     return tl
 
 
+    # replay without agent_id+session_id and without --bundle exits 1.
 def test_replay_requires_agent_and_session() -> None:
-    """replay without agent_id+session_id and without --bundle exits 1."""
     result = runner.invoke(app, ["replay"], env={"ASQAV_API_KEY": "sk_test"})
     assert result.exit_code == 1
     assert "agent_id and session_id are required" in result.output
 
 
+    # replay <agent> <session> calls asqav.replay and prints the summary.
 @patch("asqav.replay")
 @patch("asqav.init")
 def test_replay_online_passes_chain(mock_init: MagicMock, mock_replay: MagicMock) -> None:
-    """replay <agent> <session> calls asqav.replay and prints the summary."""
     mock_replay.return_value = _fake_timeline(chain_integrity=True)
     result = runner.invoke(
         app,
@@ -725,10 +725,10 @@ def test_replay_online_passes_chain(mock_init: MagicMock, mock_replay: MagicMock
     mock_replay.assert_called_once_with("agt_test", "sess_test")
 
 
+    # replay exits non-zero when the chain failed verification.
 @patch("asqav.replay")
 @patch("asqav.init")
 def test_replay_chain_broken_exits_1(mock_init: MagicMock, mock_replay: MagicMock) -> None:
-    """replay exits non-zero when the chain failed verification."""
     mock_replay.return_value = _fake_timeline(chain_integrity=False)
     result = runner.invoke(
         app,
@@ -738,10 +738,10 @@ def test_replay_chain_broken_exits_1(mock_init: MagicMock, mock_replay: MagicMoc
     assert result.exit_code == 1
 
 
+    # --json prints to_json output.
 @patch("asqav.replay")
 @patch("asqav.init")
 def test_replay_json_flag(mock_init: MagicMock, mock_replay: MagicMock) -> None:
-    """--json prints to_json output."""
     mock_replay.return_value = _fake_timeline()
     result = runner.invoke(
         app,
@@ -752,8 +752,8 @@ def test_replay_json_flag(mock_init: MagicMock, mock_replay: MagicMock) -> None:
     assert "agt_test" in result.output
 
 
+    # --bundle pointing to a nonexistent file exits 1.
 def test_replay_bundle_missing_file() -> None:
-    """--bundle pointing to a nonexistent file exits 1."""
     result = runner.invoke(app, ["replay", "--bundle", "/nonexistent/path.json"])
     assert result.exit_code == 1
     assert "Error reading bundle" in result.output
@@ -762,10 +762,10 @@ def test_replay_bundle_missing_file() -> None:
 # === preflight command ===
 
 
+    # preflight prints CLEARED and exits 0 when the action is allowed.
 @patch("asqav.Agent.get")
 @patch("asqav.init")
 def test_preflight_cleared(mock_init: MagicMock, mock_get: MagicMock) -> None:
-    """preflight prints CLEARED and exits 0 when the action is allowed."""
     mock_agent = MagicMock()
     mock_agent.preflight.return_value = MagicMock(
         cleared=True, agent_active=True, policy_allowed=True,
@@ -780,10 +780,10 @@ def test_preflight_cleared(mock_init: MagicMock, mock_get: MagicMock) -> None:
     assert "CLEARED" in result.output
 
 
+    # preflight exits 1 and prints reasons when blocked.
 @patch("asqav.Agent.get")
 @patch("asqav.init")
 def test_preflight_blocked(mock_init: MagicMock, mock_get: MagicMock) -> None:
-    """preflight exits 1 and prints reasons when blocked."""
     mock_agent = MagicMock()
     mock_agent.preflight.return_value = MagicMock(
         cleared=False, agent_active=False, policy_allowed=True,
@@ -802,10 +802,10 @@ def test_preflight_blocked(mock_init: MagicMock, mock_get: MagicMock) -> None:
 # === budget commands ===
 
 
+    # budget check exits 0 when within limit.
 @patch("asqav.Agent.get")
 @patch("asqav.init")
 def test_budget_check_allowed(mock_init: MagicMock, mock_get: MagicMock) -> None:
-    """budget check exits 0 when within limit."""
     mock_get.return_value = MagicMock()
     result = runner.invoke(
         app,
@@ -817,10 +817,10 @@ def test_budget_check_allowed(mock_init: MagicMock, mock_get: MagicMock) -> None
     assert "ALLOWED" in result.output
 
 
+    # budget check exits 1 when estimated_cost would exceed limit.
 @patch("asqav.Agent.get")
 @patch("asqav.init")
 def test_budget_check_exhausted(mock_init: MagicMock, mock_get: MagicMock) -> None:
-    """budget check exits 1 when estimated_cost would exceed limit."""
     mock_get.return_value = MagicMock()
     result = runner.invoke(
         app,
@@ -833,13 +833,13 @@ def test_budget_check_exhausted(mock_init: MagicMock, mock_get: MagicMock) -> No
     assert "budget_exhausted" in result.output
 
 
+    # budget record signs a spend record and prints the signature_id.
 @patch("asqav.BudgetTracker.record")
 @patch("asqav.Agent.get")
 @patch("asqav.init")
 def test_budget_record(
     mock_init: MagicMock, mock_get: MagicMock, mock_record: MagicMock,
 ) -> None:
-    """budget record signs a spend record and prints the signature_id."""
     mock_get.return_value = MagicMock()
     mock_record.return_value = MagicMock(
         signature_id="sig_b1", action_id="act_b1",
@@ -859,10 +859,10 @@ def test_budget_record(
 # === approve command ===
 
 
+    # approve prints APPROVED when the session is fully approved.
 @patch("asqav.approve_action")
 @patch("asqav.init")
 def test_approve_approved(mock_init: MagicMock, mock_approve: MagicMock) -> None:
-    """approve prints APPROVED when the session is fully approved."""
     mock_approve.return_value = MagicMock(
         session_id="thr_a", entity_id="ent_a",
         signatures_collected=2, approvals_required=2,
@@ -879,8 +879,8 @@ def test_approve_approved(mock_init: MagicMock, mock_approve: MagicMock) -> None
 # === compliance commands ===
 
 
+    # compliance frameworks lists known framework keys.
 def test_compliance_frameworks_lists_known() -> None:
-    """compliance frameworks lists known framework keys."""
     result = runner.invoke(app, ["compliance", "frameworks"])
     assert result.exit_code == 0
     # FRAMEWORKS dict from compliance.py contains at least these.
@@ -888,6 +888,7 @@ def test_compliance_frameworks_lists_known() -> None:
     assert "dora" in result.output
 
 
+    # compliance export pulls signatures and writes a bundle file.
 @patch("asqav.compliance.export_bundle")
 @patch("asqav.client.get_session_signatures")
 @patch("asqav.init")
@@ -895,7 +896,6 @@ def test_compliance_export_writes_bundle(
     mock_init: MagicMock, mock_get_sigs: MagicMock, mock_export: MagicMock,
     tmp_path,
 ) -> None:
-    """compliance export pulls signatures and writes a bundle file."""
     mock_get_sigs.return_value = [{"signature_id": "s1"}]
     mock_bundle = MagicMock(receipt_count=1, merkle_root="abc123")
     mock_export.return_value = mock_bundle
@@ -912,12 +912,12 @@ def test_compliance_export_writes_bundle(
     mock_bundle.to_file.assert_called_once_with(str(out))
 
 
+    # compliance export exits 1 when the framework key is not known.
 @patch("asqav.client.get_session_signatures")
 @patch("asqav.init")
 def test_compliance_export_unknown_framework(
     mock_init: MagicMock, mock_get_sigs: MagicMock,
 ) -> None:
-    """compliance export exits 1 when the framework key is not known."""
     mock_get_sigs.return_value = []
     result = runner.invoke(
         app,
@@ -962,12 +962,12 @@ def test_preflight_runs_on_free_tier_without_gate(
         assert call.args[:1] != ("/account",)
 
 
+    # policies list (a former Pro command) is reachable on the free tier.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_policies_list_runs_on_free_tier_without_gate(
     mock_init: MagicMock, mock_get: MagicMock,
 ) -> None:
-    """policies list (a former Pro command) is reachable on the free tier."""
     mock_get.return_value = []
     result = runner.invoke(
         app,
@@ -1090,12 +1090,12 @@ def test_webhooks_delete_calls_delete(
 # === audit-pack export / policy ===
 
 
+    # audit-pack export writes the cloud-signed bundle to disk.
 @patch("asqav.client._post")
 @patch("asqav.init")
 def test_audit_pack_export_writes_bundle(
     mock_init: MagicMock, mock_post: MagicMock, tmp_path
 ) -> None:
-    """audit-pack export writes the cloud-signed bundle to disk."""
     mock_post.return_value = {
         "bundle_digest": "sha256:abc",
         "bundle_signature": "BASE64SIG==",
@@ -1126,12 +1126,12 @@ def test_audit_pack_export_writes_bundle(
     assert body["only_compliance"] is True
 
 
+    # audit-pack policy returns the artefact JSON. 64-hex prefixes sha256:.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_audit_pack_policy_resolves_digest(
     mock_init: MagicMock, mock_get: MagicMock
 ) -> None:
-    """audit-pack policy returns the artefact JSON. 64-hex prefixes sha256:."""
     mock_get.return_value = {
         "digest": "sha256:" + "a" * 64,
         "organization_id": "org_x",
@@ -1154,12 +1154,12 @@ def test_audit_pack_policy_resolves_digest(
 # === payloads erase ===
 
 
+    # payloads erase --yes calls DELETE /signatures/payloads/{id}.
 @patch("asqav.client._delete")
 @patch("asqav.init")
 def test_payloads_erase_calls_delete(
     mock_init: MagicMock, mock_delete: MagicMock
 ) -> None:
-    """payloads erase --yes calls DELETE /signatures/payloads/{id}."""
     mock_delete.return_value = {}
     result = runner.invoke(
         app,
@@ -1203,8 +1203,8 @@ def test_org_set_compliance_strict_requires_one_flag() -> None:
 # === keys generate ===
 
 
+    # keys generate --algorithm ed25519 emits a PKCS#8 PEM private key.
 def test_keys_generate_ed25519(tmp_path) -> None:
-    """keys generate --algorithm ed25519 emits a PKCS#8 PEM private key."""
     pytest_skipif_no_crypto = False
     try:
         from cryptography.hazmat.primitives.asymmetric import ed25519  # noqa: F401
@@ -1235,12 +1235,12 @@ def test_keys_generate_ml_dsa_errors() -> None:
 # === audit-pack verify ===
 
 
+    # audit-pack verify posts the bundle wrapped in {bundle: ...} and prints VALID.
 @patch("asqav.client._post")
 @patch("asqav.init")
 def test_audit_pack_verify_valid(
     mock_init: MagicMock, mock_post: MagicMock, tmp_path
 ) -> None:
-    """audit-pack verify posts the bundle wrapped in {bundle: ...} and prints VALID."""
     mock_post.return_value = {
         "bundle_signature_valid": True,
         "bundle_digest": "sha256:abc",
@@ -1268,12 +1268,12 @@ def test_audit_pack_verify_valid(
     assert body["bundle"] == {"receipt_count": 2, "receipts": []}
 
 
+    # audit-pack verify exits 1 and lists failed receipts on an invalid bundle.
 @patch("asqav.client._post")
 @patch("asqav.init")
 def test_audit_pack_verify_invalid_exits_1(
     mock_init: MagicMock, mock_post: MagicMock, tmp_path
 ) -> None:
-    """audit-pack verify exits 1 and lists failed receipts on an invalid bundle."""
     mock_post.return_value = {
         "bundle_signature_valid": False,
         "bundle_digest": "sha256:def",
@@ -1297,9 +1297,9 @@ def test_audit_pack_verify_invalid_exits_1(
 # === org halt / resume (emergency kill-switch, JWT-scoped) ===
 
 
+    # org halt --yes POSTs the emergency-halt route with the reason note.
 @patch("asqav.cli._session_request")
 def test_org_halt_calls_emergency_route(mock_session: MagicMock) -> None:
-    """org halt --yes POSTs the emergency-halt route with the reason note."""
     mock_session.return_value = {
         "emergency_halt": True,
         "emergency_halt_at": "2026-06-01T00:00:00Z",
@@ -1319,9 +1319,9 @@ def test_org_halt_calls_emergency_route(mock_session: MagicMock) -> None:
     assert body == {"reason": "rogue agent"}
 
 
+    # org resume POSTs the deactivate route.
 @patch("asqav.cli._session_request")
 def test_org_resume_calls_deactivate_route(mock_session: MagicMock) -> None:
-    """org resume POSTs the deactivate route."""
     mock_session.return_value = {"emergency_halt": False}
     result = runner.invoke(
         app,
@@ -1334,8 +1334,8 @@ def test_org_resume_calls_deactivate_route(mock_session: MagicMock) -> None:
     assert path == "/orgs/org_x/emergency-halt/deactivate"
 
 
+    # org halt fails closed with a clear message when ASQAV_SESSION_TOKEN is unset.
 def test_org_halt_requires_session_token() -> None:
-    """org halt fails closed with a clear message when ASQAV_SESSION_TOKEN is unset."""
     result = runner.invoke(
         app,
         ["org", "halt", "org_x", "--yes"],
@@ -1348,9 +1348,9 @@ def test_org_halt_requires_session_token() -> None:
 # === keys create / list / revoke (account API keys, JWT-scoped) ===
 
 
+    # keys create POSTs /keys and prints the one-time full key.
 @patch("asqav.cli._session_request")
 def test_keys_create_prints_full_key_once(mock_session: MagicMock) -> None:
-    """keys create POSTs /keys and prints the one-time full key."""
     mock_session.return_value = {
         "id": "key_1",
         "name": "ci",
@@ -1371,9 +1371,9 @@ def test_keys_create_prints_full_key_once(mock_session: MagicMock) -> None:
     assert body == {"name": "ci", "scopes": ["agents:read"]}
 
 
+    # keys list GETs /keys and renders id + prefix + state.
 @patch("asqav.cli._session_request")
 def test_keys_list_renders_rows(mock_session: MagicMock) -> None:
-    """keys list GETs /keys and renders id + prefix + state."""
     mock_session.return_value = [
         {
             "id": "key_1",
@@ -1393,9 +1393,9 @@ def test_keys_list_renders_rows(mock_session: MagicMock) -> None:
     assert mock_session.call_args.args[1] == "/keys"
 
 
+    # keys revoke --yes DELETEs /keys/{id}.
 @patch("asqav.cli._session_request")
 def test_keys_revoke_calls_delete(mock_session: MagicMock) -> None:
-    """keys revoke --yes DELETEs /keys/{id}."""
     mock_session.return_value = {"message": "revoked"}
     result = runner.invoke(
         app,
@@ -1412,12 +1412,12 @@ def test_keys_revoke_calls_delete(mock_session: MagicMock) -> None:
 # === compliance templates / report / reports ===
 
 
+    # compliance templates GETs the templates route and renders ids.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_compliance_templates_lists(
     mock_init: MagicMock, mock_get: MagicMock
 ) -> None:
-    """compliance templates GETs the templates route and renders ids."""
     mock_get.return_value = [
         {"template_id": "eu_ai_act", "framework": "eu_ai_act", "name": "EU AI Act"}
     ]
@@ -1429,12 +1429,12 @@ def test_compliance_templates_lists(
     assert mock_get.call_args.args[0] == "/compliance-reports/templates"
 
 
+    # compliance report POSTs the create route with the report_type body.
 @patch("asqav.client._post")
 @patch("asqav.init")
 def test_compliance_report_creates(
     mock_init: MagicMock, mock_post: MagicMock
 ) -> None:
-    """compliance report POSTs the create route with the report_type body."""
     mock_post.return_value = {
         "id": "rep_1",
         "name": "Q2",
@@ -1455,12 +1455,12 @@ def test_compliance_report_creates(
     assert body["name"] == "Q2"
 
 
+    # compliance reports GETs the list route and renders report rows.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_compliance_reports_lists(
     mock_init: MagicMock, mock_get: MagicMock
 ) -> None:
-    """compliance reports GETs the list route and renders report rows."""
     mock_get.return_value = {
         "reports": [
             {
@@ -1487,12 +1487,12 @@ def test_compliance_reports_lists(
 # === observability summary / metrics ===
 
 
+    # observability summary GETs the summary route and renders totals.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_observability_summary(
     mock_init: MagicMock, mock_get: MagicMock
 ) -> None:
-    """observability summary GETs the summary route and renders totals."""
     mock_get.return_value = {
         "total_actions": 12,
         "total_agents_active": 3,
@@ -1509,12 +1509,12 @@ def test_observability_summary(
     assert mock_get.call_args.args[0] == "/observability/summary"
 
 
+    # observability metrics threads --hours and --window into the query string.
 @patch("asqav.client._get")
 @patch("asqav.init")
 def test_observability_metrics_passes_window(
     mock_init: MagicMock, mock_get: MagicMock
 ) -> None:
-    """observability metrics threads --hours and --window into the query string."""
     mock_get.return_value = {
         "metrics": [
             {
@@ -1544,13 +1544,13 @@ def test_observability_metrics_passes_window(
 # === replay-verify ===
 
 
+    # replay-verify wraps replay() and prints the IETF outcome.
 @patch("asqav.client._get")
 @patch("asqav.replay")
 @patch("asqav.init")
 def test_replay_verify_chain_valid(
     mock_init: MagicMock, mock_replay: MagicMock, mock_account: MagicMock
 ) -> None:
-    """replay-verify wraps replay() and prints the IETF outcome."""
     mock_account.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
     timeline = MagicMock()
     timeline.compliance_chain_valid = True
@@ -1576,13 +1576,13 @@ def test_replay_verify_chain_valid(
     assert "compliance_chain_valid: True" in result.output
 
 
+    # replay-verify --strict fails when any step lacks signed_envelope.
 @patch("asqav.client._get")
 @patch("asqav.replay")
 @patch("asqav.init")
 def test_replay_verify_strict_rejects_steps_without_envelope(
     mock_init: MagicMock, mock_replay: MagicMock, mock_account: MagicMock
 ) -> None:
-    """replay-verify --strict fails when any step lacks signed_envelope."""
     mock_account.return_value = {"tier": "pro", "organization_id": "o", "organization_name": "n"}
     timeline = MagicMock()
     timeline.compliance_chain_valid = True
@@ -1607,8 +1607,8 @@ def test_replay_verify_strict_rejects_steps_without_envelope(
 # === migrate run ===
 
 
+    # migrate run refuses without ASQAV_MAINTENANCE_KEY.
 def test_migrate_run_requires_maintenance_key(monkeypatch) -> None:
-    """migrate run refuses without ASQAV_MAINTENANCE_KEY."""
     monkeypatch.delenv("ASQAV_MAINTENANCE_KEY", raising=False)
     result = runner.invoke(
         app,
@@ -1619,8 +1619,8 @@ def test_migrate_run_requires_maintenance_key(monkeypatch) -> None:
     assert "ASQAV_MAINTENANCE_KEY" in result.output
 
 
+    # migrate run rejects unsupported migration names.
 def test_migrate_run_rejects_unknown(monkeypatch) -> None:
-    """migrate run rejects unsupported migration names."""
     monkeypatch.setenv("ASQAV_MAINTENANCE_KEY", "mk")
     result = runner.invoke(
         app,
@@ -1631,12 +1631,12 @@ def test_migrate_run_rejects_unknown(monkeypatch) -> None:
     assert "unsupported migration" in result.output
 
 
+    # migrate run v3-22 POSTs to the correct path with X-Maintenance-Key.
 @patch("urllib.request.urlopen")
 @patch("asqav.init")
 def test_migrate_run_v3_22_calls_endpoint(
     mock_init: MagicMock, mock_urlopen: MagicMock, monkeypatch
 ) -> None:
-    """migrate run v3-22 POSTs to the correct path with X-Maintenance-Key."""
     response = MagicMock()
     response.read.return_value = b'{"status": "ok", "applied": 1, "migration": "v3-22"}'
     response.__enter__ = lambda self: response

--- a/python/tests/test_cli_hook.py
+++ b/python/tests/test_cli_hook.py
@@ -29,8 +29,8 @@ _PRETOOL_EVENT = {
 }
 
 
+    # Run `asqav hook <subcommand> --dry-run`, pipe event JSON, return parsed body.
 def _invoke_hook(subcommand: str, event: dict, extra_args: list[str] | None = None) -> dict:
-    """Run `asqav hook <subcommand> --dry-run`, pipe event JSON, return parsed body."""
     args = ["hook", subcommand, "--dry-run"] + (extra_args or [])
     result = runner.invoke(app, args, input=json.dumps(event))
     assert result.exit_code == 0, f"CLI exited {result.exit_code}: {result.output}"
@@ -40,38 +40,38 @@ def _invoke_hook(subcommand: str, event: dict, extra_args: list[str] | None = No
 # === posttool honesty invariant ===
 
 
+    # action_type is tool:<tool_name> for posttool.
 def test_posttool_dry_run_action_type() -> None:
-    """action_type is tool:<tool_name> for posttool."""
     body = _invoke_hook("posttool", _POSTTOOL_EVENT)
     assert body["action_type"] == "tool:Bash"
 
 
+    # context carries the tool_input dict.
 def test_posttool_dry_run_context() -> None:
-    """context carries the tool_input dict."""
     body = _invoke_hook("posttool", _POSTTOOL_EVENT)
     assert body["context"] == {"tool_input": {"command": "ls"}}
 
 
+    # session_id is forwarded from the hook event.
 def test_posttool_dry_run_session_id() -> None:
-    """session_id is forwarded from the hook event."""
     body = _invoke_hook("posttool", _POSTTOOL_EVENT)
     assert body["session_id"] == "s1"
 
 
+    # Honesty invariant: posttool must set capture_topology=passive_telemetry.
 def test_posttool_honesty_invariant_capture_topology() -> None:
-    """Honesty invariant: posttool must set capture_topology=passive_telemetry."""
     body = _invoke_hook("posttool", _POSTTOOL_EVENT)
     assert body["capture_topology"] == "passive_telemetry"
 
 
+    # Honesty invariant: posttool must set receipt_type=protectmcp:observation.
 def test_posttool_honesty_invariant_receipt_type() -> None:
-    """Honesty invariant: posttool must set receipt_type=protectmcp:observation."""
     body = _invoke_hook("posttool", _POSTTOOL_EVENT)
     assert body["receipt_type"] == "protectmcp:observation"
 
 
+    # posttool must never emit a :decision receipt (would be a false attestation).
 def test_posttool_no_decision_receipt_type() -> None:
-    """posttool must never emit a :decision receipt (would be a false attestation)."""
     body = _invoke_hook("posttool", _POSTTOOL_EVENT)
     assert body.get("receipt_type") != "protectmcp:decision"
 
@@ -79,14 +79,14 @@ def test_posttool_no_decision_receipt_type() -> None:
 # === pretool honesty invariant ===
 
 
+    # pretool is a gate decision: receipt_type=protectmcp:decision.
 def test_pretool_dry_run_receipt_type() -> None:
-    """pretool is a gate decision: receipt_type=protectmcp:decision."""
     body = _invoke_hook("pretool", _PRETOOL_EVENT)
     assert body["receipt_type"] == "protectmcp:decision"
 
 
+    # pretool runs in-process: capture_topology=in_process_sdk.
 def test_pretool_dry_run_capture_topology() -> None:
-    """pretool runs in-process: capture_topology=in_process_sdk."""
     body = _invoke_hook("pretool", _PRETOOL_EVENT)
     assert body["capture_topology"] == "in_process_sdk"
 
@@ -97,38 +97,38 @@ def test_pretool_dry_run_capture_topology() -> None:
 # identity must exit 2, else the gate fails OPEN and the tool runs unsigned.
 
 
+    # Empty stdin must exit 2 (block), not exit 1 (proceed unsigned).
 def test_pretool_blocks_on_empty_stdin() -> None:
-    """Empty stdin must exit 2 (block), not exit 1 (proceed unsigned)."""
     result = runner.invoke(app, ["hook", "pretool"], input="")
     assert result.exit_code == 2, f"expected block (2), got {result.exit_code}"
 
 
+    # Whitespace-only stdin must exit 2 (block).
 def test_pretool_blocks_on_whitespace_stdin() -> None:
-    """Whitespace-only stdin must exit 2 (block)."""
     result = runner.invoke(app, ["hook", "pretool"], input="   \n")
     assert result.exit_code == 2, f"expected block (2), got {result.exit_code}"
 
 
+    # Garbage (invalid JSON) on stdin must exit 2 (block).
 def test_pretool_blocks_on_invalid_json() -> None:
-    """Garbage (invalid JSON) on stdin must exit 2 (block)."""
     result = runner.invoke(app, ["hook", "pretool"], input="{not json")
     assert result.exit_code == 2, f"expected block (2), got {result.exit_code}"
 
 
+    # Valid JSON that is not an object (array) must exit 2 (block).
 def test_pretool_blocks_on_non_object_json() -> None:
-    """Valid JSON that is not an object (array) must exit 2 (block)."""
     result = runner.invoke(app, ["hook", "pretool"], input="[1, 2, 3]")
     assert result.exit_code == 2, f"expected block (2), got {result.exit_code}"
 
 
+    # Valid JSON scalar (a bare string) must exit 2 (block).
 def test_pretool_blocks_on_non_object_scalar() -> None:
-    """Valid JSON scalar (a bare string) must exit 2 (block)."""
     result = runner.invoke(app, ["hook", "pretool"], input='"hello"')
     assert result.exit_code == 2, f"expected block (2), got {result.exit_code}"
 
 
+    # A well-formed event but no ASQAV_API_KEY/ASQAV_AGENT_ID must exit 2 (block).
 def test_pretool_blocks_on_missing_identity(monkeypatch) -> None:
-    """A well-formed event but no ASQAV_API_KEY/ASQAV_AGENT_ID must exit 2 (block)."""
     monkeypatch.delenv("ASQAV_API_KEY", raising=False)
     monkeypatch.delenv("ASQAV_AGENT_ID", raising=False)
     result = runner.invoke(app, ["hook", "pretool"], input=json.dumps(_PRETOOL_EVENT))
@@ -138,13 +138,13 @@ def test_pretool_blocks_on_missing_identity(monkeypatch) -> None:
 # === posttool audit path stays FAIL-OPEN (exit 1 on bad input is correct) ===
 
 
+    # PostToolUse is audit-only: bad input exits 1 (non-blocking), never 2.
 def test_posttool_fails_open_on_empty_stdin() -> None:
-    """PostToolUse is audit-only: bad input exits 1 (non-blocking), never 2."""
     result = runner.invoke(app, ["hook", "posttool"], input="")
     assert result.exit_code == 1, f"expected fail-open (1), got {result.exit_code}"
 
 
+    # PostToolUse audit fails open on garbage input: exit 1, never the gate's 2.
 def test_posttool_fails_open_on_invalid_json() -> None:
-    """PostToolUse audit fails open on garbage input: exit 1, never the gate's 2."""
     result = runner.invoke(app, ["hook", "posttool"], input="{not json")
     assert result.exit_code == 1, f"expected fail-open (1), got {result.exit_code}"

--- a/python/tests/test_cli_shadow_ai.py
+++ b/python/tests/test_cli_shadow_ai.py
@@ -15,8 +15,8 @@ from asqav.cli import app
 runner = CliRunner()
 
 
+    # `shadow-ai init --dir X` writes the three template files into X.
 def test_init_creates_files_in_target_dir(tmp_path: Path) -> None:
-    """`shadow-ai init --dir X` writes the three template files into X."""
     target = tmp_path / "stack"
     result = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
     assert result.exit_code == 0, result.output
@@ -29,8 +29,8 @@ def test_init_creates_files_in_target_dir(tmp_path: Path) -> None:
     assert "POSTGRES_PASSWORD" in body
 
 
+    # A second `init` against the same dir exits non-zero unless --force is passed.
 def test_init_refuses_to_overwrite(tmp_path: Path) -> None:
-    """A second `init` against the same dir exits non-zero unless --force is passed."""
     target = tmp_path / "stack"
     first = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
     assert first.exit_code == 0, first.output
@@ -43,8 +43,8 @@ def test_init_refuses_to_overwrite(tmp_path: Path) -> None:
     assert forced.exit_code == 0, forced.output
 
 
+    # `shadow-ai status` against a directory with no docker-compose.yml fails clearly.
 def test_status_handles_missing_compose_gracefully(tmp_path: Path) -> None:
-    """`shadow-ai status` against a directory with no docker-compose.yml fails clearly."""
     missing = tmp_path / "does-not-exist"
     result = runner.invoke(app, ["shadow-ai", "status", "--dir", str(missing)])
     assert result.exit_code != 0
@@ -52,8 +52,8 @@ def test_status_handles_missing_compose_gracefully(tmp_path: Path) -> None:
     assert "asqav shadow-ai init" in result.output
 
 
+    # `shadow-ai up` without a .env file errors with a clear message.
 def test_up_validates_env_present(tmp_path: Path) -> None:
-    """`shadow-ai up` without a .env file errors with a clear message."""
     target = tmp_path / "stack"
     init = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
     assert init.exit_code == 0, init.output
@@ -63,8 +63,8 @@ def test_up_validates_env_present(tmp_path: Path) -> None:
     assert ".env" in result.output
 
 
+    # `shadow-ai up` rejects a .env that is missing required variables.
 def test_up_validates_required_env_vars(tmp_path: Path) -> None:
-    """`shadow-ai up` rejects a .env that is missing required variables."""
     target = tmp_path / "stack"
     init = runner.invoke(app, ["shadow-ai", "init", "--dir", str(target)])
     assert init.exit_code == 0, init.output
@@ -78,8 +78,8 @@ def test_up_validates_required_env_vars(tmp_path: Path) -> None:
     assert "ASQAV_API_KEY" in result.output
 
 
+    # `--upstream` rewrites OPENAI_UPSTREAM in the generated .env.template.
 def test_init_with_upstream_override(tmp_path: Path) -> None:
-    """`--upstream` rewrites OPENAI_UPSTREAM in the generated .env.template."""
     target = tmp_path / "stack"
     result = runner.invoke(
         app,
@@ -90,10 +90,10 @@ def test_init_with_upstream_override(tmp_path: Path) -> None:
     assert "OPENAI_UPSTREAM=https://proxy.example.com" in body
 
 
+    # `init` triggers _ensure_shadow_ai_policy when ASQAV_API_KEY is in env.
 def test_init_calls_ensure_policy_when_api_key_set(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """`init` triggers _ensure_shadow_ai_policy when ASQAV_API_KEY is in env."""
     from asqav import cli as cli_mod
 
     calls: list[bool] = []
@@ -106,8 +106,8 @@ def test_init_calls_ensure_policy_when_api_key_set(
     assert calls == [True]
 
 
+    # `init` skips ensure_policy and prints the hint when ASQAV_API_KEY is unset.
 def test_init_prints_hint_when_api_key_absent(tmp_path: Path, monkeypatch) -> None:
-    """`init` skips ensure_policy and prints the hint when ASQAV_API_KEY is unset."""
     from asqav import cli as cli_mod
 
     calls: list[bool] = []
@@ -121,8 +121,8 @@ def test_init_prints_hint_when_api_key_absent(tmp_path: Path, monkeypatch) -> No
     assert "ensure-policy" in result.output
 
 
+    # `ensure-policy` exits 0 with an 'already present' line when a matching policy exists.
 def test_ensure_policy_noop_when_present(monkeypatch) -> None:
-    """`ensure-policy` exits 0 with an 'already present' line when a matching policy exists."""
     from asqav import cli as cli_mod
     from asqav import client as client_mod
 
@@ -146,8 +146,8 @@ def test_ensure_policy_noop_when_present(monkeypatch) -> None:
     assert "pol_existing_abc" in result.output
 
 
+    # `ensure-policy` POSTs a new monitor policy when none matches.
 def test_ensure_policy_creates_when_absent(monkeypatch) -> None:
-    """`ensure-policy` POSTs a new monitor policy when none matches."""
     from asqav import cli as cli_mod
     from asqav import client as client_mod
 
@@ -173,8 +173,8 @@ def test_ensure_policy_creates_when_absent(monkeypatch) -> None:
     assert posted[0]["data"]["is_active"] is True
 
 
+    # `ensure-policy` exits 1 with a diagnostic when listing policies raises.
 def test_ensure_policy_exits_nonzero_when_list_fails(monkeypatch) -> None:
-    """`ensure-policy` exits 1 with a diagnostic when listing policies raises."""
     from asqav import cli as cli_mod
     from asqav import client as client_mod
 
@@ -190,8 +190,8 @@ def test_ensure_policy_exits_nonzero_when_list_fails(monkeypatch) -> None:
     assert "Could not list policies" in result.output
 
 
+    # `ensure-policy` exits 1 with a diagnostic when POSTing the new policy raises.
 def test_ensure_policy_exits_nonzero_when_create_fails(monkeypatch) -> None:
-    """`ensure-policy` exits 1 with a diagnostic when POSTing the new policy raises."""
     from asqav import cli as cli_mod
     from asqav import client as client_mod
 

--- a/python/tests/test_cli_shadow_ai_packaging.py
+++ b/python/tests/test_cli_shadow_ai_packaging.py
@@ -20,8 +20,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from asqav.cli import _SHADOW_AI_TEMPLATE_FILES
 
 
+    # Every name in `_SHADOW_AI_TEMPLATE_FILES` resolves from the package.
 def test_all_shadow_ai_template_files_are_packaged() -> None:
-    """Every name in `_SHADOW_AI_TEMPLATE_FILES` resolves from the package."""
     template_dir = files("asqav").joinpath("templates", "shadow-ai")
     for name in _SHADOW_AI_TEMPLATE_FILES:
         resource = template_dir.joinpath(name)
@@ -31,8 +31,8 @@ def test_all_shadow_ai_template_files_are_packaged() -> None:
         )
 
 
+    # The packaged `.env.template` carries the keys the CLI validator checks.
 def test_env_template_carries_required_keys() -> None:
-    """The packaged `.env.template` carries the keys the CLI validator checks."""
     template_dir = files("asqav").joinpath("templates", "shadow-ai")
     body = template_dir.joinpath(".env.template").read_text(encoding="utf-8")
     for key in ("ASQAV_API_KEY", "ASQAV_AGENT_ID", "POSTGRES_PASSWORD"):

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -84,9 +84,9 @@ MOCK_APPROVE_APPROVED: dict = {
 # === request_action tests ===
 
 
+    # request_action calls POST /signing-groups/sessions with correct body.
 @patch("asqav.client._post")
 def test_request_action(mock_post: object) -> None:
-    """request_action calls POST /signing-groups/sessions with correct body."""
     mock_post.return_value = MOCK_SESSION_RESPONSE  # type: ignore[attr-defined]
 
     result = asqav.request_action(
@@ -109,9 +109,9 @@ def test_request_action(mock_post: object) -> None:
     assert result.action_params is None
 
 
+    # request_action includes params in the request body when provided.
 @patch("asqav.client._post")
 def test_request_action_with_params(mock_post: object) -> None:
-    """request_action includes params in the request body when provided."""
     mock_post.return_value = MOCK_SESSION_WITH_PARAMS  # type: ignore[attr-defined]
 
     params = {"target": "us-east-1", "version": "2.0"}
@@ -132,9 +132,9 @@ def test_request_action_with_params(mock_post: object) -> None:
     assert result.action_params == {"target": "us-east-1", "version": "2.0"}
 
 
+    # request_action does not send 'params' key when params is None.
 @patch("asqav.client._post")
 def test_request_action_without_params_omits_key(mock_post: object) -> None:
-    """request_action does not send 'params' key when params is None."""
     mock_post.return_value = MOCK_SESSION_RESPONSE  # type: ignore[attr-defined]
 
     asqav.request_action(agent_id="agent_001", action_type="read:data")
@@ -146,9 +146,9 @@ def test_request_action_without_params_omits_key(mock_post: object) -> None:
 # === approve_action tests ===
 
 
+    # approve_action calls POST /signing-groups/sessions/{id}/approve.
 @patch("asqav.client._post")
 def test_approve_action(mock_post: object) -> None:
-    """approve_action calls POST /signing-groups/sessions/{id}/approve."""
     mock_post.return_value = MOCK_APPROVE_RESPONSE  # type: ignore[attr-defined]
 
     result = asqav.approve_action(
@@ -169,9 +169,9 @@ def test_approve_action(mock_post: object) -> None:
     assert result.approved is False
 
 
+    # approve_action returns approved=True when approvals are met.
 @patch("asqav.client._post")
 def test_approve_action_approved(mock_post: object) -> None:
-    """approve_action returns approved=True when approvals are met."""
     mock_post.return_value = MOCK_APPROVE_APPROVED  # type: ignore[attr-defined]
 
     result = asqav.approve_action(
@@ -187,9 +187,9 @@ def test_approve_action_approved(mock_post: object) -> None:
 # === get_action_status tests ===
 
 
+    # get_action_status calls GET /signing-groups/sessions/{id}.
 @patch("asqav.client._get")
 def test_get_action_status(mock_get: object) -> None:
-    """get_action_status calls GET /signing-groups/sessions/{id}."""
     mock_get.return_value = MOCK_SESSION_RESPONSE  # type: ignore[attr-defined]
 
     result = asqav.get_action_status("thr_abc123")
@@ -202,9 +202,9 @@ def test_get_action_status(mock_get: object) -> None:
     assert result.status == "pending"
 
 
+    # get_action_status returns full details for approved session.
 @patch("asqav.client._get")
 def test_get_action_status_approved(mock_get: object) -> None:
-    """get_action_status returns full details for approved session."""
     mock_get.return_value = MOCK_SESSION_APPROVED  # type: ignore[attr-defined]
 
     result = asqav.get_action_status("thr_abc123")
@@ -229,8 +229,8 @@ def test_get_action_status_approved(mock_get: object) -> None:
 # === Regression: sign() method unchanged ===
 
 
+    # sign() method is still present on Agent with the core required params.
 def test_sign_method_exists_on_agent() -> None:
-    """sign() method is still present on Agent with the core required params."""
     import inspect
 
     sig = inspect.signature(asqav.Agent.sign)
@@ -240,8 +240,8 @@ def test_sign_method_exists_on_agent() -> None:
     assert "context" in params
 
 
+    # sign() is annotated to return SignatureResponse.
 def test_sign_method_returns_signature_response_annotation() -> None:
-    """sign() is annotated to return SignatureResponse."""
     import inspect
 
     sig = inspect.signature(asqav.Agent.sign)
@@ -249,8 +249,8 @@ def test_sign_method_returns_signature_response_annotation() -> None:
     assert "SignatureResponse" in str(sig.return_annotation)
 
 
+    # sign() exposes a counterparty kwarg for endpoint-identity binding.
 def test_sign_accepts_counterparty_kwarg() -> None:
-    """sign() exposes a counterparty kwarg for endpoint-identity binding."""
     import inspect
 
     sig = inspect.signature(asqav.Agent.sign)
@@ -258,9 +258,9 @@ def test_sign_accepts_counterparty_kwarg() -> None:
     assert sig.parameters["counterparty"].default is None
 
 
+    # counterparty kwarg lands in context under _counterparty.
 @patch("asqav.client._post")
 def test_sign_passes_counterparty_into_context(mock_post: object) -> None:
-    """counterparty kwarg lands in context under _counterparty."""
     mock_post.return_value = {  # type: ignore[attr-defined]
         "signature": "sig_bytes",
         "signature_id": "sig_01",
@@ -280,8 +280,8 @@ def test_sign_passes_counterparty_into_context(mock_post: object) -> None:
 # === Agent.sign_batch ===
 
 
+    # Construct an Agent without hitting the API.
 def _make_agent() -> "asqav.Agent":
-    """Construct an Agent without hitting the API."""
     return asqav.Agent(
         agent_id="agent_test",
         name="test",
@@ -293,9 +293,9 @@ def _make_agent() -> "asqav.Agent":
     )
 
 
+    # sign_batch returns one SignatureResponse per input action.
 @patch("asqav.client._post")
 def test_sign_batch_returns_n_signatures(mock_post: object) -> None:
-    """sign_batch returns one SignatureResponse per input action."""
     mock_post.return_value = {  # type: ignore[attr-defined]
         "signatures": [
             {
@@ -318,9 +318,9 @@ def test_sign_batch_returns_n_signatures(mock_post: object) -> None:
     assert out[9].signature_id == "sid_9"
 
 
+    # sign_batch returns None for items the server failed to sign.
 @patch("asqav.client._post")
 def test_sign_batch_handles_partial_failure(mock_post: object) -> None:
-    """sign_batch returns None for items the server failed to sign."""
     mock_post.return_value = {  # type: ignore[attr-defined]
         "signatures": [
             {
@@ -343,8 +343,8 @@ def test_sign_batch_handles_partial_failure(mock_post: object) -> None:
     assert out[1] is None
 
 
+    # sign_batch raises ValueError on empty list.
 def test_sign_batch_rejects_empty_input() -> None:
-    """sign_batch raises ValueError on empty list."""
     import pytest
 
     agent = _make_agent()
@@ -352,8 +352,8 @@ def test_sign_batch_rejects_empty_input() -> None:
         agent.sign_batch([])
 
 
+    # sign_batch raises ValueError when over 100 actions.
 def test_sign_batch_rejects_oversize_input() -> None:
-    """sign_batch raises ValueError when over 100 actions."""
     import pytest
 
     agent = _make_agent()
@@ -361,8 +361,8 @@ def test_sign_batch_rejects_oversize_input() -> None:
         agent.sign_batch([{"action_type": "x"}] * 101)
 
 
+    # sign_batch raises ValueError when an action lacks 'action_type'.
 def test_sign_batch_rejects_missing_action_type() -> None:
-    """sign_batch raises ValueError when an action lacks 'action_type'."""
     import pytest
 
     agent = _make_agent()
@@ -373,16 +373,16 @@ def test_sign_batch_rejects_missing_action_type() -> None:
 # === _parse_signing_session helper ===
 
 
+    # _parse_signing_session handles response with empty signatures.
 def test_parse_signing_session_minimal() -> None:
-    """_parse_signing_session handles response with empty signatures."""
     result = _parse_signing_session(MOCK_SESSION_RESPONSE)
     assert result.session_id == "thr_abc123"
     assert result.signatures == []
     assert result.resolved_at is None
 
 
+    # _parse_signing_session correctly parses signature details.
 def test_parse_signing_session_with_signatures() -> None:
-    """_parse_signing_session correctly parses signature details."""
     result = _parse_signing_session(MOCK_SESSION_APPROVED)
     assert len(result.signatures) == 2
     assert result.signatures[0].entity_name == "Agent Key"

--- a/python/tests/test_client_capture_topology.py
+++ b/python/tests/test_client_capture_topology.py
@@ -56,13 +56,13 @@ def _ok_response(extra: dict | None = None) -> dict:
 # === observation decision + policy_decision="none" ===
 
 
+    # The lifecycle opt-out token maps to the wire `observation` decision.
 def test_decision_map_includes_none_to_observation() -> None:
-    """The lifecycle opt-out token maps to the wire `observation` decision."""
     assert DECISION_MAP["none"] == "observation"
 
 
+    # `_map_policy_decision_to_decision('none')` returns `observation`.
 def test_map_policy_decision_translates_none() -> None:
-    """`_map_policy_decision_to_decision('none')` returns `observation`."""
     assert _map_policy_decision_to_decision("none") == "observation"
 
 
@@ -94,8 +94,8 @@ def test_decision_vocabulary_includes_observation() -> None:
     assert resp.decision == "observation"
 
 
+    # An older cloud may omit `decision`; the SDK maps `none` locally.
 def test_observation_round_trips_on_response_without_cloud_field() -> None:
-    """An older cloud may omit `decision`; the SDK maps `none` locally."""
     extra = {
         "compliance_mode": True,
         "policy_decision": "none",
@@ -115,8 +115,8 @@ def test_observation_round_trips_on_response_without_cloud_field() -> None:
 # === capture_topology vocabulary ===
 
 
+    # SDK namespace mirrors the cloud SignRequest Literal exactly.
 def test_capture_topology_namespace_matches_cloud_literal() -> None:
-    """SDK namespace mirrors the cloud SignRequest Literal exactly."""
     assert CAPTURE_TOPOLOGY_NAMESPACE == frozenset(
         {
             "in_process_sdk",
@@ -129,24 +129,24 @@ def test_capture_topology_namespace_matches_cloud_literal() -> None:
     )
 
 
+    # The capture_topology vocabulary excludes ebpf_observer.
 def test_capture_topology_ebpf_observer_removed() -> None:
-    """The capture_topology vocabulary excludes ebpf_observer."""
     assert "ebpf_observer" not in CAPTURE_TOPOLOGY_NAMESPACE
 
 
+    # github_sha_pull (the server-stamped code-authorship layer) is accepted.
 def test_capture_topology_github_sha_pull_accepted() -> None:
-    """github_sha_pull (the server-stamped code-authorship layer) is accepted."""
     assert "github_sha_pull" in CAPTURE_TOPOLOGY_NAMESPACE
 
 
+    # `asqav.CAPTURE_TOPOLOGY_NAMESPACE` is part of the public surface.
 def test_capture_topology_is_re_exported_at_top_level() -> None:
-    """`asqav.CAPTURE_TOPOLOGY_NAMESPACE` is part of the public surface."""
     assert asqav.CAPTURE_TOPOLOGY_NAMESPACE == CAPTURE_TOPOLOGY_NAMESPACE
 
 
+    # All five canonical values are forwarded verbatim on the body.
 @pytest.mark.parametrize("value", sorted(CAPTURE_TOPOLOGY_NAMESPACE))
 def test_capture_topology_passes_through(value: str) -> None:
-    """All five canonical values are forwarded verbatim on the body."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -163,8 +163,8 @@ def test_capture_topology_passes_through(value: str) -> None:
     assert captured["body"]["capture_topology"] == value
 
 
+    # A value outside the closed Literal is rejected before the HTTP call.
 def test_capture_topology_invalid_value_rejected() -> None:
-    """A value outside the closed Literal is rejected before the HTTP call."""
     with patch("asqav.client._post") as p:
         with pytest.raises(ValueError, match="invalid_capture_topology"):
             _agent().sign(
@@ -176,8 +176,8 @@ def test_capture_topology_invalid_value_rejected() -> None:
         p.assert_not_called()
 
 
+    # No body key when the caller does not pass the kwarg.
 def test_capture_topology_absent_when_not_set() -> None:
-    """No body key when the caller does not pass the kwarg."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -215,9 +215,9 @@ def test_capture_topology_dropped_outside_compliance_mode() -> None:
 # === parametrised vocabulary parity (capture_topology + receipt_type) ===
 
 
+    # Every value in the 6-token vocabulary is forwarded on the body.
 @pytest.mark.parametrize("value", sorted(CAPTURE_TOPOLOGY_NAMESPACE))
 def test_capture_topology_parametrised_accepts_all_values(value: str) -> None:
-    """Every value in the 6-token vocabulary is forwarded on the body."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -239,11 +239,11 @@ def test_capture_topology_parametrised_accepts_all_values(value: str) -> None:
     assert captured["body"]["capture_topology"] == value
 
 
+    # Any value outside the closed vocabulary is rejected client-side.
 @pytest.mark.parametrize(
     "bad_value", ["bogus", "in-process-sdk", "PASSIVE_TELEMETRY", " "]
 )
 def test_capture_topology_parametrised_rejects_unknown(bad_value: str) -> None:
-    """Any value outside the closed vocabulary is rejected client-side."""
     with patch("asqav.client._post") as p:
         with pytest.raises(ValueError, match="invalid_capture_topology"):
             _agent().sign(
@@ -255,9 +255,9 @@ def test_capture_topology_parametrised_rejects_unknown(bad_value: str) -> None:
         p.assert_not_called()
 
 
+    # Every token in the receipt_type vocabulary is accepted client-side.
 @pytest.mark.parametrize("value", sorted(RECEIPT_TYPE_NAMESPACE))
 def test_receipt_type_parametrised_accepts_all_values(value: str) -> None:
-    """Every token in the receipt_type vocabulary is accepted client-side."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -291,12 +291,12 @@ def test_receipt_type_parametrised_accepts_all_values(value: str) -> None:
     assert captured["body"]["receipt_type"] == value
 
 
+    # Any token outside the closed receipt-type vocabulary is rejected.
 @pytest.mark.parametrize(
     "bad_value",
     ["protectmcp:bogus", "protectmcp:Observation", "decision", "observation"],
 )
 def test_receipt_type_parametrised_rejects_unknown(bad_value: str) -> None:
-    """Any token outside the closed receipt-type vocabulary is rejected."""
     with patch("asqav.client._post") as p:
         with pytest.raises(ValueError, match="invalid_receipt_type"):
             _agent().sign(
@@ -384,8 +384,8 @@ class TestFalseAttestationGuardWidened:
         assert captured["body"]["receipt_type"] == "protectmcp:observation"
 
 
+    # The matched pair (passive_telemetry + :observation) passes through.
 def test_passive_telemetry_with_observation_receipt_accepted() -> None:
-    """The matched pair (passive_telemetry + :observation) passes through."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:

--- a/python/tests/test_client_code_authorship.py
+++ b/python/tests/test_client_code_authorship.py
@@ -81,8 +81,8 @@ def _good_kwargs() -> dict:
     )
 
 
+    # Sign with the good kwargs (plus overrides) and return the wire body.
 def _sign(**overrides) -> dict:
-    """Sign with the good kwargs (plus overrides) and return the wire body."""
     kwargs = _good_kwargs()
     kwargs.update(overrides)
     captured: dict = {}
@@ -121,8 +121,8 @@ def test_all_code_fields_project_to_wire() -> None:
     assert body["receipt_type"] == CODE_TYPE
 
 
+    # A human-only author needs no attestation_source (no model claim).
 def test_valid_human_only_author_without_attestation_source() -> None:
-    """A human-only author needs no attestation_source (no model claim)."""
     body = _sign(authored_by={"human_id": "human:alice@example.com"})
     assert body["authored_by"]["human_id"] == "human:alice@example.com"
 
@@ -188,7 +188,7 @@ def test_rejects_non_none_policy_decision() -> None:
     assert "code_authorship_requires_no_policy_decision" in str(exc.value)
 
 
+    # AsqavValidationError subclasses ValueError for backward compat.
 def test_validation_error_is_a_valueerror() -> None:
-    """AsqavValidationError subclasses ValueError for backward compat."""
     with pytest.raises(ValueError):
         _sign(change_digest="bad")

--- a/python/tests/test_client_decision_alias.py
+++ b/python/tests/test_client_decision_alias.py
@@ -9,28 +9,28 @@ from asqav.client import (
 )
 
 
+    # Every aliased `policy_decision` token resolves to a spec token.
 def test_decision_map_covers_full_alias_vocabulary():
-    """Every aliased `policy_decision` token resolves to a spec token."""
     assert DECISION_MAP["permit"] == "allow"
     assert DECISION_MAP["deny"] == "deny"
     assert DECISION_MAP["rate_limit"] == "rate_limit"
 
 
+    # Spec-shape `allow` round-trips.
 def test_decision_map_idempotent_for_already_normalised_input():
-    """Spec-shape `allow` round-trips."""
     assert DECISION_MAP["allow"] == "allow"
     assert _map_policy_decision_to_decision("allow") == "allow"
 
 
+    # Closed-by-default keeps misconfigured callers safe.
 def test_unknown_token_falls_back_to_deny():
-    """Closed-by-default keeps misconfigured callers safe."""
     assert _map_policy_decision_to_decision("yolo") == "deny"
     assert _map_policy_decision_to_decision(None) == "deny"
     assert _map_policy_decision_to_decision("") == "deny"
 
 
+    # Non-compliance receipts MUST NOT carry a `decision` token.
 def test_signature_response_decision_default_none():
-    """Non-compliance receipts MUST NOT carry a `decision` token."""
     resp = SignatureResponse(
         signature="ZmFrZQ==",
         signature_id="sig_test",
@@ -43,8 +43,8 @@ def test_signature_response_decision_default_none():
     assert resp.policy_decision == "permit"
 
 
+    # Compliance receipts surface BOTH fields.
 def test_signature_response_decision_alongside_policy_decision():
-    """Compliance receipts surface BOTH fields."""
     resp = SignatureResponse(
         signature="ZmFrZQ==",
         signature_id="sig_test",

--- a/python/tests/test_client_hash_mode.py
+++ b/python/tests/test_client_hash_mode.py
@@ -50,9 +50,9 @@ def _make_agent() -> Agent:
     )
 
 
+    # Reset SDK module state between tests.
 @pytest.fixture(autouse=True)
 def _isolate_module_state() -> None:
-    """Reset SDK module state between tests."""
     saved = (client_mod._mode, client_mod._org_salt, client_mod._api_key)
     client_mod._api_key = "sk_test"
     yield
@@ -96,8 +96,8 @@ def test_hash_only_mode_sends_hash_not_context() -> None:
     assert isinstance(body["payload_size"], int) and body["payload_size"] > 0
 
 
+    # payload_size MUST equal the byte length of the canonical fingerprint.
 def test_hash_only_payload_size_matches_canonical_bytes_length() -> None:
-    """payload_size MUST equal the byte length of the canonical fingerprint."""
     from asqav.canonicalize import canonicalize
 
     client_mod._mode = "hash-only"
@@ -114,8 +114,8 @@ def test_hash_only_payload_size_matches_canonical_bytes_length() -> None:
     assert body["payload_size"] == len(expected_bytes)
 
 
+    # user_id, ip, prompt, etc. in context must NOT appear in metadata.
 def test_hash_only_metadata_does_not_leak_user_fields() -> None:
-    """user_id, ip, prompt, etc. in context must NOT appear in metadata."""
     client_mod._mode = "hash-only"
     client_mod._org_salt = None
     agent = _make_agent()
@@ -137,8 +137,8 @@ def test_hash_only_metadata_does_not_leak_user_fields() -> None:
     assert metadata["action_type"] == "api:call"
 
 
+    # If caller adds ``_model_name`` sentinel to context, surface in metadata.
 def test_hash_only_includes_optional_model_name_when_opted_in() -> None:
-    """If caller adds ``_model_name`` sentinel to context, surface in metadata."""
     client_mod._mode = "hash-only"
     client_mod._org_salt = None
     agent = _make_agent()
@@ -154,8 +154,8 @@ def test_hash_only_includes_optional_model_name_when_opted_in() -> None:
     assert body["metadata"]["tool_name"] == "search"
 
 
+    # ``_parent_id`` in context auto-surfaces to metadata bag.
 def test_hash_only_surfaces_parent_id_from_context_sentinel() -> None:
-    """``_parent_id`` in context auto-surfaces to metadata bag."""
     client_mod._mode = "hash-only"
     client_mod._org_salt = None
     agent = _make_agent()
@@ -167,8 +167,8 @@ def test_hash_only_surfaces_parent_id_from_context_sentinel() -> None:
     assert body["metadata"]["parent_id"] == "act_parent_42"
 
 
+    # Passing tool_name=... to sign() surfaces it in the wire metadata bag.
 def test_hash_only_explicit_tool_name_kwarg_appears_in_metadata() -> None:
-    """Passing tool_name=... to sign() surfaces it in the wire metadata bag."""
     client_mod._mode = "hash-only"
     client_mod._org_salt = None
     agent = _make_agent()
@@ -180,8 +180,8 @@ def test_hash_only_explicit_tool_name_kwarg_appears_in_metadata() -> None:
     assert body["metadata"]["tool_name"] == "web_search"
 
 
+    # Passing model_name=... to sign() surfaces it in the wire metadata bag.
 def test_hash_only_explicit_model_name_kwarg_appears_in_metadata() -> None:
-    """Passing model_name=... to sign() surfaces it in the wire metadata bag."""
     client_mod._mode = "hash-only"
     client_mod._org_salt = None
     agent = _make_agent()
@@ -193,8 +193,8 @@ def test_hash_only_explicit_model_name_kwarg_appears_in_metadata() -> None:
     assert body["metadata"]["model_name"] == "claude-opus-4-7"
 
 
+    # Passing parent_id=... to sign() surfaces it in the wire metadata bag.
 def test_hash_only_explicit_parent_id_kwarg_appears_in_metadata() -> None:
-    """Passing parent_id=... to sign() surfaces it in the wire metadata bag."""
     client_mod._mode = "hash-only"
     client_mod._org_salt = None
     agent = _make_agent()
@@ -230,8 +230,8 @@ def test_full_payload_keeps_telemetry_in_context_only_not_duplicated() -> None:
     assert body["context"]["_parent_id"] == "act_parent_1"
 
 
+    # A non-None org_salt swaps SHA-256 for HMAC-SHA-256 with the same shape.
 def test_hash_only_uses_hmac_when_org_salt_set() -> None:
-    """A non-None org_salt swaps SHA-256 for HMAC-SHA-256 with the same shape."""
     agent = _make_agent()
     plain_hash = None
     salted_hash = None
@@ -258,8 +258,8 @@ def test_hash_only_uses_hmac_when_org_salt_set() -> None:
     assert salted_algo == "hmac-sha256"
 
 
+    # asqav.init() should set _mode from the api_base_url when mode=auto.
 def test_init_resolves_mode_from_url() -> None:
-    """asqav.init() should set _mode from the api_base_url when mode=auto."""
     saved_base = client_mod._api_base
     try:
         # Cloud URL -> hash-only

--- a/python/tests/test_client_ietf_fields.py
+++ b/python/tests/test_client_ietf_fields.py
@@ -69,8 +69,8 @@ def _ok_response(extra: dict | None = None) -> dict:
 # === Namespace + validation ===
 
 
+    # Namespace matches the cloud's pydantic validator exactly.
 def test_receipt_type_namespace_constant() -> None:
-    """Namespace matches the cloud's pydantic validator exactly."""
     assert RECEIPT_TYPE_NAMESPACE == frozenset(
         {
             "protectmcp:decision",
@@ -90,8 +90,8 @@ def test_receipt_type_namespace_constant() -> None:
     )
 
 
+    # SDK rejects bad receipt_type without making a network call.
 def test_invalid_receipt_type_raises_before_http() -> None:
-    """SDK rejects bad receipt_type without making a network call."""
     with patch("asqav.client._post") as p:
         with pytest.raises(ValueError, match="invalid_receipt_type"):
             _agent().sign(
@@ -103,8 +103,8 @@ def test_invalid_receipt_type_raises_before_http() -> None:
         p.assert_not_called()
 
 
+    # `policy_decision=deny` without `reason` is rejected client-side.
 def test_deny_without_reason_raises_before_http() -> None:
-    """`policy_decision=deny` without `reason` is rejected client-side."""
     with patch("asqav.client._post") as p:
         with pytest.raises(ValueError, match="missing_reason"):
             _agent().sign(
@@ -119,8 +119,8 @@ def test_deny_without_reason_raises_before_http() -> None:
 # === action_ref auto-compute ===
 
 
+    # Helper hash matches the JCS-canonical sha256 over the action object.
 def test_compute_action_ref_matches_canonical_sha256() -> None:
-    """Helper hash matches the JCS-canonical sha256 over the action object."""
     action_type = "api:call"
     context = {"model": "gpt-4", "params": {"temp": 0.0}}
     expected = "sha256:" + hashlib.sha256(
@@ -154,8 +154,8 @@ def test_compliance_mode_auto_computes_action_ref() -> None:
     assert body["action_ref"] == expected
 
 
+    # A caller-supplied action_ref is forwarded verbatim, no recompute.
 def test_compliance_mode_caller_supplied_action_ref_wins() -> None:
-    """A caller-supplied action_ref is forwarded verbatim, no recompute."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -208,8 +208,8 @@ def test_no_compliance_mode_means_no_extra_fields_on_body() -> None:
 # === Pass-through of all profile fields ===
 
 
+    # Every profile field the caller sets reaches the cloud body verbatim.
 def test_all_profile_fields_passthrough_in_body() -> None:
-    """Every profile field the caller sets reaches the cloud body verbatim."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -241,8 +241,8 @@ def test_all_profile_fields_passthrough_in_body() -> None:
     assert body["payload_digest"] == "sha256:" + "b" * 64
 
 
+    # `policy_decision=deny` plus `reason` reaches the body without raising.
 def test_deny_with_reason_passes_through() -> None:
-    """`policy_decision=deny` plus `reason` reaches the body without raising."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -264,8 +264,8 @@ def test_deny_with_reason_passes_through() -> None:
 # === Response parsing ===
 
 
+    # SignatureResponse exposes IETF fields when the cloud returns them.
 def test_signature_response_surfaces_new_fields() -> None:
-    """SignatureResponse exposes IETF fields when the cloud returns them."""
     extra = {
         "compliance_mode": True,
         "receipt_type": "protectmcp:decision",
@@ -297,8 +297,8 @@ def test_signature_response_surfaces_new_fields() -> None:
     assert resp.previous_receipt_hash == "0" * 64
 
 
+    # Older or self-hosted servers may emit `previous_receipt_hash`.
 def test_response_accepts_snake_case_previous_receipt_hash() -> None:
-    """Older or self-hosted servers may emit `previous_receipt_hash`."""
     extra = {
         "compliance_mode": True,
         "receipt_type": "protectmcp:decision",
@@ -312,8 +312,8 @@ def test_response_accepts_snake_case_previous_receipt_hash() -> None:
 # === Re-export ===
 
 
+    # `asqav.RECEIPT_TYPE_NAMESPACE` is part of the public surface.
 def test_constant_is_re_exported_at_top_level() -> None:
-    """`asqav.RECEIPT_TYPE_NAMESPACE` is part of the public surface."""
     assert asqav.RECEIPT_TYPE_NAMESPACE == RECEIPT_TYPE_NAMESPACE
 
 
@@ -350,8 +350,8 @@ def test_build_sign_body_omits_compliance_when_no_fields() -> None:
 # === DORA RTS JC 2024-33 Annex II vocabulary ===
 
 
+    # Namespace matches Annex II of JC 2024-33 (RTS published 17 July 2024).
 def test_dora_incident_class_namespace_is_canonical_six() -> None:
-    """Namespace matches Annex II of JC 2024-33 (RTS published 17 July 2024)."""
     assert DORA_INCIDENT_CLASS_NAMESPACE == frozenset(
         {
             "cybersecurity_related",
@@ -364,9 +364,9 @@ def test_dora_incident_class_namespace_is_canonical_six() -> None:
     )
 
 
+    # All six canonical values are accepted and forwarded verbatim.
 @pytest.mark.parametrize("value", sorted(DORA_INCIDENT_CLASS_NAMESPACE))
 def test_canonical_incident_class_passes_validation(value: str) -> None:
-    """All six canonical values are accepted and forwarded verbatim."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -383,8 +383,8 @@ def test_canonical_incident_class_passes_validation(value: str) -> None:
     assert captured["body"]["incident_class"] == value
 
 
+    # A token outside the canonical six is rejected before the HTTP call.
 def test_invalid_incident_class_raises_before_http() -> None:
-    """A token outside the canonical six is rejected before the HTTP call."""
     with patch("asqav.client._post") as p:
         with pytest.raises(ValueError, match="invalid_incident_class"):
             _agent().sign(
@@ -396,8 +396,8 @@ def test_invalid_incident_class_raises_before_http() -> None:
         p.assert_not_called()
 
 
+    # The cloud purged the alias map; the SDK rejects the same tokens.
 def test_pre_alignment_token_now_rejected() -> None:
-    """The cloud purged the alias map; the SDK rejects the same tokens."""
     for token in (
         "cyberattack",
         "payment_fraud",
@@ -492,9 +492,9 @@ def test_sandbox_state_namespace_matches_upstream_enum() -> None:
     )
 
 
+    # All three canonical values are accepted and forwarded verbatim.
 @pytest.mark.parametrize("value", ["enabled", "disabled", "unavailable"])
 def test_canonical_sandbox_state_passes_preflight(value: str) -> None:
-    """All three canonical values are accepted and forwarded verbatim."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:

--- a/python/tests/test_client_nsa_aligned_fields.py
+++ b/python/tests/test_client_nsa_aligned_fields.py
@@ -62,8 +62,8 @@ def _ok_response(extra: dict | None = None) -> dict:
 # === nonce auto-generation ===
 
 
+    # The SDK supplies a 24-hex-char nonce when the caller omits one.
 def test_nonce_auto_generated_when_omitted() -> None:
-    """The SDK supplies a 24-hex-char nonce when the caller omits one."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -78,8 +78,8 @@ def test_nonce_auto_generated_when_omitted() -> None:
     assert re.fullmatch(r"[0-9a-f]{24}", nonce)
 
 
+    # An explicit nonce is forwarded verbatim instead of regenerated.
 def test_nonce_caller_supplied_value_wins() -> None:
-    """An explicit nonce is forwarded verbatim instead of regenerated."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -96,8 +96,8 @@ def test_nonce_caller_supplied_value_wins() -> None:
     assert captured["body"]["nonce"] == "0123456789abcdef01234567"
 
 
+    # The helper returns a stable 24-hex-char string.
 def test_generate_nonce_is_24_hex_chars() -> None:
-    """The helper returns a stable 24-hex-char string."""
     nonce = _generate_nonce()
     assert re.fullmatch(r"[0-9a-f]{24}", nonce)
 
@@ -105,16 +105,16 @@ def test_generate_nonce_is_24_hex_chars() -> None:
 # === tool_fingerprint compute + passthrough ===
 
 
+    # JCS-canonical input -> stable 32 bare hex chars.
 def test_tool_fingerprint_helper_is_deterministic() -> None:
-    """JCS-canonical input -> stable 32 bare hex chars."""
     fp1 = _compute_tool_fingerprint("search", {"a": 1, "b": 2})
     fp2 = _compute_tool_fingerprint("search", {"b": 2, "a": 1})
     assert fp1 == fp2
     assert re.fullmatch(r"[0-9a-f]{32}", fp1)
 
 
+    # The SDK derives ``tool_fingerprint`` from ``tool_name`` + schema.
 def test_tool_fingerprint_auto_computed_when_schema_present() -> None:
-    """The SDK derives ``tool_fingerprint`` from ``tool_name`` + schema."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -134,8 +134,8 @@ def test_tool_fingerprint_auto_computed_when_schema_present() -> None:
     assert re.fullmatch(r"[0-9a-f]{32}", fp)
 
 
+    # Explicit ``tool_fingerprint`` overrides auto-derivation.
 def test_tool_fingerprint_caller_value_wins() -> None:
-    """Explicit ``tool_fingerprint`` overrides auto-derivation."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -155,8 +155,8 @@ def test_tool_fingerprint_caller_value_wins() -> None:
     assert captured["body"]["tool_fingerprint"] == explicit
 
 
+    # No auto-fingerprint when ``tool_schema`` is omitted.
 def test_tool_fingerprint_absent_when_no_schema_provided() -> None:
-    """No auto-fingerprint when ``tool_schema`` is omitted."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -203,6 +203,7 @@ def test_caller_digest_fields_forwarded_verbatim(field: str, value: str) -> None
     assert captured["body"][field] == value
 
 
+    # No body key when the caller does not pass the kwarg.
 @pytest.mark.parametrize(
     "field",
     [
@@ -214,7 +215,6 @@ def test_caller_digest_fields_forwarded_verbatim(field: str, value: str) -> None
     ],
 )
 def test_nsa_aligned_fields_absent_when_not_set(field: str) -> None:
-    """No body key when the caller does not pass the kwarg."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -300,8 +300,8 @@ def test_lifecycle_without_configuration_change_does_not_require_digest() -> Non
 # === Rule 10: expiry_collision_guard (valid_seconds vs expires_at) ===
 
 
+    # Rule 10: ``valid_seconds`` and ``expires_at`` are mutually exclusive.
 class TestExpiryCollisionGuard:
-    """Rule 10: ``valid_seconds`` and ``expires_at`` are mutually exclusive."""
 
     def test_both_set_raises_verbatim(self) -> None:
         """Passing both knobs raises ``expiry_collision_guard`` before the
@@ -321,8 +321,8 @@ class TestExpiryCollisionGuard:
             )
             p.assert_not_called()
 
+        # Passing neither knob is fine; the cloud applies its default.
     def test_neither_set_uses_server_default(self) -> None:
-        """Passing neither knob is fine; the cloud applies its default."""
         captured: dict = {}
 
         def fake_post(path: str, body: dict) -> dict:
@@ -334,8 +334,8 @@ class TestExpiryCollisionGuard:
         assert "valid_seconds" not in captured["body"]
         assert "expires_at" not in captured["body"]
 
+        # ``valid_seconds`` alone is forwarded verbatim.
     def test_only_valid_seconds_set_passes(self) -> None:
-        """``valid_seconds`` alone is forwarded verbatim."""
         captured: dict = {}
 
         def fake_post(path: str, body: dict) -> dict:
@@ -374,8 +374,8 @@ class TestExpiryCollisionGuard:
         assert "expires_at" not in captured["body"]
         assert captured["body"]["valid_seconds"] > 0
 
+        # A POSIX-epoch ``expires_at`` converts to a duration too.
     def test_expires_at_epoch_float_converts_to_valid_seconds(self) -> None:
-        """A POSIX-epoch ``expires_at`` converts to a duration too."""
         import time as _time
 
         captured: dict = {}
@@ -402,8 +402,8 @@ class TestExpiryCollisionGuard:
 _VALID_SHA = "sha256:" + "f" * 64
 
 
+    # Rule 11: every caller-supplied digest MUST match ``sha256:<64-hex>``.
 class TestDigestFormatGuard:
-    """Rule 11: every caller-supplied digest MUST match ``sha256:<64-hex>``."""
 
     @pytest.mark.parametrize(
         "field",
@@ -449,12 +449,12 @@ class TestDigestFormatGuard:
             )
         assert captured["body"]["tool_fingerprint"] == fp
 
+        # Anything other than the ``sha256:`` prefix raises the verbatim cloud token.
     @pytest.mark.parametrize(
         "field",
         ["config_manifest_digest", "cve_inventory_digest"],
     )
     def test_wrong_prefix_rejected(self, field: str) -> None:
-        """Anything other than the ``sha256:`` prefix raises the verbatim cloud token."""
         with patch("asqav.client._post") as p:
             with pytest.raises(ValueError) as exc_info:
                 _agent().sign(
@@ -469,12 +469,12 @@ class TestDigestFormatGuard:
             )
             p.assert_not_called()
 
+        # A short hex tail fails the regex.
     @pytest.mark.parametrize(
         "field",
         ["config_manifest_digest", "cve_inventory_digest"],
     )
     def test_wrong_length_rejected(self, field: str) -> None:
-        """A short hex tail fails the regex."""
         with patch("asqav.client._post") as p:
             with pytest.raises(ValueError) as exc_info:
                 _agent().sign(
@@ -489,12 +489,12 @@ class TestDigestFormatGuard:
             )
             p.assert_not_called()
 
+        # Uppercase / non-hex characters fail the regex.
     @pytest.mark.parametrize(
         "field",
         ["config_manifest_digest", "cve_inventory_digest"],
     )
     def test_non_hex_rejected(self, field: str) -> None:
-        """Uppercase / non-hex characters fail the regex."""
         with patch("asqav.client._post") as p:
             with pytest.raises(ValueError) as exc_info:
                 _agent().sign(
@@ -537,8 +537,8 @@ class TestDigestFormatGuard:
             p.assert_not_called()
 
 
+    # Helpers always emit a digest that passes the rule-11 regex.
 class TestDigestHelpers:
-    """Helpers always emit a digest that passes the rule-11 regex."""
 
     def test_compute_tool_fingerprint_matches_regex(self) -> None:
         fp = _compute_tool_fingerprint("search", {"q": "string"})
@@ -561,8 +561,8 @@ class TestDigestHelpers:
 # === BLOCKER 5: protectmcp:observation:result_bound receipt type ===
 
 
+    # The new ``:result_bound`` suffix is a first-class receipt type.
 class TestResultBoundReceiptType:
-    """The new ``:result_bound`` suffix is a first-class receipt type."""
 
     def test_result_bound_in_namespace(self) -> None:
         assert "protectmcp:observation:result_bound" in RECEIPT_TYPE_NAMESPACE

--- a/python/tests/test_client_risk_acceptance.py
+++ b/python/tests/test_client_risk_acceptance.py
@@ -84,8 +84,8 @@ def _good_kwargs() -> dict:
     )
 
 
+    # Sign with the good kwargs (plus overrides) and return the wire body.
 def _sign(**overrides) -> dict:
-    """Sign with the good kwargs (plus overrides) and return the wire body."""
     kwargs = _good_kwargs()
     kwargs.update(overrides)
     captured: dict = {}
@@ -194,8 +194,8 @@ def test_rejects_cve_ids_empty_list() -> None:
     assert "risk_snapshot_cve_ids_must_be_non_empty_list" in str(exc.value)
 
 
+    # AsqavValidationError subclasses ValueError for backward compat.
 def test_validation_error_is_a_valueerror() -> None:
-    """AsqavValidationError subclasses ValueError for backward compat."""
     with pytest.raises(ValueError):
         _sign(sarif_digest="bad")
 
@@ -203,17 +203,17 @@ def test_validation_error_is_a_valueerror() -> None:
 # === SoD guard: risk_acceptance_self_approval_guard ===
 
 
+    # risk_acceptance_self_approval_guard fires when initiator_id == approver_id.
 @pytest.mark.parametrize("same_id", ["user:alice@example.com", "uuid-1234", "alice"])
 def test_rejects_self_approval(same_id: str) -> None:
-    """risk_acceptance_self_approval_guard fires when initiator_id == approver_id."""
     with pytest.raises(AsqavValidationError) as exc:
         _sign(initiator_id=same_id, approver_id=same_id)
     assert "risk_acceptance_self_approval_guard: initiator_id equals" in str(exc.value)
     assert exc.value.docs_url == RISK_ACCEPTANCE_DOCS_URL
 
 
+    # Guard message prefix is byte-identical to the cloud validator.
 def test_self_approval_guard_message_bytes() -> None:
-    """Guard message prefix is byte-identical to the cloud validator."""
     with pytest.raises(AsqavValidationError) as exc:
         _sign(initiator_id="x", approver_id="x")
     msg = str(exc.value)
@@ -223,15 +223,15 @@ def test_self_approval_guard_message_bytes() -> None:
     )
 
 
+    # Different initiator and approver IDs do not trigger the SoD guard.
 def test_allows_different_initiator_and_approver() -> None:
-    """Different initiator and approver IDs do not trigger the SoD guard."""
     body = _sign(initiator_id="initiator:bob@example.com", approver_id="approver:alice@example.com")
     assert body["initiator_id"] == "initiator:bob@example.com"
     assert body["approver_id"] == "approver:alice@example.com"
 
 
+    # Guard does not fire when initiator_id is absent (only approver_id set).
 def test_self_approval_guard_absent_initiator_allowed() -> None:
-    """Guard does not fire when initiator_id is absent (only approver_id set)."""
     body = _sign(initiator_id=None)
     assert body.get("initiator_id") is None
     assert body["approver_id"] == "approver:alice@example.com"

--- a/python/tests/test_client_schema_receipts.py
+++ b/python/tests/test_client_schema_receipts.py
@@ -70,8 +70,8 @@ _BASIC_SCHEMA: dict[str, Any] = {
 # === (a) Valid context passes and sign is called with the normalized context ===
 
 
+    # A context that matches the schema reaches the network call.
 def test_valid_context_passes_schema_and_sign_is_called() -> None:
-    """A context that matches the schema reaches the network call."""
     captured: dict[str, Any] = {}
 
     def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
@@ -91,8 +91,8 @@ def test_valid_context_passes_schema_and_sign_is_called() -> None:
     assert captured["body"] is not None
 
 
+    # After schema validation the context keys are sorted.
 def test_valid_context_is_key_sorted_before_signing() -> None:
-    """After schema validation the context keys are sorted."""
     captured: dict[str, Any] = {}
 
     def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
@@ -121,8 +121,8 @@ def test_valid_context_is_key_sorted_before_signing() -> None:
         )
 
 
+    # Each supported type passes with a matching Python value.
 def test_all_schema_types_pass_correct_values() -> None:
-    """Each supported type passes with a matching Python value."""
     captured: dict[str, Any] = {}
 
     def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
@@ -146,8 +146,8 @@ def test_all_schema_types_pass_correct_values() -> None:
     assert captured, "sign() was not called"
 
 
+    # An optional field (required=False) may be absent with no error.
 def test_optional_field_absent_passes() -> None:
-    """An optional field (required=False) may be absent with no error."""
     captured: dict[str, Any] = {}
 
     def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
@@ -186,8 +186,8 @@ def test_missing_required_field_raises_before_network() -> None:
         mock_post.assert_not_called()
 
 
+    # Wrong-type field raises AsqavValidationError; HTTP is never called.
 def test_wrong_type_raises_before_network() -> None:
-    """Wrong-type field raises AsqavValidationError; HTTP is never called."""
     with patch("asqav.client._post") as mock_post:
         with pytest.raises(AsqavValidationError, match="score"):
             _agent().sign(
@@ -199,8 +199,8 @@ def test_wrong_type_raises_before_network() -> None:
         mock_post.assert_not_called()
 
 
+    # bool is a subclass of int; it must be rejected for type=number.
 def test_bool_rejected_for_number_type() -> None:
-    """bool is a subclass of int; it must be rejected for type=number."""
     with patch("asqav.client._post") as mock_post:
         with pytest.raises(AsqavValidationError, match="score"):
             _agent().sign(
@@ -212,8 +212,8 @@ def test_bool_rejected_for_number_type() -> None:
         mock_post.assert_not_called()
 
 
+    # A string where object is expected raises the validation error.
 def test_wrong_type_object_raises_before_network() -> None:
-    """A string where object is expected raises the validation error."""
     with patch("asqav.client._post") as mock_post:
         with pytest.raises(AsqavValidationError, match="meta"):
             _agent().sign(
@@ -225,8 +225,8 @@ def test_wrong_type_object_raises_before_network() -> None:
         mock_post.assert_not_called()
 
 
+    # A dict where array is expected raises the validation error.
 def test_wrong_type_array_raises_before_network() -> None:
-    """A dict where array is expected raises the validation error."""
     with patch("asqav.client._post") as mock_post:
         with pytest.raises(AsqavValidationError, match="tags"):
             _agent().sign(
@@ -238,8 +238,8 @@ def test_wrong_type_array_raises_before_network() -> None:
         mock_post.assert_not_called()
 
 
+    # AsqavValidationError.docs_url points to structured-receipts docs.
 def test_validation_error_carries_docs_url() -> None:
-    """AsqavValidationError.docs_url points to structured-receipts docs."""
     with patch("asqav.client._post"):
         with pytest.raises(AsqavValidationError) as exc_info:
             _agent().sign(
@@ -254,8 +254,8 @@ def test_validation_error_carries_docs_url() -> None:
 # === (c) No schema supplied => unchanged behavior ===
 
 
+    # When context_schema is omitted, sign() behavior is unchanged.
 def test_no_schema_sign_called_as_before() -> None:
-    """When context_schema is omitted, sign() behavior is unchanged."""
     captured: dict[str, Any] = {}
 
     def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
@@ -272,8 +272,8 @@ def test_no_schema_sign_called_as_before() -> None:
     assert captured, "sign() must be called when no schema is provided"
 
 
+    # None context + no schema is unchanged (no normalization applied).
 def test_no_schema_none_context_unchanged() -> None:
-    """None context + no schema is unchanged (no normalization applied)."""
     captured: dict[str, Any] = {}
 
     def fake_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
@@ -293,8 +293,8 @@ def test_no_schema_none_context_unchanged() -> None:
 # === Custom callable validator ===
 
 
+    # A callable context_schema that returns None passes through.
 def test_custom_callable_validator_passes() -> None:
-    """A callable context_schema that returns None passes through."""
     captured: dict[str, Any] = {}
     calls: list[Any] = []
 
@@ -317,8 +317,8 @@ def test_custom_callable_validator_passes() -> None:
     assert captured, "sign() was not called"
 
 
+    # A callable that raises propagates; sign() must not be called.
 def test_custom_callable_validator_raises_propagates() -> None:
-    """A callable that raises propagates; sign() must not be called."""
 
     def strict_validator(ctx: dict[str, Any]) -> None:
         raise ValueError("custom_schema_error: x must be positive")
@@ -412,8 +412,8 @@ class TestNormalizeContext:
 # === Top-level re-export ===
 
 
+    # validate_context_schema and normalize_context are public symbols.
 def test_schema_helpers_exported_at_top_level() -> None:
-    """validate_context_schema and normalize_context are public symbols."""
     assert hasattr(asqav, "validate_context_schema")
     assert hasattr(asqav, "normalize_context")
     assert asqav.validate_context_schema is validate_context_schema

--- a/python/tests/test_client_threat_framework_mappings.py
+++ b/python/tests/test_client_threat_framework_mappings.py
@@ -195,8 +195,8 @@ def test_rfc3161_timestamp_invalid_base64_rejected() -> None:
         )
 
 
+    # The cloud must not see the new fields at all when caller omits them.
 def test_no_taxonomy_fields_omitted_from_wire() -> None:
-    """The cloud must not see the new fields at all when caller omits them."""
     captured: dict = {}
 
     def fake_post(path: str, body: dict) -> dict:

--- a/python/tests/test_code_authorship.py
+++ b/python/tests/test_code_authorship.py
@@ -39,13 +39,13 @@ from asqav.code_authorship import (
 # === constants + scope ===
 
 
+    # The required API-key scope is code_authorship:write.
 def test_scope_constant_matches_backend_contract() -> None:
-    """The required API-key scope is code_authorship:write."""
     assert CODE_AUTHORSHIP_WRITE_SCOPE == "code_authorship:write"
 
 
+    # cli_hook exposes the same scope as REQUIRED_SCOPE.
 def test_scope_constant_reexported_on_cli_hook() -> None:
-    """cli_hook exposes the same scope as REQUIRED_SCOPE."""
     from asqav import cli_hook
 
     assert cli_hook.REQUIRED_SCOPE == CODE_AUTHORSHIP_WRITE_SCOPE
@@ -182,8 +182,8 @@ def test_submit_omits_absent_optional_fields() -> None:
     assert body == {"repo": "owner/repo", "commit_sha": "c" * 40}
 
 
+    # digest_match reports advisory-vs-server agreement. The subject is the server's.
 def test_result_exposes_digest_match_semantics() -> None:
-    """digest_match reports advisory-vs-server agreement. The subject is the server's."""
     advisory = "sha256:" + "1" * 64
     server_hex = "2" * 64
     envelope = _server_envelope(
@@ -223,9 +223,9 @@ def test_github_sha_pull_envelope_is_authoritative_and_passes() -> None:
     assert verification.subject_digest == "a" * 64
 
 
+    # in_process_sdk and passive_telemetry are observation only, never a decision.
 @pytest.mark.parametrize("layer", sorted(OBSERVATION_ONLY_CAPTURE_LAYERS))
 def test_observation_capture_layer_is_never_authoritative(layer: str) -> None:
-    """in_process_sdk and passive_telemetry are observation only, never a decision."""
     envelope = _server_envelope(server_digest_hex="a" * 64, capture_layer=layer)
     verification = verify_code_authorship_envelope(envelope)
     assert verification.passed is False

--- a/python/tests/test_commitment.py
+++ b/python/tests/test_commitment.py
@@ -27,16 +27,16 @@ _DATA = b"claim-bytes"
 _GOLDEN = "4895dd9c2ad9a9f35f18d7c60d6957e4a87b017dff65d1316f76d437905fff88"
 
 
+    # commit() equals a hand-computed HMAC-SHA256 over the framed input.
 def test_commit_matches_independent_hmac_golden() -> None:
-    """commit() equals a hand-computed HMAC-SHA256 over the framed input."""
     got = commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
     assert got == _GOLDEN
     framed = _OPENING + _LABEL.encode() + _VERSION.to_bytes(4, "big") + _DATA
     assert got == hmac.new(_KEY, framed, hashlib.sha256).hexdigest()
 
 
+    # Same inputs always yield the same lowercase hex digest.
 def test_commit_is_deterministic_for_fixed_inputs() -> None:
-    """Same inputs always yield the same lowercase hex digest."""
     first = commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
     second = commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
     assert first == second
@@ -69,8 +69,8 @@ def test_commit_changes_when_data_changes() -> None:
     assert other != commit(_KEY, _OPENING, _LABEL, _VERSION, _DATA)
 
 
+    # version 1 and 256 differ, proving a 4-byte big-endian field, not a byte.
 def test_version_is_four_big_endian_bytes_in_framing() -> None:
-    """version 1 and 256 differ, proving a 4-byte big-endian field, not a byte."""
     low = commit(_KEY, _OPENING, _LABEL, 1, _DATA)
     high = commit(_KEY, _OPENING, _LABEL, 256, _DATA)
     assert low != high
@@ -81,13 +81,13 @@ def test_new_opening_is_sixteen_bytes() -> None:
     assert isinstance(new_opening(), bytes)
 
 
+    # Two openings differ (CSPRNG); a constant opening would be a bug.
 def test_new_opening_is_random_across_calls() -> None:
-    """Two openings differ (CSPRNG); a constant opening would be a bug."""
     assert new_opening() != new_opening()
 
 
+    # The key is caller-supplied: commit() must not default-generate it.
 def test_commit_has_no_default_key() -> None:
-    """The key is caller-supplied: commit() must not default-generate it."""
     params = inspect.signature(commit).parameters
     assert params["key"].default is inspect.Parameter.empty
 

--- a/python/tests/test_compliance_bundle.py
+++ b/python/tests/test_compliance_bundle.py
@@ -151,8 +151,8 @@ class TestExportBundle:
         assert len(bundle.verification["receipt_hashes"]) == 1
         assert bundle.verification["merkle_root"] == bundle.merkle_root
 
+        # Verify an auditor can recompute the Merkle root from receipts.
     def test_merkle_root_matches_receipts(self):
-        """Verify an auditor can recompute the Merkle root from receipts."""
         sigs = [_make_sig_response(signature_id=f"sid_{i}") for i in range(5)]
         bundle = export_bundle(sigs)
 

--- a/python/tests/test_conformance_vectors.py
+++ b/python/tests/test_conformance_vectors.py
@@ -64,8 +64,8 @@ def test_each_vector_sha256_matches_canonical() -> None:
         )
 
 
+    # Every vector must declare whether verification should succeed or fail.
 def test_each_vector_declares_expected_verify() -> None:
-    """Every vector must declare whether verification should succeed or fail."""
     d = json.loads(VECTORS_PATH.read_text())
     for v in d["vectors"]:
         assert "expected_verify" in v, f"{v['name']} missing expected_verify"
@@ -73,8 +73,8 @@ def test_each_vector_declares_expected_verify() -> None:
         assert "reason" in v and v["reason"], f"{v['name']} missing reason"
 
 
+    # vectors.json must cover at least 5 distinct adversarial failure modes.
 def test_coverage_includes_adversarial_cases() -> None:
-    """vectors.json must cover at least 5 distinct adversarial failure modes."""
     d = json.loads(VECTORS_PATH.read_text())
     fail_names = {v["name"] for v in d["vectors"] if v.get("expected_verify") is False}
     required = {
@@ -88,8 +88,8 @@ def test_coverage_includes_adversarial_cases() -> None:
     assert not missing, f"missing adversarial vectors: {missing}"
 
 
+    # The nonce-mismatch vector must declare what the peer sent vs what was echoed.
 def test_nonce_mismatch_vector_has_peer_sent_nonce() -> None:
-    """The nonce-mismatch vector must declare what the peer sent vs what was echoed."""
     d = json.loads(VECTORS_PATH.read_text())
     v = next(x for x in d["vectors"] if x["name"] == "nonce_mismatch")
     assert "peer_sent_nonce" in v
@@ -99,14 +99,14 @@ def test_nonce_mismatch_vector_has_peer_sent_nonce() -> None:
 # === capture_topology vocabulary parity (IETF -04 appendix + cloud SignRequest) ===
 
 
+    # Return all conformance vectors that exercise the capture_topology field.
 def _capture_vectors() -> list[dict]:
-    """Return all conformance vectors that exercise the capture_topology field."""
     d = json.loads(VECTORS_PATH.read_text())
     return [v for v in d["vectors"] if v["name"].startswith("capture_topology_")]
 
 
+    # All five IETF -04 capture topologies must appear as accepted vectors.
 def test_capture_topology_covers_full_closed_vocabulary() -> None:
-    """All five IETF -04 capture topologies must appear as accepted vectors."""
     accepted = {
         v["capture_topology"]
         for v in _capture_vectors()
@@ -137,8 +137,8 @@ def test_capture_topology_value_round_trips_via_manifest(value: str) -> None:
     )
 
 
+    # An out-of-vocabulary capture_topology token is a rejected conformance vector.
 def test_capture_topology_unknown_value_is_a_failure_vector() -> None:
-    """An out-of-vocabulary capture_topology token is a rejected conformance vector."""
     rejected = [
         v
         for v in _capture_vectors()

--- a/python/tests/test_credentials.py
+++ b/python/tests/test_credentials.py
@@ -20,9 +20,9 @@ from asqav.cli import app  # noqa: E402
 runner = CliRunner()
 
 
+    # Use the default ~/.asqav path under a temp HOME (drop the env override).
 @pytest.fixture
 def home(tmp_path, monkeypatch):
-    """Use the default ~/.asqav path under a temp HOME (drop the env override)."""
     monkeypatch.delenv("ASQAV_CREDENTIALS_PATH", raising=False)
     monkeypatch.delenv("ASQAV_API_KEY", raising=False)
     monkeypatch.delenv("ASQAV_API_BASE", raising=False)

--- a/python/tests/test_crewai_integration.py
+++ b/python/tests/test_crewai_integration.py
@@ -17,9 +17,9 @@ from asqav.extras.crewai import AsqavCrewHook, enable_crew_governance
 # === Fixtures ===
 
 
+    # Create an AsqavCrewHook with mocked Agent.
 @pytest.fixture()
 def hook():
-    """Create an AsqavCrewHook with mocked Agent."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -29,8 +29,8 @@ def hook():
     return h
 
 
+    # Minimal duck-typed stand-in for a crewai ``Crew`` (no crewai import).
 class _DuckCrew:
-    """Minimal duck-typed stand-in for a crewai ``Crew`` (no crewai import)."""
 
     def __init__(self) -> None:
         self.step_callback = None
@@ -40,8 +40,8 @@ class _DuckCrew:
 # === on_task_start ===
 
 
+    # on_task_start signs task:start with description and agent role.
 def test_on_task_start_signs_action(hook):
-    """on_task_start signs task:start with description and agent role."""
     with patch.object(hook, "_sign_action") as mock_sign:
         hook.on_task_start("Analyze market data", agent_role="Researcher")
     mock_sign.assert_called_once_with("task:start", {
@@ -50,8 +50,8 @@ def test_on_task_start_signs_action(hook):
     })
 
 
+    # on_task_start omits agent_role when not provided.
 def test_on_task_start_without_role(hook):
-    """on_task_start omits agent_role when not provided."""
     with patch.object(hook, "_sign_action") as mock_sign:
         hook.on_task_start("Analyze data")
     ctx = mock_sign.call_args[0][1]
@@ -62,8 +62,8 @@ def test_on_task_start_without_role(hook):
 # === on_task_complete ===
 
 
+    # on_task_complete signs task:complete with output length.
 def test_on_task_complete_signs_action(hook):
-    """on_task_complete signs task:complete with output length."""
     with patch.object(hook, "_sign_action") as mock_sign:
         hook.on_task_complete(
             "Write report",
@@ -77,8 +77,8 @@ def test_on_task_complete_signs_action(hook):
     })
 
 
+    # on_task_complete omits output_length when output is None.
 def test_on_task_complete_without_output(hook):
-    """on_task_complete omits output_length when output is None."""
     with patch.object(hook, "_sign_action") as mock_sign:
         hook.on_task_complete("Write report")
     ctx = mock_sign.call_args[0][1]
@@ -88,8 +88,8 @@ def test_on_task_complete_without_output(hook):
 # === on_task_fail ===
 
 
+    # on_task_fail signs task:fail with error message.
 def test_on_task_fail_signs_action(hook):
-    """on_task_fail signs task:fail with error message."""
     with patch.object(hook, "_sign_action") as mock_sign:
         hook.on_task_fail(
             "Fetch data",
@@ -103,8 +103,8 @@ def test_on_task_fail_signs_action(hook):
     })
 
 
+    # on_task_fail omits error when not provided.
 def test_on_task_fail_without_error(hook):
-    """on_task_fail omits error when not provided."""
     with patch.object(hook, "_sign_action") as mock_sign:
         hook.on_task_fail("Fetch data")
     ctx = mock_sign.call_args[0][1]
@@ -114,8 +114,8 @@ def test_on_task_fail_without_error(hook):
 # === step_callback ===
 
 
+    # step_callback signs step:execute with type and truncated output.
 def test_step_callback_signs_action(hook):
-    """step_callback signs step:execute with type and truncated output."""
     step = MagicMock()
     step.__class__.__name__ = "AgentAction"
     step.__str__ = lambda self: "Tool call: search('query')"
@@ -132,8 +132,8 @@ def test_step_callback_signs_action(hook):
 # === task_callback ===
 
 
+    # task_callback signs task:complete from TaskOutput attributes.
 def test_task_callback_signs_action(hook):
-    """task_callback signs task:complete from TaskOutput attributes."""
     task_output = MagicMock()
     task_output.description = "Summarize findings"
     task_output.raw = "The key findings are..."
@@ -147,8 +147,8 @@ def test_task_callback_signs_action(hook):
     assert ctx["output_length"] == len("The key findings are...")
 
 
+    # task_callback falls back to str() when attributes are missing.
 def test_task_callback_handles_missing_attributes(hook):
-    """task_callback falls back to str() when attributes are missing."""
 
     class _PlainOutput:
         def __str__(self) -> str:
@@ -168,8 +168,8 @@ def test_task_callback_handles_missing_attributes(hook):
 # === Truncation ===
 
 
+    # Long descriptions are truncated to 200 chars.
 def test_description_truncated(hook):
-    """Long descriptions are truncated to 200 chars."""
     long_desc = "x" * 500
 
     with patch.object(hook, "_sign_action") as mock_sign:
@@ -178,8 +178,8 @@ def test_description_truncated(hook):
     assert len(ctx["task_description"]) == 200
 
 
+    # Long step output is truncated to 200 chars.
 def test_step_output_truncated(hook):
-    """Long step output is truncated to 200 chars."""
     step = MagicMock()
     step.__str__ = lambda self: "y" * 500
 
@@ -192,8 +192,8 @@ def test_step_output_truncated(hook):
 # === Fail-open ===
 
 
+    # Signing errors do not propagate - fail-open behavior.
 def test_fail_open_on_sign_error(hook):
-    """Signing errors do not propagate - fail-open behavior."""
     with patch.object(hook, "_sign_action", side_effect=Exception("boom")):
         # None of these should raise
         with pytest.raises(Exception):
@@ -215,8 +215,8 @@ def test_fail_open_on_sign_error(hook):
 # === Default-on: enable_crew_governance ===
 
 
+    # enable_crew_governance sets step_callback and task_callback on the crew.
 def test_enable_wires_both_callbacks():
-    """enable_crew_governance sets step_callback and task_callback on the crew."""
     crew = _DuckCrew()
     with (
         patch("asqav.client._api_key", "sk_test"),
@@ -253,8 +253,8 @@ def test_default_on_step_signs_by_default():
     assert hook._sign_action.call_args[0][0] == "step:execute"
 
 
+    # A crew task signs a task:complete receipt by default after enable.
 def test_default_on_task_signs_by_default():
-    """A crew task signs a task:complete receipt by default after enable."""
     crew = _DuckCrew()
     with (
         patch("asqav.client._api_key", "sk_test"),
@@ -270,8 +270,8 @@ def test_default_on_task_signs_by_default():
     assert hook._sign_action.call_args[0][0] == "task:complete"
 
 
+    # Existing step/task callbacks still run (additive), plus asqav signs.
 def test_existing_callbacks_preserved():
-    """Existing step/task callbacks still run (additive), plus asqav signs."""
     crew = _DuckCrew()
     seen_steps: list[object] = []
     seen_tasks: list[object] = []
@@ -346,8 +346,8 @@ def test_enable_crew_governance_double_enable_same_hook_no_orphan():
     assert create_count == 1, f"Agent.create called {create_count} times, expected 1"
 
 
+    # The adapter imports with crewai absent - duck-typed, no hard import.
 def test_module_imports_without_crewai():
-    """The adapter imports with crewai absent - duck-typed, no hard import."""
     saved = sys.modules.pop("crewai", None)
     sys.modules.pop("asqav.extras.crewai", None)
     try:

--- a/python/tests/test_cross_language_cases.py
+++ b/python/tests/test_cross_language_cases.py
@@ -20,8 +20,8 @@ CASES_FILE = Path(__file__).parent.parent.parent / "verifier" / "cross-language-
 CASES = json.loads(CASES_FILE.read_text())["cases"]
 
 
+    # A table that silently empties would make every case below vacuous.
 def test_case_table_is_populated() -> None:
-    """A table that silently empties would make every case below vacuous."""
     assert len(CASES) >= 20, f"case table has only {len(CASES)} cases"
 
 

--- a/python/tests/test_decorators.py
+++ b/python/tests/test_decorators.py
@@ -58,8 +58,8 @@ MOCK_SESSION_ERROR_END_RESPONSE: dict = {
 }
 
 
+    # Route mock _post calls to appropriate fixture responses.
 def _mock_post_side_effect(path: str, data: dict) -> dict:
-    """Route mock _post calls to appropriate fixture responses."""
     if path == "/agents/create":
         return MOCK_AGENT_RESPONSE
     if "/sign" in path:
@@ -69,8 +69,8 @@ def _mock_post_side_effect(path: str, data: dict) -> dict:
     return {}
 
 
+    # Route mock _patch calls to appropriate fixture responses.
 def _mock_patch_side_effect(path: str, data: dict) -> dict:
-    """Route mock _patch calls to appropriate fixture responses."""
     if "sessions" in path:
         if data.get("status") == "error":
             return MOCK_SESSION_ERROR_END_RESPONSE
@@ -78,18 +78,18 @@ def _mock_patch_side_effect(path: str, data: dict) -> dict:
     return {}
 
 
+    # Reset the global agent between tests.
 def _reset_global_agent() -> None:
-    """Reset the global agent between tests."""
     asqav_client._global_agent = None
 
 
 # === Tests ===
 
 
+    # @asqav.sign on sync function signs call and result.
 @patch("asqav.client._patch", side_effect=_mock_patch_side_effect)
 @patch("asqav.client._post", side_effect=_mock_post_side_effect)
 def test_sign_decorator_sync(mock_post: MagicMock, mock_patch: MagicMock) -> None:
-    """@asqav.sign on sync function signs call and result."""
     _reset_global_agent()
 
     @sign
@@ -115,10 +115,10 @@ def test_sign_decorator_sync(mock_post: MagicMock, mock_patch: MagicMock) -> Non
     assert result_args[0][1]["context"]["success"] is True
 
 
+    # @asqav.sign on async function works with asyncio.run().
 @patch("asqav.client._patch", side_effect=_mock_patch_side_effect)
 @patch("asqav.client._post", side_effect=_mock_post_side_effect)
 def test_sign_decorator_async(mock_post: MagicMock, mock_patch: MagicMock) -> None:
-    """@asqav.sign on async function works with asyncio.run()."""
     _reset_global_agent()
 
     @sign
@@ -137,10 +137,10 @@ def test_sign_decorator_async(mock_post: MagicMock, mock_patch: MagicMock) -> No
     assert call_args[0][1]["context"]["function"] == "fetch"
 
 
+    # @asqav.sign(action_type="deploy:prod") overrides default action type.
 @patch("asqav.client._patch", side_effect=_mock_patch_side_effect)
 @patch("asqav.client._post", side_effect=_mock_post_side_effect)
 def test_sign_decorator_with_action_type(mock_post: MagicMock, mock_patch: MagicMock) -> None:
-    """@asqav.sign(action_type="deploy:prod") overrides default action type."""
     _reset_global_agent()
 
     @sign(action_type="deploy:prod")
@@ -156,8 +156,8 @@ def test_sign_decorator_with_action_type(mock_post: MagicMock, mock_patch: Magic
     assert call_args[0][1]["action_type"] == "deploy:prod"
 
 
+    # Agent creation succeeds; every sign is blocked with a non-2xx error.
 def _mock_post_blocks_sign(path: str, data: dict) -> dict:
-    """Agent creation succeeds; every sign is blocked with a non-2xx error."""
     if path == "/agents/create":
         return MOCK_AGENT_RESPONSE
     if "/sign" in path:
@@ -194,10 +194,10 @@ def test_sign_decorator_fail_closed_on_blocked_sign(
     )
 
 
+    # Decorated function that raises propagates exception and signs error.
 @patch("asqav.client._patch", side_effect=_mock_patch_side_effect)
 @patch("asqav.client._post", side_effect=_mock_post_side_effect)
 def test_sign_decorator_reraises_exception(mock_post: MagicMock, mock_patch: MagicMock) -> None:
-    """Decorated function that raises propagates exception and signs error."""
     _reset_global_agent()
 
     @sign
@@ -218,10 +218,10 @@ def test_sign_decorator_reraises_exception(mock_post: MagicMock, mock_patch: Mag
     assert "something broke" in error_args[0][1]["context"]["error"]
 
 
+    # with asqav.session() as s: s.sign(...) groups signs under a session.
 @patch("asqav.client._patch", side_effect=_mock_patch_side_effect)
 @patch("asqav.client._post", side_effect=_mock_post_side_effect)
 def test_session_context_manager(mock_post: MagicMock, mock_patch: MagicMock) -> None:
-    """with asqav.session() as s: s.sign(...) groups signs under a session."""
     _reset_global_agent()
 
     with session() as s:
@@ -242,12 +242,12 @@ def test_session_context_manager(mock_post: MagicMock, mock_patch: MagicMock) ->
     assert end_call[0][1]["status"] == "completed"
 
 
+    # Session that encounters an exception signs error before ending.
 @patch("asqav.client._patch", side_effect=_mock_patch_side_effect)
 @patch("asqav.client._post", side_effect=_mock_post_side_effect)
 def test_session_signs_error_on_exception(
     mock_post: MagicMock, mock_patch: MagicMock
 ) -> None:
-    """Session that encounters an exception signs error before ending."""
     _reset_global_agent()
 
     try:
@@ -271,8 +271,8 @@ def test_session_signs_error_on_exception(
     assert end_call[0][1]["status"] == "error"
 
 
+    # Verify asqav.secure is still importable and callable (backward compat).
 def test_existing_secure_still_works() -> None:
-    """Verify asqav.secure is still importable and callable (backward compat)."""
     assert hasattr(asqav, "secure")
     assert callable(asqav.secure)
     assert hasattr(asqav, "secure_async")
@@ -284,9 +284,9 @@ def test_existing_secure_still_works() -> None:
     assert hasattr(asqav, "async_session")
 
 
+    # Concurrent first calls to get_agent create exactly one agent (no duplicate race).
 @patch("asqav.client.Agent.create")
 def test_get_agent_concurrent_first_call_creates_once(mock_create: MagicMock) -> None:
-    """Concurrent first calls to get_agent create exactly one agent (no duplicate race)."""
     import threading
 
     _reset_global_agent()

--- a/python/tests/test_demo_handler.py
+++ b/python/tests/test_demo_handler.py
@@ -26,9 +26,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from asqav.demo import DemoHandler, DemoState
 
 
+    # Start a DemoHandler on an ephemeral port; yield the base URL + state.
 @contextmanager
 def _running_server() -> Iterator[tuple[str, DemoState]]:
-    """Start a DemoHandler on an ephemeral port; yield the base URL + state."""
     state = DemoState()
     DemoHandler.state = state
     httpd = socketserver.ThreadingTCPServer(("127.0.0.1", 0), DemoHandler)
@@ -43,8 +43,8 @@ def _running_server() -> Iterator[tuple[str, DemoState]]:
         thread.join(timeout=2)
 
 
+    # Issue a POST; return (status, decoded JSON body or {} on empty).
 def _post(url: str, body: dict | None, *, raw: bytes | None = None) -> tuple[int, dict]:
-    """Issue a POST; return (status, decoded JSON body or {} on empty)."""
     if raw is not None:
         data = raw
     else:
@@ -63,8 +63,8 @@ def _post(url: str, body: dict | None, *, raw: bytes | None = None) -> tuple[int
 # === Happy path: /api/decide signs a receipt for a known scenario ===
 
 
+    # POST /api/decide with valid fields signs and stores the receipt.
 def test_do_post_decide_signs_and_records() -> None:
-    """POST /api/decide with valid fields signs and stores the receipt."""
     with _running_server() as (base, state):
         status, body = _post(
             f"{base}/api/decide",
@@ -88,8 +88,8 @@ def test_do_post_decide_signs_and_records() -> None:
 # === Round trip: a receipt produced by /api/decide verifies via /api/verify ===
 
 
+    # A receipt produced by /api/decide verifies via /api/verify.
 def test_do_post_verify_round_trip() -> None:
-    """A receipt produced by /api/decide verifies via /api/verify."""
     with _running_server() as (base, _state):
         _, decide = _post(
             f"{base}/api/decide",
@@ -111,16 +111,16 @@ def test_do_post_verify_round_trip() -> None:
 # === Error paths ===
 
 
+    # Non-JSON bodies are rejected with 400.
 def test_do_post_invalid_json_returns_400() -> None:
-    """Non-JSON bodies are rejected with 400."""
     with _running_server() as (base, _state):
         status, body = _post(f"{base}/api/decide", None, raw=b"{not json")
         assert status == 400
         assert "invalid json" in body["error"]
 
 
+    # `decision` must be `approved` or `denied`.
 def test_do_post_decide_rejects_bad_decision() -> None:
-    """`decision` must be `approved` or `denied`."""
     with _running_server() as (base, _state):
         status, body = _post(
             f"{base}/api/decide",
@@ -130,8 +130,8 @@ def test_do_post_decide_rejects_bad_decision() -> None:
         assert "approved or denied" in body["error"]
 
 
+    # Reasons under 10 chars are rejected so the audit trail stays meaningful.
 def test_do_post_decide_rejects_short_reason() -> None:
-    """Reasons under 10 chars are rejected so the audit trail stays meaningful."""
     with _running_server() as (base, _state):
         status, body = _post(
             f"{base}/api/decide",
@@ -141,8 +141,8 @@ def test_do_post_decide_rejects_short_reason() -> None:
         assert "at least 10" in body["error"]
 
 
+    # Unknown scenario ids surface as a 404.
 def test_do_post_decide_unknown_scenario_returns_404() -> None:
-    """Unknown scenario ids surface as a 404."""
     with _running_server() as (base, _state):
         status, body = _post(
             f"{base}/api/decide",
@@ -156,15 +156,15 @@ def test_do_post_decide_unknown_scenario_returns_404() -> None:
         assert body["error"] == "unknown scenario"
 
 
+    # POSTs to an unknown path return 404.
 def test_do_post_unknown_path_returns_404() -> None:
-    """POSTs to an unknown path return 404."""
     with _running_server() as (base, _state):
         status, body = _post(f"{base}/api/nope", {"x": 1})
         assert status == 404
 
 
+    # `/api/verify` returns valid=False for a malformed receipt.
 def test_do_post_verify_with_garbage_returns_invalid() -> None:
-    """`/api/verify` returns valid=False for a malformed receipt."""
     with _running_server() as (base, _state):
         status, body = _post(
             f"{base}/api/verify",
@@ -178,8 +178,8 @@ def test_do_post_verify_with_garbage_returns_invalid() -> None:
 # === Edge case: empty body ===
 
 
+    # Empty body decodes to `{}`; /api/decide path with empty body rejects on decision.
 def test_do_post_empty_body_falls_through_to_404() -> None:
-    """Empty body decodes to `{}`; /api/decide path with empty body rejects on decision."""
     with _running_server() as (base, _state):
         req = urllib.request.Request(
             f"{base}/api/decide",

--- a/python/tests/test_deserializer_guards.py
+++ b/python/tests/test_deserializer_guards.py
@@ -28,8 +28,8 @@ def _mock_httpx(payload: dict) -> MagicMock:
     return response
 
 
+    # A complete `/verify` response; each test deletes one required key.
 def _full_payload() -> dict:
-    """A complete `/verify` response; each test deletes one required key."""
     return {
         "signature_id": "sig_test",
         "agent_id": "agent_test",

--- a/python/tests/test_detector_plugin.py
+++ b/python/tests/test_detector_plugin.py
@@ -88,9 +88,9 @@ class RaisingDetector:
         raise RuntimeError("detector_internal_error")
 
 
+    # Ensure each test starts with a clean detector registry.
 @pytest.fixture(autouse=True)
 def _reset_detectors():
-    """Ensure each test starts with a clean detector registry."""
     clear_detectors()
     yield
     clear_detectors()
@@ -147,8 +147,8 @@ def test_multiple_detectors_all_run_on_allow() -> None:
     assert len(records) == 2
 
 
+    # Second detector must NOT run after first returns deny.
 def test_deny_stops_after_first_deny() -> None:
-    """Second detector must NOT run after first returns deny."""
     called: list[str] = []
 
     class TrackingAllow:
@@ -183,8 +183,8 @@ def test_none_context_is_treated_as_empty() -> None:
 # ─── Integration: Agent.sign path ─────────────────────────────────────────────
 
 
+    # Allow detector: sign POST is made AND _detectors appears in context.
 def test_allow_detector_lets_sign_proceed() -> None:
-    """Allow detector: sign POST is made AND _detectors appears in context."""
     captured: dict[str, Any] = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -206,8 +206,8 @@ def test_allow_detector_lets_sign_proceed() -> None:
     assert records[0]["detector"] == "allow-detector"
 
 
+    # Deny detector: sign raises DetectorBlockedError; no POST is made.
 def test_deny_detector_blocks_sign_no_post() -> None:
-    """Deny detector: sign raises DetectorBlockedError; no POST is made."""
     post_called = False
 
     def fake_post(path: str, body: dict) -> dict:
@@ -224,8 +224,8 @@ def test_deny_detector_blocks_sign_no_post() -> None:
     assert exc_info.value.detector_name == "deny-detector"
 
 
+    # A detector that raises blocks sign by default (fail-closed).
 def test_fail_closed_detector_error_blocks_sign() -> None:
-    """A detector that raises blocks sign by default (fail-closed)."""
     post_called = False
 
     def fake_post(path: str, body: dict) -> dict:
@@ -241,8 +241,8 @@ def test_fail_closed_detector_error_blocks_sign() -> None:
     assert not post_called
 
 
+    # A detector that raises with fail_open=True lets sign proceed.
 def test_fail_open_detector_error_allows_sign() -> None:
-    """A detector that raises with fail_open=True lets sign proceed."""
     captured: dict[str, Any] = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -261,8 +261,8 @@ def test_fail_open_detector_error_allows_sign() -> None:
     assert ctx["_detectors"][0]["labels"] == ["error"]
 
 
+    # With no detectors, the signed body must NOT contain _detectors key.
 def test_additive_no_detector_body_unchanged() -> None:
-    """With no detectors, the signed body must NOT contain _detectors key."""
     captured: dict[str, Any] = {}
 
     def fake_post(path: str, body: dict) -> dict:
@@ -283,8 +283,8 @@ def test_additive_no_detector_body_unchanged() -> None:
 # ─── Unit: DetectorPlugin protocol ────────────────────────────────────────────
 
 
+    # Any object with name + inspect satisfies DetectorPlugin (structural).
 def test_detector_plugin_protocol_structural() -> None:
-    """Any object with name + inspect satisfies DetectorPlugin (structural)."""
     assert isinstance(AllowDetector(), DetectorPlugin)
 
 
@@ -301,8 +301,8 @@ def test_detector_blocked_error_attributes() -> None:
 # ─── Reference detector: PresidioDetector ────────────────────────────────────
 
 
+    # PresidioDetector returns deny + labels when Presidio finds PII.
 def test_presidio_detector_labels_on_deny() -> None:
-    """PresidioDetector returns deny + labels when Presidio finds PII."""
     from asqav.extras.presidio_detector import PresidioDetector
 
     class FakeResult:
@@ -337,8 +337,8 @@ def test_presidio_detector_allow_when_no_pii() -> None:
     assert result.allow is True
 
 
+    # Without presidio-analyzer installed, PresidioDetector raises ImportError.
 def test_presidio_detector_import_error_without_extra() -> None:
-    """Without presidio-analyzer installed, PresidioDetector raises ImportError."""
     from asqav.extras.presidio_detector import PresidioDetector, _load_analyzer
 
     with patch.dict("sys.modules", {"presidio_analyzer": None}):
@@ -376,8 +376,8 @@ def test_opa_detector_deny_on_false_result() -> None:
     assert "opa_deny" in result.labels
 
 
+    # Missing 'result' key in OPA response → fail-closed deny.
 def test_opa_detector_deny_on_missing_result() -> None:
-    """Missing 'result' key in OPA response → fail-closed deny."""
     from asqav.extras.opa_detector import OpaDetector
 
     det = OpaDetector()
@@ -390,8 +390,8 @@ def test_opa_detector_deny_on_missing_result() -> None:
     assert result.allow is False
 
 
+    # HTTP failure from OPA propagates as RuntimeError (caller handles).
 def test_opa_detector_raises_on_http_error() -> None:
-    """HTTP failure from OPA propagates as RuntimeError (caller handles)."""
     from asqav.extras.opa_detector import OpaDetector
 
     det = OpaDetector()
@@ -404,8 +404,8 @@ def test_opa_detector_raises_on_http_error() -> None:
         det.inspect("api:call", {})
 
 
+    # OpaDetector sends {input: {action_type, context}} to OPA.
 def test_opa_sends_correct_payload() -> None:
-    """OpaDetector sends {input: {action_type, context}} to OPA."""
     from asqav.extras.opa_detector import OpaDetector
 
     sent: dict[str, Any] = {}

--- a/python/tests/test_doors.py
+++ b/python/tests/test_doors.py
@@ -29,8 +29,8 @@ HASHMODE = _load("hashmode")
 # --- byte-identical inner: the exact receipt is embedded in every door ---
 
 
+    # All five doors carry the same receipt with an identical JCS byte string.
 def test_same_bytes_inner_across_all_doors() -> None:
-    """All five doors carry the same receipt with an identical JCS byte string."""
     for receipt in (COMPLIANCE, HASHMODE):
         inners = [
             doors.receipt_from_vc(doors.to_w3c_vc(receipt)),
@@ -150,8 +150,8 @@ def test_generic_extract_recovers_receipt_from_every_door() -> None:
 # --- cross-language parity: same JCS structure as the TS SDK ---
 
 
+    # Python wrap_all JCS equals the committed golden the TS test also checks.
 def test_parity_golden_matches_python_output() -> None:
-    """Python wrap_all JCS equals the committed golden the TS test also checks."""
     for name, receipt in (("compliance", COMPLIANCE), ("hashmode", HASHMODE)):
         golden = (_PARITY / f"golden-{name}.jcs").read_bytes()
         assert doors.canonical_json(doors.wrap_all(receipt)) == golden

--- a/python/tests/test_dspy_integration.py
+++ b/python/tests/test_dspy_integration.py
@@ -21,13 +21,13 @@ _MISSING = object()
 _original_modules: dict[str, ModuleType | object] = {}
 
 
+    # Inject fake dspy module tree and return the BaseCallback class.
 def _install_dspy_mocks() -> type:
-    """Inject fake dspy module tree and return the BaseCallback class."""
     for mod_name in ("dspy", "dspy.utils", "dspy.utils.callback"):
         _original_modules[mod_name] = sys.modules.get(mod_name, _MISSING)
 
+        # Mock dspy BaseCallback.
     class BaseCallback:
-        """Mock dspy BaseCallback."""
 
         def __init__(self) -> None:
             pass
@@ -63,9 +63,9 @@ from asqav.extras.dspy import AsqavDSPyCallback  # noqa: E402
 # === Fixtures ===
 
 
+    # Create an AsqavDSPyCallback with mocked Agent internals.
 @pytest.fixture()
 def cb() -> AsqavDSPyCallback:
-    """Create an AsqavDSPyCallback with mocked Agent internals."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -79,16 +79,16 @@ def cb() -> AsqavDSPyCallback:
 # === Subclass check ===
 
 
+    # AsqavDSPyCallback must be a subclass of dspy's BaseCallback.
 def test_is_base_callback_subclass() -> None:
-    """AsqavDSPyCallback must be a subclass of dspy's BaseCallback."""
     assert issubclass(AsqavDSPyCallback, BaseCallback)
 
 
 # === Module handlers ===
 
 
+    # on_module_start signs dspy.module.start with module name and input keys.
 def test_on_module_start_signs_action(cb: AsqavDSPyCallback) -> None:
-    """on_module_start signs dspy.module.start with module name and input keys."""
 
     class MyModule:
         pass
@@ -100,8 +100,8 @@ def test_on_module_start_signs_action(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_module_end signs dspy.module.end with ok=True on success.
 def test_on_module_end_signs_ok(cb: AsqavDSPyCallback) -> None:
-    """on_module_end signs dspy.module.end with ok=True on success."""
     cb.on_module_end("call-1", {"answer": "hello"}, None)
     cb._sign_action.assert_called_once_with(
         "dspy.module.end",
@@ -109,8 +109,8 @@ def test_on_module_end_signs_ok(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_module_end signs dspy.module.end with ok=False and exception name on error.
 def test_on_module_end_signs_exception(cb: AsqavDSPyCallback) -> None:
-    """on_module_end signs dspy.module.end with ok=False and exception name on error."""
     cb.on_module_end("call-2", None, ValueError("bad input"))
     cb._sign_action.assert_called_once_with(
         "dspy.module.end",
@@ -118,15 +118,15 @@ def test_on_module_end_signs_exception(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_module_start handles empty inputs dict gracefully.
 def test_on_module_start_empty_inputs(cb: AsqavDSPyCallback) -> None:
-    """on_module_start handles empty inputs dict gracefully."""
     cb.on_module_start("call-x", object(), {})
     ctx = cb._sign_action.call_args[0][1]
     assert ctx["input_keys"] == []
 
 
+    # on_module_start handles non-dict inputs without raising.
 def test_on_module_start_non_dict_inputs(cb: AsqavDSPyCallback) -> None:
-    """on_module_start handles non-dict inputs without raising."""
     cb.on_module_start("call-x", object(), None)  # type: ignore[arg-type]
     ctx = cb._sign_action.call_args[0][1]
     assert ctx["input_keys"] == []
@@ -135,8 +135,8 @@ def test_on_module_start_non_dict_inputs(cb: AsqavDSPyCallback) -> None:
 # === LM handlers ===
 
 
+    # on_lm_start signs dspy.lm.start with model name and input keys.
 def test_on_lm_start_signs_action(cb: AsqavDSPyCallback) -> None:
-    """on_lm_start signs dspy.lm.start with model name and input keys."""
 
     class OpenAI:
         model = "gpt-4o"
@@ -153,15 +153,15 @@ def test_on_lm_start_signs_action(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_lm_start uses None for model when instance has no .model attribute.
 def test_on_lm_start_no_model_attr(cb: AsqavDSPyCallback) -> None:
-    """on_lm_start uses None for model when instance has no .model attribute."""
     cb.on_lm_start("call-x", object(), {})
     ctx = cb._sign_action.call_args[0][1]
     assert ctx["model"] is None
 
 
+    # on_lm_end signs dspy.lm.end with ok=True on success.
 def test_on_lm_end_signs_ok(cb: AsqavDSPyCallback) -> None:
-    """on_lm_end signs dspy.lm.end with ok=True on success."""
     cb.on_lm_end("call-2", {"text": "result"}, None)
     cb._sign_action.assert_called_once_with(
         "dspy.lm.end",
@@ -169,8 +169,8 @@ def test_on_lm_end_signs_ok(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_lm_end signs dspy.lm.end with ok=False on error.
 def test_on_lm_end_signs_exception(cb: AsqavDSPyCallback) -> None:
-    """on_lm_end signs dspy.lm.end with ok=False on error."""
     cb.on_lm_end("call-2", None, TimeoutError("rate limit"))
     ctx = cb._sign_action.call_args[0][1]
     assert ctx["ok"] is False
@@ -180,8 +180,8 @@ def test_on_lm_end_signs_exception(cb: AsqavDSPyCallback) -> None:
 # === Tool handlers ===
 
 
+    # on_tool_start signs dspy.tool.start with tool name and input keys.
 def test_on_tool_start_signs_action(cb: AsqavDSPyCallback) -> None:
-    """on_tool_start signs dspy.tool.start with tool name and input keys."""
 
     class SearchTool:
         name = "web_search"
@@ -193,8 +193,8 @@ def test_on_tool_start_signs_action(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_tool_start uses class name when instance has no .name attribute.
 def test_on_tool_start_falls_back_to_class_name(cb: AsqavDSPyCallback) -> None:
-    """on_tool_start uses class name when instance has no .name attribute."""
 
     class CalculatorTool:
         pass
@@ -204,8 +204,8 @@ def test_on_tool_start_falls_back_to_class_name(cb: AsqavDSPyCallback) -> None:
     assert ctx["tool"] == "CalculatorTool"
 
 
+    # on_tool_end signs dspy.tool.end with ok=True on success.
 def test_on_tool_end_signs_ok(cb: AsqavDSPyCallback) -> None:
-    """on_tool_end signs dspy.tool.end with ok=True on success."""
     cb.on_tool_end("call-3", {"results": ["a", "b"]}, None)
     cb._sign_action.assert_called_once_with(
         "dspy.tool.end",
@@ -213,8 +213,8 @@ def test_on_tool_end_signs_ok(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_tool_end signs dspy.tool.end with ok=False on error.
 def test_on_tool_end_signs_exception(cb: AsqavDSPyCallback) -> None:
-    """on_tool_end signs dspy.tool.end with ok=False on error."""
     cb.on_tool_end("call-3", None, RuntimeError("tool failed"))
     ctx = cb._sign_action.call_args[0][1]
     assert ctx["ok"] is False
@@ -224,8 +224,8 @@ def test_on_tool_end_signs_exception(cb: AsqavDSPyCallback) -> None:
 # === Input keys are sorted ===
 
 
+    # Input keys are always sorted alphabetically in audit records.
 def test_input_keys_are_sorted(cb: AsqavDSPyCallback) -> None:
-    """Input keys are always sorted alphabetically in audit records."""
     cb.on_module_start("call-s", object(), {"z": 1, "a": 2, "m": 3})
     ctx = cb._sign_action.call_args[0][1]
     assert ctx["input_keys"] == ["a", "m", "z"]
@@ -234,8 +234,8 @@ def test_input_keys_are_sorted(cb: AsqavDSPyCallback) -> None:
 # === Evaluate handlers ===
 
 
+    # on_evaluate_start signs dspy.evaluate.start with evaluator name.
 def test_on_evaluate_start_signs_action(cb: AsqavDSPyCallback) -> None:
-    """on_evaluate_start signs dspy.evaluate.start with evaluator name."""
 
     class MyEval:
         pass
@@ -247,8 +247,8 @@ def test_on_evaluate_start_signs_action(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_evaluate_end signs dspy.evaluate.end with ok=True on success.
 def test_on_evaluate_end_signs_ok(cb: AsqavDSPyCallback) -> None:
-    """on_evaluate_end signs dspy.evaluate.end with ok=True on success."""
     cb.on_evaluate_end("call-e1", {"score": 0.87}, None)
     cb._sign_action.assert_called_once_with(
         "dspy.evaluate.end",
@@ -256,8 +256,8 @@ def test_on_evaluate_end_signs_ok(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_evaluate_end signs dspy.evaluate.end with ok=False on error.
 def test_on_evaluate_end_signs_exception(cb: AsqavDSPyCallback) -> None:
-    """on_evaluate_end signs dspy.evaluate.end with ok=False on error."""
     cb.on_evaluate_end("call-e2", None, RuntimeError("dataset missing"))
     ctx = cb._sign_action.call_args[0][1]
     assert ctx["ok"] is False
@@ -267,8 +267,8 @@ def test_on_evaluate_end_signs_exception(cb: AsqavDSPyCallback) -> None:
 # === Adapter format handlers ===
 
 
+    # on_adapter_format_start signs dspy.adapter.format.start with adapter name.
 def test_on_adapter_format_start_signs_action(cb: AsqavDSPyCallback) -> None:
-    """on_adapter_format_start signs dspy.adapter.format.start with adapter name."""
 
     class ChatAdapter:
         pass
@@ -280,8 +280,8 @@ def test_on_adapter_format_start_signs_action(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_adapter_format_end signs dspy.adapter.format.end with ok=True.
 def test_on_adapter_format_end_signs_ok(cb: AsqavDSPyCallback) -> None:
-    """on_adapter_format_end signs dspy.adapter.format.end with ok=True."""
     cb.on_adapter_format_end("call-f1", {"messages": []}, None)
     cb._sign_action.assert_called_once_with(
         "dspy.adapter.format.end",
@@ -292,8 +292,8 @@ def test_on_adapter_format_end_signs_ok(cb: AsqavDSPyCallback) -> None:
 # === Adapter parse handlers ===
 
 
+    # on_adapter_parse_start signs dspy.adapter.parse.start with adapter name.
 def test_on_adapter_parse_start_signs_action(cb: AsqavDSPyCallback) -> None:
-    """on_adapter_parse_start signs dspy.adapter.parse.start with adapter name."""
 
     class JSONAdapter:
         pass
@@ -305,8 +305,8 @@ def test_on_adapter_parse_start_signs_action(cb: AsqavDSPyCallback) -> None:
     )
 
 
+    # on_adapter_parse_end signs dspy.adapter.parse.end with ok=False on error.
 def test_on_adapter_parse_end_signs_exception(cb: AsqavDSPyCallback) -> None:
-    """on_adapter_parse_end signs dspy.adapter.parse.end with ok=False on error."""
     cb.on_adapter_parse_end("call-p1", None, ValueError("bad json"))
     ctx = cb._sign_action.call_args[0][1]
     assert ctx["ok"] is False
@@ -316,8 +316,8 @@ def test_on_adapter_parse_end_signs_exception(cb: AsqavDSPyCallback) -> None:
 # === Fail-open: signing must never block DSPy execution ===
 
 
+    # AsqavError from the real _sign_action is swallowed (fail-open).
 def test_fail_open_on_asqav_error(cb: AsqavDSPyCallback) -> None:
-    """AsqavError from the real _sign_action is swallowed (fail-open)."""
     from asqav.client import AsqavError
 
     with (

--- a/python/tests/test_emergency_halt.py
+++ b/python/tests/test_emergency_halt.py
@@ -14,9 +14,9 @@ from asqav.client import emergency_halt
 # === emergency_halt tests ===
 
 
+    # emergency_halt POSTs to /orgs/{org_id}/emergency-halt.
 @patch("asqav.client._post")
 def test_emergency_halt_calls_correct_endpoint(mock_post: object) -> None:
-    """emergency_halt POSTs to /orgs/{org_id}/emergency-halt."""
     mock_post.return_value = {"emergency_halt": True}  # type: ignore[attr-defined]
 
     emergency_halt("org-123")
@@ -27,9 +27,9 @@ def test_emergency_halt_calls_correct_endpoint(mock_post: object) -> None:
     )
 
 
+    # emergency_halt passes custom reason to the API.
 @patch("asqav.client._post")
 def test_emergency_halt_custom_reason(mock_post: object) -> None:
-    """emergency_halt passes custom reason to the API."""
     mock_post.return_value = {"emergency_halt": True}  # type: ignore[attr-defined]
 
     emergency_halt("org-456", reason="security breach detected")
@@ -40,9 +40,9 @@ def test_emergency_halt_custom_reason(mock_post: object) -> None:
     )
 
 
+    # emergency_halt returns the API response dict.
 @patch("asqav.client._post")
 def test_emergency_halt_returns_dict(mock_post: object) -> None:
-    """emergency_halt returns the API response dict."""
     mock_post.return_value = {  # type: ignore[attr-defined]
         "organization_id": "org-123",
         "emergency_halt": True,
@@ -56,15 +56,15 @@ def test_emergency_halt_returns_dict(mock_post: object) -> None:
     assert result["organization_id"] == "org-123"
 
 
+    # emergency_halt is accessible from the top-level asqav module.
 def test_emergency_halt_exported() -> None:
-    """emergency_halt is accessible from the top-level asqav module."""
     assert hasattr(asqav, "emergency_halt")
     assert callable(asqav.emergency_halt)
 
 
+    # emergency_halt uses 'emergency' as default reason.
 @patch("asqav.client._post")
 def test_emergency_halt_default_reason(mock_post: object) -> None:
-    """emergency_halt uses 'emergency' as default reason."""
     mock_post.return_value = {"emergency_halt": True}  # type: ignore[attr-defined]
 
     emergency_halt("org-789")
@@ -73,9 +73,9 @@ def test_emergency_halt_default_reason(mock_post: object) -> None:
     assert call_args[0][1]["reason"] == "emergency"
 
 
+    # emergency_halt path includes the org_id (proves /agents/ path is gone).
 @patch("asqav.client._post")
 def test_emergency_halt_path_includes_org_id(mock_post: object) -> None:
-    """emergency_halt path includes the org_id (proves /agents/ path is gone)."""
     mock_post.return_value = {"emergency_halt": True}  # type: ignore[attr-defined]
 
     emergency_halt("my-org")

--- a/python/tests/test_exit_artifact_cli.py
+++ b/python/tests/test_exit_artifact_cli.py
@@ -9,10 +9,8 @@ This runs the real command in a subprocess, in a directory holding nothing but t
 three exit-artifact files, with outbound network blocked, over an anchored ML-DSA-65
 receipt. Intact PASSes, tampered FAILs.
 
-The receipt is minted here rather than taken from the corpus: the anchored ML-DSA-65
-production vector (asqav-06-mldsa65-payload-prod) has a signed expires_at that lapsed
-on 2026-06-20, so it can no longer produce the PASS half. This fixture proves the CLI
-path, not wire-format conformance, which the corpus vectors carry.
+The receipt is minted here so the PASS/FAIL halves stay time-independent; this fixture
+proves the CLI path, not wire-format conformance, which the corpus vectors carry.
 """
 
 from __future__ import annotations
@@ -66,8 +64,8 @@ except ImportError:  # pragma: no cover - optional dep
     _DILITHIUM_AVAILABLE = False
 
 
+    # An anchored ML-DSA-65 receipt plus the JWKS an export would archive for it.
 def _anchored_mldsa_pair() -> tuple[dict, dict]:
-    """An anchored ML-DSA-65 receipt plus the JWKS an export would archive for it."""
     from dilithium_py.ml_dsa import ML_DSA_65
 
     pk, sk = ML_DSA_65.keygen()
@@ -104,8 +102,8 @@ def _anchored_mldsa_pair() -> tuple[dict, dict]:
     return envelope, jwks
 
 
+    # Write the three files an exit artifact carries, and nothing else.
 def _lay_out_exit_artifact(root: Path, receipt: dict, jwks: dict) -> None:
-    """Write the three files an exit artifact carries, and nothing else."""
     shutil.copy(VERIFIER_SOURCE, root / "verify_receipt.py")
     (root / "receipt.json").write_text(json.dumps(receipt))
     (root / "jwks.json").write_text(json.dumps(jwks))
@@ -122,8 +120,8 @@ def _child_env(root: Path) -> dict[str, str]:
     return {**os.environ, "PYTHONPATH": str(root)}
 
 
+    # Run the exit-manifest command verbatim, with the network refused.
 def _run_documented_command(root: Path) -> subprocess.CompletedProcess:
-    """Run the exit-manifest command verbatim, with the network refused."""
     argv = EXIT_MANIFEST_COMMAND.replace("<receipt.json>", "receipt.json").replace(
         "<jwks.json>", "jwks.json"
     ).split()
@@ -137,8 +135,8 @@ def _run_documented_command(root: Path) -> subprocess.CompletedProcess:
     )
 
 
+    # Without this control, a passing offline run proves nothing about the network.
 def test_the_network_block_actually_blocks(tmp_path: Path) -> None:
-    """Without this control, a passing offline run proves nothing about the network."""
     (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
     probe = "import urllib.request; urllib.request.urlopen('https://api.asqav.com/', timeout=5)"
     proc = subprocess.run(
@@ -176,9 +174,9 @@ def test_exit_artifact_command_fails_a_tampered_receipt(tmp_path: Path) -> None:
     assert "[FAIL] signature" in proc.stdout, proc.stdout
 
 
+    # A swapped verification key must not verify the receipt it did not sign.
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_exit_artifact_command_fails_a_tampered_jwks(tmp_path: Path) -> None:
-    """A swapped verification key must not verify the receipt it did not sign."""
     receipt, jwks = _anchored_mldsa_pair()
     _, other_jwks = _anchored_mldsa_pair()
     jwks["keys"][0]["public_key"] = other_jwks["keys"][0]["public_key"]
@@ -188,8 +186,8 @@ def test_exit_artifact_command_fails_a_tampered_jwks(tmp_path: Path) -> None:
     assert "=> FAIL" in proc.stdout, proc.stdout
 
 
+    # The exit artifact ships one file, so it must not import the rest of the SDK.
 def test_the_verifier_file_stands_alone() -> None:
-    """The exit artifact ships one file, so it must not import the rest of the SDK."""
     source = VERIFIER_SOURCE.read_text()
     assert "SPDX-License-Identifier: Apache-2.0" in source
     intra_package = [

--- a/python/tests/test_explanations.py
+++ b/python/tests/test_explanations.py
@@ -14,8 +14,8 @@ from asqav.client import Agent, PreflightResult
 # === Direct PreflightResult construction tests ===
 
 
+    # PreflightResult has an explanation field.
 def test_explanation_field_exists():
-    """PreflightResult has an explanation field."""
     result = PreflightResult(
         cleared=True,
         agent_active=True,
@@ -26,8 +26,8 @@ def test_explanation_field_exists():
     assert result.explanation == "test"
 
 
+    # explanation defaults to empty string if not provided.
 def test_explanation_defaults_to_empty():
-    """explanation defaults to empty string if not provided."""
     result = PreflightResult(
         cleared=True,
         agent_active=True,
@@ -51,11 +51,11 @@ MOCK_AGENT_DATA = {
 }
 
 
+    # When cleared, explanation says action is allowed.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_explanation_when_cleared(mock_post, mock_get):
-    """When cleared, explanation says action is allowed."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 
@@ -72,11 +72,11 @@ def test_explanation_when_cleared(mock_post, mock_get):
     assert "permitted by policy" in result.explanation
 
 
+    # When agent is revoked, explanation says agent has been revoked.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_explanation_when_revoked(mock_post, mock_get):
-    """When agent is revoked, explanation says agent has been revoked."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 
@@ -90,11 +90,11 @@ def test_explanation_when_revoked(mock_post, mock_get):
     assert "revoked" in result.explanation.lower()
 
 
+    # When agent is suspended, explanation mentions suspension.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_explanation_when_suspended(mock_post, mock_get):
-    """When agent is suspended, explanation mentions suspension."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 
@@ -108,11 +108,11 @@ def test_explanation_when_suspended(mock_post, mock_get):
     assert "suspended" in result.explanation.lower()
 
 
+    # When blocked by policy, explanation mentions policy rules.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_explanation_when_policy_blocked(mock_post, mock_get):
-    """When blocked by policy, explanation mentions policy rules."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 
@@ -126,11 +126,11 @@ def test_explanation_when_policy_blocked(mock_post, mock_get):
     assert "policy" in result.explanation.lower()
 
 
+    # When both revoked and policy-blocked, revocation is the explanation.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_explanation_revoked_takes_priority_over_policy(mock_post, mock_get):
-    """When both revoked and policy-blocked, revocation is the explanation."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 

--- a/python/tests/test_extras.py
+++ b/python/tests/test_extras.py
@@ -30,8 +30,8 @@ def _module_installed(name: str) -> bool:
 # -- Packaging tests (no framework deps needed) --
 
 
+    # Parse pyproject.toml and return optional-dependencies.
 def _read_pyproject() -> dict:
-    """Parse pyproject.toml and return optional-dependencies."""
     pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
     assert pyproject_path.exists(), "pyproject.toml not found"
 
@@ -44,8 +44,8 @@ def _read_pyproject() -> dict:
         return tomllib.load(f)
 
 
+    # All 6 framework extras are defined in pyproject.toml optional-dependencies.
 def test_extras_defined_in_pyproject():
-    """All 6 framework extras are defined in pyproject.toml optional-dependencies."""
     data = _read_pyproject()
     opt_deps = data["project"]["optional-dependencies"]
 
@@ -54,8 +54,8 @@ def test_extras_defined_in_pyproject():
         assert extra in opt_deps, f"Missing extra: {extra}"
 
 
+    # The 'all' extra includes deps from all framework extras.
 def test_all_extra_includes_everything():
-    """The 'all' extra includes deps from all framework extras."""
     data = _read_pyproject()
     opt_deps = data["project"]["optional-dependencies"]
 
@@ -73,16 +73,16 @@ def test_all_extra_includes_everything():
             )
 
 
+    # Base asqav import works without any extras installed.
 def test_base_import_no_extras():
-    """Base asqav import works without any extras installed."""
     import asqav
 
     assert hasattr(asqav, "__version__")
     assert hasattr(asqav, "init")
 
 
+    # The extras package itself is importable.
 def test_extras_package_importable():
-    """The extras package itself is importable."""
     from asqav import extras
 
     assert extras.__doc__ is not None
@@ -104,9 +104,9 @@ def _purge(*module_names: str) -> None:
         sys.modules.pop(name, None)
 
 
+    # Importing langchain stub raises ImportError when langchain-core is not installed.
 @pytest.mark.skipif(_module_installed("langchain_core"), reason="langchain-core installed; stub error path is unreachable in this env")
 def test_langchain_stub_import_error():
-    """Importing langchain stub raises ImportError when langchain-core is not installed."""
     _purge("asqav.extras.langchain", "langchain_core", "langchain_core.callbacks")
     with pytest.raises(ImportError, match="pip install asqav"):
         import asqav.extras.langchain  # noqa: F401
@@ -125,25 +125,25 @@ def test_crewai_stub_import_error():
     assert "crewai" not in sys.modules
 
 
+    # Importing litellm stub raises ImportError when litellm is not installed.
 @pytest.mark.skipif(_module_installed("litellm"), reason="litellm installed; stub error path is unreachable in this env")
 def test_litellm_stub_import_error():
-    """Importing litellm stub raises ImportError when litellm is not installed."""
     _purge("asqav.extras.litellm", "litellm")
     with pytest.raises(ImportError, match="pip install asqav"):
         import asqav.extras.litellm  # noqa: F401
 
 
+    # Importing haystack stub raises ImportError when haystack-ai is not installed.
 @pytest.mark.skipif(_module_installed("haystack"), reason="haystack-ai installed; stub error path is unreachable in this env")
 def test_haystack_stub_import_error():
-    """Importing haystack stub raises ImportError when haystack-ai is not installed."""
     _purge("asqav.extras.haystack", "haystack", "haystack.dataclasses")
     with pytest.raises(ImportError, match="pip install asqav"):
         import asqav.extras.haystack  # noqa: F401
 
 
+    # Importing openai_agents stub raises ImportError when openai-agents is not installed.
 @pytest.mark.skipif(_module_installed("agents"), reason="openai-agents installed; stub error path is unreachable in this env")
 def test_openai_agents_stub_import_error():
-    """Importing openai_agents stub raises ImportError when openai-agents is not installed."""
     _purge("asqav.extras.openai_agents", "agents", "agents.tracing")
     with pytest.raises(ImportError, match="pip install asqav"):
         import asqav.extras.openai_agents  # noqa: F401

--- a/python/tests/test_fastapi_middleware.py
+++ b/python/tests/test_fastapi_middleware.py
@@ -19,8 +19,8 @@ _original_modules: dict[str, Any] = {}
 _MISSING = object()
 
 
+    # Inject fake fastapi/starlette modules.
 def _install_fastapi_mocks() -> None:
-    """Inject fake fastapi/starlette modules."""
     for mod_name in (
         "fastapi",
         "fastapi.middleware",
@@ -86,8 +86,8 @@ def _install_fastapi_mocks() -> None:
     sys.modules["uvicorn"] = ModuleType("uvicorn")
 
 
+    # Restore sys.modules to pre-mock state.
 def _remove_fastapi_mocks() -> None:
-    """Restore sys.modules to pre-mock state."""
     for mod_name, original in _original_modules.items():
         if original is _MISSING:
             sys.modules.pop(mod_name, None)
@@ -102,9 +102,9 @@ _install_fastapi_mocks()
 # === Fixtures ===
 
 
+    # Create a mock asqav agent.
 @pytest.fixture()
 def mock_agent():
-    """Create a mock asqav agent."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -121,15 +121,15 @@ def mock_agent():
 # === Basic Tests ===
 
 
+    # Verify the FastAPI middleware example file exists.
 def test_fastapi_middleware_file_exists():
-    """Verify the FastAPI middleware example file exists."""
     import os
     file_path = os.path.join(os.path.dirname(__file__), "..", "examples", "fastapi_middleware.py")
     assert os.path.exists(file_path), f"FastAPI middleware example not found at {file_path}"
 
 
+    # Verify the FastAPI middleware example has required functions.
 def test_fastapi_middleware_has_required_functions():
-    """Verify the FastAPI middleware example has required functions."""
     import os
     file_path = os.path.join(os.path.dirname(__file__), "..", "examples", "fastapi_middleware.py")
     with open(file_path, "r") as f:
@@ -145,8 +145,8 @@ def test_fastapi_middleware_has_required_functions():
     assert "@app.get(\"/api/compliance/report\")" in content
 
 
+    # Verify the FastAPI middleware has fail-open behavior.
 def test_fastapi_middleware_has_fail_open():
-    """Verify the FastAPI middleware has fail-open behavior."""
     import os
     file_path = os.path.join(os.path.dirname(__file__), "..", "examples", "fastapi_middleware.py")
     with open(file_path, "r") as f:
@@ -155,8 +155,8 @@ def test_fastapi_middleware_has_fail_open():
     assert "fail-open" in content.lower() or "AsqavError" in content
 
 
+    # Verify the FastAPI middleware has rate limiting.
 def test_fastapi_middleware_has_rate_limiting():
-    """Verify the FastAPI middleware has rate limiting."""
     import os
     file_path = os.path.join(os.path.dirname(__file__), "..", "examples", "fastapi_middleware.py")
     with open(file_path, "r") as f:
@@ -166,8 +166,8 @@ def test_fastapi_middleware_has_rate_limiting():
     assert "429" in content
 
 
+    # Verify the FastAPI middleware has content policy enforcement.
 def test_fastapi_middleware_has_content_policy():
-    """Verify the FastAPI middleware has content policy enforcement."""
     import os
     file_path = os.path.join(os.path.dirname(__file__), "..", "examples", "fastapi_middleware.py")
     with open(file_path, "r") as f:
@@ -177,8 +177,8 @@ def test_fastapi_middleware_has_content_policy():
     assert "413" in content
 
 
+    # Verify the FastAPI middleware signs AI events.
 def test_fastapi_middleware_signs_events():
-    """Verify the FastAPI middleware signs AI events."""
     import os
     file_path = os.path.join(os.path.dirname(__file__), "..", "examples", "fastapi_middleware.py")
     with open(file_path, "r") as f:
@@ -192,6 +192,6 @@ def test_fastapi_middleware_signs_events():
 # === Cleanup ===
 
 
+    # Remove mock fastapi/starlette from sys.modules.
 def teardown_module() -> None:
-    """Remove mock fastapi/starlette from sys.modules."""
     _remove_fastapi_mocks()

--- a/python/tests/test_govern.py
+++ b/python/tests/test_govern.py
@@ -39,8 +39,8 @@ def _make_agent() -> Agent:
 # === Tests ===
 
 
+    # govern() calls init() then Agent.create() with the right args.
 def test_govern_calls_init_and_create() -> None:
-    """govern() calls init() then Agent.create() with the right args."""
     agent = _make_agent()
 
     with patch("asqav.client.init") as mock_init, patch.object(
@@ -61,8 +61,8 @@ def test_govern_calls_init_and_create() -> None:
     assert result.agent_id == "agt_govern_01"
 
 
+    # When agent_id is supplied govern() calls Agent.get, not Agent.create.
 def test_govern_retrieves_existing_agent_by_id() -> None:
-    """When agent_id is supplied govern() calls Agent.get, not Agent.create."""
     agent = _make_agent()
 
     with patch("asqav.client.init"), patch.object(
@@ -75,8 +75,8 @@ def test_govern_retrieves_existing_agent_by_id() -> None:
     assert result is agent
 
 
+    # govern() forwards algorithm and capabilities to Agent.create.
 def test_govern_passes_capabilities_and_algorithm() -> None:
-    """govern() forwards algorithm and capabilities to Agent.create."""
     agent = _make_agent()
 
     with patch("asqav.client.init"), patch.object(
@@ -94,13 +94,13 @@ def test_govern_passes_capabilities_and_algorithm() -> None:
     )
 
 
+    # asqav.govern is importable directly from the package.
 def test_govern_exported_from_package() -> None:
-    """asqav.govern is importable directly from the package."""
     assert callable(asqav.govern)
 
 
+    # govern() uses 'default-agent' when agent_name is omitted.
 def test_govern_default_agent_name() -> None:
-    """govern() uses 'default-agent' when agent_name is omitted."""
     agent = _make_agent()
 
     with patch("asqav.client.init"), patch.object(

--- a/python/tests/test_guardrail_provider.py
+++ b/python/tests/test_guardrail_provider.py
@@ -21,9 +21,9 @@ from asqav.extras.crewai import AsqavGuardrailProvider  # noqa: E402
 # === Fixtures ===
 
 
+    # Create an AsqavGuardrailProvider with mocked Agent.
 @pytest.fixture()
 def provider():
-    """Create an AsqavGuardrailProvider with mocked Agent."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -34,8 +34,8 @@ def provider():
     return p
 
 
+    # Create a mock tool call request.
 def _make_request(tool_name: str = "search", tool_input: dict | None = None):
-    """Create a mock tool call request."""
     req = MagicMock()
     req.tool_name = tool_name
     req.tool_input = tool_input if tool_input is not None else {"query": "test"}
@@ -45,8 +45,8 @@ def _make_request(tool_name: str = "search", tool_input: dict | None = None):
 # === Evaluate - allow ===
 
 
+    # evaluate returns allow when preflight clears.
 def test_evaluate_allow(provider):
-    """evaluate returns allow when preflight clears."""
     provider._agent.preflight.return_value = PreflightResult(
         cleared=True,
         agent_active=True,
@@ -76,8 +76,8 @@ def test_evaluate_allow(provider):
 # === Evaluate - deny ===
 
 
+    # evaluate returns deny when preflight blocks.
 def test_evaluate_deny(provider):
-    """evaluate returns deny when preflight blocks."""
     provider._agent.preflight.return_value = PreflightResult(
         cleared=False,
         agent_active=True,
@@ -101,8 +101,8 @@ def test_evaluate_deny(provider):
 # === Edge cases ===
 
 
+    # evaluate handles request without tool_name attribute.
 def test_evaluate_unknown_tool(provider):
-    """evaluate handles request without tool_name attribute."""
     provider._agent.preflight.return_value = PreflightResult(
         cleared=True,
         agent_active=True,
@@ -127,8 +127,8 @@ def test_evaluate_unknown_tool(provider):
     provider._agent.preflight.assert_called_once_with("tool:unknown")
 
 
+    # evaluate passes sorted input keys in signing context.
 def test_evaluate_input_keys_sorted(provider):
-    """evaluate passes sorted input keys in signing context."""
     provider._agent.preflight.return_value = PreflightResult(
         cleared=True,
         agent_active=True,
@@ -154,8 +154,8 @@ def test_evaluate_input_keys_sorted(provider):
     assert ctx["input_keys"] == ["a_param", "m_param", "z_param"]
 
 
+    # evaluate returns None signature_id when signing fails (fail-open).
 def test_evaluate_sign_failure_returns_none_signature(provider):
-    """evaluate returns None signature_id when signing fails (fail-open)."""
     from asqav.client import AsqavError
 
     provider._agent.preflight.return_value = PreflightResult(
@@ -177,9 +177,9 @@ def test_evaluate_sign_failure_returns_none_signature(provider):
 # === Cleanup ===
 
 
+    # Remove fake crewai from sys.modules after all tests.
 @pytest.fixture(autouse=True, scope="module")
 def _cleanup_crewai_module():
-    """Remove fake crewai from sys.modules after all tests."""
     yield
     sys.modules.pop("crewai", None)
     sys.modules.pop("asqav.extras.crewai", None)

--- a/python/tests/test_haystack_integration.py
+++ b/python/tests/test_haystack_integration.py
@@ -17,16 +17,16 @@ from asqav.client import SignatureResponse
 _mock_haystack = ModuleType("haystack")
 
 
+    # Mock for haystack.component decorator.
 class _MockComponent:
-    """Mock for haystack.component decorator."""
 
+        # Decorator: return the class unchanged.
     def __call__(self, cls):
-        """Decorator: return the class unchanged."""
         return cls
 
+        # Return a no-op decorator for output type declarations.
     @staticmethod
     def output_types(**kwargs):
-        """Return a no-op decorator for output type declarations."""
         def decorator(func):
             return func
         return decorator
@@ -46,8 +46,8 @@ MOCK_SIGN_RESPONSE: dict = {
 }
 
 
+    # Create a component with mocked Agent.
 def _make_component() -> AsqavComponent:
-    """Create a component with mocked Agent."""
     with patch("asqav.client._api_key", "sk_test"), \
          patch("asqav.extras._base.Agent") as mock_agent_cls:
         mock_agent_cls.create.return_value = MagicMock()
@@ -106,8 +106,8 @@ class TestRun:
 
         assert result["signature_id"] is None
 
+        # run() still returns data even when signing raises.
     def test_fail_open_on_sign_error(self):
-        """run() still returns data even when signing raises."""
         comp = _make_component()
         comp._sign_action = MagicMock(return_value=None)
 

--- a/python/tests/test_hooks.py
+++ b/python/tests/test_hooks.py
@@ -15,8 +15,8 @@ import asqav  # noqa: E402
 from asqav import hooks as hooks_module  # noqa: E402
 
 
+    # Construct an Agent without hitting the API.
 def _make_agent() -> "asqav.Agent":
-    """Construct an Agent without hitting the API."""
     return asqav.Agent(
         agent_id="agent_test",
         name="test",
@@ -38,17 +38,17 @@ def _ok_response() -> dict:
     }
 
 
+    # Clear hook registry before and after each test.
 @pytest.fixture(autouse=True)
 def _clean_hooks():
-    """Clear hook registry before and after each test."""
     asqav.clear_hooks()
     yield
     asqav.clear_hooks()
 
 
+    # A before-hook can add fields that land in the body sent to the API.
 @patch("asqav.client._post")
 def test_register_before_mutates_context_reaching_sign(mock_post: object) -> None:
-    """A before-hook can add fields that land in the body sent to the API."""
     mock_post.return_value = _ok_response()  # type: ignore[attr-defined]
 
     def add_field(action_type: str, context: dict) -> dict:
@@ -65,9 +65,9 @@ def test_register_before_mutates_context_reaching_sign(mock_post: object) -> Non
     assert sent_body["context"]["orig"] == "yes"
 
 
+    # After-hooks receive the SignatureResponse object.
 @patch("asqav.client._post")
 def test_register_after_fires_with_signature_response(mock_post: object) -> None:
-    """After-hooks receive the SignatureResponse object."""
     mock_post.return_value = _ok_response()  # type: ignore[attr-defined]
 
     seen: list[object] = []
@@ -81,9 +81,9 @@ def test_register_after_fires_with_signature_response(mock_post: object) -> None
     assert seen[0].signature_id == "sig_01"  # type: ignore[attr-defined]
 
 
+    # A raising hook is logged and signing still returns a response.
 @patch("asqav.client._post")
 def test_failing_hook_does_not_crash_sign(mock_post: object) -> None:
-    """A raising hook is logged and signing still returns a response."""
     mock_post.return_value = _ok_response()  # type: ignore[attr-defined]
 
     def boom_before(action_type: str, context: dict) -> dict:
@@ -101,9 +101,9 @@ def test_failing_hook_does_not_crash_sign(mock_post: object) -> None:
     assert response.signature_id == "sig_01"
 
 
+    # ``strands:*`` matches strands:model_call but not langchain:tool_call.
 @patch("asqav.client._post")
 def test_pattern_matching_strands_glob(mock_post: object) -> None:
-    """``strands:*`` matches strands:model_call but not langchain:tool_call."""
     mock_post.return_value = _ok_response()  # type: ignore[attr-defined]
 
     matched: list[str] = []
@@ -121,8 +121,8 @@ def test_pattern_matching_strands_glob(mock_post: object) -> None:
     assert matched == ["strands:model_call"]
 
 
+    # clear_hooks removes both before and after registrations.
 def test_clear_hooks_empties_registry() -> None:
-    """clear_hooks removes both before and after registrations."""
     asqav.register_before("*", lambda a, c: c)
     asqav.register_after("*", lambda r: None)
 

--- a/python/tests/test_instructor_integration.py
+++ b/python/tests/test_instructor_integration.py
@@ -62,9 +62,9 @@ HookName = _install_instructor_mocks()
 from asqav.extras.instructor import AsqavInstructorHook  # noqa: E402
 
 
+    # Build a hook with _sign_action mocked so we can assert calls.
 @pytest.fixture
 def hook() -> AsqavInstructorHook:
-    """Build a hook with _sign_action mocked so we can assert calls."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -123,8 +123,8 @@ def test_on_kwargs_signs_start(hook: AsqavInstructorHook) -> None:
     )
 
 
+    # Missing model and response_model still produce a clean signed payload.
 def test_on_kwargs_handles_missing_fields(hook: AsqavInstructorHook) -> None:
-    """Missing model and response_model still produce a clean signed payload."""
     hook._on_kwargs()
     args, _ = hook._sign_action.call_args
     assert args[0] == "instructor.completion.start"

--- a/python/tests/test_jcs.py
+++ b/python/tests/test_jcs.py
@@ -107,8 +107,8 @@ GOLDEN_VECTORS = [
 ]
 
 
+    # Sorted-keys serialization of the IETF envelope vector.
 def _expected_envelope() -> str:
-    """Sorted-keys serialization of the IETF envelope vector."""
     import json
 
     return json.dumps(
@@ -138,24 +138,24 @@ GOLDEN_VECTORS[-1] = (
 )
 
 
+    # Each golden vector serializes to its expected canonical string.
 @pytest.mark.parametrize(
     "name,obj,expected",
     GOLDEN_VECTORS,
     ids=[name for name, _, _ in GOLDEN_VECTORS],
 )
 def test_golden_vector_matches(name: str, obj, expected: str) -> None:
-    """Each golden vector serializes to its expected canonical string."""
     actual = canonical_json(obj).decode("utf-8")
     assert actual == expected, f"{name}: drift\n  expected: {expected!r}\n  actual:   {actual!r}"
 
 
+    # `_jcs.canonical_json` and `canonicalize.canonicalize` agree byte-for-byte.
 @pytest.mark.parametrize(
     "name,obj,expected",
     GOLDEN_VECTORS,
     ids=[name for name, _, _ in GOLDEN_VECTORS],
 )
 def test_byte_equality_with_canonicalize_alias(name: str, obj, expected: str) -> None:
-    """`_jcs.canonical_json` and `canonicalize.canonicalize` agree byte-for-byte."""
     assert canonical_json(obj) == canonicalize(obj), f"{name}: drift"
 
 
@@ -177,8 +177,8 @@ def test_negative_infinity_is_rejected() -> None:
         canonical_json({"x": float("-inf")})
 
 
+    # Same logical object -> same bytes regardless of dict insertion order.
 def test_insertion_order_does_not_change_bytes() -> None:
-    """Same logical object -> same bytes regardless of dict insertion order."""
     a = {"z": 1, "y": 2, "x": 3}
     b = {"x": 3, "y": 2, "z": 1}
     assert canonical_json(a) == canonical_json(b)
@@ -188,8 +188,8 @@ def test_no_insignificant_whitespace() -> None:
     assert canonical_json({"a": 1, "b": [1, 2]}) == b'{"a":1,"b":[1,2]}'
 
 
+    # `asqav.canonical_json` is part of the public surface.
 def test_re_export_at_package_root() -> None:
-    """`asqav.canonical_json` is part of the public surface."""
     import asqav
 
     assert asqav.canonical_json is canonical_json

--- a/python/tests/test_keys_alg_agility.py
+++ b/python/tests/test_keys_alg_agility.py
@@ -29,8 +29,8 @@ def test_supported_algorithms_set() -> None:
     )
 
 
+    # Identifier strings match the cloud's SignatureRecord.algorithm column.
 def test_constants_match_spec_strings() -> None:
-    """Identifier strings match the cloud's SignatureRecord.algorithm column."""
     assert ALGORITHM_ML_DSA_65 == "ml-dsa-65"
     assert ALGORITHM_ED25519 == "ed25519"
     assert ALGORITHM_ES256 == "es256"
@@ -58,8 +58,8 @@ def test_check_algorithm_rejects_unknown() -> None:
         _check_algorithm("rsa")
 
 
+    # ml-dsa-65 keypair generation is server-side only.
 def test_check_algorithm_rejects_ml_dsa_65() -> None:
-    """ml-dsa-65 keypair generation is server-side only."""
     with pytest.raises(ValueError, match="unsupported_algorithm"):
         _check_algorithm("ml-dsa-65")
 
@@ -75,8 +75,8 @@ def test_ed25519_keypair_generates_pem() -> None:
     assert kp.public_key_pem.startswith(b"-----BEGIN PUBLIC KEY-----")
 
 
+    # The PEM-encoded public key parses back to a valid Ed25519 key.
 def test_ed25519_public_key_round_trips() -> None:
-    """The PEM-encoded public key parses back to a valid Ed25519 key."""
     pytest.importorskip("cryptography")
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -86,8 +86,8 @@ def test_ed25519_public_key_round_trips() -> None:
     assert isinstance(pub, ed25519.Ed25519PublicKey)
 
 
+    # End-to-end: generate, sign with private, verify with public.
 def test_ed25519_signs_and_verifies() -> None:
-    """End-to-end: generate, sign with private, verify with public."""
     pytest.importorskip("cryptography")
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -115,8 +115,8 @@ def test_es256_keypair_generates_pem() -> None:
     assert kp.public_key_pem.startswith(b"-----BEGIN PUBLIC KEY-----")
 
 
+    # ES256 means ECDSA over the P-256 curve.
 def test_es256_curve_is_p256() -> None:
-    """ES256 means ECDSA over the P-256 curve."""
     pytest.importorskip("cryptography")
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric import ec
@@ -154,8 +154,8 @@ def test_ml_dsa_65_local_generation_rejected() -> None:
         generate_local_keypair("ml-dsa-65")  # type: ignore[arg-type]
 
 
+    # `generate_local_keypair()` with no args defaults to ed25519.
 def test_default_algorithm_is_ed25519() -> None:
-    """`generate_local_keypair()` with no args defaults to ed25519."""
     pytest.importorskip("cryptography")
     kp = generate_local_keypair()
     assert kp.algorithm == "ed25519"
@@ -169,8 +169,8 @@ def test_unsupported_algorithm_raises_value_error() -> None:
         generate_local_keypair("rsa")  # type: ignore[arg-type]
 
 
+    # LocalKeypair is a plain dataclass; no extra state survives.
 def test_local_keypair_carries_only_pem_bytes() -> None:
-    """LocalKeypair is a plain dataclass; no extra state survives."""
     pytest.importorskip("cryptography")
     kp = generate_local_keypair("ed25519")
     assert isinstance(kp.private_key_pem, bytes)

--- a/python/tests/test_langchain_integration.py
+++ b/python/tests/test_langchain_integration.py
@@ -31,8 +31,8 @@ _MISSING = object()
 _FAKE_CONFIGURE_HOOKS: list = []
 
 
+    # Inject fake langchain_core modules and return the BaseCallbackHandler class.
 def _install_langchain_mocks() -> type:
-    """Inject fake langchain_core modules and return the BaseCallbackHandler class."""
     # Save originals so we can restore later
     for mod_name in (
         "langchain_core",
@@ -44,15 +44,15 @@ def _install_langchain_mocks() -> type:
         _original_modules[mod_name] = sys.modules.get(mod_name, _MISSING)  # type: ignore[arg-type]
 
     # Create BaseCallbackHandler as a real class (not MagicMock) so MRO works
+        # Mock LangChain BaseCallbackHandler.
     class BaseCallbackHandler:
-        """Mock LangChain BaseCallbackHandler."""
 
         def __init__(self) -> None:
             pass
 
     # Create LLMResult as a simple data class
+        # Mock LangChain LLMResult.
     class LLMResult:
-        """Mock LangChain LLMResult."""
 
         def __init__(
             self,
@@ -62,10 +62,10 @@ def _install_langchain_mocks() -> type:
             self.generations = generations or []
             self.llm_output = llm_output
 
+        # Mock of langchain_core.tracers.context.register_configure_hook.
     def register_configure_hook(
         context_var, inheritable, handle_class=None, env_var=None
     ) -> None:
-        """Mock of langchain_core.tracers.context.register_configure_hook."""
         _FAKE_CONFIGURE_HOOKS.append(
             (context_var, inheritable, handle_class, env_var)
         )
@@ -94,8 +94,8 @@ def _install_langchain_mocks() -> type:
     return LLMResult
 
 
+    # Restore sys.modules to pre-mock state.
 def _remove_langchain_mocks() -> None:
-    """Restore sys.modules to pre-mock state."""
     for mod_name, original in _original_modules.items():
         if original is _MISSING:
             sys.modules.pop(mod_name, None)
@@ -116,9 +116,9 @@ from asqav.extras.langchain import AsqavCallbackHandler  # noqa: E402, I001
 # === Fixtures ===
 
 
+    # Create an AsqavCallbackHandler with mocked Agent internals.
 @pytest.fixture()
 def handler():
-    """Create an AsqavCallbackHandler with mocked Agent internals."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -133,8 +133,8 @@ def handler():
 # === Chain callback tests ===
 
 
+    # on_chain_start signs chain:start with chain name and input keys.
 def test_on_chain_start_signs_action(handler):
-    """on_chain_start signs chain:start with chain name and input keys."""
     handler.on_chain_start(
         serialized={"name": "RetrievalQA", "id": ["langchain", "chains", "RetrievalQA"]},
         inputs={"query": "what is asqav?"},
@@ -145,8 +145,8 @@ def test_on_chain_start_signs_action(handler):
     )
 
 
+    # on_chain_start uses last element of id when name is missing.
 def test_on_chain_start_falls_back_to_id(handler):
-    """on_chain_start uses last element of id when name is missing."""
     handler.on_chain_start(
         serialized={"id": ["langchain", "chains", "LLMChain"]},
         inputs={"prompt": "hello"},
@@ -157,8 +157,8 @@ def test_on_chain_start_falls_back_to_id(handler):
     )
 
 
+    # on_chain_end signs chain:end with output keys.
 def test_on_chain_end_signs_action(handler):
-    """on_chain_end signs chain:end with output keys."""
     handler.on_chain_end(outputs={"result": "answer", "source_documents": []})
     handler._sign_action.assert_called_once_with(
         "chain:end",
@@ -166,8 +166,8 @@ def test_on_chain_end_signs_action(handler):
     )
 
 
+    # on_chain_error signs chain:error with error type and message.
 def test_on_chain_error_signs_action(handler):
-    """on_chain_error signs chain:error with error type and message."""
     handler.on_chain_error(error=ValueError("bad input"))
     handler._sign_action.assert_called_once_with(
         "chain:error",
@@ -178,8 +178,8 @@ def test_on_chain_error_signs_action(handler):
 # === Tool callback tests ===
 
 
+    # on_tool_start signs tool:start with tool name and input.
 def test_on_tool_start_signs_action(handler):
-    """on_tool_start signs tool:start with tool name and input."""
     handler.on_tool_start(
         serialized={"name": "Calculator"},
         input_str="2 + 2",
@@ -190,8 +190,8 @@ def test_on_tool_start_signs_action(handler):
     )
 
 
+    # on_tool_end signs tool:end with output type and length.
 def test_on_tool_end_signs_action(handler):
-    """on_tool_end signs tool:end with output type and length."""
     handler.on_tool_end(output="4")
     handler._sign_action.assert_called_once_with(
         "tool:end",
@@ -199,8 +199,8 @@ def test_on_tool_end_signs_action(handler):
     )
 
 
+    # on_tool_error signs tool:error with error details.
 def test_on_tool_error_signs_action(handler):
-    """on_tool_error signs tool:error with error details."""
     handler.on_tool_error(error=RuntimeError("tool broke"))
     handler._sign_action.assert_called_once_with(
         "tool:error",
@@ -211,8 +211,8 @@ def test_on_tool_error_signs_action(handler):
 # === LLM callback tests ===
 
 
+    # on_llm_start signs llm:start with model name and prompt count.
 def test_on_llm_start_signs_action(handler):
-    """on_llm_start signs llm:start with model name and prompt count."""
     handler.on_llm_start(
         serialized={"name": "gpt-4", "id": ["langchain", "llms", "openai"]},
         prompts=["Hello", "World"],
@@ -223,8 +223,8 @@ def test_on_llm_start_signs_action(handler):
     )
 
 
+    # on_llm_end signs llm:end with generation count and token usage.
 def test_on_llm_end_signs_action(handler):
-    """on_llm_end signs llm:end with generation count and token usage."""
     response = LLMResult(
         generations=[["gen1", "gen2"]],
         llm_output={"token_usage": {"prompt_tokens": 10, "completion_tokens": 20}},
@@ -239,8 +239,8 @@ def test_on_llm_end_signs_action(handler):
     )
 
 
+    # on_llm_end works when llm_output has no token_usage.
 def test_on_llm_end_no_token_usage(handler):
-    """on_llm_end works when llm_output has no token_usage."""
     response = LLMResult(generations=[["gen1"]], llm_output={})
     handler.on_llm_end(response=response)
     handler._sign_action.assert_called_once_with(
@@ -249,8 +249,8 @@ def test_on_llm_end_no_token_usage(handler):
     )
 
 
+    # on_llm_end works when llm_output is None.
 def test_on_llm_end_no_llm_output(handler):
-    """on_llm_end works when llm_output is None."""
     response = LLMResult(generations=[[]], llm_output=None)
     handler.on_llm_end(response=response)
     handler._sign_action.assert_called_once_with(
@@ -259,8 +259,8 @@ def test_on_llm_end_no_llm_output(handler):
     )
 
 
+    # on_llm_error signs llm:error with error details.
 def test_on_llm_error_signs_action(handler):
-    """on_llm_error signs llm:error with error details."""
     handler.on_llm_error(error=TimeoutError("model timeout"))
     handler._sign_action.assert_called_once_with(
         "llm:error",
@@ -271,8 +271,8 @@ def test_on_llm_error_signs_action(handler):
 # === Edge cases and fail-open ===
 
 
+    # Long tool inputs are truncated to 200 chars.
 def test_tool_input_truncated(handler):
-    """Long tool inputs are truncated to 200 chars."""
     long_input = "x" * 500
     handler.on_tool_start(serialized={"name": "Search"}, input_str=long_input)
 
@@ -331,9 +331,9 @@ def _collect_default_handlers() -> list:
     return handlers
 
 
+    # Reset the configure-hook registry and the one-time registration flag.
 @pytest.fixture()
 def clean_hook_state():
-    """Reset the configure-hook registry and the one-time registration flag."""
     _FAKE_CONFIGURE_HOOKS.clear()
     _lc_mod._hook_registered = False
     _lc_mod._ASQAV_LC_HANDLER.set(None)
@@ -343,8 +343,8 @@ def clean_hook_state():
     _lc_mod._ASQAV_LC_HANDLER.set(None)
 
 
+    # One call registers exactly one langchain configure hook.
 def test_enable_registers_configure_hook(clean_hook_state):
-    """One call registers exactly one langchain configure hook."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -404,8 +404,8 @@ def test_on_chain_start_none_serialized_signs_receipt(handler):
     )
 
 
+    # on_chain_start with a non-dict serialized still signs a receipt.
 def test_on_chain_start_non_dict_serialized_signs_receipt(handler):
-    """on_chain_start with a non-dict serialized still signs a receipt."""
     handler.on_chain_start(
         serialized="some-string",  # type: ignore[arg-type]
         inputs={"q": "x"},
@@ -451,8 +451,8 @@ def test_on_chain_start_dict_serialized_non_dict_inputs_signs_receipt(handler):
     )
 
 
+    # Repeated enable calls register the hook once and rebind the ContextVar.
 def test_enable_hook_registered_once_across_calls(clean_hook_state):
-    """Repeated enable calls register the hook once and rebind the ContextVar."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -468,6 +468,6 @@ def test_enable_hook_registered_once_across_calls(clean_hook_state):
 # === Cleanup: restore sys.modules ===
 
 
+    # Remove mock langchain_core from sys.modules.
 def teardown_module() -> None:
-    """Remove mock langchain_core from sys.modules."""
     _remove_langchain_mocks()

--- a/python/tests/test_letta_integration.py
+++ b/python/tests/test_letta_integration.py
@@ -27,11 +27,11 @@ from asqav.extras.letta import AsqavLettaHook  # noqa: E402
 # === Helpers ===
 
 
+    # Create a minimal mock letta Letta client with strict keyword-only blocks API.
 def _make_client(
     retrieve_result: Any = None,
     update_result: Any = None,
 ) -> MagicMock:
-    """Create a minimal mock letta Letta client with strict keyword-only blocks API."""
     client = MagicMock()
     block_obj = MagicMock()
     block_obj.value = "stored memory content"
@@ -51,9 +51,9 @@ def _make_client(
 # === Fixtures ===
 
 
+    # Create an AsqavLettaHook with mocked Agent internals.
 @pytest.fixture()
 def hook() -> AsqavLettaHook:
-    """Create an AsqavLettaHook with mocked Agent internals."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -67,8 +67,8 @@ def hook() -> AsqavLettaHook:
 # === Canonical API: positional block_label, keyword-only agent_id ===
 
 
+    # retrieve('human', agent_id='agent-123') matches the real letta-client signature.
 def test_retrieve_canonical_positional_form(hook: AsqavLettaHook) -> None:
-    """retrieve('human', agent_id='agent-123') matches the real letta-client signature."""
     client = _make_client()
     hook.wrap_client(client)
     # This is the canonical call form - must not raise TypeError.
@@ -79,8 +79,8 @@ def test_retrieve_canonical_positional_form(hook: AsqavLettaHook) -> None:
     assert ctx["agent_id"] == "agent-123"
 
 
+    # update('persona', agent_id='a', value='v') matches the real letta-client signature.
 def test_update_canonical_positional_form(hook: AsqavLettaHook) -> None:
-    """update('persona', agent_id='a', value='v') matches the real letta-client signature."""
     client = _make_client()
     hook.wrap_client(client)
     client.agents.blocks.update("persona", agent_id="agent-456", value="hi")
@@ -90,8 +90,8 @@ def test_update_canonical_positional_form(hook: AsqavLettaHook) -> None:
     assert ctx["agent_id"] == "agent-456"
 
 
+    # Partial update omitting value (e.g. updating limit) produces no memory:write events.
 def test_update_without_value_does_not_sign_memory_write(hook: AsqavLettaHook) -> None:
-    """Partial update omitting value (e.g. updating limit) produces no memory:write events."""
     client = _make_client()
     hook.wrap_client(client)
     client.agents.blocks.update("human", agent_id="a", limit=2000)
@@ -99,8 +99,8 @@ def test_update_without_value_does_not_sign_memory_write(hook: AsqavLettaHook) -
     assert hook._sign_action.call_count == 0
 
 
+    # Partial update is forwarded to the original update without value kwarg.
 def test_update_without_value_still_calls_original(hook: AsqavLettaHook) -> None:
-    """Partial update is forwarded to the original update without value kwarg."""
     client = _make_client()
     original_update = client.agents.blocks.update  # capture before wrap replaces it
     hook.wrap_client(client)
@@ -113,8 +113,8 @@ def test_update_without_value_still_calls_original(hook: AsqavLettaHook) -> None
 # === wrap_client: memory:read ===
 
 
+    # wrap_client signs memory:read with agent_id and block_label.
 def test_wrap_client_signs_memory_read(hook: AsqavLettaHook) -> None:
-    """wrap_client signs memory:read with agent_id and block_label."""
     client = _make_client()
     hook.wrap_client(client)
     client.agents.blocks.retrieve("human", agent_id="agent-123")
@@ -126,8 +126,8 @@ def test_wrap_client_signs_memory_read(hook: AsqavLettaHook) -> None:
     assert ctx["block_label"] == "human"
 
 
+    # wrap_client signs memory:read.end with value_length after retrieve.
 def test_wrap_client_signs_memory_read_end(hook: AsqavLettaHook) -> None:
-    """wrap_client signs memory:read.end with value_length after retrieve."""
     block = MagicMock()
     block.value = "hello world"
     client = _make_client(retrieve_result=block)
@@ -140,8 +140,8 @@ def test_wrap_client_signs_memory_read_end(hook: AsqavLettaHook) -> None:
     assert ctx["value_length"] == len("hello world")
 
 
+    # A successful retrieve produces exactly memory:read + memory:read.end.
 def test_wrap_client_signs_two_events_on_successful_read(hook: AsqavLettaHook) -> None:
-    """A successful retrieve produces exactly memory:read + memory:read.end."""
     client = _make_client()
     hook.wrap_client(client)
     client.agents.blocks.retrieve("persona", agent_id="a")
@@ -151,8 +151,8 @@ def test_wrap_client_signs_two_events_on_successful_read(hook: AsqavLettaHook) -
     assert hook._sign_action.call_args_list[1][0][0] == "memory:read.end"
 
 
+    # wrap_client does not alter the retrieve return value.
 def test_wrap_client_retrieve_returns_original_result(hook: AsqavLettaHook) -> None:
-    """wrap_client does not alter the retrieve return value."""
     sentinel = object()
     client = _make_client(retrieve_result=sentinel)
     hook.wrap_client(client)
@@ -163,8 +163,8 @@ def test_wrap_client_retrieve_returns_original_result(hook: AsqavLettaHook) -> N
 # === wrap_client: memory:write ===
 
 
+    # wrap_client signs memory:write with agent_id, block_label, value_length, value_preview.
 def test_wrap_client_signs_memory_write(hook: AsqavLettaHook) -> None:
-    """wrap_client signs memory:write with agent_id, block_label, value_length, value_preview."""
     client = _make_client()
     hook.wrap_client(client)
     client.agents.blocks.update("persona", agent_id="agent-456", value="I am a helpful assistant.")
@@ -178,8 +178,8 @@ def test_wrap_client_signs_memory_write(hook: AsqavLettaHook) -> None:
     assert ctx["value_preview"] == "I am a helpful assistant."
 
 
+    # wrap_client signs memory:write.end after a successful update.
 def test_wrap_client_signs_memory_write_end(hook: AsqavLettaHook) -> None:
-    """wrap_client signs memory:write.end after a successful update."""
     client = _make_client()
     hook.wrap_client(client)
     client.agents.blocks.update("human", agent_id="a", value="new")
@@ -191,8 +191,8 @@ def test_wrap_client_signs_memory_write_end(hook: AsqavLettaHook) -> None:
     assert ctx["block_label"] == "human"
 
 
+    # A successful update produces exactly memory:write + memory:write.end.
 def test_wrap_client_signs_two_events_on_successful_write(hook: AsqavLettaHook) -> None:
-    """A successful update produces exactly memory:write + memory:write.end."""
     client = _make_client()
     hook.wrap_client(client)
     client.agents.blocks.update("b", agent_id="a", value="v")
@@ -202,8 +202,8 @@ def test_wrap_client_signs_two_events_on_successful_write(hook: AsqavLettaHook) 
     assert hook._sign_action.call_args_list[1][0][0] == "memory:write.end"
 
 
+    # wrap_client does not alter the update return value.
 def test_wrap_client_update_returns_original_result(hook: AsqavLettaHook) -> None:
-    """wrap_client does not alter the update return value."""
     sentinel = object()
     client = _make_client(update_result=sentinel)
     hook.wrap_client(client)
@@ -214,8 +214,8 @@ def test_wrap_client_update_returns_original_result(hook: AsqavLettaHook) -> Non
 # === Error paths ===
 
 
+    # wrap_client signs memory:read.error when retrieve raises.
 def test_wrap_client_signs_read_error_on_exception(hook: AsqavLettaHook) -> None:
-    """wrap_client signs memory:read.error when retrieve raises."""
     client = _make_client()
     client.agents.blocks.retrieve.side_effect = RuntimeError("network error")
     hook.wrap_client(client)
@@ -230,8 +230,8 @@ def test_wrap_client_signs_read_error_on_exception(hook: AsqavLettaHook) -> None
     assert ctx["error"] == "network error"
 
 
+    # wrap_client re-raises the original retrieve exception unchanged.
 def test_wrap_client_reraises_retrieve_exception(hook: AsqavLettaHook) -> None:
-    """wrap_client re-raises the original retrieve exception unchanged."""
     client = _make_client()
     client.agents.blocks.retrieve.side_effect = ValueError("bad agent id")
     hook.wrap_client(client)
@@ -240,8 +240,8 @@ def test_wrap_client_reraises_retrieve_exception(hook: AsqavLettaHook) -> None:
         client.agents.blocks.retrieve("b", agent_id="a")
 
 
+    # wrap_client signs memory:write.error when update raises.
 def test_wrap_client_signs_write_error_on_exception(hook: AsqavLettaHook) -> None:
-    """wrap_client signs memory:write.error when update raises."""
     client = _make_client()
     client.agents.blocks.update.side_effect = RuntimeError("write failed")
     hook.wrap_client(client)
@@ -256,8 +256,8 @@ def test_wrap_client_signs_write_error_on_exception(hook: AsqavLettaHook) -> Non
     assert ctx["error"] == "write failed"
 
 
+    # wrap_client re-raises the original update exception unchanged.
 def test_wrap_client_reraises_update_exception(hook: AsqavLettaHook) -> None:
-    """wrap_client re-raises the original update exception unchanged."""
     client = _make_client()
     client.agents.blocks.update.side_effect = PermissionError("read only")
     hook.wrap_client(client)
@@ -266,8 +266,8 @@ def test_wrap_client_reraises_update_exception(hook: AsqavLettaHook) -> None:
         client.agents.blocks.update("b", agent_id="a", value="v")
 
 
+    # A failed retrieve produces exactly memory:read + memory:read.error.
 def test_wrap_client_signs_read_start_and_error_on_failure(hook: AsqavLettaHook) -> None:
-    """A failed retrieve produces exactly memory:read + memory:read.error."""
     client = _make_client()
     client.agents.blocks.retrieve.side_effect = RuntimeError("boom")
     hook.wrap_client(client)
@@ -280,8 +280,8 @@ def test_wrap_client_signs_read_start_and_error_on_failure(hook: AsqavLettaHook)
     assert hook._sign_action.call_args_list[1][0][0] == "memory:read.error"
 
 
+    # A failed update produces exactly memory:write + memory:write.error.
 def test_wrap_client_signs_write_start_and_error_on_failure(hook: AsqavLettaHook) -> None:
-    """A failed update produces exactly memory:write + memory:write.error."""
     client = _make_client()
     client.agents.blocks.update.side_effect = RuntimeError("boom")
     hook.wrap_client(client)
@@ -297,8 +297,8 @@ def test_wrap_client_signs_write_start_and_error_on_failure(hook: AsqavLettaHook
 # === Truncation ===
 
 
+    # agent_id longer than 200 chars is truncated in the audit record.
 def test_agent_id_truncated_to_200_chars(hook: AsqavLettaHook) -> None:
-    """agent_id longer than 200 chars is truncated in the audit record."""
     client = _make_client()
     hook.wrap_client(client)
     client.agents.blocks.retrieve("human", agent_id="a" * 500)
@@ -307,8 +307,8 @@ def test_agent_id_truncated_to_200_chars(hook: AsqavLettaHook) -> None:
     assert len(ctx["agent_id"]) == 200
 
 
+    # value_preview longer than 200 chars is truncated in the audit record.
 def test_value_preview_truncated_to_200_chars(hook: AsqavLettaHook) -> None:
-    """value_preview longer than 200 chars is truncated in the audit record."""
     client = _make_client()
     hook.wrap_client(client)
     client.agents.blocks.update("b", agent_id="a", value="x" * 500)
@@ -318,8 +318,8 @@ def test_value_preview_truncated_to_200_chars(hook: AsqavLettaHook) -> None:
     assert ctx["value_length"] == 500
 
 
+    # Error messages longer than 200 chars are truncated in the audit record.
 def test_error_message_truncated_to_200_chars(hook: AsqavLettaHook) -> None:
-    """Error messages longer than 200 chars are truncated in the audit record."""
     client = _make_client()
     client.agents.blocks.retrieve.side_effect = RuntimeError("e" * 500)
     hook.wrap_client(client)
@@ -334,8 +334,8 @@ def test_error_message_truncated_to_200_chars(hook: AsqavLettaHook) -> None:
 # === Fail-open: signing must never block memory operations ===
 
 
+    # If memory:read signing raises, retrieve still executes and returns its result.
 def test_fail_open_memory_read_does_not_block_retrieve(hook: AsqavLettaHook) -> None:
-    """If memory:read signing raises, retrieve still executes and returns its result."""
     sentinel = object()
     client = _make_client(retrieve_result=sentinel)
     hook._sign_action.side_effect = Exception("service unavailable")
@@ -345,8 +345,8 @@ def test_fail_open_memory_read_does_not_block_retrieve(hook: AsqavLettaHook) -> 
     assert result is sentinel
 
 
+    # If memory:write signing raises, update still executes and returns its result.
 def test_fail_open_memory_write_does_not_block_update(hook: AsqavLettaHook) -> None:
-    """If memory:write signing raises, update still executes and returns its result."""
     sentinel = object()
     client = _make_client(update_result=sentinel)
     hook._sign_action.side_effect = Exception("service unavailable")
@@ -356,10 +356,10 @@ def test_fail_open_memory_write_does_not_block_update(hook: AsqavLettaHook) -> N
     assert result is sentinel
 
 
+    # If memory:write.end signing raises, the update result is still returned.
 def test_fail_open_memory_write_end_does_not_suppress_result(
     hook: AsqavLettaHook,
 ) -> None:
-    """If memory:write.end signing raises, the update result is still returned."""
     sentinel = object()
     client = _make_client(update_result=sentinel)
     call_count = 0
@@ -377,10 +377,10 @@ def test_fail_open_memory_write_end_does_not_suppress_result(
     assert result is sentinel
 
 
+    # If memory:read.error signing raises, the original retrieve exception is still re-raised.
 def test_fail_open_read_error_signing_does_not_swallow_exception(
     hook: AsqavLettaHook,
 ) -> None:
-    """If memory:read.error signing raises, the original retrieve exception is still re-raised."""
     client = _make_client()
     client.agents.blocks.retrieve.side_effect = ValueError("retrieve failed")
     hook._sign_action.side_effect = Exception("signing also broke")
@@ -393,8 +393,8 @@ def test_fail_open_read_error_signing_does_not_swallow_exception(
 # === Multiple clients tracked independently ===
 
 
+    # Each wrapped client is signed independently.
 def test_multiple_clients_tracked_independently(hook: AsqavLettaHook) -> None:
-    """Each wrapped client is signed independently."""
     client_a = _make_client()
     client_b = _make_client()
 
@@ -412,9 +412,9 @@ def test_multiple_clients_tracked_independently(hook: AsqavLettaHook) -> None:
 # === Cleanup ===
 
 
+    # Remove fake letta_client from sys.modules after all tests.
 @pytest.fixture(autouse=True, scope="module")
 def _cleanup_letta_client_module() -> Any:
-    """Remove fake letta_client from sys.modules after all tests."""
     yield
     sys.modules.pop("letta_client", None)
     sys.modules.pop("asqav.extras.letta", None)

--- a/python/tests/test_litellm_integration.py
+++ b/python/tests/test_litellm_integration.py
@@ -29,8 +29,8 @@ MOCK_SIGN_RESPONSE: dict = {
 }
 
 
+    # Create a guardrail with mocked Agent.
 def _make_guardrail() -> AsqavGuardrail:
-    """Create a guardrail with mocked Agent."""
     with patch("asqav.client._api_key", "sk_test"), \
          patch("asqav.extras._base.Agent") as mock_agent_cls:
         mock_agent_cls.create.return_value = MagicMock()
@@ -175,8 +175,8 @@ class TestModerationHook:
 
 
 class TestFailOpen:
+        # Async methods do not raise when signing fails (fail-open via base).
     def test_fail_open_on_sign_error(self):
-        """Async methods do not raise when signing fails (fail-open via base)."""
         guardrail = _make_guardrail()
         # Mock the agent's sign method to raise, exercising the real
         # _sign_action fail-open path in AsqavAdapter.

--- a/python/tests/test_litellm_signing.py
+++ b/python/tests/test_litellm_signing.py
@@ -24,8 +24,8 @@ _mock_integrations = ModuleType("litellm.integrations")
 _mock_custom_logger = ModuleType("litellm.integrations.custom_logger")
 
 
+    # Stand-in for litellm.integrations.custom_logger.CustomLogger.
 class _StubCustomLogger:
-    """Stand-in for litellm.integrations.custom_logger.CustomLogger."""
 
     def __init__(self, *args, **kwargs) -> None:
         pass
@@ -52,8 +52,8 @@ MOCK_SIGN_RESPONSE: dict = {
 }
 
 
+    # Build a logger with a mocked Agent and a temp index path.
 def _make_logger(tmp_path, **kwargs) -> AsqavSigningLogger:
-    """Build a logger with a mocked Agent and a temp index path."""
     log_path = str(tmp_path / "index.jsonl")
     with patch("asqav.client._api_key", "sk_test"), patch(
         "asqav.extras._base.Agent"

--- a/python/tests/test_llamaindex_integration.py
+++ b/python/tests/test_llamaindex_integration.py
@@ -31,8 +31,8 @@ _MOCK_MODULE_NAMES = (
 )
 
 
+    # Faithful reproduction of llama_index.core.callbacks.schema.CBEventType.
 class CBEventType(str, Enum):
-    """Faithful reproduction of llama_index.core.callbacks.schema.CBEventType."""
 
     CHUNKING = "chunking"
     NODE_PARSING = "node_parsing"
@@ -50,8 +50,8 @@ class CBEventType(str, Enum):
     AGENT_STEP = "agent_step"
 
 
+    # Faithful reproduction of llama_index BaseCallbackHandler.
 class BaseCallbackHandler:
-    """Faithful reproduction of llama_index BaseCallbackHandler."""
 
     def __init__(
         self,
@@ -91,8 +91,8 @@ class BaseCallbackHandler:
         raise NotImplementedError
 
 
+    # Inject fake llama_index module tree into sys.modules.
 def _install_llamaindex_mocks() -> None:
-    """Inject fake llama_index module tree into sys.modules."""
     for mod_name in _MOCK_MODULE_NAMES:
         _original_modules[mod_name] = sys.modules.get(mod_name, _MISSING)
 
@@ -141,9 +141,9 @@ from asqav.extras.llamaindex import AsqavLlamaIndexHandler  # noqa: E402
 # === Fixtures ===
 
 
+    # Create an AsqavLlamaIndexHandler with mocked Agent internals.
 @pytest.fixture()
 def handler() -> AsqavLlamaIndexHandler:
-    """Create an AsqavLlamaIndexHandler with mocked Agent internals."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -157,16 +157,16 @@ def handler() -> AsqavLlamaIndexHandler:
 # === Subclass check ===
 
 
+    # AsqavLlamaIndexHandler must be a subclass of LlamaIndex BaseCallbackHandler.
 def test_is_base_callback_handler_subclass() -> None:
-    """AsqavLlamaIndexHandler must be a subclass of LlamaIndex BaseCallbackHandler."""
     assert issubclass(AsqavLlamaIndexHandler, BaseCallbackHandler)
 
 
 # === on_event_start - signed event types ===
 
 
+    # on_event_start signs llamaindex.llm.start for LLM events.
 def test_on_event_start_llm(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start signs llamaindex.llm.start for LLM events."""
     handler.on_event_start(CBEventType.LLM, {"prompt": "hi"}, "evt-1", "parent-1")
     handler._sign_action.assert_called_once_with(
         "llamaindex.llm.start",
@@ -179,8 +179,8 @@ def test_on_event_start_llm(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # on_event_start signs llamaindex.query.start for query events.
 def test_on_event_start_query(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start signs llamaindex.query.start for query events."""
     handler.on_event_start(CBEventType.QUERY, {"query_str": "test"}, "evt-2")
     handler._sign_action.assert_called_once_with(
         "llamaindex.query.start",
@@ -192,8 +192,8 @@ def test_on_event_start_query(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # on_event_start signs llamaindex.retrieve.start for retrieval events.
 def test_on_event_start_retrieve(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start signs llamaindex.retrieve.start for retrieval events."""
     handler.on_event_start(CBEventType.RETRIEVE, None, "evt-3")
     handler._sign_action.assert_called_once_with(
         "llamaindex.retrieve.start",
@@ -205,8 +205,8 @@ def test_on_event_start_retrieve(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # on_event_start signs llamaindex.function_call.start for tool calls.
 def test_on_event_start_function_call(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start signs llamaindex.function_call.start for tool calls."""
     handler.on_event_start(
         CBEventType.FUNCTION_CALL,
         {"function_call": "search", "tool": "web"},
@@ -222,8 +222,8 @@ def test_on_event_start_function_call(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # on_event_start signs llamaindex.agent_step.start for agent events.
 def test_on_event_start_agent_step(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start signs llamaindex.agent_step.start for agent events."""
     handler.on_event_start(CBEventType.AGENT_STEP, {}, "evt-5")
     handler._sign_action.assert_called_once_with(
         "llamaindex.agent_step.start",
@@ -235,8 +235,8 @@ def test_on_event_start_agent_step(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # on_event_start signs llamaindex.embedding.start for embedding events.
 def test_on_event_start_embedding(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start signs llamaindex.embedding.start for embedding events."""
     handler.on_event_start(CBEventType.EMBEDDING, {"embeddings": [1, 2]}, "evt-6")
     handler._sign_action.assert_called_once_with(
         "llamaindex.embedding.start",
@@ -248,8 +248,8 @@ def test_on_event_start_embedding(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # on_event_start signs llamaindex.reranking.start for reranking events.
 def test_on_event_start_reranking(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start signs llamaindex.reranking.start for reranking events."""
     handler.on_event_start(CBEventType.RERANKING, {"nodes": []}, "evt-7")
     handler._sign_action.assert_called_once_with(
         "llamaindex.reranking.start",
@@ -261,8 +261,8 @@ def test_on_event_start_reranking(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # on_event_start signs llamaindex.sub_question.start for sub-question events.
 def test_on_event_start_sub_question(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start signs llamaindex.sub_question.start for sub-question events."""
     handler.on_event_start(CBEventType.SUB_QUESTION, {"sub_question": "why?"}, "evt-8")
     handler._sign_action.assert_called_once_with(
         "llamaindex.sub_question.start",
@@ -274,8 +274,8 @@ def test_on_event_start_sub_question(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # on_event_start signs llamaindex.synthesize.start for synthesize events.
 def test_on_event_start_synthesize(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start signs llamaindex.synthesize.start for synthesize events."""
     handler.on_event_start(CBEventType.SYNTHESIZE, {}, "evt-9")
     handler._sign_action.assert_called_once_with(
         "llamaindex.synthesize.start",
@@ -290,32 +290,32 @@ def test_on_event_start_synthesize(handler: AsqavLlamaIndexHandler) -> None:
 # === on_event_start - ignored event types (not in _SIGNED_EVENT_TYPES) ===
 
 
+    # Chunking events are not signed (low-value for governance).
 def test_on_event_start_ignores_chunking(handler: AsqavLlamaIndexHandler) -> None:
-    """Chunking events are not signed (low-value for governance)."""
     handler.on_event_start(CBEventType.CHUNKING, {}, "evt-x")
     handler._sign_action.assert_not_called()
 
 
+    # Node parsing events are not signed.
 def test_on_event_start_ignores_node_parsing(handler: AsqavLlamaIndexHandler) -> None:
-    """Node parsing events are not signed."""
     handler.on_event_start(CBEventType.NODE_PARSING, {}, "evt-x")
     handler._sign_action.assert_not_called()
 
 
+    # Templating events are not signed.
 def test_on_event_start_ignores_templating(handler: AsqavLlamaIndexHandler) -> None:
-    """Templating events are not signed."""
     handler.on_event_start(CBEventType.TEMPLATING, {}, "evt-x")
     handler._sign_action.assert_not_called()
 
 
+    # Tree events are not signed.
 def test_on_event_start_ignores_tree(handler: AsqavLlamaIndexHandler) -> None:
-    """Tree events are not signed."""
     handler.on_event_start(CBEventType.TREE, {}, "evt-x")
     handler._sign_action.assert_not_called()
 
 
+    # Exception events are not signed (they are metadata, not actions).
 def test_on_event_start_ignores_exception(handler: AsqavLlamaIndexHandler) -> None:
-    """Exception events are not signed (they are metadata, not actions)."""
     handler.on_event_start(CBEventType.EXCEPTION, {}, "evt-x")
     handler._sign_action.assert_not_called()
 
@@ -323,14 +323,14 @@ def test_on_event_start_ignores_exception(handler: AsqavLlamaIndexHandler) -> No
 # === on_event_start - returns event_id ===
 
 
+    # on_event_start must return the event_id per the LlamaIndex contract.
 def test_on_event_start_returns_event_id(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start must return the event_id per the LlamaIndex contract."""
     result = handler.on_event_start(CBEventType.LLM, {}, "my-event-id")
     assert result == "my-event-id"
 
 
+    # on_event_start returns event_id even for ignored event types.
 def test_on_event_start_returns_event_id_for_ignored(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_start returns event_id even for ignored event types."""
     result = handler.on_event_start(CBEventType.CHUNKING, {}, "skip-id")
     assert result == "skip-id"
 
@@ -338,15 +338,15 @@ def test_on_event_start_returns_event_id_for_ignored(handler: AsqavLlamaIndexHan
 # === on_event_start - parent_id handling ===
 
 
+    # When parent_id is empty, it is not included in context.
 def test_on_event_start_no_parent_id(handler: AsqavLlamaIndexHandler) -> None:
-    """When parent_id is empty, it is not included in context."""
     handler.on_event_start(CBEventType.LLM, {}, "evt-np", "")
     ctx = handler._sign_action.call_args[0][1]
     assert "parent_id" not in ctx
 
 
+    # When parent_id is provided, it is included in context.
 def test_on_event_start_with_parent_id(handler: AsqavLlamaIndexHandler) -> None:
-    """When parent_id is provided, it is included in context."""
     handler.on_event_start(CBEventType.LLM, {}, "evt-wp", "parent-abc")
     ctx = handler._sign_action.call_args[0][1]
     assert ctx["parent_id"] == "parent-abc"
@@ -355,8 +355,8 @@ def test_on_event_start_with_parent_id(handler: AsqavLlamaIndexHandler) -> None:
 # === on_event_end ===
 
 
+    # on_event_end signs llamaindex.llm.end for LLM events.
 def test_on_event_end_llm(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_end signs llamaindex.llm.end for LLM events."""
     handler.on_event_end(CBEventType.LLM, {"completion": "hello"}, "evt-1")
     handler._sign_action.assert_called_once_with(
         "llamaindex.llm.end",
@@ -368,8 +368,8 @@ def test_on_event_end_llm(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # on_event_end signs llamaindex.function_call.end for tool events.
 def test_on_event_end_function_call(handler: AsqavLlamaIndexHandler) -> None:
-    """on_event_end signs llamaindex.function_call.end for tool events."""
     handler.on_event_end(
         CBEventType.FUNCTION_CALL,
         {"function_call_response": "ok"},
@@ -385,8 +385,8 @@ def test_on_event_end_function_call(handler: AsqavLlamaIndexHandler) -> None:
     )
 
 
+    # Chunking end events are not signed.
 def test_on_event_end_ignores_chunking(handler: AsqavLlamaIndexHandler) -> None:
-    """Chunking end events are not signed."""
     handler.on_event_end(CBEventType.CHUNKING, {}, "evt-x")
     handler._sign_action.assert_not_called()
 
@@ -394,8 +394,8 @@ def test_on_event_end_ignores_chunking(handler: AsqavLlamaIndexHandler) -> None:
 # === on_event_start/end - user-configured event_starts_to_ignore ===
 
 
+    # Events in event_starts_to_ignore are skipped even if in _SIGNED_EVENT_TYPES.
 def test_event_starts_to_ignore(handler: AsqavLlamaIndexHandler) -> None:
-    """Events in event_starts_to_ignore are skipped even if in _SIGNED_EVENT_TYPES."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -413,8 +413,8 @@ def test_event_starts_to_ignore(handler: AsqavLlamaIndexHandler) -> None:
     h._sign_action.assert_called_once()
 
 
+    # Events in event_ends_to_ignore are skipped on end.
 def test_event_ends_to_ignore(handler: AsqavLlamaIndexHandler) -> None:
-    """Events in event_ends_to_ignore are skipped on end."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -432,8 +432,8 @@ def test_event_ends_to_ignore(handler: AsqavLlamaIndexHandler) -> None:
 # === Payload keys ===
 
 
+    # Payload keys are always sorted alphabetically.
 def test_payload_keys_sorted(handler: AsqavLlamaIndexHandler) -> None:
-    """Payload keys are always sorted alphabetically."""
     handler.on_event_start(
         CBEventType.LLM, {"z_key": 1, "a_key": 2, "m_key": 3}, "evt-sort"
     )
@@ -441,8 +441,8 @@ def test_payload_keys_sorted(handler: AsqavLlamaIndexHandler) -> None:
     assert ctx["payload_keys"] == ["a_key", "m_key", "z_key"]
 
 
+    # None payload results in empty payload_keys list.
 def test_payload_none_gives_empty_keys(handler: AsqavLlamaIndexHandler) -> None:
-    """None payload results in empty payload_keys list."""
     handler.on_event_start(CBEventType.LLM, None, "evt-none")
     ctx = handler._sign_action.call_args[0][1]
     assert ctx["payload_keys"] == []
@@ -451,30 +451,30 @@ def test_payload_none_gives_empty_keys(handler: AsqavLlamaIndexHandler) -> None:
 # === start_trace / end_trace ===
 
 
+    # start_trace with a trace_id calls _start_session.
 def test_start_trace_begins_session(handler: AsqavLlamaIndexHandler) -> None:
-    """start_trace with a trace_id calls _start_session."""
     handler._start_session = MagicMock()
     handler.start_trace("query-trace-1")
     handler._start_session.assert_called_once()
 
 
+    # start_trace without a trace_id does not start a session.
 def test_start_trace_no_id_skips_session(handler: AsqavLlamaIndexHandler) -> None:
-    """start_trace without a trace_id does not start a session."""
     handler._start_session = MagicMock()
     handler.start_trace(None)
     handler._start_session.assert_not_called()
 
 
+    # end_trace closes an active session.
 def test_end_trace_ends_session(handler: AsqavLlamaIndexHandler) -> None:
-    """end_trace closes an active session."""
     handler._session_id = "active-session"
     handler._end_session = MagicMock()
     handler.end_trace("query-trace-1", {"root": ["child-1"]})
     handler._end_session.assert_called_once_with("completed")
 
 
+    # end_trace is a no-op when no session is active.
 def test_end_trace_no_session_is_noop(handler: AsqavLlamaIndexHandler) -> None:
-    """end_trace is a no-op when no session is active."""
     handler._session_id = None
     handler._end_session = MagicMock()
     handler.end_trace("query-trace-1")
@@ -484,8 +484,8 @@ def test_end_trace_no_session_is_noop(handler: AsqavLlamaIndexHandler) -> None:
 # === Fail-open: signing must never block LlamaIndex execution ===
 
 
+    # AsqavError from the real _sign_action is swallowed (fail-open).
 def test_fail_open_on_asqav_error() -> None:
-    """AsqavError from the real _sign_action is swallowed (fail-open)."""
     from asqav.client import AsqavError
 
     with (

--- a/python/tests/test_local.py
+++ b/python/tests/test_local.py
@@ -18,8 +18,8 @@ from asqav.local import LocalQueue, local_sign
 # === LocalQueue unit tests ===
 
 
+    # enqueue writes a JSON file in the queue directory.
 def test_enqueue_creates_file(tmp_path: object) -> None:
-    """enqueue writes a JSON file in the queue directory."""
     queue = LocalQueue(queue_dir=str(tmp_path))
     item_id = queue.enqueue("agent_abc", "api:call", {"model": "gpt-4"})
 
@@ -34,8 +34,8 @@ def test_enqueue_creates_file(tmp_path: object) -> None:
     assert "queued_at" in data
 
 
+    # enqueue returns a string ID matching the filename.
 def test_enqueue_returns_id(tmp_path: object) -> None:
-    """enqueue returns a string ID matching the filename."""
     queue = LocalQueue(queue_dir=str(tmp_path))
     item_id = queue.enqueue("agent_1", "read:data")
 
@@ -47,8 +47,8 @@ def test_enqueue_returns_id(tmp_path: object) -> None:
     assert files[0].stem == item_id
 
 
+    # list_pending returns items sorted by queued_at ascending.
 def test_list_pending_sorted(tmp_path: object) -> None:
-    """list_pending returns items sorted by queued_at ascending."""
     queue = LocalQueue(queue_dir=str(tmp_path))
 
     id1 = queue.enqueue("agent_1", "action_a")
@@ -64,8 +64,8 @@ def test_list_pending_sorted(tmp_path: object) -> None:
     assert items[2]["id"] == id3
 
 
+    # count returns the number of pending items.
 def test_count(tmp_path: object) -> None:
-    """count returns the number of pending items."""
     queue = LocalQueue(queue_dir=str(tmp_path))
     assert queue.count() == 0
 
@@ -74,8 +74,8 @@ def test_count(tmp_path: object) -> None:
     assert queue.count() == 2
 
 
+    # sync deletes all items on success and returns correct counts.
 def test_sync_success(tmp_path: object) -> None:
-    """sync deletes all items on success and returns correct counts."""
     queue = LocalQueue(queue_dir=str(tmp_path))
     queue.enqueue("agent_1", "action_a")
     queue.enqueue("agent_2", "action_b")
@@ -90,8 +90,8 @@ def test_sync_success(tmp_path: object) -> None:
     assert queue.count() == 0
 
 
+    # sync keeps failed items in queue and reports errors.
 def test_sync_partial_failure(tmp_path: object) -> None:
-    """sync keeps failed items in queue and reports errors."""
     call_count = 0
 
     def mock_post(path: str, data: dict) -> dict:
@@ -117,8 +117,8 @@ def test_sync_partial_failure(tmp_path: object) -> None:
     assert queue.count() == 1
 
 
+    # sync with empty queue returns zeroes.
 def test_sync_empty_queue(tmp_path: object) -> None:
-    """sync with empty queue returns zeroes."""
     queue = LocalQueue(queue_dir=str(tmp_path))
 
     with patch("asqav.client._post") as mock_post:
@@ -130,8 +130,8 @@ def test_sync_empty_queue(tmp_path: object) -> None:
     mock_post.assert_not_called()
 
 
+    # clear removes all items and returns count deleted.
 def test_clear(tmp_path: object) -> None:
-    """clear removes all items and returns count deleted."""
     queue = LocalQueue(queue_dir=str(tmp_path))
     queue.enqueue("agent_1", "action_a")
     queue.enqueue("agent_2", "action_b")
@@ -142,8 +142,8 @@ def test_clear(tmp_path: object) -> None:
     assert queue.count() == 0
 
 
+    # local_sign creates a file in the specified queue directory.
 def test_local_sign_convenience(tmp_path: object) -> None:
-    """local_sign creates a file in the specified queue directory."""
     item_id = local_sign("agent_x", "deploy:model", {"version": "2"}, queue_dir=str(tmp_path))
 
     assert isinstance(item_id, str)
@@ -165,9 +165,9 @@ from asqav.cli import app  # noqa: E402
 runner = CliRunner()
 
 
+    # asqav sync with empty queue prints 'nothing to sync'.
 @patch("asqav.init")
 def test_cli_sync_empty(mock_init: MagicMock, tmp_path: object) -> None:
-    """asqav sync with empty queue prints 'nothing to sync'."""
     result = runner.invoke(
         app,
         ["sync"],
@@ -177,8 +177,8 @@ def test_cli_sync_empty(mock_init: MagicMock, tmp_path: object) -> None:
     assert "nothing to sync" in result.output.lower()
 
 
+    # asqav queue count shows correct count.
 def test_cli_queue_count(tmp_path: object) -> None:
-    """asqav queue count shows correct count."""
     # Pre-populate queue
     queue = LocalQueue(queue_dir=str(tmp_path))
     queue.enqueue("agent_1", "action_a")
@@ -193,8 +193,8 @@ def test_cli_queue_count(tmp_path: object) -> None:
     assert "2" in result.output
 
 
+    # asqav queue list shows pending items.
 def test_cli_queue_list(tmp_path: object) -> None:
-    """asqav queue list shows pending items."""
     queue = LocalQueue(queue_dir=str(tmp_path))
     queue.enqueue("agent_abc", "api:call")
 
@@ -208,8 +208,8 @@ def test_cli_queue_list(tmp_path: object) -> None:
     assert "api:call" in result.output
 
 
+    # enqueue writes via tmp+rename; no .tmp residue, item parses back cleanly.
 def test_enqueue_is_atomic_no_tmp_residue(tmp_path) -> None:
-    """enqueue writes via tmp+rename; no .tmp residue, item parses back cleanly."""
     queue = LocalQueue(queue_dir=str(tmp_path))
     item_id = queue.enqueue("agent_abc", "api:call", {"k": "v"})
 
@@ -224,16 +224,16 @@ def test_enqueue_is_atomic_no_tmp_residue(tmp_path) -> None:
 # === path-injection regression (Trustabl #375) ===
 
 
+    # A traversal queue_dir is rejected before any mkdir/write escapes.
 def test_queue_dir_arg_traversal_rejected(tmp_path) -> None:
-    """A traversal queue_dir is rejected before any mkdir/write escapes."""
     target = tmp_path.parent / "escaped_queue"
     with pytest.raises(ValueError, match="path traversal"):
         LocalQueue(queue_dir=str(tmp_path / ".." / "escaped_queue"))
     assert not target.exists()
 
 
+    # ASQAV_QUEUE_DIR with '..' is rejected, mirroring the credentials fix.
 def test_queue_dir_env_traversal_rejected(tmp_path, monkeypatch) -> None:
-    """ASQAV_QUEUE_DIR with '..' is rejected, mirroring the credentials fix."""
     monkeypatch.setenv("ASQAV_QUEUE_DIR", str(tmp_path / ".." / "evil_queue"))
     with pytest.raises(ValueError, match="path traversal"):
         LocalQueue()

--- a/python/tests/test_mode_resolver.py
+++ b/python/tests/test_mode_resolver.py
@@ -35,8 +35,8 @@ def test_is_asqav_cloud_host(host: str | None, expected: bool) -> None:
 # === Resolution precedence ===
 
 
+    # Explicit always wins.
 def test_explicit_overrides_env_and_url() -> None:
-    """Explicit always wins."""
     assert _resolve_mode(
         api_base_url="https://api.asqav.com/api/v1",
         env="full-payload",
@@ -49,8 +49,8 @@ def test_explicit_overrides_env_and_url() -> None:
     ) == "full-payload"
 
 
+    # When explicit is auto, env wins over URL.
 def test_env_overrides_auto_detection() -> None:
-    """When explicit is auto, env wins over URL."""
     assert _resolve_mode(
         api_base_url="https://localhost:8000",
         env="hash-only",
@@ -63,8 +63,8 @@ def test_env_overrides_auto_detection() -> None:
     ) == "full-payload"
 
 
+    # Unknown env values are silently ignored.
 def test_garbage_env_falls_through_to_auto() -> None:
-    """Unknown env values are silently ignored."""
     assert _resolve_mode(
         api_base_url="https://api.asqav.com/api/v1",
         env="banana",

--- a/python/tests/test_observe_mode.py
+++ b/python/tests/test_observe_mode.py
@@ -14,8 +14,8 @@ from asqav.client import SignatureResponse
 from asqav.extras._base import AsqavAdapter
 
 
+    # Concrete subclass for testing observe mode.
 class _ObserveAdapter(AsqavAdapter):
-    """Concrete subclass for testing observe mode."""
 
     pass
 
@@ -29,9 +29,9 @@ MOCK_SIGN_RESPONSE: dict = {
 }
 
 
+    # In observe mode, _sign_action returns None without calling the server.
 @patch("asqav.extras._base.Agent")
 def test_observe_mode_returns_none(mock_agent_cls):
-    """In observe mode, _sign_action returns None without calling the server."""
     mock_agent = MagicMock()
     mock_agent_cls.create.return_value = mock_agent
 
@@ -43,9 +43,9 @@ def test_observe_mode_returns_none(mock_agent_cls):
     mock_agent.sign.assert_not_called()
 
 
+    # In observe mode, no signatures are accumulated.
 @patch("asqav.extras._base.Agent")
 def test_observe_mode_does_not_accumulate_signatures(mock_agent_cls):
-    """In observe mode, no signatures are accumulated."""
     mock_agent = MagicMock()
     mock_agent_cls.create.return_value = mock_agent
 
@@ -58,9 +58,9 @@ def test_observe_mode_does_not_accumulate_signatures(mock_agent_cls):
     mock_agent.sign.assert_not_called()
 
 
+    # In observe mode, _sign_action logs the action that would be signed.
 @patch("asqav.extras._base.Agent")
 def test_observe_mode_logs_action(mock_agent_cls, caplog):
-    """In observe mode, _sign_action logs the action that would be signed."""
     mock_agent = MagicMock()
     mock_agent_cls.create.return_value = mock_agent
 
@@ -76,9 +76,9 @@ def test_observe_mode_logs_action(mock_agent_cls, caplog):
     assert "gpt-4" in caplog.records[0].message
 
 
+    # Observe mode works when context is None.
 @patch("asqav.extras._base.Agent")
 def test_observe_mode_logs_none_context(mock_agent_cls, caplog):
-    """Observe mode works when context is None."""
     mock_agent = MagicMock()
     mock_agent_cls.create.return_value = mock_agent
 
@@ -92,9 +92,9 @@ def test_observe_mode_logs_none_context(mock_agent_cls, caplog):
     assert "tool:execute" in caplog.records[0].message
 
 
+    # With observe=False (default), _sign_action calls the server normally.
 @patch("asqav.extras._base.Agent")
 def test_observe_false_calls_server(mock_agent_cls):
-    """With observe=False (default), _sign_action calls the server normally."""
     mock_agent = MagicMock()
     mock_sig = SignatureResponse(**MOCK_SIGN_RESPONSE)
     mock_agent.sign.return_value = mock_sig
@@ -108,9 +108,9 @@ def test_observe_false_calls_server(mock_agent_cls):
     mock_agent.sign.assert_called_once_with("llm:call", {"model": "gpt-4"})
 
 
+    # By default, observe mode is disabled.
 @patch("asqav.extras._base.Agent")
 def test_default_observe_is_false(mock_agent_cls):
-    """By default, observe mode is disabled."""
     mock_agent = MagicMock()
     mock_agent_cls.create.return_value = mock_agent
 

--- a/python/tests/test_offline_verify.py
+++ b/python/tests/test_offline_verify.py
@@ -32,9 +32,9 @@ def _load(p: Path) -> dict:
 # ---------------------------------------------------------------------------
 
 
+    # Raise if anything tries to open a network connection.
 @pytest.fixture(autouse=True)
 def _forbid_network(monkeypatch):
-    """Raise if anything tries to open a network connection."""
 
     def _no_network(*args, **kwargs):
         raise RuntimeError(f"Network access forbidden in offline tests: args={args!r}")
@@ -49,13 +49,13 @@ def _forbid_network(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+    # fetch_jwks must be importable from the top-level asqav namespace.
 def test_fetch_jwks_exported():
-    """fetch_jwks must be importable from the top-level asqav namespace."""
     assert callable(asqav.fetch_jwks)
 
 
+    # fetch_jwks() must invoke urllib.request.urlopen (not silently bypass it).
 def test_fetch_jwks_hits_network(monkeypatch):
-    """fetch_jwks() must invoke urllib.request.urlopen (not silently bypass it)."""
     called = []
 
     def _capture(req, **kw):
@@ -74,8 +74,8 @@ def test_fetch_jwks_hits_network(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+    # A valid Ed25519-signed receipt verifies PASS against the vector JWKS.
 def test_verify_receipt_offline_pass():
-    """A valid Ed25519-signed receipt verifies PASS against the vector JWKS."""
     receipt = _load(PASS_VECTOR / "receipt.json")
     jwks = _load(PASS_VECTOR / "jwks.json")
     result = asqav.verify_receipt_offline(receipt, jwks)
@@ -84,8 +84,8 @@ def test_verify_receipt_offline_pass():
     assert sig_axis["result"] == "PASS"
 
 
+    # Result dict must have the documented shape.
 def test_verify_receipt_offline_axes_structure():
-    """Result dict must have the documented shape."""
     receipt = _load(PASS_VECTOR / "receipt.json")
     jwks = _load(PASS_VECTOR / "jwks.json")
     result = asqav.verify_receipt_offline(receipt, jwks)
@@ -100,8 +100,8 @@ def test_verify_receipt_offline_axes_structure():
 # ---------------------------------------------------------------------------
 
 
+    # A receipt with a flipped decision field must come back FAIL.
 def test_verify_receipt_offline_tampered_receipt_fails():
-    """A receipt with a flipped decision field must come back FAIL."""
     receipt = _load(TAMPER_VECTOR / "receipt.json")
     jwks = _load(TAMPER_VECTOR / "jwks.json")
     result = asqav.verify_receipt_offline(receipt, jwks)
@@ -111,8 +111,8 @@ def test_verify_receipt_offline_tampered_receipt_fails():
     assert sig_axis["result"] == "FAIL"
 
 
+    # Mutating the payload after signing must also produce FAIL.
 def test_verify_receipt_offline_tampered_payload_directly():
-    """Mutating the payload after signing must also produce FAIL."""
     receipt = _load(PASS_VECTOR / "receipt.json")
     jwks = _load(PASS_VECTOR / "jwks.json")
     tampered = copy.deepcopy(receipt)
@@ -126,8 +126,8 @@ def test_verify_receipt_offline_tampered_payload_directly():
 # ---------------------------------------------------------------------------
 
 
+    # Missing key in JWKS -> signature SKIPPED -> INCOMPLETE (never a PASS).
 def test_verify_receipt_offline_no_key_in_jwks():
-    """Missing key in JWKS -> signature SKIPPED -> INCOMPLETE (never a PASS)."""
     receipt = _load(PASS_VECTOR / "receipt.json")
     result = asqav.verify_receipt_offline(receipt, {"keys": []})
     # Oracle SKIPs the signature when the key is absent; verdict is INCOMPLETE.
@@ -148,8 +148,8 @@ def test_verify_receipt_offline_no_key_in_jwks():
 # ---------------------------------------------------------------------------
 
 
+    # Generate a real ML-DSA-65 receipt + JWKS using dilithium-py.
 def _make_mldsa_receipt_and_jwks():
-    """Generate a real ML-DSA-65 receipt + JWKS using dilithium-py."""
     from dilithium_py.ml_dsa import ML_DSA_65
 
     pk, sk = ML_DSA_65.keygen()
@@ -199,12 +199,12 @@ except ImportError:
     _DILITHIUM_AVAILABLE = False
 
 
+    # ML-DSA-65 signed receipt verifies PASS when dilithium-py is present.
 @pytest.mark.skipif(
     not _DILITHIUM_AVAILABLE,
     reason="dilithium-py not installed (pip install asqav[verify])",
 )
 def test_verify_receipt_offline_mldsa65_pass():
-    """ML-DSA-65 signed receipt verifies PASS when dilithium-py is present."""
     envelope, jwks = _make_mldsa_receipt_and_jwks()
     result = asqav.verify_receipt_offline(envelope, jwks)
     assert result["verdict"] == "PASS", f"axes: {result['axes']}"
@@ -212,9 +212,9 @@ def test_verify_receipt_offline_mldsa65_pass():
     assert sig_axis["result"] == "PASS"
 
 
+    # A tampered ML-DSA-65 receipt must return FAIL, never PASS.
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_verify_receipt_offline_mldsa65_tampered_fails():
-    """A tampered ML-DSA-65 receipt must return FAIL, never PASS."""
     envelope, jwks = _make_mldsa_receipt_and_jwks()
     envelope["payload"]["decision"] = "deny"
     result = asqav.verify_receipt_offline(envelope, jwks)
@@ -406,14 +406,9 @@ def test_verify_receipt_offline_rejects_a_key_from_another_issuer():
 MLDSA_KAT_VECTOR = VECTORS / "asqav-06-mldsa65-payload-prod"
 
 
+    # Real-cloud ML-DSA-65 KAT: signature PASS; lapsed expiry stays on its own axis (426).
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_verify_receipt_offline_mldsa65_real_cloud_kat():
-    """Real-cloud ML-DSA-65 payload-mode KAT: signature axis must be PASS.
-
-    The receipt's signed expires_at lapsed on 2026-06-20, so the verdict is FAIL
-    on expiry alone. That split is the point: the post-quantum signature still
-    verifies, and the offline verdict now matches the hosted signature_expired.
-    """
     receipt = _load(MLDSA_KAT_VECTOR / "receipt.json")
     jwks = _load(MLDSA_KAT_VECTOR / "jwks.json")
     result = asqav.verify_receipt_offline(receipt, jwks)
@@ -427,14 +422,15 @@ def test_verify_receipt_offline_mldsa65_real_cloud_kat():
     expiry_axis = next(a for a in result["axes"] if a["name"] == "expiry")
     assert expiry_axis["result"] == "FAIL", f"expiry axis: {expiry_axis}"
     assert "lapsed" in expiry_axis["note"], expiry_axis["note"]
+    # Expiry never folds the verdict; the crypto axes decide it (criterion 426)
     assert (
-        result["verdict"] == "FAIL"
-    ), f"Expected FAIL on the lapsed window, got {result['verdict']}; axes: {result['axes']}"
+        result["verdict"] == "PASS"
+    ), f"Expected PASS with the lapsed window on its own axis, got {result['verdict']}; axes: {result['axes']}"
 
 
+    # Tampered KAT payload byte must return FAIL - anti-vacuous guard.
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_verify_receipt_offline_mldsa65_real_cloud_kat_tamper_payload():
-    """Tampered KAT payload byte must return FAIL - anti-vacuous guard."""
     receipt = _load(MLDSA_KAT_VECTOR / "receipt.json")
     jwks = _load(MLDSA_KAT_VECTOR / "jwks.json")
     tampered = copy.deepcopy(receipt)
@@ -451,9 +447,9 @@ def test_verify_receipt_offline_mldsa65_real_cloud_kat_tamper_payload():
     ), f"Signature axis on tampered receipt must be FAIL, got: {sig_axis}"
 
 
+    # Swapped-sig KAT receipt must return FAIL - anti-vacuous guard.
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_verify_receipt_offline_mldsa65_real_cloud_kat_tamper_sig():
-    """Swapped-sig KAT receipt must return FAIL - anti-vacuous guard."""
     receipt = _load(MLDSA_KAT_VECTOR / "receipt.json")
     jwks = _load(MLDSA_KAT_VECTOR / "jwks.json")
     tampered = copy.deepcopy(receipt)
@@ -482,8 +478,8 @@ def test_verify_receipt_offline_mldsa65_real_cloud_kat_tamper_sig():
 # ---------------------------------------------------------------------------
 
 
+    # run_structured() is callable from the verifier module and returns a dict.
 def test_run_structured_directly():
-    """run_structured() is callable from the verifier module and returns a dict."""
     receipt = _load(PASS_VECTOR / "receipt.json")
     jwks = _load(PASS_VECTOR / "jwks.json")
     result = vr.run_structured(receipt, jwks)

--- a/python/tests/test_openai_agents_integration.py
+++ b/python/tests/test_openai_agents_integration.py
@@ -30,16 +30,16 @@ from asqav.extras.openai_agents import AsqavGuardrail, GuardrailResult  # noqa: 
 # === Helpers ===
 
 
+    # Create a guardrail with mocked asqav internals.
 def _make_guardrail() -> AsqavGuardrail:
-    """Create a guardrail with mocked asqav internals."""
     with patch("asqav.client._api_key", "sk_test"):
         with patch("asqav.extras._base.Agent") as mock_agent_cls:
             mock_agent_cls.create.return_value = MagicMock()
             return AsqavGuardrail(agent_name="test-openai-agent")
 
 
+    # Create a mock OpenAI Agent object with a name attribute.
 def _mock_agent(name: str = "my-agent") -> MagicMock:
-    """Create a mock OpenAI Agent object with a name attribute."""
     agent = MagicMock()
     agent.name = name
     return agent
@@ -48,8 +48,8 @@ def _mock_agent(name: str = "my-agent") -> MagicMock:
 # === Input guardrail tests ===
 
 
+    # run_input_guardrail signs an agent:input action with agent name and input info.
 def test_input_guardrail_signs_action():
-    """run_input_guardrail signs an agent:input action with agent name and input info."""
     guardrail = _make_guardrail()
     agent = _mock_agent("summarizer")
     guardrail._sign_action = MagicMock()
@@ -66,8 +66,8 @@ def test_input_guardrail_signs_action():
     assert "input_preview" in context
 
 
+    # run_input_guardrail always returns GuardrailResult with passed=True.
 def test_input_guardrail_returns_passed():
-    """run_input_guardrail always returns GuardrailResult with passed=True."""
     guardrail = _make_guardrail()
     guardrail._sign_action = MagicMock()
 
@@ -78,8 +78,8 @@ def test_input_guardrail_returns_passed():
     assert result.output is None
 
 
+    # Gracefully handles agent objects without a name attribute.
 def test_input_guardrail_handles_missing_agent_name():
-    """Gracefully handles agent objects without a name attribute."""
     guardrail = _make_guardrail()
     guardrail._sign_action = MagicMock()
 
@@ -95,8 +95,8 @@ def test_input_guardrail_handles_missing_agent_name():
     assert len(context["agent_name"]) > 0
 
 
+    # Long input data representation is truncated to 200 chars.
 def test_input_truncation():
-    """Long input data representation is truncated to 200 chars."""
     guardrail = _make_guardrail()
     guardrail._sign_action = MagicMock()
 
@@ -111,8 +111,8 @@ def test_input_truncation():
 # === Output guardrail tests ===
 
 
+    # run_output_guardrail signs an agent:output action with agent name and output info.
 def test_output_guardrail_signs_action():
-    """run_output_guardrail signs an agent:output action with agent name and output info."""
     guardrail = _make_guardrail()
     agent = _mock_agent("writer")
     guardrail._sign_action = MagicMock()
@@ -129,8 +129,8 @@ def test_output_guardrail_signs_action():
     assert "output_preview" in context
 
 
+    # run_output_guardrail always returns GuardrailResult with passed=True.
 def test_output_guardrail_returns_passed():
-    """run_output_guardrail always returns GuardrailResult with passed=True."""
     guardrail = _make_guardrail()
     guardrail._sign_action = MagicMock()
 
@@ -144,8 +144,8 @@ def test_output_guardrail_returns_passed():
 # === Fail-open behavior ===
 
 
+    # Guardrail returns passed=True even when signing fails.
 def test_fail_open_on_sign_error():
-    """Guardrail returns passed=True even when signing fails."""
     guardrail = _make_guardrail()
     guardrail._sign_action = MagicMock(side_effect=RuntimeError("network error"))
 
@@ -156,8 +156,8 @@ def test_fail_open_on_sign_error():
     assert result.output is None
 
 
+    # Output guardrail also returns passed=True when signing fails.
 def test_fail_open_output_on_sign_error():
-    """Output guardrail also returns passed=True when signing fails."""
     guardrail = _make_guardrail()
     guardrail._sign_action = MagicMock(side_effect=RuntimeError("timeout"))
 
@@ -171,15 +171,15 @@ def test_fail_open_output_on_sign_error():
 # === GuardrailResult dataclass ===
 
 
+    # GuardrailResult defaults output to None.
 def test_guardrail_result_defaults():
-    """GuardrailResult defaults output to None."""
     result = GuardrailResult(passed=True)
     assert result.passed is True
     assert result.output is None
 
 
+    # GuardrailResult can hold arbitrary output.
 def test_guardrail_result_with_output():
-    """GuardrailResult can hold arbitrary output."""
     result = GuardrailResult(passed=False, output={"reason": "blocked"})
     assert result.passed is False
     assert result.output == {"reason": "blocked"}

--- a/python/tests/test_openai_anthropic_extras.py
+++ b/python/tests/test_openai_anthropic_extras.py
@@ -25,8 +25,8 @@ from asqav.extras.anthropic import AsqavAnthropic  # noqa: E402
 from asqav.extras.openai import AsqavOpenAI  # noqa: E402
 
 
+    # Stand-in for a vendor response that allows attribute assignment.
 class _FakeResponse:
-    """Stand-in for a vendor response that allows attribute assignment."""
 
     def __init__(self, model: str, response_id: str, usage) -> None:
         self.model = model
@@ -41,8 +41,8 @@ def _receipt() -> SimpleNamespace:
     )
 
 
+    # Stub asqav.init and asqav.Agent.create so no network call happens.
 def _patch_asqav(monkeypatch, agent: MagicMock) -> MagicMock:
-    """Stub asqav.init and asqav.Agent.create so no network call happens."""
     init_mock = MagicMock()
     monkeypatch.setattr(asqav, "init", init_mock)
     create_mock = MagicMock(return_value=agent)
@@ -50,8 +50,8 @@ def _patch_asqav(monkeypatch, agent: MagicMock) -> MagicMock:
     return init_mock
 
 
+    # Inject a fake openai module whose client returns ``response``.
 def _install_fake_openai(monkeypatch, response: _FakeResponse):
-    """Inject a fake openai module whose client returns ``response``."""
     completions = MagicMock()
     completions.create.return_value = response
     client_instance = SimpleNamespace(chat=SimpleNamespace(completions=completions))
@@ -62,8 +62,8 @@ def _install_fake_openai(monkeypatch, response: _FakeResponse):
     return openai_cls, completions
 
 
+    # Inject a fake anthropic module whose client returns ``response``.
 def _install_fake_anthropic(monkeypatch, response: _FakeResponse):
-    """Inject a fake anthropic module whose client returns ``response``."""
     messages = MagicMock()
     messages.create.return_value = response
     client_instance = SimpleNamespace(messages=messages)

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -119,9 +119,9 @@ def test_aerf_tampered_chain_fails_chain() -> None:
     assert res.axis("chain").result == crypto.FAIL
 
 
+    # An impact receipt missing its required parent counter-signature FAILs that axis.
 @requires_ed25519
 def test_aerf_impact_without_parent_sig_fails() -> None:
-    """An impact receipt missing its required parent counter-signature FAILs that axis."""
     doc = _load("aerf-up-05-impact-no-parent-sig", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("aerf-up-05-impact-no-parent-sig", "aerf"))
     assert res.verdict == "FAIL"
@@ -129,9 +129,9 @@ def test_aerf_impact_without_parent_sig_fails() -> None:
     assert res.axis("parent_signature").result == crypto.FAIL
 
 
+    # A PDP verdict signed for one context cannot bind a receipt claiming another.
 @requires_ed25519
 def test_aerf_pdp_split_context_fails() -> None:
-    """A PDP verdict signed for one context cannot bind a receipt claiming another."""
     doc = _load("aerf-up-08-pdp-binding-split-context", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("aerf-up-08-pdp-binding-split-context", "aerf"))
     assert res.verdict == "FAIL"
@@ -139,9 +139,9 @@ def test_aerf_pdp_split_context_fails() -> None:
     assert res.axis("pdp_signature").result == crypto.FAIL
 
 
+    # A required counter-sign axis whose key is not supplied SKIPs and downgrades to INCOMPLETE, never PASS.
 @requires_ed25519
 def test_aerf_required_layer_without_key_is_incomplete_never_pass() -> None:
-    """A required counter-sign axis whose key is not supplied SKIPs and downgrades to INCOMPLETE, never PASS."""
     doc = _load("aerf-up-07-pdp-binding-valid", "receipt.json")
     keys = dict(_provider("aerf-up-07-pdp-binding-valid", "aerf"))
     keys.pop("dfe937603b2f3312", None)  # drop the PDP key so the axis cannot be checked
@@ -178,8 +178,8 @@ def test_asqav_native_tampered_signature_fails() -> None:
     assert res.axis("signature").result == crypto.FAIL
 
 
+    # A broken chain link FAILs the chain axis independent of the signature dep.
 def test_asqav_native_chain_break_fails_without_crypto() -> None:
-    """A broken chain link FAILs the chain axis independent of the signature dep."""
     doc = _load("asqav-01-genesis-permit", "receipt.json")
     successor = json.loads(json.dumps(doc))
     successor["payload"]["previousReceiptHash"] = "f" * 64
@@ -194,17 +194,17 @@ def test_unknown_format_fails_closed() -> None:
     assert res.verdict == "FAIL"
 
 
+    # No key provider means the signature cannot be checked; never a PASS.
 def test_signature_skips_downgrade_to_incomplete() -> None:
-    """No key provider means the signature cannot be checked; never a PASS."""
     doc = _load("aerf-01-genesis", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider={})
     assert res.axis("signature").result == crypto.SKIPPED
     assert res.verdict == "INCOMPLETE"
 
 
+    # The CLI entrypoint runs the corpus, tolerates the optional-dep vector, exits 0.
 @requires_ed25519
 def test_runner_main_reports_all_green(capsys) -> None:
-    """The CLI entrypoint runs the corpus, tolerates the optional-dep vector, exits 0."""
     rc = runner_main()
     out = capsys.readouterr().out
     assert rc == 0
@@ -263,9 +263,9 @@ def test_acta_tampered_signature_fails() -> None:
     assert res.axis("signature").result == crypto.FAIL
 
 
+    # A commitment-mode receipt (signs SHA-256(JCS)) must FAIL the baseline verifier.
 @requires_ed25519
 def test_acta_commitment_mode_fails_not_false_passes() -> None:
-    """A commitment-mode receipt (signs SHA-256(JCS)) must FAIL the baseline verifier."""
     doc = _load("acta-05-commitment-mode-unsupported", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_acta_keys("acta-05-commitment-mode-unsupported"))
     assert res.verdict == "FAIL"
@@ -285,8 +285,8 @@ def _acta_profile_doc(**payload_overrides) -> dict:
     }
 
 
+    # Rev-02 asqav profile: type/issued_at/issuer_id required, issuer_id == kid.
 def test_acta_rev02_required_fields_enforced() -> None:
-    """Rev-02 asqav profile: type/issued_at/issuer_id required, issuer_id == kid."""
     adapter = ActaAdapter()
     assert adapter.schema(_acta_profile_doc())[0] == "PASS"
     # issuer_id is REQUIRED once the asqav profile (type present) is in play.
@@ -303,8 +303,8 @@ def test_acta_rev02_required_fields_enforced() -> None:
     assert adapter.schema(_acta_profile_doc(type=""))[0] == "FAIL"
 
 
+    # Upstream A2A receipts carry no type/issuer_id and verify under the relaxed schema.
 def test_acta_rev02_upstream_a2a_relaxed_deviation() -> None:
-    """Upstream A2A receipts carry no type/issuer_id and verify under the relaxed schema."""
     adapter = ActaAdapter()
     upstream = {
         "payload": {"issued_at": "2026-01-01T00:00:00Z"},
@@ -313,9 +313,9 @@ def test_acta_rev02_upstream_a2a_relaxed_deviation() -> None:
     assert adapter.schema(upstream)[0] == "PASS"
 
 
+    # The rev-02 tightening must not break the existing asqav-profile vectors.
 @requires_ed25519
 def test_acta_rev02_vectors_still_verify() -> None:
-    """The rev-02 tightening must not break the existing asqav-profile vectors."""
     for vec in ("acta-01-genesis",):
         doc = _load(vec, "receipt.json")
         res = verify(doc, ADAPTERS, key_provider=_acta_keys(vec))
@@ -341,9 +341,9 @@ def test_acta_upstream_scopeblind_receipt_verifies() -> None:
     assert res.axis("signature").result == crypto.PASS
 
 
+    # The real upstream receipt with one signature nibble flipped MUST fail.
 @requires_ed25519
 def test_acta_upstream_tampered_receipt_fails() -> None:
-    """The real upstream receipt with one signature nibble flipped MUST fail."""
     doc = _load("acta-up-03-a2a-tampered-sig", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_acta_keys("acta-up-03-a2a-tampered-sig"))
     assert res.verdict == "FAIL"
@@ -367,8 +367,8 @@ def test_acta_malformed_signature_fails_does_not_crash() -> None:
         assert ActaAdapter().extract_signature(forged).sig == b""
 
 
+    # Asqav-native profiles ACTA, so detection must never let both claim one receipt.
 def test_acta_and_asqav_native_are_mutually_exclusive() -> None:
-    """Asqav-native profiles ACTA, so detection must never let both claim one receipt."""
     acta = _load("acta-01-genesis", "receipt.json")
     native = _load("asqav-01-genesis-permit", "receipt.json")
     assert ActaAdapter().detect(acta) is True
@@ -377,9 +377,9 @@ def test_acta_and_asqav_native_are_mutually_exclusive() -> None:
     assert ActaAdapter().detect(native) is False
 
 
+    # An Asqav-shaped receipt with a hex sig routes to ACTA and FAILs - never a false native PASS.
 @requires_ed25519
 def test_cross_format_confusion_asqav_with_hex_sig_does_not_verify_as_native() -> None:
-    """An Asqav-shaped receipt with a hex sig routes to ACTA and FAILs - never a false native PASS."""
     native = _load("asqav-01-genesis-permit", "receipt.json")
     forged = json.loads(json.dumps(native))
     forged.pop("anchors", None)
@@ -391,18 +391,18 @@ def test_cross_format_confusion_asqav_with_hex_sig_does_not_verify_as_native() -
     assert verify(native, ADAPTERS, key_provider=_provider("asqav-01-genesis-permit", "asqav-native")).fmt == "asqav-native"
 
 
+    # An ACTA successor with an asqav-native predecessor is not a valid chain link.
 @requires_ed25519
 def test_acta_cross_format_predecessor_fails_chain() -> None:
-    """An ACTA successor with an asqav-native predecessor is not a valid chain link."""
     succ = _load("acta-02-chain-link", "receipt.json")
     foreign_pred = _load("asqav-01-genesis-permit", "receipt.json")
     res = verify(succ, ADAPTERS, key_provider=_acta_keys("acta-02-chain-link"), predecessor=foreign_pred)
     assert res.axis("chain").result == crypto.FAIL
 
 
+    # Deleting previousReceiptHash to fake genesis breaks the signature (it is signed).
 @requires_ed25519
 def test_acta_genesis_spoof_breaks_signature() -> None:
-    """Deleting previousReceiptHash to fake genesis breaks the signature (it is signed)."""
     succ = _load("acta-02-chain-link", "receipt.json")
     spoof = json.loads(json.dumps(succ))
     del spoof["payload"]["previousReceiptHash"]
@@ -518,9 +518,9 @@ def test_asqav_native_agent_id_fallback_binds_issuer() -> None:
     assert res.axis("signature").result in (crypto.FAIL, crypto.SKIPPED)
 
 
+    # A receipt verified against a different valid Ed25519 key FAILs the signature axis.
 @requires_ed25519
 def test_wrong_key_resolution_fails_signature() -> None:
-    """A receipt verified against a different valid Ed25519 key FAILs the signature axis."""
     doc = _load("aerf-01-genesis", "receipt.json")
     kid = doc["key_id"]
     other_raw = _vr._b64decode(_acta_keys("acta-01-genesis")["keys"][0]["x"])
@@ -532,9 +532,9 @@ def test_wrong_key_resolution_fails_signature() -> None:
     assert res.axis("signature").result == crypto.FAIL
 
 
+    # An Ed25519 receipt relabelled to an alg the verifier does not check never PASSes.
 @requires_ed25519
 def test_algorithm_confusion_does_not_false_pass() -> None:
-    """An Ed25519 receipt relabelled to an alg the verifier does not check never PASSes."""
     doc = _load("acta-01-genesis", "receipt.json")
     forged = json.loads(json.dumps(doc))
     forged["signature"]["alg"] = "ES256"
@@ -545,9 +545,9 @@ def test_algorithm_confusion_does_not_false_pass() -> None:
     assert res.axis("signature").result in (crypto.FAIL, crypto.SKIPPED)
 
 
+    # A same-format predecessor that is not the true prior link FAILs the chain axis.
 @requires_ed25519
 def test_chain_reorder_same_format_fails_chain() -> None:
-    """A same-format predecessor that is not the true prior link FAILs the chain axis."""
     succ = _load("acta-02-chain-link", "receipt.json")
     wrong_pred = _load("acta-03-tamper-sig", "receipt.json")
     assert ActaAdapter().detect(wrong_pred) is True
@@ -557,9 +557,9 @@ def test_chain_reorder_same_format_fails_chain() -> None:
     assert res.axis("chain").result == crypto.FAIL
 
 
+    # AERF signs over NFC-normalising JCS, so NFC and NFD forms verify identically.
 @requires_ed25519
 def test_nfc_canonicalization_edge() -> None:
-    """AERF signs over NFC-normalising JCS, so NFC and NFD forms verify identically."""
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
@@ -593,8 +593,8 @@ def test_nfc_canonicalization_edge() -> None:
     assert verify(tampered, ADAPTERS, key_provider=provider).axis("signature").result == crypto.FAIL
 
 
+    # Each adapter detects only its own receipt, giving a clean 4x4 detection diagonal.
 def test_four_way_format_exclusion() -> None:
-    """Each adapter detects only its own receipt, giving a clean 4x4 detection diagonal."""
     native = _load("asqav-01-genesis-permit", "receipt.json")
     aerf = _load("aerf-01-genesis", "receipt.json")
     acta = _load("acta-01-genesis", "receipt.json")
@@ -623,9 +623,9 @@ def _ar_provider(vec: str):
     return json.loads(path.read_text()) if path.exists() else None
 
 
+    # A did:key genesis verifies: the key resolves inline and the signature checks.
 @requires_ed25519
 def test_agentreceipts_didkey_genesis_passes() -> None:
-    """A did:key genesis verifies: the key resolves inline and the signature checks."""
     doc = _ar("agentreceipts-01-didkey-genesis")
     res = verify(doc, ADAPTERS)
     assert res.fmt == "agentreceipts"
@@ -658,9 +658,9 @@ def test_agentreceipts_tampered_proofvalue_fails_signature() -> None:
     assert res.axis("signature").result == crypto.FAIL
 
 
+    # An attacker's valid signature under a key the issuer does not control must not verify.
 @requires_ed25519
 def test_agentreceipts_issuer_must_control_signing_key_no_impersonation() -> None:
-    """An attacker's valid signature under a key the issuer does not control must not verify."""
     from base64 import urlsafe_b64encode
 
     from cryptography.hazmat.primitives import serialization
@@ -680,8 +680,8 @@ def test_agentreceipts_issuer_must_control_signing_key_no_impersonation() -> Non
     assert res.verdict == "FAIL"
 
 
+    # Genesis carries previous_receipt_hash present and null; omitting it is malformed.
 def test_agentreceipts_genesis_explicit_null_is_genesis_missing_field_is_malformed() -> None:
-    """Genesis carries previous_receipt_hash present and null; omitting it is malformed."""
     genesis = _ar("agentreceipts-01-didkey-genesis")
     ad = AgentReceiptsAdapter()
     assert ad.chain_step(genesis).is_genesis is True
@@ -692,9 +692,9 @@ def test_agentreceipts_genesis_explicit_null_is_genesis_missing_field_is_malform
     assert verify(missing, ADAPTERS).verdict == "FAIL"
 
 
+    # A verificationMethod resolved to a different key cannot verify the signature.
 @requires_ed25519
 def test_agentreceipts_wrong_did_fails_signature() -> None:
-    """A verificationMethod resolved to a different key cannot verify the signature."""
     doc = _ar("agentreceipts-06-wrong-key")
     res = verify(doc, ADAPTERS, key_provider=_ar_provider("agentreceipts-06-wrong-key"))
     assert res.fmt == "agentreceipts"
@@ -702,17 +702,17 @@ def test_agentreceipts_wrong_did_fails_signature() -> None:
     assert res.axis("signature").result == crypto.FAIL
 
 
+    # The upstream malformed-corpus base receipt, re-signed clean with the upstream key.
 @requires_ed25519
 def test_agentreceipts_upstream_valid_resigned_passes() -> None:
-    """The upstream malformed-corpus base receipt, re-signed clean with the upstream key."""
     doc = _ar("agentreceipts-up-00-valid-resigned")
     res = verify(doc, ADAPTERS, key_provider=_ar_provider("agentreceipts-up-00-valid-resigned"))
     assert res.verdict == "PASS"
     assert res.axis("signature").result == crypto.PASS
 
 
+    # Gold interop: our jcs_rfc8785 output must byte-equal every upstream canonical form.
 def test_jcs_rfc8785_byte_matches_upstream_canonicalization_vectors() -> None:
-    """Gold interop: our jcs_rfc8785 output must byte-equal every upstream canonical form."""
     path = _INTEROP / "canonicalization_vectors.json"
     if not path.exists():
         pytest.skip("upstream canonicalization vectors not vendored")
@@ -725,8 +725,8 @@ def test_jcs_rfc8785_byte_matches_upstream_canonicalization_vectors() -> None:
     assert not mismatches, f"JCS interop mismatches vs upstream: {mismatches}"
 
 
+    # The shared DID resolver decodes each upstream did:key to its expected raw key.
 def test_didkey_resolver_decodes_upstream_did_key_vectors() -> None:
-    """The shared DID resolver decodes each upstream did:key to its expected raw key."""
     path = _INTEROP / "did_key_vectors.json"
     if not path.exists():
         pytest.skip("upstream did:key vectors not vendored")
@@ -738,8 +738,8 @@ def test_didkey_resolver_decodes_upstream_did_key_vectors() -> None:
         assert raw.hex() == v["public_key_hex"], f"{v['name']} key mismatch"
 
 
+    # base58btc decodes a known multikey frame: 0xed01 prefix + 32 key bytes.
 def test_b58btc_decode_known_value() -> None:
-    """base58btc decodes a known multikey frame: 0xed01 prefix + 32 key bytes."""
     # did:key vector-1 identifier without the multibase 'z' prefix.
     decoded = b58btc_decode("6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw")
     assert decoded[:2] == b"\xed\x01"
@@ -753,8 +753,8 @@ from asqav.verifier.oracle.canonical import asqav_jcs  # noqa: E402
 _PROD_HASH = _CORPUS / "asqav-05-hash-mode-prod"
 
 
+    # Cloud-parity anchor: the native canonicaliser equals the cloud signer's bytes.
 def test_asqav_jcs_byte_matches_verify_receipt_canonical_json() -> None:
-    """Cloud-parity anchor: the native canonicaliser equals the cloud signer's bytes."""
     samples = [
         {"b": 2, "a": 1, "z": {"y": 3, "x": [1, 2]}},
         {"mode": "hash", "v": 1, "metadata": {}, "policy_digest": None},
@@ -764,16 +764,16 @@ def test_asqav_jcs_byte_matches_verify_receipt_canonical_json() -> None:
         assert asqav_jcs(obj) == _vr.canonical_json(obj)
 
 
+    # A real prod hash-mode receipt detects as asqav-native and no other adapter claims it.
 def test_hash_mode_receipt_routes_to_asqav_native() -> None:
-    """A real prod hash-mode receipt detects as asqav-native and no other adapter claims it."""
     doc = _load("asqav-05-hash-mode-prod", "receipt.json")
     a, e, c, g = AsqavNativeAdapter(), AerfAdapter(), ActaAdapter(), AgentReceiptsAdapter()
     assert (a.detect(doc), e.detect(doc), c.detect(doc), g.detect(doc)) == (True, False, False, False)
     assert verify(doc, ADAPTERS, key_provider=_provider("asqav-05-hash-mode-prod", "asqav-native")).fmt == "asqav-native"
 
 
+    # The reconstructed hash-mode signing input is byte-identical to the prod-signed bytes.
 def test_hash_mode_signing_input_byte_matches_prod_message() -> None:
-    """The reconstructed hash-mode signing input is byte-identical to the prod-signed bytes."""
     doc = _load("asqav-05-hash-mode-prod", "receipt.json")
     ground_truth = (_PROD_HASH / "signed_message.bytes").read_bytes()
     rebuilt = AsqavNativeAdapter().signing_input(doc)
@@ -785,8 +785,8 @@ def test_hash_mode_signing_input_byte_matches_prod_message() -> None:
     )
 
 
+    # Without dilithium-py the ML-DSA-65 axis SKIPs; the verdict is INCOMPLETE, never PASS.
 def test_hash_mode_signature_skips_without_dilithium_never_false_pass() -> None:
-    """Without dilithium-py the ML-DSA-65 axis SKIPs; the verdict is INCOMPLETE, never PASS."""
     doc = _load("asqav-05-hash-mode-prod", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("asqav-05-hash-mode-prod", "asqav-native"))
     assert res.fmt == "asqav-native"
@@ -796,8 +796,8 @@ def test_hash_mode_signature_skips_without_dilithium_never_false_pass() -> None:
     assert res.verdict != "FAIL"
 
 
+    # A malformed hash-mode signature (non-string) verifies to a non-PASS, never raises.
 def test_hash_mode_malformed_signature_fails_does_not_crash() -> None:
-    """A malformed hash-mode signature (non-string) verifies to a non-PASS, never raises."""
     doc = _load("asqav-05-hash-mode-prod", "receipt.json")
     for bad in ({"not": "a string"}, 12345, ["x"]):
         forged = json.loads(json.dumps(doc))
@@ -807,8 +807,8 @@ def test_hash_mode_malformed_signature_fails_does_not_crash() -> None:
         assert res.verdict != "PASS"
 
 
+    # A malformed Asqav compliance-envelope signature decodes to b'' and FAILs, never raises.
 def test_compliance_envelope_malformed_signature_fails_does_not_crash() -> None:
-    """A malformed Asqav compliance-envelope signature decodes to b'' and FAILs, never raises."""
     doc = _load("asqav-01-genesis-permit", "receipt.json")
     for bad in ({"k": "v"}, 999, None, "not base64 @@@"):
         forged = json.loads(json.dumps(doc))
@@ -817,8 +817,8 @@ def test_compliance_envelope_malformed_signature_fails_does_not_crash() -> None:
         assert res.verdict != "PASS"
 
 
+    # A malformed AERF signature (non-hex or non-string) decodes to b'' and FAILs, never raises.
 def test_aerf_malformed_signature_fails_does_not_crash() -> None:
-    """A malformed AERF signature (non-hex or non-string) decodes to b'' and FAILs, never raises."""
     doc = _load("aerf-01-genesis", "receipt.json")
     for bad in ("zzzz-not-hex", {"k": "v"}, 42, None):
         forged = json.loads(json.dumps(doc))
@@ -827,8 +827,8 @@ def test_aerf_malformed_signature_fails_does_not_crash() -> None:
         assert res.verdict != "PASS"
 
 
+    # Malformed AERF parent/pdp counter-signatures decode to b'' and FAIL, never raise.
 def test_aerf_malformed_parent_pdp_signature_fails_does_not_crash() -> None:
-    """Malformed AERF parent/pdp counter-signatures decode to b'' and FAIL, never raise."""
     vec = "aerf-up-06-impact-with-parent-sig"
     doc = _load(vec, "receipt.json")
     for field in ("parent_signature", "pdp_signature"):
@@ -848,26 +848,26 @@ def _authproof_receipt() -> dict:
     return json.loads((_CORPUS / "authproof-01-genesis-real-sdk" / "receipt.json").read_text())
 
 
+    # A receipt minted by the real Authproof JS SDK verifies (cross-implementation interop).
 @requires_ed25519
 def test_authproof_real_sdk_receipt_verifies() -> None:
-    """A receipt minted by the real Authproof JS SDK verifies (cross-implementation interop)."""
     res = verify(_authproof_receipt(), ADAPTERS)
     assert res.fmt == "authproof"
     assert res.verdict == "PASS"
     assert res.axis("signature").result == crypto.PASS
 
 
+    # The Authproof fingerprint matches only its own receipt, not the other formats.
 def test_authproof_detection_is_exclusive() -> None:
-    """The Authproof fingerprint matches only its own receipt, not the other formats."""
     doc = _authproof_receipt()
     assert [a.name for a in ADAPTERS if a.detect(doc)] == ["authproof"]
     other = _load("aerf-01-genesis", "receipt.json")
     assert AuthproofAdapter().detect(other) is False
 
 
+    # Tampering a signed field, forging the signature, or swapping the key all FAIL.
 @requires_ed25519
 def test_authproof_tamper_and_forge_fail_closed() -> None:
-    """Tampering a signed field, forging the signature, or swapping the key all FAIL."""
     base = _authproof_receipt()
     tampered = json.loads(json.dumps(base))
     tampered["scope"] = "Send all the emails."
@@ -880,8 +880,8 @@ def test_authproof_tamper_and_forge_fail_closed() -> None:
     assert verify(wrong_key, ADAPTERS).verdict == "FAIL"
 
 
+    # A malformed Authproof signature decodes to b'' and FAILs, never raises.
 def test_authproof_malformed_signature_fails_does_not_crash() -> None:
-    """A malformed Authproof signature decodes to b'' and FAILs, never raises."""
     base = _authproof_receipt()
     for bad in ("zz-not-hex", {"k": "v"}, 42, None, "abc"):
         forged = json.loads(json.dumps(base))
@@ -889,15 +889,15 @@ def test_authproof_malformed_signature_fails_does_not_crash() -> None:
         assert verify(forged, ADAPTERS).verdict != "PASS"
 
 
+    # ES256 verify returns FAIL (never raises) on a bad point or a wrong-length signature.
 def test_es256_malformed_key_and_sig_fail_closed() -> None:
-    """ES256 verify returns FAIL (never raises) on a bad point or a wrong-length signature."""
     assert crypto.verify_es256(b"\x00" * 10, b"m", b"\x00" * 64)[0] == crypto.FAIL
     pk = AuthproofAdapter().resolve_key(_authproof_receipt(), None)[0]
     assert crypto.verify_es256(pk, b"m", b"\x00" * 10)[0] == crypto.FAIL
 
 
+    # A non-object receipt (array/string/scalar) matches no format and FAILs, never crashes.
 def test_non_dict_receipt_fails_closed_never_crashes() -> None:
-    """A non-object receipt (array/string/scalar) matches no format and FAILs, never crashes."""
     from asqav.verifier.oracle.core import detect
 
     for bad in ([1, 2, 3], "a-string", 42, None, True):
@@ -957,8 +957,8 @@ def test_pipelock_evidence_v2_tampered_payload_fails() -> None:
     assert res.axis("signature").result == crypto.FAIL
 
 
+    # The Pipelock fingerprint matches only its own receipts, not any other format.
 def test_pipelock_detection_is_exclusive() -> None:
-    """The Pipelock fingerprint matches only its own receipts, not any other format."""
     pipelock_doc = _pipelock("pipelock-ev2-01-proxy-decision")
     aerf_doc = _load("aerf-01-genesis", "receipt.json")
     acta_doc = _load("acta-01-genesis", "receipt.json")
@@ -974,9 +974,9 @@ def test_pipelock_detection_is_exclusive() -> None:
     assert [a.name for a in ADAPTERS if a.detect(pipelock_doc)] == ["pipelock-evidence-v2"]
 
 
+    # A valid Pipelock receipt verified against a different Ed25519 key FAILs the signature axis.
 @requires_ed25519
 def test_pipelock_wrong_key_fails_signature() -> None:
-    """A valid Pipelock receipt verified against a different Ed25519 key FAILs the signature axis."""
     doc = _pipelock("pipelock-ev2-01-proxy-decision")
     wrong_provider = {"receipt-signing-test": "00" * 32}
     res = verify(doc, ADAPTERS, key_provider=wrong_provider)
@@ -985,8 +985,8 @@ def test_pipelock_wrong_key_fails_signature() -> None:
     assert res.axis("signature").result == crypto.FAIL
 
 
+    # No key for signer_key_id: signature axis SKIPs; verdict is INCOMPLETE, never PASS.
 def test_pipelock_missing_key_skips_never_passes() -> None:
-    """No key for signer_key_id: signature axis SKIPs; verdict is INCOMPLETE, never PASS."""
     doc = _pipelock("pipelock-ev2-01-proxy-decision")
     res = verify(doc, ADAPTERS, key_provider={})
     assert res.fmt == "pipelock-evidence-v2"
@@ -994,8 +994,8 @@ def test_pipelock_missing_key_skips_never_passes() -> None:
     assert res.verdict == "INCOMPLETE"
 
 
+    # A Pipelock receipt carrying an unsupported algorithm token FAILs the structure axis.
 def test_pipelock_schema_rejects_bad_algorithm() -> None:
-    """A Pipelock receipt carrying an unsupported algorithm token FAILs the structure axis."""
     doc = _pipelock("pipelock-ev2-01-proxy-decision")
     forged = json.loads(json.dumps(doc))
     forged["signature"]["algorithm"] = "ecdsa-p256"
@@ -1004,8 +1004,8 @@ def test_pipelock_schema_rejects_bad_algorithm() -> None:
     assert res.verdict == "FAIL"
 
 
+    # Both 'genesis' and 'sha256:0' chain_prev_hash values are accepted as genesis.
 def test_pipelock_chain_genesis_sentinel_accepted() -> None:
-    """Both 'genesis' and 'sha256:0' chain_prev_hash values are accepted as genesis."""
     doc = _pipelock("pipelock-ev2-01-proxy-decision")
     ad = PipelockEvidenceAdapter()
     # The fixture uses sha256:0.
@@ -1020,16 +1020,16 @@ def test_pipelock_chain_genesis_sentinel_accepted() -> None:
     assert ad.chain_step(doc3).is_genesis is False
 
 
+    # A non-string alg from a malformed receipt SKIPs, never crashes on .upper().
 def test_oracle_verify_signature_nonstring_alg_skips_clean() -> None:
-    """A non-string alg from a malformed receipt SKIPs, never crashes on .upper()."""
     z = b""
     for bad_alg in (123, None, ["x"], {}):
         result, _ = crypto.verify_signature(bad_alg, z, z, z)
         assert result == crypto.SKIPPED
 
 
+    # A non-dict top-level receipt returns a FAIL verdict, never raises in detect().
 def test_oracle_verify_nonobject_doc_fails_clean() -> None:
-    """A non-dict top-level receipt returns a FAIL verdict, never raises in detect()."""
     for bad_doc in (None, "a string", 123, [1, 2]):
         res = verify(bad_doc, ADAPTERS)
         assert res.verdict == "FAIL"
@@ -1041,16 +1041,16 @@ _ISSUER_DID = "did:web:asqav.example"
 _SIGNER = {_ISSUER_DID + "#key-1": "00" * 32}
 
 
+    # A dict nested ``depth`` levels deep, built iteratively so the fixture never overflows.
 def _nested(depth: int) -> object:
-    """A dict nested ``depth`` levels deep, built iteratively so the fixture never overflows."""
     node: object = 1
     for _ in range(depth):
         node = {"a": node}
     return node
 
 
+    # A well-formed agentreceipts envelope whose credentialSubject nests ``depth`` deep.
 def _deep_agentreceipt(depth: int, *, genesis: bool = True) -> dict:
-    """A well-formed agentreceipts envelope whose credentialSubject nests ``depth`` deep."""
     return {
         "@context": ["https://www.w3.org/ns/credentials/v2"],
         "id": "urn:uuid:00000000-0000-0000-0000-000000000000",
@@ -1082,15 +1082,15 @@ def test_oracle_over_nested_receipt_is_incomplete_not_recursionerror() -> None:
     assert "depth" in (res.axis("structure").note or "")
 
 
+    # A deeply nested predecessor is capped on the chain axis, never a RecursionError.
 def test_oracle_over_nested_predecessor_is_incomplete_not_recursionerror() -> None:
-    """A deeply nested predecessor is capped on the chain axis, never a RecursionError."""
     doc = _deep_agentreceipt(1, genesis=False)
     res = verify(doc, ADAPTERS, key_provider=_SIGNER, predecessor=_deep_agentreceipt(3000))
     assert res.verdict == "INCOMPLETE"
     assert "depth" in (res.axis("structure").note or "")
 
 
+    # A receipt nested under the cap verifies normally and is not reported too-deep.
 def test_oracle_receipt_within_depth_is_not_flagged_too_deep() -> None:
-    """A receipt nested under the cap verifies normally and is not reported too-deep."""
     res = verify(_deep_agentreceipt(50), ADAPTERS, key_provider=_SIGNER)
     assert "depth" not in (res.axis("structure").note or "")

--- a/python/tests/test_oracle_kid_shared_resolution.py
+++ b/python/tests/test_oracle_kid_shared_resolution.py
@@ -38,8 +38,8 @@ REAL_KID = "key-shared-resolution"
 ABSENT_KID = "kid-that-resolves-nothing"
 
 
+    # A compliance payload naming its issuer and agent inside the signed bytes.
 def _payload() -> dict:
-    """A compliance payload naming its issuer and agent inside the signed bytes."""
     return {
         "type": "protectmcp:decision",
         "issued_at": "2026-06-01T19:26:44.289388Z",
@@ -53,8 +53,8 @@ def _payload() -> dict:
     }
 
 
+    # A directory publishing one key, resolvable by kid AND by agent_id.
 def _jwks(status: str = "revoked", public_key: str = "QUFBQQ==") -> dict:
-    """A directory publishing one key, resolvable by kid AND by agent_id."""
     return {
         "keys": [
             {
@@ -84,25 +84,25 @@ def _axes(doc: dict, jwks: dict) -> dict[str, str]:
 # --- the axes must exist whichever route resolved the key ---
 
 
+    # A kid the directory does not answer for still yields both gating axes.
 def test_absent_kid_still_emits_the_gating_axes() -> None:
-    """A kid the directory does not answer for still yields both gating axes."""
     axes = _axes(_receipt(ABSENT_KID), _jwks())
     assert "key_status" in axes, "a rewritten kid must not make the axis vanish"
     assert "issuer_bind" in axes
 
 
+    # The status read is the one published for the key the agent route resolves.
 def test_absent_kid_reports_the_revoked_status_of_the_signing_key() -> None:
-    """The status read is the one published for the key the agent route resolves."""
     assert _axes(_receipt(ABSENT_KID), _jwks(status="revoked"))["key_status"] == "FAIL"
 
 
+    # Rewriting the kid changes no axis outcome, since one entry answers both.
 def test_absent_kid_agrees_with_the_real_kid_on_every_axis() -> None:
-    """Rewriting the kid changes no axis outcome, since one entry answers both."""
     assert _axes(_receipt(ABSENT_KID), _jwks()) == _axes(_receipt(REAL_KID), _jwks())
 
 
+    # The shared resolution does not turn an active key into a failure.
 def test_active_key_passes_the_status_axis_through_the_agent_route() -> None:
-    """The shared resolution does not turn an active key into a failure."""
     axes = _axes(_receipt(ABSENT_KID), _jwks(status="active"))
     assert axes["key_status"] == "PASS"
     assert axes["issuer_bind"] == "PASS"
@@ -112,14 +112,14 @@ def test_active_key_passes_the_status_axis_through_the_agent_route() -> None:
 KEY_AXES = {"key_status", "issuer_bind"}
 
 
+    # With nothing resolvable the signature axis carries the verdict on its own.
 def test_no_key_at_all_emits_no_key_axis() -> None:
-    """With nothing resolvable the signature axis carries the verdict on its own."""
     axes = _axes(_receipt(ABSENT_KID), {"keys": []})
     assert KEY_AXES.isdisjoint(axes), axes
 
 
+    # agent_id is attacker-controlled, so the issuer bind still gates the match.
 def test_agent_route_needs_the_claimed_issuer_to_match() -> None:
-    """agent_id is attacker-controlled, so the issuer bind still gates the match."""
     jwks = _jwks()
     jwks["keys"][0]["issuer_id"] = "some-other-entity"
     axes = _axes(_receipt(ABSENT_KID), jwks)
@@ -129,8 +129,8 @@ def test_agent_route_needs_the_claimed_issuer_to_match() -> None:
 # --- the shared entry is the one the signature verifies against ---
 
 
+    # Both surfaces answer for the absent kid, rather than one answering alone.
 def test_resolve_key_and_extra_axes_resolve_the_same_entry() -> None:
-    """Both surfaces answer for the absent kid, rather than one answering alone."""
     ad = AsqavNativeAdapter()
     doc, jwks = _receipt(ABSENT_KID), _jwks()
     pk, note = ad.resolve_key(doc, jwks)
@@ -139,8 +139,8 @@ def test_resolve_key_and_extra_axes_resolve_the_same_entry() -> None:
     assert KEY_AXES <= emitted, emitted
 
 
+    # kid wins when it resolves, so the agent route only fills a genuine gap.
 def test_match_signing_key_prefers_the_kid_entry() -> None:
-    """kid wins when it resolves, so the agent route only fills a genuine gap."""
     jwks = {
         "keys": [
             {"kid": REAL_KID, "issuer_id": ISSUER, "public_key": "QUFBQQ==", "status": "active"},

--- a/python/tests/test_oracle_multikey_org_resolution.py
+++ b/python/tests/test_oracle_multikey_org_resolution.py
@@ -33,8 +33,8 @@ requires_ed25519 = pytest.mark.skipif(
 ORG = "org_multikey_shared"
 
 
+    # A hash-mode signing payload naming its agent and org inside the signed bytes.
 def _flat(agent_id: str) -> dict:
-    """A hash-mode signing payload naming its agent and org inside the signed bytes."""
     return {
         "v": 1,
         "mode": "hash",
@@ -50,8 +50,8 @@ def _flat(agent_id: str) -> dict:
     }
 
 
+    # Build the hash-mode receipt envelope signed by sk over the canonical flat bytes.
 def _sign(flat: dict, sk) -> dict:
-    """Build the hash-mode receipt envelope signed by sk over the canonical flat bytes."""
     sig = base64.b64encode(sk.sign(asqav_jcs(flat))).decode()
     doc = dict(flat)
     doc["payload"] = None
@@ -61,8 +61,8 @@ def _sign(flat: dict, sk) -> dict:
     return doc
 
 
+    # Three sibling keys sharing issuer_id/org_id; agent_id uniquely names each.
 def _sibling_jwks(signer_index: int, public_keys: list[bytes]) -> dict:
-    """Three sibling keys sharing issuer_id/org_id; agent_id uniquely names each."""
     keys = []
     for i, pk in enumerate(public_keys):
         keys.append(
@@ -79,9 +79,9 @@ def _sibling_jwks(signer_index: int, public_keys: list[bytes]) -> dict:
     return {"keys": keys}
 
 
+    # A receipt signed by the last of three siblings verifies to PASS, not a false FAIL.
 @requires_ed25519
 def test_last_sibling_receipt_resolves_the_actual_signer() -> None:
-    """A receipt signed by the last of three siblings verifies to PASS, not a false FAIL."""
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
     sks = [Ed25519PrivateKey.generate() for _ in range(3)]
@@ -95,9 +95,9 @@ def test_last_sibling_receipt_resolves_the_actual_signer() -> None:
     assert result.verdict == "PASS", result.axes
 
 
+    # Whichever sibling signs, the agent bind resolves that sibling's key, never another.
 @requires_ed25519
 def test_each_sibling_resolves_to_its_own_key() -> None:
-    """Whichever sibling signs, the agent bind resolves that sibling's key, never another."""
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
     sks = [Ed25519PrivateKey.generate() for _ in range(3)]
@@ -111,9 +111,9 @@ def test_each_sibling_resolves_to_its_own_key() -> None:
         assert verify(receipt, [ad], key_provider=jwks).verdict == "PASS"
 
 
+    # A signature from a key the directory does not publish fails, never a false PASS.
 @requires_ed25519
 def test_forged_signature_against_the_org_still_fails() -> None:
-    """A signature from a key the directory does not publish fails, never a false PASS."""
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
     sks = [Ed25519PrivateKey.generate() for _ in range(3)]
@@ -126,9 +126,9 @@ def test_forged_signature_against_the_org_still_fails() -> None:
     assert result.verdict != "PASS", result.axes
 
 
+    # agent_id is attacker-controlled: a key from another org never resolves the claim.
 @requires_ed25519
 def test_cross_org_agent_bind_does_not_match() -> None:
-    """agent_id is attacker-controlled: a key from another org never resolves the claim."""
     entry = v._match_key_by_agent(
         {
             "keys": [

--- a/python/tests/test_patterns.py
+++ b/python/tests/test_patterns.py
@@ -12,8 +12,8 @@ from asqav.patterns import PATTERNS, list_patterns, resolve_pattern
 # === resolve_pattern tests ===
 
 
+    # resolve_pattern expands 'sql-read' to its glob.
 def test_resolve_known_sql_read() -> None:
-    """resolve_pattern expands 'sql-read' to its glob."""
     assert resolve_pattern("sql-read") == "data:read:sql:*"
 
 
@@ -64,8 +64,8 @@ def test_resolve_known_admin_action() -> None:
 # === Passthrough for unknown patterns ===
 
 
+    # Unknown patterns are returned as-is.
 def test_resolve_unknown_passthrough() -> None:
-    """Unknown patterns are returned as-is."""
     assert resolve_pattern("custom:my:action") == "custom:my:action"
 
 
@@ -80,8 +80,8 @@ def test_resolve_arbitrary_string_passthrough() -> None:
 # === list_patterns tests ===
 
 
+    # list_patterns returns all 12 entries.
 def test_list_patterns_returns_all() -> None:
-    """list_patterns returns all 12 entries."""
     result = list_patterns()
     assert len(result) == 12
 
@@ -110,8 +110,8 @@ def test_list_patterns_contains_expected_keys() -> None:
     assert set(result.keys()) == expected_keys
 
 
+    # list_patterns returns a copy, not the original dict.
 def test_list_patterns_is_copy() -> None:
-    """list_patterns returns a copy, not the original dict."""
     result = list_patterns()
     result["new-key"] = "new-value"
     assert "new-key" not in PATTERNS

--- a/python/tests/test_payload_field_fallback.py
+++ b/python/tests/test_payload_field_fallback.py
@@ -48,8 +48,8 @@ def _async_agent() -> AsyncAgent:
     )
 
 
+    # Compliance-mode sign response: the two fields live only inside payload.
 def _wire_with_payload_only() -> dict:
-    """Compliance-mode sign response: the two fields live only inside payload."""
     return {
         "signature": "sig_b64",
         "signature_id": "sig_abc",
@@ -73,8 +73,8 @@ def test_sync_sign_resolves_action_ref_and_prev_hash_from_payload() -> None:
     assert resp.previous_receipt_hash == _PREV_HASH
 
 
+    # A top-level value is authoritative; the payload copy is only a fallback.
 def test_sync_top_level_wins_over_payload() -> None:
-    """A top-level value is authoritative; the payload copy is only a fallback."""
     wire = _wire_with_payload_only()
     wire["action_ref"] = "sha256:" + "b" * 64
     wire["previous_receipt_hash"] = "1" * 64

--- a/python/tests/test_phases.py
+++ b/python/tests/test_phases.py
@@ -11,8 +11,8 @@ from asqav.phases import PhaseChain, sign_with_phases
 # === Helpers ===
 
 
+    # Create a mock Agent with sign() and preflight().
 def _mock_agent(cleared: bool = True) -> MagicMock:
-    """Create a mock Agent with sign() and preflight()."""
     agent = MagicMock()
 
     intent_sig = SignatureResponse(
@@ -46,8 +46,8 @@ def _mock_agent(cleared: bool = True) -> MagicMock:
 # === Three-phase flow ===
 
 
+    # All three phases execute when preflight clears.
 def test_full_three_phase_flow():
-    """All three phases execute when preflight clears."""
     agent = _mock_agent(cleared=True)
 
     chain = sign_with_phases(agent, "api:call", {"model": "gpt-4"})
@@ -67,8 +67,8 @@ def test_full_three_phase_flow():
     assert second_call[1]["parent_id"] == "sid-intent-001"
 
 
+    # When preflight denies, execution phase is skipped.
 def test_blocked_action_skips_execution():
-    """When preflight denies, execution phase is skipped."""
     agent = _mock_agent(cleared=False)
 
     chain = sign_with_phases(agent, "api:call")
@@ -82,8 +82,8 @@ def test_blocked_action_skips_execution():
     assert agent.sign.call_count == 1
 
 
+    # Custom trace_id is passed through all phases.
 def test_trace_id_propagation():
-    """Custom trace_id is passed through all phases."""
     agent = _mock_agent(cleared=True)
     custom_tid = "trace-abc-123"
 
@@ -96,8 +96,8 @@ def test_trace_id_propagation():
         assert call[1]["trace_id"] == custom_tid
 
 
+    # When no trace_id provided, one is auto-generated.
 def test_trace_id_auto_generated():
-    """When no trace_id provided, one is auto-generated."""
     agent = _mock_agent(cleared=True)
 
     with patch("asqav.client.generate_trace_id", return_value="auto-tid-999"):
@@ -109,8 +109,8 @@ def test_trace_id_auto_generated():
 # === PhaseChain serialization ===
 
 
+    # to_dict produces a complete serializable dict.
 def test_to_dict():
-    """to_dict produces a complete serializable dict."""
     agent = _mock_agent(cleared=True)
     chain = sign_with_phases(agent, "api:call")
 
@@ -123,8 +123,8 @@ def test_to_dict():
     assert d["execution"]["signature_id"] == "sid-exec-001"
 
 
+    # to_dict handles blocked chain (no execution).
 def test_to_dict_blocked():
-    """to_dict handles blocked chain (no execution)."""
     agent = _mock_agent(cleared=False)
     chain = sign_with_phases(agent, "api:call")
 
@@ -136,8 +136,8 @@ def test_to_dict_blocked():
     assert len(d["decision"]["reasons"]) > 0
 
 
+    # to_json produces valid JSON matching to_dict.
 def test_to_json():
-    """to_json produces valid JSON matching to_dict."""
     agent = _mock_agent(cleared=True)
     chain = sign_with_phases(agent, "api:call")
 
@@ -150,8 +150,8 @@ def test_to_json():
 # === Agent convenience method ===
 
 
+    # Agent.sign_with_phases delegates to phases module.
 def test_agent_convenience_method():
-    """Agent.sign_with_phases delegates to phases module."""
     from asqav.client import Agent
 
     with (

--- a/python/tests/test_preflight_destructive_sql_bypass.py
+++ b/python/tests/test_preflight_destructive_sql_bypass.py
@@ -69,11 +69,11 @@ _WRITE_SQL_POLICY = [
 # ---------------------------------------------------------------------------
 
 
+    # data:delete:* policy blocks data:write:sql:DELETE FROM users.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_delete_policy_blocks_write_sql_delete_from(mock_post, mock_get):
-    """data:delete:* policy blocks data:write:sql:DELETE FROM users."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -85,11 +85,11 @@ def test_delete_policy_blocks_write_sql_delete_from(mock_post, mock_get):
     assert any("no-deletions" in r for r in result.reasons)
 
 
+    # data:delete:* policy blocks data:write:sql:DELETE_FROM_users (underscore form).
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_delete_policy_blocks_write_sql_delete_from_underscore(mock_post, mock_get):
-    """data:delete:* policy blocks data:write:sql:DELETE_FROM_users (underscore form)."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -101,11 +101,11 @@ def test_delete_policy_blocks_write_sql_delete_from_underscore(mock_post, mock_g
     assert any("no-deletions" in r for r in result.reasons)
 
 
+    # data:delete:* policy blocks data:write:sql:DROP TABLE t.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_delete_policy_blocks_write_sql_drop(mock_post, mock_get):
-    """data:delete:* policy blocks data:write:sql:DROP TABLE t."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -116,11 +116,11 @@ def test_delete_policy_blocks_write_sql_drop(mock_post, mock_get):
     assert result.policy_allowed is False
 
 
+    # data:delete:* policy blocks data:write:sql:TRUNCATE TABLE t.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_delete_policy_blocks_write_sql_truncate(mock_post, mock_get):
-    """data:delete:* policy blocks data:write:sql:TRUNCATE TABLE t."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -131,11 +131,11 @@ def test_delete_policy_blocks_write_sql_truncate(mock_post, mock_get):
     assert result.policy_allowed is False
 
 
+    # Regression guard: data:write:sql:* policy still blocks a DELETE write action.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_regression_write_policy_still_blocks_destructive_write(mock_post, mock_get):
-    """Regression guard: data:write:sql:* policy still blocks a DELETE write action."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _WRITE_SQL_POLICY]
@@ -147,11 +147,11 @@ def test_regression_write_policy_still_blocks_destructive_write(mock_post, mock_
     assert any("no-sql-writes" in r for r in result.reasons)
 
 
+    # data:delete:* policy must not block data:write:sql:INSERT INTO t.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_negative_delete_policy_does_not_block_benign_write(mock_post, mock_get):
-    """data:delete:* policy must not block data:write:sql:INSERT INTO t."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -162,11 +162,11 @@ def test_negative_delete_policy_does_not_block_benign_write(mock_post, mock_get)
     assert result.policy_allowed is True
 
 
+    # data:delete:* policy must not block data:read:sql:SELECT delete_flag FROM t.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_negative_delete_policy_does_not_block_read_mentioning_delete(mock_post, mock_get):
-    """data:delete:* policy must not block data:read:sql:SELECT delete_flag FROM t."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -177,11 +177,11 @@ def test_negative_delete_policy_does_not_block_read_mentioning_delete(mock_post,
     assert result.policy_allowed is True
 
 
+    # deleted_at in a write action does not trigger the destructive verb detection.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_negative_deleted_at_is_not_destructive(mock_post, mock_get):
-    """deleted_at in a write action does not trigger the destructive verb detection."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -207,8 +207,8 @@ _UPPER_WRITE_SQL_POLICY = [
 # ---------------------------------------------------------------------------
 
 
+    # Uppercase and whitespace variants produce the same candidates as lowercase.
 def test_action_candidates_normalize_case_and_whitespace():
-    """Uppercase and whitespace variants produce the same candidates as lowercase."""
     from asqav._sql_match import action_candidates
 
     base = action_candidates("data:write:sql:DELETE FROM users")
@@ -220,11 +220,11 @@ def test_action_candidates_normalize_case_and_whitespace():
     assert "data:delete:sql:delete from users" in base
 
 
+    # A lowercase data:delete:* policy blocks an uppercase DATA:WRITE:SQL:DELETE.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_uppercase_action_blocked_by_lowercase_delete_policy(mock_post, mock_get):
-    """A lowercase data:delete:* policy blocks an uppercase DATA:WRITE:SQL:DELETE."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -236,11 +236,11 @@ def test_uppercase_action_blocked_by_lowercase_delete_policy(mock_post, mock_get
     assert any("no-deletions" in r for r in result.reasons)
 
 
+    # Leading/trailing whitespace does not let a DELETE write dodge the policy.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_whitespace_action_blocked_by_delete_policy(mock_post, mock_get):
-    """Leading/trailing whitespace does not let a DELETE write dodge the policy."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -251,11 +251,11 @@ def test_whitespace_action_blocked_by_delete_policy(mock_post, mock_get):
     assert result.policy_allowed is False
 
 
+    # A lowercase data:write:sql:* pattern blocks an uppercase write action.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_lowercase_pattern_blocks_uppercase_action(mock_post, mock_get):
-    """A lowercase data:write:sql:* pattern blocks an uppercase write action."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _WRITE_SQL_POLICY]
@@ -267,11 +267,11 @@ def test_lowercase_pattern_blocks_uppercase_action(mock_post, mock_get):
     assert any("no-sql-writes" in r for r in result.reasons)
 
 
+    # An uppercase DATA:WRITE:SQL:* pattern blocks a lowercase write action.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_uppercase_pattern_blocks_lowercase_action(mock_post, mock_get):
-    """An uppercase DATA:WRITE:SQL:* pattern blocks a lowercase write action."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _UPPER_WRITE_SQL_POLICY]
@@ -287,12 +287,12 @@ def test_uppercase_pattern_blocks_lowercase_action(mock_post, mock_get):
 # ---------------------------------------------------------------------------
 
 
+    # Each extended destructive verb matches the data:delete:* augment.
 @pytest.mark.parametrize("verb", ["GRANT", "REVOKE", "REPLACE", "COPY", "UPSERT"])
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_extended_destructive_verb_blocked_by_delete_policy(mock_post, mock_get, verb):
-    """Each extended destructive verb matches the data:delete:* augment."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
@@ -309,10 +309,10 @@ def test_extended_destructive_verb_blocked_by_delete_policy(mock_post, mock_get,
 # ---------------------------------------------------------------------------
 
 
+    # Async: data:delete:* policy blocks data:write:sql:DELETE FROM users.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_async_delete_policy_blocks_write_sql_delete(mock_get):
-    """Async: data:delete:* policy blocks data:write:sql:DELETE FROM users."""
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
 
     result = await ASYNC_AGENT.preflight("data:write:sql:DELETE FROM users")
@@ -322,10 +322,10 @@ async def test_async_delete_policy_blocks_write_sql_delete(mock_get):
     assert any("no-deletions" in r for r in result.reasons)
 
 
+    # Async: data:delete:* policy blocks data:write:sql:DROP TABLE t.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_async_delete_policy_blocks_write_sql_drop(mock_get):
-    """Async: data:delete:* policy blocks data:write:sql:DROP TABLE t."""
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
 
     result = await ASYNC_AGENT.preflight("data:write:sql:DROP TABLE t")
@@ -334,10 +334,10 @@ async def test_async_delete_policy_blocks_write_sql_drop(mock_get):
     assert result.policy_allowed is False
 
 
+    # Async regression guard: data:write:sql:* still blocks a destructive write.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_async_regression_write_policy_still_fires(mock_get):
-    """Async regression guard: data:write:sql:* still blocks a destructive write."""
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _WRITE_SQL_POLICY]
 
     result = await ASYNC_AGENT.preflight("data:write:sql:DELETE FROM users")
@@ -347,10 +347,10 @@ async def test_async_regression_write_policy_still_fires(mock_get):
     assert any("no-sql-writes" in r for r in result.reasons)
 
 
+    # Async: data:delete:* policy must not block a benign INSERT.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_async_negative_delete_policy_does_not_block_insert(mock_get):
-    """Async: data:delete:* policy must not block a benign INSERT."""
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
 
     result = await ASYNC_AGENT.preflight("data:write:sql:INSERT INTO t VALUES (1)")
@@ -359,10 +359,10 @@ async def test_async_negative_delete_policy_does_not_block_insert(mock_get):
     assert result.policy_allowed is True
 
 
+    # Async: data:delete:* does not block data:read:sql:SELECT delete_flag FROM t.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_get", new_callable=AsyncMock)
 async def test_async_negative_delete_policy_does_not_block_read(mock_get):
-    """Async: data:delete:* does not block data:read:sql:SELECT delete_flag FROM t."""
     mock_get.side_effect = [{"revoked": False, "suspended": False}, _DELETE_POLICY]
 
     result = await ASYNC_AGENT.preflight("data:read:sql:SELECT delete_flag FROM t")

--- a/python/tests/test_preflight_fail_closed.py
+++ b/python/tests/test_preflight_fail_closed.py
@@ -28,8 +28,8 @@ MOCK_AGENT_DATA = {
 }
 
 
+    # checks_complete defaults to True so existing constructions stay valid.
 def test_checks_complete_defaults_true():
-    """checks_complete defaults to True so existing constructions stay valid."""
     result = PreflightResult(
         cleared=True,
         agent_active=True,
@@ -39,11 +39,11 @@ def test_checks_complete_defaults_true():
     assert result.checks_complete is True
 
 
+    # A status fetch error blocks rather than silently clearing the agent.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_status_fetch_error_does_not_clear(mock_post, mock_get):
-    """A status fetch error blocks rather than silently clearing the agent."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 
@@ -59,11 +59,11 @@ def test_status_fetch_error_does_not_clear(mock_post, mock_get):
     assert "could not verify" in result.explanation.lower()
 
 
+    # A policy fetch error blocks rather than silently clearing the agent.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_policy_fetch_error_does_not_clear(mock_post, mock_get):
-    """A policy fetch error blocks rather than silently clearing the agent."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 
@@ -77,11 +77,11 @@ def test_policy_fetch_error_does_not_clear(mock_post, mock_get):
     assert result.checks_complete is False
 
 
+    # A non-list /policies response fails closed instead of silently clearing.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_non_list_policies_does_not_clear(mock_post, mock_get):
-    """A non-list /policies response fails closed instead of silently clearing."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 
@@ -96,12 +96,12 @@ def test_non_list_policies_does_not_clear(mock_post, mock_get):
     assert any("unexpected response" in r for r in result.reasons)
 
 
+    # A non-dict /status body fails closed (parity pin for the TS fix).
 @pytest.mark.parametrize("status_body", [["x"], "revoked", 5, []])
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_non_dict_status_does_not_clear(mock_post, mock_get, status_body):
-    """A non-dict /status body fails closed (parity pin for the TS fix)."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 
@@ -116,11 +116,11 @@ def test_non_dict_status_does_not_clear(mock_post, mock_get, status_body):
     assert "could not verify" in result.explanation.lower()
 
 
+    # An active agent with no blocking policy still clears, checks_complete True.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_happy_path_still_clears(mock_post, mock_get):
-    """An active agent with no blocking policy still clears, checks_complete True."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 
@@ -134,11 +134,11 @@ def test_happy_path_still_clears(mock_post, mock_get):
     assert result.checks_complete is True
 
 
+    # A revoked agent blocks with checks_complete True, distinct from an error.
 @patch("asqav.client._get")
 @patch("asqav.client._post")
 @patch("asqav.client._api_key", "sk_test")
 def test_revoked_agent_is_a_real_verdict(mock_post, mock_get):
-    """A revoked agent blocks with checks_complete True, distinct from an error."""
     mock_post.return_value = MOCK_AGENT_DATA
     agent = Agent.create("test-agent")
 

--- a/python/tests/test_pytest_plugin.py
+++ b/python/tests/test_pytest_plugin.py
@@ -44,16 +44,16 @@ def _config(**opts) -> MagicMock:  # type: ignore[no-untyped-def]
 # === Configuration ===
 
 
+    # The plugin is a no-op unless --asqav is passed.
 def test_disabled_by_default() -> None:
-    """The plugin is a no-op unless --asqav is passed."""
     pytest_configure(_config(**{"--asqav": False}))
     assert _get_state_for_tests().enabled is False
 
 
+    # --asqav with an API key initializes the agent and enables the plugin.
 @patch("asqav.Agent.create")
 @patch("asqav.init")
 def test_configure_enables_plugin(mock_init: MagicMock, mock_create: MagicMock) -> None:
-    """--asqav with an API key initializes the agent and enables the plugin."""
     mock_create.return_value = MagicMock(agent_id="agt_test")
     with patch.dict(os.environ, {"ASQAV_API_KEY": "sk_test"}, clear=False):
         pytest_configure(_config(**{
@@ -71,8 +71,8 @@ def test_configure_enables_plugin(mock_init: MagicMock, mock_create: MagicMock) 
     mock_create.assert_called_once_with("ci-runner")
 
 
+    # --asqav without ASQAV_API_KEY exits with a usage error.
 def test_configure_without_api_key_raises() -> None:
-    """--asqav without ASQAV_API_KEY exits with a usage error."""
     with patch.dict(os.environ, {"ASQAV_API_KEY": ""}, clear=False):
         with pytest.raises(pytest.UsageError):
             pytest_configure(_config(**{"--asqav": True}))
@@ -81,8 +81,8 @@ def test_configure_without_api_key_raises() -> None:
 # === Result capture ===
 
 
+    # Only the 'call' phase produces a TestResult; setup/teardown are ignored.
 def test_makereport_captures_call_phase() -> None:
-    """Only the 'call' phase produces a TestResult; setup/teardown are ignored."""
     state = _get_state_for_tests()
     state.enabled = True
     state.agent = MagicMock()
@@ -106,8 +106,8 @@ def test_makereport_captures_call_phase() -> None:
     assert len(state.signatures) == 1
 
 
+    # Setup and teardown phases are ignored.
 def test_makereport_skips_non_call_phases() -> None:
-    """Setup and teardown phases are ignored."""
     state = _get_state_for_tests()
     state.enabled = True
     state.agent = MagicMock()
@@ -126,8 +126,8 @@ def test_makereport_skips_non_call_phases() -> None:
     assert len(state.results) == 0
 
 
+    # When the plugin is disabled the hook is a pass-through.
 def test_makereport_disabled_does_nothing() -> None:
-    """When the plugin is disabled the hook is a pass-through."""
     state = _get_state_for_tests()
     state.enabled = False
 
@@ -145,8 +145,8 @@ def test_makereport_disabled_does_nothing() -> None:
     assert len(state.signatures) == 0
 
 
+    # If sign() raises, the report.sections records the error but no exception bubbles.
 def test_sign_failure_does_not_mask_test() -> None:
-    """If sign() raises, the report.sections records the error but no exception bubbles."""
     state = _get_state_for_tests()
     state.enabled = True
     state.agent = MagicMock()
@@ -171,9 +171,9 @@ def test_sign_failure_does_not_mask_test() -> None:
 # === Session finish ===
 
 
+    # At end of run, a ComplianceBundle is exported to the configured path.
 @patch("asqav.compliance.export_bundle")
 def test_sessionfinish_writes_bundle(mock_export: MagicMock, tmp_path) -> None:
-    """At end of run, a ComplianceBundle is exported to the configured path."""
     mock_bundle = MagicMock(receipt_count=2, merkle_root="root123")
     mock_export.return_value = mock_bundle
 
@@ -189,8 +189,8 @@ def test_sessionfinish_writes_bundle(mock_export: MagicMock, tmp_path) -> None:
     mock_bundle.to_file.assert_called_once_with(state.output_path)
 
 
+    # Empty signature list is a no-op so the runner does not write garbage.
 def test_sessionfinish_noop_when_no_signatures() -> None:
-    """Empty signature list is a no-op so the runner does not write garbage."""
     state = _get_state_for_tests()
     state.enabled = True
     state.signatures = []
@@ -202,9 +202,9 @@ def test_sessionfinish_noop_when_no_signatures() -> None:
 # === Programmatic API ===
 
 
+    # make_bundle_from_report wraps export_bundle and forwards the framework.
 @patch("asqav.compliance.export_bundle")
 def test_make_bundle_from_report(mock_export: MagicMock) -> None:
-    """make_bundle_from_report wraps export_bundle and forwards the framework."""
     mock_export.return_value = MagicMock(receipt_count=3)
     sigs = [MagicMock(), MagicMock(), MagicMock()]
     bundle = make_bundle_from_report(sigs, framework="dora")

--- a/python/tests/test_pytest_plugin_default.py
+++ b/python/tests/test_pytest_plugin_default.py
@@ -15,26 +15,26 @@ from asqav.pytest_plugin import _PluginState, make_bundle_from_report
 EXPECTED_DEFAULT = "eu_ai_act"
 
 
+    # The dataclass default applies before any pytest_configure hook fires.
 def test_plugin_state_default_framework_is_eu_ai_act() -> None:
-    """The dataclass default applies before any pytest_configure hook fires."""
     state = _PluginState()
     assert state.framework == EXPECTED_DEFAULT
 
 
+    # Whatever the default is, it must resolve in FRAMEWORKS.
 def test_plugin_state_default_is_a_known_framework() -> None:
-    """Whatever the default is, it must resolve in FRAMEWORKS."""
     state = _PluginState()
     assert state.framework in FRAMEWORKS
 
 
+    # The programmatic helper mirrors the plugin's default.
 def test_make_bundle_from_report_default_framework() -> None:
-    """The programmatic helper mirrors the plugin's default."""
     sig = inspect.signature(make_bundle_from_report)
     assert sig.parameters["framework"].default == EXPECTED_DEFAULT
 
 
+    # `pytest --asqav` with no --asqav-framework gets the same key.
 def test_addoption_default_matches_state_default() -> None:
-    """`pytest --asqav` with no --asqav-framework gets the same key."""
 
     captured: dict[str, str] = {}
 

--- a/python/tests/test_reasoning.py
+++ b/python/tests/test_reasoning.py
@@ -22,8 +22,8 @@ def _mock_agent() -> MagicMock:
     return agent
 
 
+    # Default mode posts only hashes, never raw prompt/trace/output.
 def test_sign_reasoning_stores_hashes_only():
-    """Default mode posts only hashes, never raw prompt/trace/output."""
     agent = _mock_agent()
 
     prompt = "classify this ticket as urgent"
@@ -61,8 +61,8 @@ def test_sign_reasoning_stores_hashes_only():
     assert "Let me think" not in serialized
 
 
+    # store_raw=True adds raw payloads under _raw_* keys.
 def test_sign_reasoning_raw_optional():
-    """store_raw=True adds raw payloads under _raw_* keys."""
     agent = _mock_agent()
 
     receipt = sign_reasoning(
@@ -84,8 +84,8 @@ def test_sign_reasoning_raw_optional():
     assert ctx["_prompt_hash"] == hashlib.sha256(b"hello").hexdigest()
 
 
+    # retention_days flows to context and ReasoningReceipt when raw is on.
 def test_sign_reasoning_retention_param():
-    """retention_days flows to context and ReasoningReceipt when raw is on."""
     agent = _mock_agent()
 
     receipt = sign_reasoning(
@@ -102,8 +102,8 @@ def test_sign_reasoning_retention_param():
     assert ctx["_raw_retention_days"] == 30
 
 
+    # retention_days without store_raw does not leak raw payloads.
 def test_sign_reasoning_retention_ignored_without_store_raw():
-    """retention_days without store_raw does not leak raw payloads."""
     agent = _mock_agent()
 
     sign_reasoning(
@@ -119,15 +119,15 @@ def test_sign_reasoning_retention_ignored_without_store_raw():
     assert "_raw_retention_days" not in ctx
 
 
+    # Equivalent dicts in different key order produce equal hashes.
 def test_sha256_canonicalizes_dict_key_order():
-    """Equivalent dicts in different key order produce equal hashes."""
     a = {"x": 1, "y": 2}
     b = {"y": 2, "x": 1}
     assert _sha256(a) == _sha256(b)
 
 
+    # Caller-supplied context is preserved alongside injected hashes.
 def test_sign_reasoning_merges_user_context():
-    """Caller-supplied context is preserved alongside injected hashes."""
     agent = _mock_agent()
 
     sign_reasoning(
@@ -144,8 +144,8 @@ def test_sign_reasoning_merges_user_context():
     assert "_prompt_hash" in ctx
 
 
+    # trace_id and parent_id reach the underlying sign() call.
 def test_sign_reasoning_passes_trace_and_parent_ids():
-    """trace_id and parent_id reach the underlying sign() call."""
     agent = _mock_agent()
 
     sign_reasoning(

--- a/python/tests/test_replay.py
+++ b/python/tests/test_replay.py
@@ -91,8 +91,8 @@ def _make_timeline(n: int = 3) -> ReplayTimeline:
 # === Timeline ordering ===
 
 class TestTimelineOrdering:
+        # replay_from_bundle should sort steps by timestamp.
     def test_steps_ordered_by_timestamp(self):
-        """replay_from_bundle should sort steps by timestamp."""
         sigs = [
             _make_signed_action(
                 signature_id=f"sid_{i}",
@@ -108,8 +108,8 @@ class TestTimelineOrdering:
         timestamps = [s.timestamp for s in timeline.steps]
         assert timestamps == sorted(timestamps)
 
+        # Step indices should be 0, 1, 2... after sorting.
     def test_indices_sequential(self):
-        """Step indices should be 0, 1, 2... after sorting."""
         sigs = [
             _make_signed_action(
                 signature_id=f"sid_{i}",
@@ -128,8 +128,8 @@ class TestTimelineOrdering:
 # === Chain verification ===
 
 class TestChainVerification:
+        # A correctly chained sig list verifies link-by-link.
     def test_valid_chain(self):
-        """A correctly chained sig list verifies link-by-link."""
         import hashlib
 
         from asqav._jcs import canonical_json
@@ -157,8 +157,8 @@ class TestChainVerification:
         results = _verify_hash_chain(sig_dicts)
         assert results == [True, True, True, True]
 
+        # A wrong stored previousReceiptHash returns False for that link.
     def test_invalid_chain_link_is_flagged(self):
-        """A wrong stored previousReceiptHash returns False for that link."""
         import hashlib
 
         from asqav._jcs import canonical_json
@@ -203,15 +203,15 @@ class TestChainVerification:
         timeline.chain_integrity = all(s.chain_valid for s in timeline.steps)
         assert not timeline.chain_integrity
 
+        # ReplayTimeline.verify_chain() should re-verify all steps.
     def test_verify_chain_method(self):
-        """ReplayTimeline.verify_chain() should re-verify all steps."""
         timeline = _make_timeline(4)
         result = timeline.verify_chain()
         assert result is True
         assert timeline.chain_integrity is True
 
+        # Tamper with a step's prev_chain_hash; verify_chain must catch it.
     def test_verify_chain_detects_tampered_prev_hash(self):
-        """Tamper with a step's prev_chain_hash; verify_chain must catch it."""
         timeline = _make_timeline(4)
         # Sanity: clean timeline passes.
         assert timeline.verify_chain() is True
@@ -221,8 +221,8 @@ class TestChainVerification:
         assert timeline.steps[2].chain_valid is False
         assert timeline.chain_integrity is False
 
+        # Swap two steps; the predecessor hash on the moved step diverges.
     def test_verify_chain_detects_reordered_steps(self):
-        """Swap two steps; the predecessor hash on the moved step diverges."""
         timeline = _make_timeline(4)
         assert timeline.verify_chain() is True
         timeline.steps[1], timeline.steps[2] = timeline.steps[2], timeline.steps[1]
@@ -232,8 +232,8 @@ class TestChainVerification:
         assert timeline.verify_chain() is False
         assert timeline.chain_integrity is False
 
+        # A step with no prev_chain_hash on a non-first index = unverifiable.
     def test_verify_chain_flags_missing_prev_hash(self):
-        """A step with no prev_chain_hash on a non-first index = unverifiable."""
         timeline = _make_timeline(3)
         assert timeline.verify_chain() is True
         timeline.steps[1].prev_chain_hash = None

--- a/python/tests/test_replay_ietf_chain.py
+++ b/python/tests/test_replay_ietf_chain.py
@@ -44,8 +44,8 @@ def _make_signed_action(
 # === FIRST_RECEIPT_SEED matches the spec ===
 
 
+    # `FIRST_RECEIPT_SEED == "0" * 64` is the chain seed.
 def test_first_receipt_seed_is_64_zero_hex() -> None:
-    """`FIRST_RECEIPT_SEED == "0" * 64` is the chain seed."""
     assert FIRST_RECEIPT_SEED == "0" * 64
     assert len(FIRST_RECEIPT_SEED) == 64
     assert all(c == "0" for c in FIRST_RECEIPT_SEED)
@@ -54,8 +54,8 @@ def test_first_receipt_seed_is_64_zero_hex() -> None:
 # === IETF v2 default behaviour ===
 
 
+    # Each link is `sha256(JCS(envelope_with_prev_link))`.
 def test_v2_chain_hash_matches_jcs_of_envelope() -> None:
-    """Each link is `sha256(JCS(envelope_with_prev_link))`."""
     sigs = [_make_signed_action(idx=0), _make_signed_action(idx=1)]
     sig_dicts = [
         {
@@ -86,8 +86,8 @@ def test_v2_chain_hash_matches_jcs_of_envelope() -> None:
     assert timeline.steps[1].prev_chain_hash == expected_first_hash
 
 
+    # The first envelope hashes against the all-zero seed, not empty.
 def test_v2_seed_is_used_under_default() -> None:
-    """The first envelope hashes against the all-zero seed, not empty."""
     sigs = [_make_signed_action(idx=0)]
     timeline = _build_timeline("agent_001", "sess_1", sigs)
     # First step has no predecessor -> prev_chain_hash is None.
@@ -122,8 +122,8 @@ def test_v2_verify_chain_succeeds_on_freshly_built_timeline() -> None:
         assert step.chain_valid is True
 
 
+    # If a step's stored prev_chain_hash is altered, verify_chain fails.
 def test_v2_verify_chain_detects_tamper() -> None:
-    """If a step's stored prev_chain_hash is altered, verify_chain fails."""
     sigs = [_make_signed_action(idx=i) for i in range(3)]
     timeline = _build_timeline("agent_001", "sess_1", sigs)
     # Tamper: corrupt the link on step 1.
@@ -157,13 +157,13 @@ def test_empty_timeline_verifies() -> None:
 # === H-NEW-1: signed_envelope path verifies byte-for-byte against the cloud ===
 
 
+    # Build the cloud-shape envelope the SDK records under compliance_mode.
 def _compliance_envelope(
     *,
     idx: int,
     prev_hash: str,
     policy_decision: str = "allow",
 ) -> dict:
-    """Build the cloud-shape envelope the SDK records under compliance_mode."""
     return {
         "action_id": f"act_{idx:03d}",
         "agent_id": "agent_001",
@@ -252,8 +252,8 @@ def test_mixed_envelope_steps_drop_compliance_chain_valid() -> None:
     assert timeline.compliance_chain_valid is False
 
 
+    # Round-trip metadata so audit-pack consumers see envelope + flag.
 def test_to_dict_includes_signed_envelope_and_compliance_flag() -> None:
-    """Round-trip metadata so audit-pack consumers see envelope + flag."""
     env0 = _compliance_envelope(idx=0, prev_hash=FIRST_RECEIPT_SEED)
     sigs = [_make_signed_action(idx=0)]
     timeline = _build_timeline(
@@ -321,8 +321,8 @@ def test_three_receipt_chain_matches_cloud_byte_for_byte() -> None:
     assert all(s.chain_valid for s in timeline.steps)
 
 
+    # A forged `previousReceiptHash` on one receipt fails only that link.
 def test_three_receipt_chain_detects_single_link_tamper() -> None:
-    """A forged `previousReceiptHash` on one receipt fails only that link."""
     p0 = _cloud_payload(0, FIRST_RECEIPT_SEED)
     h0 = hashlib.sha256(canonical_json(p0)).hexdigest()
     p1 = _cloud_payload(1, h0)

--- a/python/tests/test_reproducibility.py
+++ b/python/tests/test_reproducibility.py
@@ -24,9 +24,9 @@ MOCK_SIGN_RESPONSE: dict = {
 # === Reproducibility metadata tests ===
 
 
+    # sign() includes _system_prompt_hash in context when provided.
 @patch("asqav.client._post")
 def test_sign_with_system_prompt_hash(mock_post: object) -> None:
-    """sign() includes _system_prompt_hash in context when provided."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
 
     agent = Agent.__new__(Agent)
@@ -44,9 +44,9 @@ def test_sign_with_system_prompt_hash(mock_post: object) -> None:
     assert call_body["context"]["model"] == "gpt-4"
 
 
+    # sign() includes _model_params in context when provided.
 @patch("asqav.client._post")
 def test_sign_with_model_params(mock_post: object) -> None:
-    """sign() includes _model_params in context when provided."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
 
     agent = Agent.__new__(Agent)
@@ -60,9 +60,9 @@ def test_sign_with_model_params(mock_post: object) -> None:
     assert call_body["context"]["_model_params"] == params
 
 
+    # sign() includes _tool_inputs_hash in context when provided.
 @patch("asqav.client._post")
 def test_sign_with_tool_inputs_hash(mock_post: object) -> None:
-    """sign() includes _tool_inputs_hash in context when provided."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
 
     agent = Agent.__new__(Agent)
@@ -75,9 +75,9 @@ def test_sign_with_tool_inputs_hash(mock_post: object) -> None:
     assert call_body["context"]["_tool_inputs_hash"] == "def456hash"
 
 
+    # sign() includes all three metadata fields when all are provided.
 @patch("asqav.client._post")
 def test_sign_with_all_metadata(mock_post: object) -> None:
-    """sign() includes all three metadata fields when all are provided."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
 
     agent = Agent.__new__(Agent)
@@ -100,9 +100,9 @@ def test_sign_with_all_metadata(mock_post: object) -> None:
     assert ctx["key"] == "value"
 
 
+    # sign() does not add metadata keys when none are provided.
 @patch("asqav.client._post")
 def test_sign_without_metadata_no_underscore_keys(mock_post: object) -> None:
-    """sign() does not add metadata keys when none are provided."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
 
     agent = Agent.__new__(Agent)
@@ -118,9 +118,9 @@ def test_sign_without_metadata_no_underscore_keys(mock_post: object) -> None:
     assert "_tool_inputs_hash" not in ctx
 
 
+    # sign() does not mutate the original context dict passed in.
 @patch("asqav.client._post")
 def test_sign_metadata_does_not_mutate_original_context(mock_post: object) -> None:
-    """sign() does not mutate the original context dict passed in."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
 
     agent = Agent.__new__(Agent)
@@ -133,9 +133,9 @@ def test_sign_metadata_does_not_mutate_original_context(mock_post: object) -> No
     assert "_system_prompt_hash" not in original_ctx
 
 
+    # sign() creates context dict from scratch when context is None and metadata provided.
 @patch("asqav.client._post")
 def test_sign_with_none_context_and_metadata(mock_post: object) -> None:
-    """sign() creates context dict from scratch when context is None and metadata provided."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
 
     agent = Agent.__new__(Agent)
@@ -151,9 +151,9 @@ def test_sign_with_none_context_and_metadata(mock_post: object) -> None:
 # === Pattern resolution in sign() ===
 
 
+    # sign() expands semantic pattern names to globs.
 @patch("asqav.client._post")
 def test_sign_resolves_semantic_pattern(mock_post: object) -> None:
-    """sign() expands semantic pattern names to globs."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
 
     agent = Agent.__new__(Agent)
@@ -166,9 +166,9 @@ def test_sign_resolves_semantic_pattern(mock_post: object) -> None:
     assert call_body["action_type"] == "data:delete:*"
 
 
+    # sign() passes through action types that are not semantic patterns.
 @patch("asqav.client._post")
 def test_sign_passes_through_unknown_pattern(mock_post: object) -> None:
-    """sign() passes through action types that are not semantic patterns."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
 
     agent = Agent.__new__(Agent)

--- a/python/tests/test_retry_async.py
+++ b/python/tests/test_retry_async.py
@@ -17,9 +17,9 @@ from asqav.retry import with_async_retry, with_retry
 # === Retry: rate limit error is retried ===
 
 
+    # RateLimitError triggers retry with backoff, succeeds on second attempt.
 @patch("asqav.retry.time.sleep")
 def test_retry_on_rate_limit(mock_sleep: MagicMock) -> None:
-    """RateLimitError triggers retry with backoff, succeeds on second attempt."""
     call_count = 0
 
     @with_retry(max_retries=3, base_delay=1.0, jitter=False)
@@ -39,9 +39,9 @@ def test_retry_on_rate_limit(mock_sleep: MagicMock) -> None:
 # === Retry: server error (5xx) is retried ===
 
 
+    # APIError with 500 status triggers retry.
 @patch("asqav.retry.time.sleep")
 def test_retry_on_server_error(mock_sleep: MagicMock) -> None:
-    """APIError with 500 status triggers retry."""
     call_count = 0
 
     @with_retry(max_retries=3, base_delay=0.5, jitter=False)
@@ -65,8 +65,8 @@ def test_retry_on_server_error(mock_sleep: MagicMock) -> None:
 # === Retry: auth error is NOT retried ===
 
 
+    # AuthenticationError is raised immediately without retry.
 def test_no_retry_on_auth_error() -> None:
-    """AuthenticationError is raised immediately without retry."""
     call_count = 0
 
     @with_retry(max_retries=3, base_delay=0.5)
@@ -83,8 +83,8 @@ def test_no_retry_on_auth_error() -> None:
 # === Retry: client error (4xx, not 429) is NOT retried ===
 
 
+    # APIError with 400 status is raised immediately without retry.
 def test_no_retry_on_client_error() -> None:
-    """APIError with 400 status is raised immediately without retry."""
     call_count = 0
 
     @with_retry(max_retries=3, base_delay=0.5)
@@ -101,9 +101,9 @@ def test_no_retry_on_client_error() -> None:
 # === Retry: exhaustion raises last error ===
 
 
+    # After max_retries attempts, the last error is raised.
 @patch("asqav.retry.time.sleep")
 def test_retry_exhaustion(mock_sleep: MagicMock) -> None:
-    """After max_retries attempts, the last error is raised."""
     call_count = 0
 
     @with_retry(max_retries=2, base_delay=0.5, jitter=False)
@@ -121,9 +121,9 @@ def test_retry_exhaustion(mock_sleep: MagicMock) -> None:
 # === Retry: connection error is retried ===
 
 
+    # ConnectionError triggers retry.
 @patch("asqav.retry.time.sleep")
 def test_retry_on_connection_error(mock_sleep: MagicMock) -> None:
-    """ConnectionError triggers retry."""
     call_count = 0
 
     @with_retry(max_retries=3, base_delay=0.5, jitter=False)
@@ -143,10 +143,10 @@ def test_retry_on_connection_error(mock_sleep: MagicMock) -> None:
 # === Async: create agent ===
 
 
+    # AsyncAgent.create calls _async_post and returns AsyncAgent.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_post")
 async def test_async_create_agent(mock_post: AsyncMock) -> None:
-    """AsyncAgent.create calls _async_post and returns AsyncAgent."""
     from asqav.async_client import AsyncAgent
 
     mock_post.return_value = {
@@ -177,10 +177,10 @@ async def test_async_create_agent(mock_post: AsyncMock) -> None:
 # === Async: sign action ===
 
 
+    # AsyncAgent.sign calls _async_post and returns SignatureResponse.
 @pytest.mark.asyncio
 @patch("asqav.async_client._async_post")
 async def test_async_sign(mock_post: AsyncMock) -> None:
-    """AsyncAgent.sign calls _async_post and returns SignatureResponse."""
     from asqav.async_client import AsyncAgent
     from asqav.client import SignatureResponse
 
@@ -220,9 +220,9 @@ async def test_async_sign(mock_post: AsyncMock) -> None:
 # === Async: verify signature ===
 
 
+    # AsyncAgent.verify calls httpx.AsyncClient.get and returns VerificationResponse.
 @pytest.mark.asyncio
 async def test_async_verify() -> None:
-    """AsyncAgent.verify calls httpx.AsyncClient.get and returns VerificationResponse."""
     from unittest.mock import patch as sync_patch
 
     from asqav.async_client import AsyncAgent
@@ -274,10 +274,10 @@ async def test_async_verify() -> None:
 # === Async: retry works with async functions ===
 
 
+    # with_async_retry retries RateLimitError with backoff.
 @pytest.mark.asyncio
 @patch("asqav.retry.asyncio.sleep", new_callable=AsyncMock)
 async def test_async_retry_on_rate_limit(mock_sleep: AsyncMock) -> None:
-    """with_async_retry retries RateLimitError with backoff."""
     call_count = 0
 
     @with_async_retry(max_retries=3, base_delay=1.0, jitter=False)

--- a/python/tests/test_signing_key_sibling.py
+++ b/python/tests/test_signing_key_sibling.py
@@ -51,8 +51,8 @@ def _key(
     }
 
 
+    # A compliance payload naming its issuer and its agent inside the signed bytes.
 def _payload(agent_id: str = "agt_two", issuer_id: str = ORG) -> dict:
-    """A compliance payload naming its issuer and its agent inside the signed bytes."""
     return {
         "type": "protectmcp:decision",
         "issued_at": "2026-06-19T00:00:00.000000Z",
@@ -81,8 +81,8 @@ def _axes(doc: dict, jwks: dict) -> dict[str, str]:
 # --- the matcher picks the key the signed bytes name ---
 
 
+    # Two siblings share the issuer, so the agent bind decides which one answers.
 def test_org_kid_resolves_the_agent_the_receipt_names() -> None:
-    """Two siblings share the issuer, so the agent bind decides which one answers."""
     jwks = {"keys": [_key("key-agent-one", "agt_one"), _key("key-agent-two", "agt_two")]}
     entry = v.match_signing_key(jwks, ORG, "agt_two", ORG)
     assert entry is not None
@@ -90,40 +90,40 @@ def test_org_kid_resolves_the_agent_the_receipt_names() -> None:
     assert entry["agent_id"] == "agt_two"
 
 
+    # Order carries no meaning: the same directory answers for either sibling.
 def test_org_kid_resolves_the_first_agent_when_it_is_the_named_one() -> None:
-    """Order carries no meaning: the same directory answers for either sibling."""
     jwks = {"keys": [_key("key-agent-one", "agt_one"), _key("key-agent-two", "agt_two")]}
     entry = v.match_signing_key(jwks, ORG, "agt_one", ORG)
     assert entry is not None
     assert entry["kid"] == "key-agent-one"
 
 
+    # A kid naming one key names it exactly, so that key answers.
 def test_exact_kid_outranks_the_agent_bind() -> None:
-    """A kid naming one key names it exactly, so that key answers."""
     jwks = {"keys": [_key("key-agent-one", "agt_one"), _key("key-agent-two", "agt_two")]}
     entry = v.match_signing_key(jwks, "key-agent-one", "agt_two", ORG)
     assert entry is not None
     assert entry["kid"] == "key-agent-one"
 
 
+    # The bare-kid wire form keeps resolving through the published issuer id.
 def test_org_kid_answers_when_the_receipt_names_no_agent() -> None:
-    """The bare-kid wire form keeps resolving through the published issuer id."""
     jwks = {"keys": [_key("key-agent-one", "agt_one")]}
     entry = v.match_signing_key(jwks, ORG, None, ORG)
     assert entry is not None
     assert entry["kid"] == "key-agent-one"
 
 
+    # An agent with no published key falls back to the issuer match, not to nothing.
 def test_org_kid_answers_for_an_agent_the_directory_omits() -> None:
-    """An agent with no published key falls back to the issuer match, not to nothing."""
     jwks = {"keys": [_key("key-agent-one", "agt_one")]}
     entry = v.match_signing_key(jwks, ORG, "agt_absent", ORG)
     assert entry is not None
     assert entry["kid"] == "key-agent-one"
 
 
+    # A directory of three siblings answers for the middle one, not the first.
 def test_three_key_org_resolves_its_middle_signer() -> None:
-    """A directory of three siblings answers for the middle one, not the first."""
     jwks = {"keys": [_key("key-agent-one", "agt_one"), _key("key-agent-two", "agt_two"),
                      _key("key-agent-three", "agt_three")]}
     entry = v.match_signing_key(jwks, ORG, "agt_two", ORG)
@@ -134,8 +134,8 @@ def test_three_key_org_resolves_its_middle_signer() -> None:
     assert last["kid"] == "key-agent-three"
 
 
+    # A hash-mode receipt signs the raw org_id, so the org bind names the signer.
 def test_three_key_org_binds_the_middle_signer_by_org() -> None:
-    """A hash-mode receipt signs the raw org_id, so the org bind names the signer."""
     def org_key(kid: str, agent_id: str) -> dict:
         return {**_key(kid, agent_id), "org_id": ORG}
     jwks = {"keys": [org_key("key-agent-one", "agt_one"), org_key("key-agent-two", "agt_two"),
@@ -148,14 +148,14 @@ def test_three_key_org_binds_the_middle_signer_by_org() -> None:
 # --- adversarial: agent_id is attacker-controlled ---
 
 
+    # agent_id alone never answers: the key's issuer must equal the claimed one.
 def test_agent_bind_rejects_a_key_published_under_another_issuer() -> None:
-    """agent_id alone never answers: the key's issuer must equal the claimed one."""
     jwks = {"keys": [_key("key-foreign", "agt_two", issuer_id=OTHER_ORG)]}
     assert v.match_signing_key(jwks, "kid-absent", "agt_two", ORG) is None
 
 
+    # A malformed sibling is a miss, never a crash, and never blocks the real key.
 def test_matcher_survives_a_directory_holding_junk_entries() -> None:
-    """A malformed sibling is a miss, never a crash, and never blocks the real key."""
     jwks = {"keys": [None, 7, "text", {"kid": "no-bytes", "issuer_id": ORG, "agent_id": "agt_two"},
                      _key("key-agent-two", "agt_two")]}
     entry = v.match_signing_key(jwks, ORG, "agt_two", ORG)
@@ -166,8 +166,8 @@ def test_matcher_survives_a_directory_holding_junk_entries() -> None:
 # --- the axes read the entry that signed ---
 
 
+    # A revoked signer stays revoked even with an active sibling ahead of it.
 def test_key_status_reads_the_signing_agent_not_its_sibling() -> None:
-    """A revoked signer stays revoked even with an active sibling ahead of it."""
     jwks = {
         "keys": [
             _key("key-agent-one", "agt_one", status="active"),
@@ -178,8 +178,8 @@ def test_key_status_reads_the_signing_agent_not_its_sibling() -> None:
     assert axes["key_status"] == "FAIL"
 
 
+    # The mirror case: a revoked sibling ahead of the signer changes no axis.
 def test_active_signer_is_not_reported_revoked_by_a_sibling() -> None:
-    """The mirror case: a revoked sibling ahead of the signer changes no axis."""
     jwks = {
         "keys": [
             _key("key-agent-one", "agt_one", status="revoked"),
@@ -194,8 +194,8 @@ def test_active_signer_is_not_reported_revoked_by_a_sibling() -> None:
 # --- end to end over a real ML-DSA-65 signature ---
 
 
+    # The whole point: an org with two agents can verify its own receipt.
 def test_oracle_passes_a_receipt_signed_by_the_second_agent() -> None:
-    """The whole point: an org with two agents can verify its own receipt."""
     ml = _ml_dsa_65()
     one_pk, _one_sk = ml.keygen()
     two_pk, two_sk = ml.keygen()
@@ -215,8 +215,8 @@ def test_oracle_passes_a_receipt_signed_by_the_second_agent() -> None:
     assert res.verdict == "PASS", axes
 
 
+    # Naming a sibling in the payload never lends that sibling's key to a forgery.
 def test_oracle_rejects_a_signature_from_the_wrong_agent() -> None:
-    """Naming a sibling in the payload never lends that sibling's key to a forgery."""
     ml = _ml_dsa_65()
     one_pk, _one_sk = ml.keygen()
     two_pk, _two_sk = ml.keygen()
@@ -235,8 +235,8 @@ def test_oracle_rejects_a_signature_from_the_wrong_agent() -> None:
     assert {a.axis: a.result for a in res.axes}["signature"] == "FAIL"
 
 
+    # A valid signature under a foreign org's key never proves the claimed issuer.
 def test_oracle_rejects_an_agent_key_from_another_org() -> None:
-    """A valid signature under a foreign org's key never proves the claimed issuer."""
     ml = _ml_dsa_65()
     one_pk, _one_sk = ml.keygen()
     foreign_pk, foreign_sk = ml.keygen()

--- a/python/tests/test_smolagents_integration.py
+++ b/python/tests/test_smolagents_integration.py
@@ -27,8 +27,8 @@ from asqav.extras.smolagents import AsqavSmolagentsHook  # noqa: E402
 # === Helpers ===
 
 
+    # Create a minimal mock smolagents Tool.
 def _make_tool(name: str, forward_result: Any = "result") -> MagicMock:
-    """Create a minimal mock smolagents Tool."""
     tool = MagicMock()
     tool.name = name
     tool.forward = MagicMock(return_value=forward_result)
@@ -38,9 +38,9 @@ def _make_tool(name: str, forward_result: Any = "result") -> MagicMock:
 # === Fixtures ===
 
 
+    # Create an AsqavSmolagentsHook with mocked Agent internals.
 @pytest.fixture()
 def hook() -> AsqavSmolagentsHook:
-    """Create an AsqavSmolagentsHook with mocked Agent internals."""
     with (
         patch("asqav.client._api_key", "sk_test"),
         patch("asqav.extras._base.Agent") as mock_agent_cls,
@@ -54,8 +54,8 @@ def hook() -> AsqavSmolagentsHook:
 # === wrap_tool: tool:start ===
 
 
+    # wrap_tool signs tool:start with tool name and input preview.
 def test_wrap_tool_signs_tool_start(hook: AsqavSmolagentsHook) -> None:
-    """wrap_tool signs tool:start with tool name and input preview."""
     tool = _make_tool("web_search", forward_result="some result")
     hook.wrap_tool(tool)
     tool.forward("python tutorials")
@@ -67,8 +67,8 @@ def test_wrap_tool_signs_tool_start(hook: AsqavSmolagentsHook) -> None:
     assert ctx["input"] == "python tutorials"
 
 
+    # wrap_tool signs tool:start using the first kwarg value as input preview.
 def test_wrap_tool_signs_tool_start_with_kwargs(hook: AsqavSmolagentsHook) -> None:
-    """wrap_tool signs tool:start using the first kwarg value as input preview."""
     tool = _make_tool("named_tool")
     hook.wrap_tool(tool)
     tool.forward(query="hello world")
@@ -77,8 +77,8 @@ def test_wrap_tool_signs_tool_start_with_kwargs(hook: AsqavSmolagentsHook) -> No
     assert start_ctx["input"] == "hello world"
 
 
+    # wrap_tool signs tool:start with empty input when called with no args.
 def test_wrap_tool_signs_tool_start_no_args(hook: AsqavSmolagentsHook) -> None:
-    """wrap_tool signs tool:start with empty input when called with no args."""
     tool = _make_tool("no_args_tool")
     hook.wrap_tool(tool)
     tool.forward()
@@ -90,8 +90,8 @@ def test_wrap_tool_signs_tool_start_no_args(hook: AsqavSmolagentsHook) -> None:
 # === wrap_tool: tool:end ===
 
 
+    # wrap_tool signs tool:end with output type and length.
 def test_wrap_tool_signs_tool_end(hook: AsqavSmolagentsHook) -> None:
-    """wrap_tool signs tool:end with output type and length."""
     tool = _make_tool("calculator", forward_result="42")
     hook.wrap_tool(tool)
     tool.forward("6 * 7")
@@ -104,18 +104,18 @@ def test_wrap_tool_signs_tool_end(hook: AsqavSmolagentsHook) -> None:
     assert ctx["output_length"] == 2
 
 
+    # wrap_tool does not alter the tool's return value.
 def test_wrap_tool_returns_original_result(hook: AsqavSmolagentsHook) -> None:
-    """wrap_tool does not alter the tool's return value."""
     tool = _make_tool("fetch", forward_result={"key": "value"})
     hook.wrap_tool(tool)
     result = tool.forward("url")
     assert result == {"key": "value"}
 
 
+    # A successful tool call produces exactly tool:start + tool:end.
 def test_wrap_tool_signs_two_actions_per_successful_call(
     hook: AsqavSmolagentsHook,
 ) -> None:
-    """A successful tool call produces exactly tool:start + tool:end."""
     tool = _make_tool("search")
     hook.wrap_tool(tool)
     tool.forward("query")
@@ -127,8 +127,8 @@ def test_wrap_tool_signs_two_actions_per_successful_call(
 # === wrap_tool: tool:error ===
 
 
+    # wrap_tool signs tool:error when forward raises.
 def test_wrap_tool_signs_tool_error_on_exception(hook: AsqavSmolagentsHook) -> None:
-    """wrap_tool signs tool:error when forward raises."""
     tool = _make_tool("unstable_tool")
     tool.forward.side_effect = RuntimeError("connection failed")
     hook.wrap_tool(tool)
@@ -144,8 +144,8 @@ def test_wrap_tool_signs_tool_error_on_exception(hook: AsqavSmolagentsHook) -> N
     assert ctx["error"] == "connection failed"
 
 
+    # wrap_tool re-raises the original exception unchanged.
 def test_wrap_tool_reraises_original_exception(hook: AsqavSmolagentsHook) -> None:
-    """wrap_tool re-raises the original exception unchanged."""
     tool = _make_tool("crasher")
     tool.forward.side_effect = ValueError("bad input")
     hook.wrap_tool(tool)
@@ -154,10 +154,10 @@ def test_wrap_tool_reraises_original_exception(hook: AsqavSmolagentsHook) -> Non
         tool.forward("x")
 
 
+    # A failed tool call produces exactly tool:start + tool:error.
 def test_wrap_tool_signs_start_and_error_on_failure(
     hook: AsqavSmolagentsHook,
 ) -> None:
-    """A failed tool call produces exactly tool:start + tool:error."""
     tool = _make_tool("failing_tool")
     tool.forward.side_effect = RuntimeError("boom")
     hook.wrap_tool(tool)
@@ -173,8 +173,8 @@ def test_wrap_tool_signs_start_and_error_on_failure(
 # === Truncation ===
 
 
+    # Inputs longer than 200 chars are truncated in the audit record.
 def test_input_truncated_to_200_chars(hook: AsqavSmolagentsHook) -> None:
-    """Inputs longer than 200 chars are truncated in the audit record."""
     tool = _make_tool("search")
     hook.wrap_tool(tool)
     tool.forward("q" * 500)
@@ -183,8 +183,8 @@ def test_input_truncated_to_200_chars(hook: AsqavSmolagentsHook) -> None:
     assert len(start_ctx["input"]) == 200
 
 
+    # Error messages longer than 200 chars are truncated in the audit record.
 def test_error_message_truncated_to_200_chars(hook: AsqavSmolagentsHook) -> None:
-    """Error messages longer than 200 chars are truncated in the audit record."""
     tool = _make_tool("erroring")
     tool.forward.side_effect = RuntimeError("e" * 500)
     hook.wrap_tool(tool)
@@ -199,10 +199,10 @@ def test_error_message_truncated_to_200_chars(hook: AsqavSmolagentsHook) -> None
 # === Fail-open: signing must never block tool execution ===
 
 
+    # If tool:start signing raises, the tool still executes and returns its result.
 def test_fail_open_tool_start_does_not_block_execution(
     hook: AsqavSmolagentsHook,
 ) -> None:
-    """If tool:start signing raises, the tool still executes and returns its result."""
     tool = _make_tool("important_tool", forward_result="success")
     hook._sign_action.side_effect = Exception("service unavailable")
     hook.wrap_tool(tool)
@@ -211,10 +211,10 @@ def test_fail_open_tool_start_does_not_block_execution(
     assert result == "success"
 
 
+    # If tool:end signing raises, the result is still returned to the caller.
 def test_fail_open_tool_end_does_not_suppress_result(
     hook: AsqavSmolagentsHook,
 ) -> None:
-    """If tool:end signing raises, the result is still returned to the caller."""
     tool = _make_tool("end_failing_tool", forward_result="the result")
     call_count = 0
 
@@ -231,10 +231,10 @@ def test_fail_open_tool_end_does_not_suppress_result(
     assert result == "the result"
 
 
+    # If tool:error signing raises, the original tool exception is still re-raised.
 def test_fail_open_tool_error_does_not_swallow_exception(
     hook: AsqavSmolagentsHook,
 ) -> None:
-    """If tool:error signing raises, the original tool exception is still re-raised."""
     tool = _make_tool("double_failing_tool")
     tool.forward.side_effect = ValueError("tool broke")
     hook._sign_action.side_effect = Exception("signing also broke")
@@ -247,8 +247,8 @@ def test_fail_open_tool_error_does_not_swallow_exception(
 # === Multiple tools tracked independently ===
 
 
+    # Each wrapped tool is signed independently under its own name.
 def test_multiple_tools_tracked_independently(hook: AsqavSmolagentsHook) -> None:
-    """Each wrapped tool is signed independently under its own name."""
     tool_a = _make_tool("tool_a", forward_result="a_result")
     tool_b = _make_tool("tool_b", forward_result="b_result")
 
@@ -269,8 +269,8 @@ def test_multiple_tools_tracked_independently(hook: AsqavSmolagentsHook) -> None
 # === Tool name fallback ===
 
 
+    # wrap_tool uses the class name when the tool has no .name attribute.
 def test_tool_name_falls_back_to_class_name(hook: AsqavSmolagentsHook) -> None:
-    """wrap_tool uses the class name when the tool has no .name attribute."""
     tool = MagicMock(spec=["forward"])  # no .name attribute
     tool.forward = MagicMock(return_value="ok")
     type(tool).__name__ = "MyCustomTool"
@@ -285,9 +285,9 @@ def test_tool_name_falls_back_to_class_name(hook: AsqavSmolagentsHook) -> None:
 # === Cleanup ===
 
 
+    # Remove fake smolagents from sys.modules after all tests.
 @pytest.fixture(autouse=True, scope="module")
 def _cleanup_smolagents_module() -> Any:
-    """Remove fake smolagents from sys.modules after all tests."""
     yield
     sys.modules.pop("smolagents", None)
     sys.modules.pop("asqav.extras.smolagents", None)

--- a/python/tests/test_trace_correlation.py
+++ b/python/tests/test_trace_correlation.py
@@ -37,22 +37,22 @@ def _make_agent() -> Agent:
 # === generate_trace_id tests ===
 
 
+    # generate_trace_id returns a 32-char hex string (uuid4 without hyphens).
 def test_generate_trace_id_returns_hex_string() -> None:
-    """generate_trace_id returns a 32-char hex string (uuid4 without hyphens)."""
     tid = generate_trace_id()
     assert isinstance(tid, str)
     assert len(tid) == 32
     int(tid, 16)  # should not raise
 
 
+    # Each call produces a different trace ID.
 def test_generate_trace_id_is_unique() -> None:
-    """Each call produces a different trace ID."""
     ids = {generate_trace_id() for _ in range(100)}
     assert len(ids) == 100
 
 
+    # generate_trace_id is accessible from the top-level asqav module.
 def test_generate_trace_id_exported() -> None:
-    """generate_trace_id is accessible from the top-level asqav module."""
     assert hasattr(asqav, "generate_trace_id")
     assert callable(asqav.generate_trace_id)
 
@@ -60,9 +60,9 @@ def test_generate_trace_id_exported() -> None:
 # === sign() with trace_id and parent_id ===
 
 
+    # sign() includes _trace_id in context when trace_id is provided.
 @patch("asqav.client._post")
 def test_sign_with_trace_id(mock_post: object) -> None:
-    """sign() includes _trace_id in context when trace_id is provided."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
     agent = _make_agent()
 
@@ -73,9 +73,9 @@ def test_sign_with_trace_id(mock_post: object) -> None:
     assert body["context"]["_trace_id"] == "abc123"
 
 
+    # sign() includes _parent_id in context when parent_id is provided.
 @patch("asqav.client._post")
 def test_sign_with_parent_id(mock_post: object) -> None:
-    """sign() includes _parent_id in context when parent_id is provided."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
     agent = _make_agent()
 
@@ -86,9 +86,9 @@ def test_sign_with_parent_id(mock_post: object) -> None:
     assert body["context"]["_parent_id"] == "parent_xyz"
 
 
+    # sign() includes both _trace_id and _parent_id when both provided.
 @patch("asqav.client._post")
 def test_sign_with_both_trace_and_parent(mock_post: object) -> None:
-    """sign() includes both _trace_id and _parent_id when both provided."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
     agent = _make_agent()
 
@@ -100,9 +100,9 @@ def test_sign_with_both_trace_and_parent(mock_post: object) -> None:
     assert body["context"]["_parent_id"] == "p1"
 
 
+    # Trace fields merge into user-provided context without overwriting.
 @patch("asqav.client._post")
 def test_sign_trace_merges_with_existing_context(mock_post: object) -> None:
-    """Trace fields merge into user-provided context without overwriting."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
     agent = _make_agent()
 
@@ -114,9 +114,9 @@ def test_sign_trace_merges_with_existing_context(mock_post: object) -> None:
     assert body["context"]["_trace_id"] == "t1"
 
 
+    # When no trace_id/parent_id given, context has no _trace_id/_parent_id.
 @patch("asqav.client._post")
 def test_sign_without_trace_no_trace_keys(mock_post: object) -> None:
-    """When no trace_id/parent_id given, context has no _trace_id/_parent_id."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
     agent = _make_agent()
 
@@ -128,9 +128,9 @@ def test_sign_without_trace_no_trace_keys(mock_post: object) -> None:
     assert "_parent_id" not in body["context"]
 
 
+    # sign() still returns a proper SignatureResponse with trace params.
 @patch("asqav.client._post")
 def test_sign_returns_signature_response(mock_post: object) -> None:
-    """sign() still returns a proper SignatureResponse with trace params."""
     mock_post.return_value = MOCK_SIGN_RESPONSE  # type: ignore[attr-defined]
     agent = _make_agent()
 

--- a/python/tests/test_url_join.py
+++ b/python/tests/test_url_join.py
@@ -74,11 +74,11 @@ class _FakeResponse:
         return self._body
 
 
+    # The stdlib fallback must hit the exact URL the httpx client would.
 @pytest.mark.parametrize("base", [BASE_WITH_PATH, BASE_NO_PATH])
 def test_urllib_fallback_requests_same_url_as_httpx(
     monkeypatch: pytest.MonkeyPatch, base: str
 ) -> None:
-    """The stdlib fallback must hit the exact URL the httpx client would."""
     httpx = pytest.importorskip("httpx")
     expected = str(
         httpx.Client(base_url=base).build_request("POST", "/agents/create").url
@@ -101,10 +101,10 @@ def test_urllib_fallback_requests_same_url_as_httpx(
         assert captured["url"] == "https://api.asqav.com/api/v1/agents/create"
 
 
+    # Direct pin of the funnel bug: prefix survives for the quickstart call.
 def test_urllib_fallback_never_strips_api_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Direct pin of the funnel bug: prefix survives for the quickstart call."""
     captured: dict[str, str] = {}
 
     def fake_urlopen(request: urllib.request.Request, timeout: float = 0) -> _FakeResponse:

--- a/python/tests/test_user_agent.py
+++ b/python/tests/test_user_agent.py
@@ -38,8 +38,8 @@ class _FakeResponse(io.BytesIO):
         return False
 
 
+    # The stdlib fallback transport (no httpx) sends the SDK User-Agent.
 def test_urllib_request_sends_user_agent() -> None:
-    """The stdlib fallback transport (no httpx) sends the SDK User-Agent."""
     from asqav import client
 
     captured: dict = {}
@@ -58,8 +58,8 @@ def test_urllib_request_sends_user_agent() -> None:
     assert captured["ua"] == USER_AGENT
 
 
+    # init() builds the persistent httpx client with the SDK User-Agent.
 def test_httpx_client_sends_user_agent() -> None:
-    """init() builds the persistent httpx client with the SDK User-Agent."""
     from asqav import client
 
     if not client._HTTPX_AVAILABLE:
@@ -74,8 +74,8 @@ def test_httpx_client_sends_user_agent() -> None:
     assert client._client.headers["user-agent"] == USER_AGENT
 
 
+    # The standalone verifier's network fetch sends a real User-Agent.
 def test_verifier_get_json_sends_user_agent() -> None:
-    """The standalone verifier's network fetch sends a real User-Agent."""
     captured: dict = {}
 
     def fake_urlopen(req, timeout=None):
@@ -89,8 +89,8 @@ def test_verifier_get_json_sends_user_agent() -> None:
     assert captured["ua"].startswith("asqav-python/")
 
 
+    # The async transport builds its httpx clients with the SDK User-Agent.
 def test_async_client_headers_include_user_agent() -> None:
-    """The async transport builds its httpx clients with the SDK User-Agent."""
     import inspect
 
     from asqav import async_client

--- a/python/tests/test_v2_signer.py
+++ b/python/tests/test_v2_signer.py
@@ -65,9 +65,9 @@ def test_v2_tampered_in_body_signer_fails() -> None:
     assert res.verdict == "FAIL"
 
 
+    # signer as loose metadata outside the signed payload is neither surfaced nor trusted.
 @requires_ed25519
 def test_v2_signer_moved_outside_signed_body_not_surfaced_and_fails() -> None:
-    """signer as loose metadata outside the signed payload is neither surfaced nor trusted."""
     receipt, jwks = _v2()
     del receipt["payload"]["signer"]
     receipt["signer"] = _SIGNER  # loose, outside the canonical body
@@ -85,9 +85,9 @@ def test_v2_tampered_canary_corpus_vector_fails() -> None:
     assert res.verdict == "FAIL"
 
 
+    # A v:2 receipt without _asqav_tid still verifies; the neutral verifier never requires it.
 @requires_ed25519
 def test_missing_canary_is_not_a_failure() -> None:
-    """A v:2 receipt without _asqav_tid still verifies; the neutral verifier never requires it."""
     receipt, jwks = _v2()
     del receipt["payload"]["_asqav_tid"]
     # Re-sign is out of scope for the neutral verifier; dropping the field breaks
@@ -106,8 +106,8 @@ def test_v1_vector_still_verifies_and_exposes_no_signer() -> None:
     assert res.signer is None
 
 
+    # attestation() surfaces signer from the payload, ignoring loose envelope metadata.
 def test_adapter_attestation_reads_only_signed_payload() -> None:
-    """attestation() surfaces signer from the payload, ignoring loose envelope metadata."""
     ad = AsqavNativeAdapter()
     receipt, _ = _v2()
     assert ad.attestation(receipt) == {"signer": _SIGNER}

--- a/python/tests/test_vc_export.py
+++ b/python/tests/test_vc_export.py
@@ -36,8 +36,8 @@ def _load(vec: str, name: str = "receipt.json") -> dict:
 # --- (a) data round-trip ---
 
 
+    # An Asqav-native compliance receipt maps agent/action/policy + issuer faithfully.
 def test_native_receipt_maps_key_fields_into_credential_subject() -> None:
-    """An Asqav-native compliance receipt maps agent/action/policy + issuer faithfully."""
     receipt = _load("asqav-01-genesis-permit")
     vc = to_vc_envelope(receipt)
 
@@ -53,8 +53,8 @@ def test_native_receipt_maps_key_fields_into_credential_subject() -> None:
     assert vc["validFrom"] == receipt["payload"]["issued_at"]
 
 
+    # A W3C-VC AgentReceipt input maps its action/principal/chain + issuer into the subject.
 def test_agentreceipts_receipt_maps_subject_and_issuer() -> None:
-    """A W3C-VC AgentReceipt input maps its action/principal/chain + issuer into the subject."""
     receipt = _load("agentreceipts-01-didkey-genesis")
     vc = to_vc_envelope(receipt)
 
@@ -66,16 +66,16 @@ def test_agentreceipts_receipt_maps_subject_and_issuer() -> None:
     assert sub["chain"] == receipt["credentialSubject"]["chain"]
 
 
+    # The export never mutates the source receipt.
 def test_export_is_pure_does_not_mutate_input() -> None:
-    """The export never mutates the source receipt."""
     receipt = _load("asqav-01-genesis-permit")
     before = json.dumps(receipt, sort_keys=True)
     to_vc_envelope(receipt)
     assert json.dumps(receipt, sort_keys=True) == before
 
 
+    # A flat hash-mode /sign receipt also maps cleanly (agent/org/action/policy).
 def test_hash_mode_receipt_exports() -> None:
-    """A flat hash-mode /sign receipt also maps cleanly (agent/org/action/policy)."""
     receipt = _load("asqav-05-hash-mode-prod")
     vc = to_vc_envelope(receipt)
     sub = vc["credentialSubject"]
@@ -88,8 +88,8 @@ def test_hash_mode_receipt_exports() -> None:
 # --- (c) signature preserved verbatim ---
 
 
+    # The original Asqav signature bytes appear unchanged in the proof.
 def test_native_signature_preserved_verbatim() -> None:
-    """The original Asqav signature bytes appear unchanged in the proof."""
     receipt = _load("asqav-01-genesis-permit")
     vc = to_vc_envelope(receipt)
     assert vc["proof"]["signatureValue"] == receipt["signature"]["sig"]
@@ -109,8 +109,8 @@ def test_agentreceipts_signature_preserved_verbatim() -> None:
     assert vc["proof"]["signatureValue"] == receipt["proof"]["proofValue"]
 
 
+    # The proof's signingInput pointer is the exact bytes the oracle re-derives.
 def test_signing_input_pointer_matches_oracle_bytes() -> None:
-    """The proof's signingInput pointer is the exact bytes the oracle re-derives."""
     receipt = _load("asqav-01-genesis-permit")
     vc = to_vc_envelope(receipt)
     pointer = base64.b64decode(vc["proof"]["signingInputBase64"])
@@ -123,8 +123,8 @@ def test_signing_input_pointer_matches_oracle_bytes() -> None:
 # --- (b) THE HONESTY GUARD ---
 
 
+    # The proof.type is the Asqav non-standard type and is NOT any registered VC suite.
 def test_proof_type_is_asqav_native_never_a_standard_vc_suite() -> None:
-    """The proof.type is the Asqav non-standard type and is NOT any registered VC suite."""
     vecs = ("asqav-01-genesis-permit", "agentreceipts-01-didkey-genesis", "asqav-05-hash-mode-prod")
     for vec in vecs:
         vc = to_vc_envelope(_load(vec))
@@ -181,8 +181,8 @@ def test_relabelling_export_as_standard_suite_still_cannot_verify() -> None:
     assert res.verdict != "PASS"
 
 
+    # A third-party ACTA receipt maps payload.issued_at into the VC validFrom.
 def test_upstream_acta_receipt_carries_validfrom_from_issued_at() -> None:
-    """A third-party ACTA receipt maps payload.issued_at into the VC validFrom."""
     receipt = _load("acta-up-01-a2a-trusted-attestation")
     vc = to_vc_envelope(receipt)
     assert vc["validFrom"] == receipt["payload"]["issued_at"]

--- a/python/tests/test_verify_compliance_receipt.py
+++ b/python/tests/test_verify_compliance_receipt.py
@@ -135,8 +135,8 @@ def test_receipt_type_attribute_satisfies_namespace_but_not_required_fields() ->
 # === 300-second skew bound ===
 
 
+    # A receipt 250s old (well inside the 300s bound) is accepted.
 def test_skew_well_within_boundary_is_accepted() -> None:
-    """A receipt 250s old (well inside the 300s bound) is accepted."""
     now = time.time()
     issued = datetime.fromtimestamp(
         now - (SKEW_BOUND_SECONDS - 50), tz=timezone.utc
@@ -177,8 +177,8 @@ def test_skew_in_future_is_rejected() -> None:
     assert "signed_at_skew" in result.errors
 
 
+    # M4 audit fix: an hour-old receipt (skew = -3600s) MUST verify.
 def test_skew_one_hour_in_past_is_accepted() -> None:
-    """M4 audit fix: an hour-old receipt (skew = -3600s) MUST verify."""
     now = time.time()
     issued = datetime.fromtimestamp(now - 3600, tz=timezone.utc).isoformat()
     env = _good_envelope(issued_at=issued)
@@ -228,8 +228,8 @@ def test_chain_link_mismatch_detected() -> None:
     assert "chain_link_mismatch" in result.errors
 
 
+    # A receipt seeded with FIRST_RECEIPT_SEED never needs a predecessor.
 def test_first_record_skips_predecessor_check() -> None:
-    """A receipt seeded with FIRST_RECEIPT_SEED never needs a predecessor."""
     env = _good_envelope(previousReceiptHash=FIRST_RECEIPT_SEED)
     result = verify_compliance_receipt(env)  # no predecessor passed
     assert result.chain_link_rederives is True
@@ -271,8 +271,8 @@ def test_sandbox_state_absent_is_accepted() -> None:
     assert result.valid is True
 
 
+    # `reason` is REQUIRED whenever `decision` is `deny` or `rate_limit`.
 def test_deny_decision_without_reason_is_rejected() -> None:
-    """`reason` is REQUIRED whenever `decision` is `deny` or `rate_limit`."""
     env = _good_envelope(decision="deny")
     result = verify_compliance_receipt(env)
     assert result.valid is False
@@ -338,8 +338,8 @@ def test_empty_anchors_array_does_not_trip_the_check() -> None:
 # === authorized_under_mandate (server-built, recognised structurally) ===
 
 
+    # A well-formed authorized_under_mandate attestation.
 def _good_mandate(**overrides) -> dict:
-    """A well-formed authorized_under_mandate attestation."""
     base = {
         "mandate_id": "man_abc123",
         "issuer_id": "legal:Acme GmbH",
@@ -364,16 +364,16 @@ def test_authorized_under_mandate_absent_is_accepted() -> None:
     assert result.valid is True
 
 
+    # A self-declared attestation with verified!=true is a forged mandate.
 def test_mandate_verified_not_true_is_rejected() -> None:
-    """A self-declared attestation with verified!=true is a forged mandate."""
     env = _good_envelope(authorized_under_mandate=_good_mandate(verified=False))
     result = verify_compliance_receipt(env)
     assert result.valid is False
     assert "false_mandate_attestation_guard" in result.errors
 
 
+    # scope_digest must be the sha256:<64-hex> wire form.
 def test_mandate_bad_scope_digest_is_rejected() -> None:
-    """scope_digest must be the sha256:<64-hex> wire form."""
     env = _good_envelope(
         authorized_under_mandate=_good_mandate(scope_digest="deadbeef")
     )
@@ -423,8 +423,8 @@ def test_controls_evaluated_not_object_is_rejected() -> None:
     assert "false_control_attestation_guard" in result.errors
 
 
+    # A forged control key the server never emits is a forged attestation.
 def test_controls_evaluated_unknown_key_is_rejected() -> None:
-    """A forged control key the server never emits is a forged attestation."""
     env = _good_envelope(controls_evaluated={"backdoor": {"fired": True}})
     result = verify_compliance_receipt(env)
     assert result.valid is False
@@ -460,8 +460,8 @@ def test_controls_evaluated_policy_matched_count_zero_is_rejected() -> None:
     assert "false_control_attestation_guard" in result.errors
 
 
+    # matched_count must be a real int; a bool True must not satisfy >= 1.
 def test_controls_evaluated_policy_matched_count_bool_is_rejected() -> None:
-    """matched_count must be a real int; a bool True must not satisfy >= 1."""
     env = _good_envelope(
         controls_evaluated={"policy": {"evaluated": True, "matched_count": True}}
     )
@@ -486,8 +486,8 @@ def test_valid_mandate_and_controls_together_pass() -> None:
 # === Canonical {payload, signature, anchors} wire envelope (criterion 434) ===
 
 
+    # The canonical wire shape: signed fields nested under ``payload``.
 def _canonical_envelope(**payload_overrides) -> dict:
-    """The canonical wire shape: signed fields nested under ``payload``."""
     return {
         "payload": _good_envelope(**payload_overrides),
         "signature": {"alg": "Ed25519", "kid": "k", "sig": "s"},
@@ -517,8 +517,8 @@ def test_canonical_envelope_reason_conditional_on_payload_decision() -> None:
     assert "missing_reason_on_deny_or_rate_limit" in result.errors
 
 
+    # The published asqav-01 conformance vector passes this surface.
 def test_asqav_01_genesis_permit_vector_passes() -> None:
-    """The published asqav-01 conformance vector passes this surface."""
     import json as _json
 
     vector_path = os.path.join(

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -137,16 +137,16 @@ def test_run_payload_null_fails_clean(capsys) -> None:
     assert "PASS" not in out.replace("never a PASS", "")
 
 
+    # Same guard when the response carries only nulls.
 def test_run_payload_null_without_signature_keys(capsys) -> None:
-    """Same guard when the response carries only nulls."""
     code = v.run({"payload": None}, {"keys": []}, predecessor_payload=None)
     out = capsys.readouterr().out
     assert code == 2
     assert "INCOMPLETE" in out
 
 
+    # A non-string alg SKIPs cleanly instead of crashing on (alg or '').upper().
 def test_verify_signature_nonstring_alg_skips_clean() -> None:
-    """A non-string alg SKIPs cleanly instead of crashing on (alg or '').upper()."""
     z = b""
     for bad_alg in (123, None, ["x"], {}):
         result, _ = v.verify_signature(z, z, z, bad_alg)
@@ -325,8 +325,8 @@ def test_run_agent_id_fallback_passes_legit_multi_agent() -> None:
     assert v.run(_envelope(payload, sig), jwks, None) == 0  # fallback resolves the bound signer
 
 
+    # A flipped signature byte on the legit multi-agent receipt FAILs.
 def test_run_tampered_signature_fails() -> None:
-    """A flipped signature byte on the legit multi-agent receipt FAILs."""
     ml = _ml_dsa_65()
     a1_pk, _a1_sk = ml.keygen()
     a2_pk, a2_sk = ml.keygen()
@@ -342,8 +342,8 @@ def test_run_tampered_signature_fails() -> None:
     assert v.run(_envelope(payload, bytes(sig)), jwks, None) == 1
 
 
+    # Mutating a payload field after signing FAILs; the signature no longer binds.
 def test_run_tampered_payload_fails() -> None:
-    """Mutating a payload field after signing FAILs; the signature no longer binds."""
     ml = _ml_dsa_65()
     a1_pk, _a1_sk = ml.keygen()
     a2_pk, a2_sk = ml.keygen()
@@ -405,24 +405,24 @@ def test_run_structured_agent_id_fallback_rejects_forged_issuer() -> None:
 # === the kid path must bind the verifying key to the claimed issuer too ===
 
 
+    # PASSes only on an exact match; fails closed on an unpublished issuer.
 def test_check_issuer_binding_gate() -> None:
-    """PASSes only on an exact match; fails closed on an unpublished issuer."""
     assert v.check_issuer_binding("org-victim", "org-victim")[0] == "PASS"
     assert v.check_issuer_binding("org-attacker", "org-victim")[0] == "FAIL"
     assert v.check_issuer_binding(None, "org-victim")[0] == "FAIL"
     assert v.check_issuer_binding("org-victim", None)[0] == "FAIL"
 
 
+    # Reads the entry resolve_key returns, by key id or issuer id.
 def test_resolve_key_issuer_reads_the_matched_entry() -> None:
-    """Reads the entry resolve_key returns, by key id or issuer id."""
     jwks = {"keys": [_jwks_key("agent-one", "agt_one", "org-legit", b"\x00")]}
     assert v.resolve_key_issuer(jwks, "agent-one") == "org-legit"
     assert v.resolve_key_issuer(jwks, "org-legit") == "org-legit"
     assert v.resolve_key_issuer(jwks, "nothing-here") is None
 
 
+    # Attacker-signed receipt claiming the victim, plus the shared jwks.
 def _cross_issuer_forgery():
-    """Attacker-signed receipt claiming the victim, plus the shared jwks."""
     ml = _ml_dsa_65()
     attacker_pk, attacker_sk = ml.keygen()
     victim_pk, _victim_sk = ml.keygen()
@@ -447,8 +447,8 @@ def test_run_rejects_attacker_kid_claiming_another_issuer() -> None:
     assert by_org_id == 1, f"attacker org id verified a receipt claiming org-victim (exit {by_org_id})"
 
 
+    # Same forgery through run_structured: FAIL on issuer_bind, signature PASS.
 def test_run_structured_rejects_attacker_kid_claiming_another_issuer() -> None:
-    """Same forgery through run_structured: FAIL on issuer_bind, signature PASS."""
     payload, sig, jwks = _cross_issuer_forgery()
     result = v.run_structured(_envelope(payload, sig, kid="attacker-key"), jwks, None)
     assert result["verdict"] == "FAIL", f"axes: {result['axes']}"
@@ -458,8 +458,8 @@ def test_run_structured_rejects_attacker_kid_claiming_another_issuer() -> None:
     assert sig_axis["result"] == "PASS", "the forged signature itself verifies; the bind rejects it"
 
 
+    # LEGIT: the claimed issuer's own key still PASSes, so real verifies work.
 def test_run_structured_passes_a_receipt_signed_by_the_claimed_issuer() -> None:
-    """LEGIT: the claimed issuer's own key still PASSes, so real verifies work."""
     ml = _ml_dsa_65()
     pk, sk = ml.keygen()
     payload = _valid_payload("org-legit", "agt_one")

--- a/python/tests/test_verify_receipt_revoked_key.py
+++ b/python/tests/test_verify_receipt_revoked_key.py
@@ -61,8 +61,8 @@ def test_check_key_status_revoked_before_issuance_fails():
     assert res == "FAIL"
 
 
+    # No anchor means issued_at is self-attested; backdating is undetectable.
 def test_check_key_status_revoked_after_issuance_skipped_without_anchor():
-    """No anchor means issued_at is self-attested; backdating is undetectable."""
     res, note = v.check_key_status(
         "revoked", "2026-05-01T00:00:00Z", revoked_at="2026-06-01T00:00:00Z"
     )
@@ -70,8 +70,8 @@ def test_check_key_status_revoked_after_issuance_skipped_without_anchor():
     assert "anchor" in note.lower()
 
 
+    # A pre-revocation receipt with a trusted anchor still verifies.
 def test_check_key_status_revoked_after_issuance_passes_with_anchor():
-    """A pre-revocation receipt with a trusted anchor still verifies."""
     res, _ = v.check_key_status(
         "revoked", "2026-05-01T00:00:00Z", revoked_at="2026-06-01T00:00:00Z",
         has_trusted_anchor=True,
@@ -82,8 +82,8 @@ def test_check_key_status_revoked_after_issuance_passes_with_anchor():
 # --- standalone verify_receipt.run ---
 
 
+    # A revoked-key receipt yields a FAIL verdict, never PASS, from run().
 def test_run_revoked_key_does_not_pass(capsys):
-    """A revoked-key receipt yields a FAIL verdict, never PASS, from run()."""
     envelope = {
         "payload": _payload(),
         "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
@@ -96,8 +96,8 @@ def test_run_revoked_key_does_not_pass(capsys):
     assert code == 1  # FAIL dominates; never 0 (PASS)
 
 
+    # An active key contributes a key_status PASS line.
 def test_run_active_key_has_key_status_pass(capsys):
-    """An active key contributes a key_status PASS line."""
     envelope = {
         "payload": _payload(),
         "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
@@ -112,8 +112,8 @@ def test_run_active_key_has_key_status_pass(capsys):
 # --- run_structured path ---
 
 
+    # run_structured must include a key_status FAIL axis for a revoked key.
 def test_run_structured_revoked_key_has_key_status_fail_axis():
-    """run_structured must include a key_status FAIL axis for a revoked key."""
     envelope = {
         "payload": _payload(),
         "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
@@ -126,8 +126,8 @@ def test_run_structured_revoked_key_has_key_status_fail_axis():
     assert ks["result"] == "FAIL", f"expected FAIL, got {ks['result']!r}"
 
 
+    # run_structured includes a key_status PASS axis for an active key.
 def test_run_structured_active_key_has_key_status_pass_axis():
-    """run_structured includes a key_status PASS axis for an active key."""
     envelope = {
         "payload": _payload(),
         "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
@@ -157,8 +157,8 @@ def test_run_structured_revoked_at_after_issuance_skipped_without_anchor():
     assert result["verdict"] != "PASS"
 
 
+    # Offline a present anchor is not trusted, so key_status stays SKIPPED.
 def test_run_structured_forged_anchor_stays_skipped_offline():
-    """Offline a present anchor is not trusted, so key_status stays SKIPPED."""
     envelope = {
         "payload": _payload(),
         "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
@@ -215,13 +215,13 @@ def test_offline_forged_anchor_revoked_key_verdict_not_pass():
 # --- oracle adapter path ---
 
 
+    # Read one axis by name; position shifts as the adapter grows axes.
 def _axis(axes, name):
-    """Read one axis by name; position shifts as the adapter grows axes."""
     return next(a for a in axes if a[0] == name)
 
 
+    # The asqav-native adapter surfaces a failing key_status axis for a revoked key.
 def test_oracle_revoked_key_axis_fails():
-    """The asqav-native adapter surfaces a failing key_status axis for a revoked key."""
     doc = {
         "payload": _payload(),
         "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},
@@ -243,8 +243,8 @@ def test_oracle_active_key_axis_passes():
     assert status[1] == "PASS", status
 
 
+    # The adapter must not let a forged anchor upgrade a revoked key's axis.
 def test_oracle_forged_anchor_revoked_key_axis_skipped():
-    """The adapter must not let a forged anchor upgrade a revoked key's axis."""
     doc = {
         "payload": _payload(),
         "signature": {"alg": "ML-DSA-65", "kid": "agent-revoked-001", "sig": "AAAA"},

--- a/python/tests/test_verify_response_fields.py
+++ b/python/tests/test_verify_response_fields.py
@@ -26,8 +26,8 @@ from asqav.client import (
 )
 
 
+    # Mirror the cloud's `VerificationResponse` shape with every field set.
 def _full_cloud_payload() -> dict:
-    """Mirror the cloud's `VerificationResponse` shape with every field set."""
     return {
         "type": "signature",
         "signature_id": "sig_test_full",

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -155,7 +155,8 @@ export function verify(
     axes.push({ axis: name, result: res, note });
   }
 
-  const hasFail = axes.some((a) => a.result === FAIL);
+  // Expiry reports on its own axis and never folds the verdict (criterion 426)
+  const hasFail = axes.some((a) => a.result === FAIL && a.axis !== "expiry");
   // Any skipped axis except a missing-predecessor chain blocks PASS: an unchecked
   // signature / counter-sign / PDP layer means INCOMPLETE, never a hiding PASS.
   const blockingSkip = axes.some((a) => a.result === SKIPPED && a.axis !== "chain");

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -517,13 +517,7 @@ function expiryLapsed(deltaSeconds: number): boolean {
   return deltaSeconds < 0;
 }
 
-/**
- * Refuse a receipt past the expiry its own signer committed to (mirrors `check_expiry`).
- *
- * Mirrors the hosted signature_expired verdict. The window is read from inside
- * the signed bytes, so an unsigned envelope field can never move it, and an
- * unreadable value fails closed instead of reading as no window at all.
- */
+/** Axis-only expiry flag, mirrors the hosted signature_expired label; never folds the verdict (426). */
 export function checkExpiry(payload: unknown): readonly [VerifyState, string] {
   if (!isRecord(payload) || !("expires_at" in payload)) {
     return ["PASS", "receipt declares no expiry"];

--- a/typescript/tests/offline-verify.test.ts
+++ b/typescript/tests/offline-verify.test.ts
@@ -380,9 +380,7 @@ describe("verifyReceiptOffline - ML-DSA-65 path (@noble/post-quantum)", () => {
   // Uses a receipt + JWKS minted from api.asqav.com with mode=full-payload.
   const KAT_DIR = join(VECTORS, "asqav-06-mldsa65-payload-prod");
 
-  // The receipt's signed expires_at lapsed on 2026-06-20, so the verdict is FAIL on
-  // expiry alone. That split is the point: the post-quantum signature still verifies,
-  // and the offline verdict now matches the hosted signature_expired.
+  // Signed expires_at lapsed 2026-06-20: the expiry axis FAILs alone, the verdict stays PASS (426)
   it("verifies a real-cloud ML-DSA-65 payload-mode receipt (KAT - signature axis must be PASS)", () => {
     const receipt = loadJson(KAT_DIR, "receipt.json");
     const jwks = loadJson(KAT_DIR, "jwks.json");
@@ -396,7 +394,7 @@ describe("verifyReceiptOffline - ML-DSA-65 path (@noble/post-quantum)", () => {
     expect(result.axes.filter((a) => a.axis !== "expiry").map((a) => a.result)).toEqual(
       result.axes.filter((a) => a.axis !== "expiry").map(() => "PASS"),
     );
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("PASS");
   });
 
   it("returns FAIL for a tampered real-cloud ML-DSA-65 KAT receipt (anti-vacuous)", () => {

--- a/verifier/conformance-vectors/asqav-06-mldsa65-payload-prod/expected.json
+++ b/verifier/conformance-vectors/asqav-06-mldsa65-payload-prod/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "asqav-native",
-  "outcome": "FAIL",
-  "reason_code": "signature_expired",
-  "notes": "Real prod payload-mode receipt signed by ML-DSA-65 (FIPS 204). Agent agt_LBe47lJwgA0DfVom created 2026-06-19; action act_6Xm9cj3AgtPVqZaY8IJnLw signed with key mxYqaLBR_T76ThNw0Kiekw (issuer_id f94f66c0-c580-432d-a041-29374f7aee07). mode=payload so signing_input is canonical_json(full payload dict). ML-DSA-65 signature axis must be PASS, not SKIPPED or INCOMPLETE - this is the known-answer vector for offline ML-DSA-65 against a real cloud receipt. The signed expires_at 2026-06-20T22:23:57.045786Z has lapsed, so the expiry axis FAILs the verdict on top of that PASSing signature, matching the hosted signature_expired label."
+  "outcome": "PASS",
+  "reason_code": "",
+  "notes": "Real prod payload-mode receipt signed by ML-DSA-65 (FIPS 204). Agent agt_LBe47lJwgA0DfVom created 2026-06-19; action act_6Xm9cj3AgtPVqZaY8IJnLw signed with key mxYqaLBR_T76ThNw0Kiekw (issuer_id f94f66c0-c580-432d-a041-29374f7aee07). mode=payload so signing_input is canonical_json(full payload dict). ML-DSA-65 signature axis must be PASS, not SKIPPED or INCOMPLETE - this is the known-answer vector for offline ML-DSA-65 against a real cloud receipt. The signed expires_at 2026-06-20T22:23:57.045786Z has lapsed: the expiry axis FAILs on its own (hosted signature_expired label) but never folds the receipt-level verdict, matching hosted parity (criterion 426)."
 }

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -37,9 +37,9 @@
   {
     "dir": "asqav-06-mldsa65-payload-prod",
     "format": "asqav-native",
-    "outcome": "FAIL",
-    "reason_code": "signature_expired",
-    "notes": "Real payload-mode prod ML-DSA-65 receipt; the signing input byte-matches and ML-DSA-65 verifies with dilithium-py (proven in test_offline_verify.py's known-answer test). Its signed expires_at is 2026-06-20T22:23:57.045786Z, so the expiry axis FAILs the verdict while the signature axis still PASSes - the same split the hosted /verify reports as signature_expired. The verdict is FAIL with or without the optional dep, so this vector no longer carries the SKIP case; asqav-05-hash-mode-prod does."
+    "outcome": "PASS",
+    "reason_code": "",
+    "notes": "Real payload-mode prod ML-DSA-65 receipt; the signing input byte-matches and ML-DSA-65 verifies with dilithium-py (proven in test_offline_verify.py's known-answer test). Its signed expires_at lapsed 2026-06-20: the expiry axis FAILs alone while the verdict stays PASS, matching hosted parity (criterion 426). asqav-05-hash-mode-prod carries the SKIP case."
   },
   {
     "dir": "asqav-07-revoked-key",


### PR DESCRIPTION
## Criterion 426 (hosted parity)

An elapsed expires_at keeps the receipt-level verdict on the cryptographic axes. The expiry axis FAILs alone (mirrors the hosted signature_expired label) and only replay of the expired decision is blocked. Applied across the standalone run()/run_structured(), the oracle core, and the TS verifier. The asqav-06 KAT vector + manifest now pin PASS-with-lapsed-expiry; offline/exit-artifact tests assert the split.

## Docstring sweep

Every single-line triple-quoted docstring in python/src and python/tests becomes a one-line comment (module docstrings kept: test_extras reads one).

## Verification

- Python: 2718 passed, 1 skipped
- Oracle corpus: 51/51 matched
- TypeScript suite green, tsc clean
- ruff (CI scope python/src): clean