### PR TITLE
feat(verifier): strict JSON ingest + tri-state verdict vocabulary (criteria 419, 418, 438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ### Changed
 
+- **BREAKING: the verifier speaks a three-verdict vocabulary and never collapses
+  failure classes (criteria 418/438).** Every public verifier surface — the
+  standalone `verify_receipt.py` (text + structured + exit codes), the oracle
+  `verify()` / `VerifyResult`, the oracle runner, the TypeScript `verify()` /
+  `verifyReceiptOffline`, and `verify_attestation_offline` — now reports
+  `verified` | `verified_keyed` | `unverified` instead of PASS | FAIL |
+  INCOMPLETE. Every `unverified` verdict carries a `failure_class` of `invalid`
+  (a check ran and a cryptographic/policy binding failed: signature mismatch,
+  chain-link mismatch, invalid anchor, counterparty binding mismatch, revoked or
+  changed signer key, algorithm mismatch, or `issued_at` future-skew) or
+  `unverifiable` (recomputation could not complete: unresolvable key, missing or
+  broken chain predecessor, malformed member, canonicalisation or parse failure,
+  unresolvable policy digest, or a pending anchor without proof). The two are
+  never collapsed, and a receipt is never reported verified when recomputation
+  failed. A keyed digest (e.g. HMAC-SHA256) that fully checks reports
+  `verified_keyed`, never plain `verified`. Exit codes keep the stable mapping:
+  `verified`/`verified_keyed` → 0, `unverified`+`invalid` → 1,
+  `unverified`+`unverifiable` → 2 (the blocked state INCOMPLETE used to carry).
+  The per-axis PASS/FAIL/SKIPPED tokens stay internal. Both language halves and
+  the conformance corpus agree byte for byte on verdict and failure_class.
+
+- **BREAKING: duplicate JSON member names are rejected at any depth (criterion
+  419).** Every receipt- and record-parsing path — `verify_receipt` ingest, the
+  oracle runner and CLI, the attestation signed-message re-parse, the doors OTel
+  receipt recovery, the CLI JSON arguments and signing-log records, the API
+  response parsers, and the TypeScript `parseJsonPreservingFloats` plus the
+  receipt/bundle/doors/DSSE loaders — now fails closed on a duplicated member
+  name, before any hashing, canonicalisation, or signature check. The stdlib
+  last-wins behaviour would hash the bytes an attacker kept and drop the ones
+  they replaced, so a duplicate is a terminal parse failure, reported
+  `unverified`/`unverifiable`.
+
 - **BREAKING for hand-assembled receipts: an anchor `value` must be one unwrapped
   base64 token.** A value carrying whitespace, including a trailing newline or MIME
   line wrapping, reported PASS on the anchors axis and now reports FAIL. Both language

--- a/docs/offline-verification.md
+++ b/docs/offline-verification.md
@@ -12,7 +12,8 @@ pip install "asqav[verify]"
 ```
 
 The `verify` extra adds `dilithium-py` (ML-DSA-65) and `cryptography` (Ed25519, ES256).
-Without it, the signature axis reports `SKIPPED`/`INCOMPLETE`, never a false PASS.
+Without it, the signature axis reports `SKIPPED` and the verdict is `unverified`
+(`failure_class=unverifiable`), never a false `verified`.
 
 ### 2. Snapshot the JWKS while online
 
@@ -32,9 +33,10 @@ receipt = json.load(open("receipt.json"))
 jwks    = json.load(open("jwks.json"))
 
 result = asqav.verify_receipt_offline(receipt, jwks)
-# result: {"verdict": "PASS"|"FAIL"|"INCOMPLETE", "axes": [...], "fmt": "..."}
+# result: {"verdict": "verified"|"verified_keyed"|"unverified",
+#          "failure_class": "invalid"|"unverifiable"|None, "axes": [...], "fmt": "..."}
 
-assert result["verdict"] == "PASS", result["axes"]
+assert result["verdict"] == "verified", result["axes"]
 ```
 
 To check a hash-chain link, supply the predecessor receipt:
@@ -45,11 +47,20 @@ result = asqav.verify_receipt_offline(receipt, jwks, predecessor=prev_receipt)
 
 ### Verdicts
 
-| Verdict      | Meaning                                                    |
-|--------------|------------------------------------------------------------|
-| `PASS`       | All axes checked and passed.                               |
-| `FAIL`       | At least one axis failed (signature mismatch, bad chain).  |
-| `INCOMPLETE` | A blocking axis was skipped (e.g., dilithium-py missing).  |
+| Verdict          | Meaning                                                    |
+|------------------|------------------------------------------------------------|
+| `verified`       | All axes checked and passed.                               |
+| `verified_keyed` | All axes passed, but the digest is keyed (e.g. HMAC-SHA256) and not third-party re-derivable. Never reported as plain `verified`. |
+| `unverified`     | Not verified; carries `failure_class` `invalid` or `unverifiable`. |
+
+Every `unverified` verdict names its `failure_class`, and the two are never collapsed:
+
+- `invalid` - a check ran and a cryptographic/policy binding failed (signature
+  mismatch, chain-link mismatch, invalid anchor, counterparty binding mismatch,
+  revoked/changed signer key, algorithm mismatch, or `issued_at` future-skew).
+- `unverifiable` - recomputation could not complete (unresolvable key, missing
+  or broken chain predecessor, malformed member, canonicalisation or parse
+  failure, unresolvable policy digest, or a pending anchor without proof).
 
 ## Standalone single-file verifier (no asqav install)
 
@@ -94,11 +105,12 @@ const receipt = JSON.parse(readFileSync("receipt.json", "utf-8"));
 const jwksSaved = JSON.parse(readFileSync("jwks.json", "utf-8"));
 
 const result = verifyReceiptOffline(receipt, jwksSaved);
-// result.verdict: "PASS" | "FAIL" | "INCOMPLETE"
-// result.axes: AxisResult[]  (axis, result, note)
+// result.verdict: "verified" | "verified_keyed" | "unverified"
+// result.failureClass: "invalid" | "unverifiable" | null
+// result.axes: AxisResult[]  (axis, result, note, failureClass)
 
-if (result.verdict !== "PASS") {
-  throw new Error(`Receipt invalid: ${JSON.stringify(result.axes)}`);
+if (result.verdict !== "verified" && result.verdict !== "verified_keyed") {
+  throw new Error(`Receipt not verified (${result.failureClass}): ${JSON.stringify(result.axes)}`);
 }
 ```
 
@@ -181,4 +193,4 @@ changes to `revoked`. The verifier rejects signatures from revoked keys.
 |-----------|--------|
 | Ed25519 | Fully validated with real known-answer (tamper) vectors. |
 | ES256 | Fully validated with real known-answer (tamper) vectors. |
-| ML-DSA-65 | Fully proven. Known-answer conformance vector `asqav-06-mldsa65-payload-prod` was minted from a real api.asqav.com payload-mode receipt (2026-06-19, agent `agt_LBe47lJwgA0DfVom`, key `mxYqaLBR_T76ThNw0Kiekw`). Both Python (`test_verify_receipt_offline_mldsa65_real_cloud_kat`) and TypeScript test suites exercise the signature axis against this vector and assert PASS; tamper tests assert FAIL. |
+| ML-DSA-65 | Fully proven. Known-answer conformance vector `asqav-06-mldsa65-payload-prod` was minted from a real api.asqav.com payload-mode receipt (2026-06-19, agent `agt_LBe47lJwgA0DfVom`, key `mxYqaLBR_T76ThNw0Kiekw`). Both Python (`test_verify_receipt_offline_mldsa65_real_cloud_kat`) and TypeScript test suites exercise the signature axis against this vector and assert `verified`; tamper tests assert `unverified`/`invalid`. |

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -40,7 +40,10 @@ from ._schema import normalize_context, validate_context_schema
 from .async_client import AsyncAgent
 from .attestation import (
     ATTESTATION_STATEMENT_SCHEMA,
-    VERDICT_VERIFIED_NOT_REDERIVABLE,
+    FAILURE_INVALID,
+    FAILURE_UNVERIFIABLE,
+    VERDICT_UNVERIFIED,
+    VERDICT_VERIFIED_KEYED,
     compute_statement_hash,
     reconstruct_signed_message,
     verify_attestation_offline,
@@ -382,7 +385,10 @@ __all__ = [
     "verify_attestation_offline",
     "verify_merkle_inclusion",
     "ATTESTATION_STATEMENT_SCHEMA",
-    "VERDICT_VERIFIED_NOT_REDERIVABLE",
+    "VERDICT_VERIFIED_KEYED",
+    "VERDICT_UNVERIFIED",
+    "FAILURE_INVALID",
+    "FAILURE_UNVERIFIABLE",
     # Structured receipts (criterion 328)
     "validate_context_schema",
     "normalize_context",
@@ -408,7 +414,7 @@ def verify_receipt_offline(
     Runs the full oracle: structure, signature (Ed25519/ES256/ML-DSA-65),
     hash-chain link. No network call is made; all crypto happens in-process.
     ML-DSA-65 requires ``pip install asqav[verify]``; without it the signature
-    axis is SKIPPED and the verdict is INCOMPLETE, never a false PASS.
+    axis is SKIPPED and the verdict is unverified/unverifiable, never verified.
 
     Args:
         receipt: Parsed receipt envelope dict (``{payload, signature, anchors}``).
@@ -419,8 +425,10 @@ def verify_receipt_offline(
     Returns:
         dict with keys:
 
-          - ``"verdict"``: "PASS" | "FAIL" | "INCOMPLETE"
-          - ``"axes"``: list of per-axis dicts (name, result, note)
+          - ``"verdict"``: "verified" | "verified_keyed" | "unverified"
+          - ``"failure_class"``: "invalid" | "unverifiable" when unverified,
+            else None; the two are never collapsed (criterion 418)
+          - ``"axes"``: list of per-axis dicts (name, result, note, failure_class)
           - ``"fmt"``: detected receipt format name
 
     Example::
@@ -428,7 +436,7 @@ def verify_receipt_offline(
         jwks = asqav.fetch_jwks()       # snapshot online
         # ... go offline ...
         result = asqav.verify_receipt_offline(receipt, jwks)
-        assert result["verdict"] == "PASS"
+        assert result["verdict"] == "verified"
     """
     predecessor_payload = None
     if predecessor is not None:
@@ -438,6 +446,10 @@ def verify_receipt_offline(
     )
     return {
         "verdict": vr.verdict,
-        "axes": [{"name": a.axis, "result": a.result, "note": a.note} for a in vr.axes],
+        "failure_class": vr.failure_class,
+        "axes": [
+            {"name": a.axis, "result": a.result, "note": a.note, "failure_class": a.failure_class}
+            for a in vr.axes
+        ],
         "fmt": vr.fmt,
     }

--- a/python/src/asqav/async_client.py
+++ b/python/src/asqav/async_client.py
@@ -22,6 +22,7 @@ from .client import (
     _parse_timestamp,
     _resolve_action_ref,
     _resolve_previous_receipt_hash,
+    _strict_response_json,
     require_field,
 )
 from .patterns import resolve_pattern
@@ -87,7 +88,7 @@ async def _async_get(path: str) -> dict[str, Any]:
     ) as client:
         response = await client.get(path)
         await _handle_response(response)
-        result: dict[str, Any] = response.json()
+        result: dict[str, Any] = _strict_response_json(response)
         return result
 
 
@@ -105,7 +106,7 @@ async def _async_post(path: str, data: dict[str, Any]) -> dict[str, Any]:
     ) as client:
         response = await client.post(path, json=data)
         await _handle_response(response)
-        result: dict[str, Any] = response.json()
+        result: dict[str, Any] = _strict_response_json(response)
         return result
 
 
@@ -123,7 +124,7 @@ async def _async_patch(path: str, data: dict[str, Any]) -> dict[str, Any]:
     ) as client:
         response = await client.patch(path, json=data)
         await _handle_response(response)
-        result: dict[str, Any] = response.json()
+        result: dict[str, Any] = _strict_response_json(response)
         return result
 
 
@@ -391,7 +392,7 @@ class AsyncAgent:
                 raise APIError("Signature not found", 404)
             if response.status_code >= 400:
                 raise APIError(response.text, response.status_code)
-            data: dict[str, Any] = response.json()
+            data: dict[str, Any] = _strict_response_json(response)
 
         return VerificationResponse(
             signature_id=require_field(data, "signature_id"),

--- a/python/src/asqav/attestation.py
+++ b/python/src/asqav/attestation.py
@@ -21,15 +21,18 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
-import json
 from collections.abc import Callable
 from typing import Any
 
+from . import strict_json
 from ._jcs import canonical_json
 
 __all__ = [
     "ATTESTATION_STATEMENT_SCHEMA",
-    "VERDICT_VERIFIED_NOT_REDERIVABLE",
+    "VERDICT_VERIFIED_KEYED",
+    "VERDICT_UNVERIFIED",
+    "FAILURE_INVALID",
+    "FAILURE_UNVERIFIABLE",
     "compute_statement_hash",
     "reconstruct_signed_message",
     "merkle_leaf_hash",
@@ -44,10 +47,15 @@ __all__ = [
 ATTESTATION_STATEMENT_SCHEMA = "asqav.attestation/1"
 DEFAULT_COMMITMENT_ALG = "HMAC-SHA256"
 
-#: Distinct outcome for a good attestation receipt. Never a plain PASS.
-VERDICT_VERIFIED_NOT_REDERIVABLE = "VERIFIED_COMMITMENT_NOT_REDERIVABLE"
-VERDICT_FAIL = "FAIL"
-VERDICT_INCOMPLETE = "INCOMPLETE"
+#: Public verdict vocabulary (criteria 418/438). A good attestation receipt is
+#: verified_keyed, never plain verified: the commitment is an HMAC sealed with a
+#: holder-only key, so the commitment itself is never re-derivable here.
+VERDICT_VERIFIED_KEYED = "verified_keyed"
+VERDICT_UNVERIFIED = "unverified"
+
+#: Failure classes carried by every unverified verdict; never collapsed (418).
+FAILURE_INVALID = "invalid"
+FAILURE_UNVERIFIABLE = "unverifiable"
 
 _AXIS_PASS = "PASS"
 _AXIS_FAIL = "FAIL"
@@ -196,8 +204,28 @@ def verify_merkle_inclusion(
 # === Offline attestation verification ===
 
 
-def _axis(name: str, result: str, note: str) -> dict[str, str]:
-    return {"name": name, "result": result, "note": note}
+    # Per-axis failure token (criterion 418); a good receipt never carries one.
+def _axis_failure_class(result: str, note: str) -> str | None:
+    if result in (_AXIS_PASS, _AXIS_NOT_REDERIVABLE):
+        return None
+    if result == _AXIS_SKIP:
+        return FAILURE_UNVERIFIABLE
+    # Parse failures and malformed members stop recomputation; they are not a
+    # proven binding break, so they never read invalid.
+    if note.startswith(("signed message rejected:", "signed message is not valid")):
+        return FAILURE_UNVERIFIABLE
+    if note == "receipt signature is not valid base64":
+        return FAILURE_UNVERIFIABLE
+    return FAILURE_INVALID
+
+
+def _axis(name: str, result: str, note: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "result": result,
+        "note": note,
+        "failure_class": _axis_failure_class(result, note),
+    }
 
 
 def verify_attestation_offline(
@@ -215,7 +243,7 @@ def verify_attestation_offline(
     asqav's signature over the signed message, and checks the inclusion proof
     against a supplied signed tree head. The commitment is an HMAC sealed with
     a holder-only key, so it can never be re-derived here. A good receipt
-    yields VERDICT_VERIFIED_NOT_REDERIVABLE, never a plain PASS.
+    yields ``verified_keyed``, never plain ``verified`` (criteria 418/438).
 
     Args:
         claim: The original claim dict the caller submitted.
@@ -230,11 +258,12 @@ def verify_attestation_offline(
         commitment_alg: Commitment algorithm id. Defaults to HMAC-SHA256.
 
     Returns:
-        dict with ``verdict`` (VERIFIED_COMMITMENT_NOT_REDERIVABLE | FAIL |
-        INCOMPLETE), ``axes`` (per-axis name/result/note), and ``statementHash``
-        (the recomputed value).
+        dict with ``verdict`` ("verified_keyed" | "unverified"),
+        ``failure_class`` ("invalid" | "unverifiable" when unverified, else
+        None), ``axes`` (per-axis name/result/note/failure_class), and
+        ``statementHash`` (the recomputed value).
     """
-    axes: list[dict[str, str]] = []
+    axes: list[dict[str, Any]] = []
 
     recomputed = compute_statement_hash(
         claim,
@@ -284,8 +313,10 @@ def verify_attestation_offline(
         )
     )
 
+    verdict, failure_class = _verdict(axes)
     return {
-        "verdict": _verdict(axes),
+        "verdict": verdict,
+        "failure_class": failure_class,
         "axes": axes,
         "statementHash": recomputed,
     }
@@ -299,7 +330,10 @@ def _check_signature(
     verify_signature: Callable[[bytes, bytes], bool],
 ) -> tuple[str, str]:
     try:
-        message_obj = json.loads(signed_message)
+        # Strict ingest (419): a duplicated member name never reaches the bind check.
+        message_obj = strict_json.loads(signed_message)
+    except strict_json.DuplicateMemberError as exc:
+        return _AXIS_FAIL, f"signed message rejected: {exc}"
     except (ValueError, TypeError):
         return _AXIS_FAIL, "signed message is not valid canonical JSON"
     if message_obj.get("statement_hash") != recomputed_hash:
@@ -313,16 +347,19 @@ def _check_signature(
     return _AXIS_FAIL, "signature does not verify over the signed message"
 
 
-    # Map per-axis results to a verdict. A good receipt is never a plain PASS.
-def _verdict(axes: list[dict[str, str]]) -> str:
+    # Fold per-axis results; a good receipt is verified_keyed, never verified.
+def _verdict(axes: list[dict[str, Any]]) -> tuple[str, str | None]:
     results = {a["name"]: a["result"] for a in axes}
-    if any(r == _AXIS_FAIL for r in results.values()):
-        return VERDICT_FAIL
+    failed = [a for a in axes if a["result"] == _AXIS_FAIL]
+    if failed:
+        classes = {a["failure_class"] for a in failed}
+        failure_class = FAILURE_INVALID if FAILURE_INVALID in classes else FAILURE_UNVERIFIABLE
+        return VERDICT_UNVERIFIED, failure_class
     checked = (
         results.get("statement_hash") == _AXIS_PASS
         and results.get("signature") == _AXIS_PASS
         and results.get("inclusion") == _AXIS_PASS
     )
     if checked:
-        return VERDICT_VERIFIED_NOT_REDERIVABLE
-    return VERDICT_INCOMPLETE
+        return VERDICT_VERIFIED_KEYED, None
+    return VERDICT_UNVERIFIED, FAILURE_UNVERIFIABLE

--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -212,7 +212,7 @@ def verify_litellm_log(
     """
     import json as json_mod
 
-    from asqav import APIError, verify_signature
+    from asqav import APIError, strict_json, verify_signature
 
     try:
         with open(path) as fh:
@@ -226,8 +226,9 @@ def verify_litellm_log(
     failures: list[dict[str, Any]] = []
     for lineno, raw in enumerate(lines, start=1):
         try:
-            record = json_mod.loads(raw)
-        except json_mod.JSONDecodeError as exc:
+            # Strict ingest (419): a duplicated member name fails the record.
+            record = strict_json.loads(raw)
+        except (json_mod.JSONDecodeError, strict_json.DuplicateMemberError) as exc:
             total += 1
             failures.append({"line": lineno, "reason": f"bad json: {exc}"})
             continue
@@ -274,19 +275,23 @@ def _load_json_arg(source: str, label: str) -> dict | None:
     """Load a JSON arg from a file path, stdin (`-`), or return None when empty.
 
     Used by `sign` for `--action-json` and `--policy-artefact`. Exits 1 on
-    OSError or JSONDecodeError with a clear `label`-prefixed message so
-    the caller knows which arg failed.
+    OSError, JSONDecodeError, or a duplicated member name (419) with a clear
+    `label`-prefixed message so the caller knows which arg failed.
     """
     import json as json_mod
+
+    from asqav import strict_json
 
     if not source:
         return None
     try:
         if source == "-":
-            return json_mod.loads(sys.stdin.read())
-        with open(source) as f:
-            return json_mod.load(f)
-    except (OSError, json_mod.JSONDecodeError) as exc:
+            text = sys.stdin.read()
+        else:
+            with open(source) as f:
+                text = f.read()
+        return strict_json.loads(text)
+    except (OSError, json_mod.JSONDecodeError, strict_json.DuplicateMemberError) as exc:
         print(f"Error reading {label}: {exc}")
         raise typer.Exit(code=1) from exc
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -55,6 +55,14 @@ _MAX_RETRIES = 5
 _RETRY_DELAYS = [0.5, 1.0, 2.0, 4.0, 8.0]  # Exponential backoff
 
 
+    # Strict ingest (419): API responses carrying receipts/records never parse
+    # last-wins; a duplicated member name is a terminal failure, raised loud.
+def _strict_response_json(response: Any) -> dict[str, Any]:
+    from . import strict_json
+
+    return strict_json.loads(response.text)
+
+
     # Execute function with exponential backoff retry on rate limit/network errors.
 def _with_retry(func: Callable[[], Any]) -> Any:
     last_error: Exception | None = None
@@ -2978,7 +2986,7 @@ def _get(path: str) -> dict[str, Any]:
     if _HTTPX_AVAILABLE and _client:
         response = _client.get(path)
         _handle_response(response)
-        result: dict[str, Any] = response.json()
+        result: dict[str, Any] = _strict_response_json(response)
         return result
     else:
         # Use stdlib urllib if httpx not installed
@@ -2993,7 +3001,7 @@ def _post(path: str, data: dict[str, Any]) -> dict[str, Any]:
     if _HTTPX_AVAILABLE and _client:
         response = _client.post(path, json=data)
         _handle_response(response)
-        result: dict[str, Any] = response.json()
+        result: dict[str, Any] = _strict_response_json(response)
         return result
     else:
         return _urllib_request("POST", path, data)
@@ -3007,7 +3015,7 @@ def _patch(path: str, data: dict[str, Any]) -> dict[str, Any]:
     if _HTTPX_AVAILABLE and _client:
         response = _client.patch(path, json=data)
         _handle_response(response)
-        result: dict[str, Any] = response.json()
+        result: dict[str, Any] = _strict_response_json(response)
         return result
     else:
         return _urllib_request("PATCH", path, data)
@@ -3021,7 +3029,7 @@ def _put(path: str, data: dict[str, Any]) -> dict[str, Any]:
     if _HTTPX_AVAILABLE and _client:
         response = _client.put(path, json=data)
         _handle_response(response)
-        result: dict[str, Any] = response.json()
+        result: dict[str, Any] = _strict_response_json(response)
         return result
     else:
         return _urllib_request("PUT", path, data)
@@ -3035,7 +3043,7 @@ def _delete(path: str) -> dict[str, Any]:
     if _HTTPX_AVAILABLE and _client:
         response = _client.delete(path)
         _handle_response(response)
-        result: dict[str, Any] = response.json()
+        result: dict[str, Any] = _strict_response_json(response)
         return result
     else:
         return _urllib_request("DELETE", path)
@@ -3092,7 +3100,10 @@ def _urllib_request(
     def _do_request() -> dict[str, Any]:
         request = urllib.request.Request(url, data=body, headers=headers, method=method)
         with urllib.request.urlopen(request, timeout=30) as response:
-            result: dict[str, Any] = json.loads(response.read().decode("utf-8"))
+            # Strict ingest (419): a duplicated member name fails the response.
+            from . import strict_json
+
+            result: dict[str, Any] = strict_json.loads(response.read().decode("utf-8"))
             return result
 
     try:
@@ -3361,17 +3372,18 @@ def verify_signature(signature_id: str) -> VerificationResponse:
             raise APIError("Signature not found", 404)
         if response.status_code >= 400:
             raise APIError(response.text, response.status_code)
-        data: dict[str, Any] = response.json()
+        data: dict[str, Any] = _strict_response_json(response)
     else:
         # Fallback to urllib
-        import json
         import urllib.error
         import urllib.request
+
+        from . import strict_json
 
         try:
             req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
             with urllib.request.urlopen(req, timeout=30) as response:
-                data = json.loads(response.read().decode("utf-8"))
+                data = strict_json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
             if e.code == 404:
                 raise APIError("Signature not found", 404) from e

--- a/python/src/asqav/doors.py
+++ b/python/src/asqav/doors.py
@@ -29,9 +29,9 @@ use an Asqav-aware verifier to check the signature.
 from __future__ import annotations
 
 import hashlib
-import json
 from typing import Any
 
+from . import strict_json
 from ._jcs import canonical_json
 
 __all__ = [
@@ -295,7 +295,8 @@ def receipt_from_cloudevent(event: dict) -> dict:
 
     # Recover the inner receipt from an OTel GenAI attribute map.
 def receipt_from_otel_genai_attributes(attrs: dict) -> dict:
-    return json.loads(attrs[OTEL_RECEIPT_ATTR])
+    # Strict ingest (419): a duplicated member name never reaches the caller.
+    return strict_json.loads(attrs[OTEL_RECEIPT_ATTR])
 
 
     # Recover the inner receipt from a C2PA door.

--- a/python/src/asqav/strict_json.py
+++ b/python/src/asqav/strict_json.py
@@ -1,0 +1,40 @@
+"""Strict JSON ingest for receipts and records (criterion 419).
+
+Every receipt- and record-parsing path routes through ``loads`` so a duplicated
+JSON member name at ANY nesting depth is a terminal parse failure, raised before
+any hashing, canonicalisation, or signature check. The stdlib ``json`` decoder is
+last-wins on duplicate members, which would silently hash the bytes an attacker
+kept and drop the ones they replaced; refusing the document outright is the only
+fail-closed reading.
+
+The standalone verifier (``verifier/verify_receipt.py``) ships as one file and
+carries its own copy of this hook rather than importing this module.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = ["DuplicateMemberError", "reject_duplicate_members", "loads"]
+
+
+class DuplicateMemberError(ValueError):
+    """A JSON object repeated a member name; last-wins ingest is never allowed."""
+
+
+    # object_pairs_hook: reject a repeated member name, else build the object.
+def reject_duplicate_members(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in out:
+            raise DuplicateMemberError(f"duplicate JSON member name: {key!r}")
+        out[key] = value
+    return out
+
+
+    # Parse JSON with duplicate-member rejection at every depth.
+def loads(text: str | bytes, **kwargs: Any) -> Any:
+    if "object_pairs_hook" in kwargs:
+        raise ValueError("object_pairs_hook is reserved for duplicate-member rejection")
+    return json.loads(text, object_pairs_hook=reject_duplicate_members, **kwargs)

--- a/python/src/asqav/verifier/oracle/README.md
+++ b/python/src/asqav/verifier/oracle/README.md
@@ -60,7 +60,8 @@ signature axis has a real upstream-keypair fixture.
   oracle runs only those three axes; it does NOT run the standalone
   `verify_receipt` clock-skew (`issued_at`) or anchor-liveness axes, which need
   wall-clock freshness and network the oracle deliberately omits. A receipt the
-  oracle PASSes can still fail those two liveness axes at ingestion time.
+  oracle reports `verified` for can still fail those two liveness axes at
+  ingestion time.
 - **aerf** - Ed25519 over RFC 8785 JCS, signed directly. Genesis OMITS
   `previous_receipt_hash`; the chain hash EXCLUDES the signature, per the AERF
   spec (the agentmint reference producer includes it; this adapter targets the
@@ -151,9 +152,10 @@ python -m asqav.verifier.oracle receipt.json --keys keys.json [--predecessor pre
 ```
 
 It prints the verdict and per-axis result as JSON and sets the exit status from
-the verdict: `0` on PASS, `1` on FAIL, `2` on INCOMPLETE. INCOMPLETE means an
-axis (the signature, when its library is absent) could not be checked; it is
-never reported as a PASS.
+the verdict: `0` on `verified`/`verified_keyed`, `1` on `unverified` with
+`failure_class=invalid`, `2` on `unverified` with `failure_class=unverifiable`.
+`unverifiable` means an axis (the signature, when its library is absent) could
+not be checked; it is never reported as verified.
 
 `--keys` is the format-shaped key provider: a JWKS dict for asqav-native, a
 `{key_id: hex}` map for AERF, a `{key_id: pem}` map for ACTA, a `did_map` for
@@ -174,8 +176,8 @@ chmod +x asqav-verify-macos
 ./asqav-verify-macos receipt.json --keys keys.json
 ```
 
-It prints the same JSON verdict and uses the same exit codes (0 PASS, 1 FAIL,
-2 INCOMPLETE).
+It prints the same JSON verdict and uses the same exit codes (0 verified /
+verified_keyed, 1 unverified+invalid, 2 unverified+unverifiable).
 
 ### What the binary verifies (and what it never does)
 
@@ -212,7 +214,8 @@ pyinstaller --onefile --name asqav-verify \
 
 Installing `dilithium-py` into the build environment is what bundles ML-DSA-65
 into the binary; without it the binary would downgrade the ML-DSA signature axis
-to SKIPPED and report INCOMPLETE on Asqav's primary receipt format.
+to SKIPPED and report `unverified`/`unverifiable` on Asqav's primary receipt
+format.
 
 ### Cross-platform builds (CI)
 

--- a/python/src/asqav/verifier/oracle/__main__.py
+++ b/python/src/asqav/verifier/oracle/__main__.py
@@ -5,10 +5,18 @@ knows, with one self-contained call::
 
     python -m asqav.verifier.oracle receipt.json [--keys keys.json] [--predecessor pred.json]
 
-It loads the receipt, runs :func:`verify` over the bundled ``ADAPTERS``, prints
-the verdict and per-axis result as JSON, and sets the exit status from the
-verdict: 0 on PASS, 1 on FAIL, 2 on INCOMPLETE. INCOMPLETE means an axis (the
-signature, typically) could not be checked - it is never reported as a PASS.
+It loads the receipt (strict ingest: a duplicated JSON member name at any depth
+is a terminal parse failure, rejected before any hashing - criterion 419), runs
+:func:`verify` over the bundled ``ADAPTERS``, prints the verdict and per-axis
+result as JSON, and sets the exit status from the verdict vocabulary
+(criteria 418/438):
+
+  - 0  verified / verified_keyed
+  - 1  unverified, failure_class=invalid (a binding was proven broken)
+  - 2  unverified, failure_class=unverifiable (verification could not complete)
+
+Exit 2 is NOT a verified outcome: it means a check (the signature, typically)
+could not be run, and the verifier never reports a broken receipt as verified.
 
 ``--keys`` is the format-shaped key provider: a JWKS dict for Asqav-native, a
 ``{key_id: hex}`` map for AERF, an ``{key_id: pem}`` map for ACTA, or a did_map
@@ -26,11 +34,18 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
-from . import ADAPTERS
-from .core import verify
+from asqav import strict_json
 
-#: verdict -> process exit status; PASS is the only success, INCOMPLETE is not a PASS.
-_EXIT = {"PASS": 0, "FAIL": 1, "INCOMPLETE": 2}
+from . import ADAPTERS
+from .core import FAILURE_INVALID, VERDICT_UNVERIFIED, verify
+
+
+def _exit_code(verdict: str, failure_class: str | None) -> int:
+    # verified/verified_keyed -> 0; invalid -> 1; unverifiable keeps the exit-2
+    # blocked-verification state the old INCOMPLETE verdict carried.
+    if verdict != VERDICT_UNVERIFIED:
+        return 0
+    return 1 if failure_class == FAILURE_INVALID else 2
 
 
 def _load(path: str | None) -> dict | None:
@@ -42,7 +57,11 @@ def _load(path: str | None) -> dict | None:
         print(f"asqav-verify: cannot read {path}: {exc.strerror or exc}", file=sys.stderr)
         raise SystemExit(2) from None
     try:
-        return json.loads(text)
+        return strict_json.loads(text)
+    except strict_json.DuplicateMemberError as exc:
+        # Terminal ingest failure (419): never hash or verify last-wins bytes.
+        print(f"asqav-verify: {path} rejected: {exc}", file=sys.stderr)
+        raise SystemExit(2) from None
     except json.JSONDecodeError as exc:
         print(f"asqav-verify: {path} is not valid JSON: {exc}", file=sys.stderr)
         raise SystemExit(2) from None
@@ -59,10 +78,11 @@ def run(receipt_path: str, keys_path: str | None, predecessor_path: str | None) 
     report = {
         "format": result.fmt,
         "verdict": result.verdict,
+        "failure_class": result.failure_class,
         "axes": [asdict(a) for a in result.axes],
     }
     print(json.dumps(report, indent=2))
-    return _EXIT.get(result.verdict, 2)
+    return _exit_code(result.verdict, result.failure_class)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/python/src/asqav/verifier/oracle/adapter.py
+++ b/python/src/asqav/verifier/oracle/adapter.py
@@ -115,3 +115,12 @@ class FormatAdapter(ABC):
         returns it here so the verdict exposes it. Default is none.
         """
         return {}
+
+    def keyed_digest(self, doc: dict) -> bool:
+        """True when the receipt's digest is keyed (criterion 438).
+
+        A keyed digest (e.g. HMAC-SHA256) is internally consistent but not
+        third-party re-derivable, so a fully-checked receipt reports
+        ``verified_keyed``, never plain ``verified``. Default is False.
+        """
+        return False

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -268,3 +268,12 @@ class AsqavNativeAdapter(FormatAdapter):
             return {}
         signer = _payload(doc).get("signer")
         return {"signer": signer} if signer is not None else {}
+
+    def keyed_digest(self, doc: dict) -> bool:
+        """A hash-mode digest sealed with the org salt is keyed (criterion 438).
+
+        hash_algo hmac-sha256 is internally consistent but not third-party
+        re-derivable, so a fully-checked receipt reports verified_keyed, never
+        plain verified. Read from the signed field set only.
+        """
+        return _is_hash_mode(doc) and doc.get("hash_algo") == "hmac-sha256"

--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -15,6 +15,17 @@ from typing import Any
 from . import crypto
 from .adapter import FormatAdapter
 
+#: Public verdict vocabulary (criteria 418/438). The per-axis PASS/FAIL/SKIPPED
+#: tokens stay internal; the surface a caller reads speaks these three only.
+VERDICT_VERIFIED = "verified"
+VERDICT_VERIFIED_KEYED = "verified_keyed"
+VERDICT_UNVERIFIED = "unverified"
+
+#: Failure classes carried by every unverified verdict (criterion 418); the two
+#: are never collapsed - a proven binding failure is not an incomplete check.
+FAILURE_INVALID = "invalid"
+FAILURE_UNVERIFIABLE = "unverifiable"
+
 
 @dataclass(frozen=True)
 class AxisResult:
@@ -22,27 +33,33 @@ class AxisResult:
 
     Fields:
       axis: which check (structure / signature / chain).
-      result: PASS / FAIL / SKIPPED.
+      result: PASS / FAIL / SKIPPED (internal token).
       note: human-readable detail for the report.
+      failure_class: invalid / unverifiable for a non-PASS axis, None on PASS.
     """
 
     axis: str
     result: str
     note: str
+    failure_class: str | None = None
 
 
 @dataclass
 class VerifyResult:
     """The aggregate outcome of verifying one receipt.
 
-    ``verdict`` is PASS only when every non-skipped axis passed AND the signature
-    was actually checked; a skipped signature downgrades to INCOMPLETE, never a
-    PASS, mirroring the standalone verifier. The expiry axis never folds it (426).
+    ``verdict`` is ``verified`` only when every non-skipped axis passed AND the
+    signature was actually checked; ``verified_keyed`` when the digest is keyed
+    (internally consistent but not third-party re-derivable). A skipped signature
+    downgrades to ``unverified`` with ``failure_class=unverifiable``, never a
+    verified, mirroring the standalone verifier. The expiry axis never folds the
+    verdict (426). Defaults fail closed: an unfolded result reads unverified.
     """
 
     fmt: str
     axes: list[AxisResult] = field(default_factory=list)
-    verdict: str = "INCOMPLETE"
+    verdict: str = VERDICT_UNVERIFIED
+    failure_class: str | None = FAILURE_UNVERIFIABLE
     #: In-body origin attestation (v:2 ``signer``), surfaced from the signed
     #: payload. None when the receipt carries none (v:1). Never gates the verdict.
     signer: str | None = None
@@ -50,6 +67,80 @@ class VerifyResult:
         # Return the result for one axis, or None if it was not run.
     def axis(self, name: str) -> AxisResult | None:
         return next((a for a in self.axes if a.axis == name), None)
+
+
+#: Axes whose FAIL proves a cryptographic/policy binding failure (invalid).
+_INVALID_FAIL_AXES = frozenset(
+    {
+        "signature",
+        "anchors",
+        "issuer_bind",
+        "key_status",
+        "nonce",
+        "parent_signature",
+        "pdp_signature",
+    }
+)
+
+
+def axis_failure_class(axis: str, result: str, note: str) -> str | None:
+    """Map one axis outcome to its failure class (criterion 418).
+
+    PASS carries none; SKIPPED means recomputation could not complete
+    (unverifiable); a FAIL is invalid when a binding was proven broken and
+    unverifiable when the receipt's own bytes stopped the recompute. A FAIL this
+    table does not name reads unverifiable: an unclassified failure is never
+    reported as a proven binding failure.
+    """
+    if result == crypto.PASS:
+        return None
+    if result == crypto.SKIPPED:
+        return FAILURE_UNVERIFIABLE
+    if axis in _INVALID_FAIL_AXES:
+        return FAILURE_INVALID
+    if axis == "chain":
+        # A mismatched link or a cross-format predecessor is a proven break; a
+        # predecessor the canonicaliser cannot walk stops the recompute instead.
+        if note.startswith("chain break:") or note == "predecessor is a different receipt format":
+            return FAILURE_INVALID
+        return FAILURE_UNVERIFIABLE
+    if axis == "skew":
+        if note.startswith("unparseable issued_at"):
+            return FAILURE_UNVERIFIABLE
+        return FAILURE_INVALID
+    if axis == "structure":
+        if note.startswith("unsupported ACTA alg") or note.startswith(
+            "unsupported signature algorithm"
+        ):
+            return FAILURE_INVALID
+        if note.startswith("key_purpose mismatch"):
+            return FAILURE_INVALID
+        if "signing-key DID != issuer DID" in note:
+            return FAILURE_INVALID
+        return FAILURE_UNVERIFIABLE
+    if axis == "expiry":
+        if note.startswith("unreadable expires_at"):
+            return FAILURE_UNVERIFIABLE
+        return FAILURE_INVALID
+    # issuer_key / ingest and anything unlisted: the recompute could not complete.
+    return FAILURE_UNVERIFIABLE
+
+
+    # Fold per-axis outcomes into the public verdict + failure class (418/438).
+def fold_verdict(axes: list[AxisResult], keyed: bool) -> tuple[str, str | None]:
+    failed = [a for a in axes if a.result == crypto.FAIL and a.axis != "expiry"]
+    blocking_skip = any(a.result == crypto.SKIPPED and a.axis != "chain" for a in axes)
+    if failed:
+        # A proven binding failure dominates a malformed-member failure: the
+        # receipt is invalid on the strongest ground the axes established.
+        classes = {a.failure_class for a in failed}
+        failure_class = FAILURE_INVALID if FAILURE_INVALID in classes else FAILURE_UNVERIFIABLE
+        return VERDICT_UNVERIFIED, failure_class
+    if blocking_skip:
+        return VERDICT_UNVERIFIED, FAILURE_UNVERIFIABLE
+    if keyed:
+        return VERDICT_VERIFIED_KEYED, None
+    return VERDICT_VERIFIED, None
 
 
     # Return the first adapter whose structural fingerprint matches ``doc``.
@@ -61,14 +152,18 @@ def detect(doc: dict, adapters: list[FormatAdapter]) -> FormatAdapter | None:
     return next((a for a in adapters if a.detect(doc)), None)
 
 
+def _axis(axis: str, result: str, note: str) -> AxisResult:
+    return AxisResult(axis, result, note, axis_failure_class(axis, result, note))
+
+
 def _signature_axis(ad: FormatAdapter, doc: dict, key_provider: Any) -> AxisResult:
     sm = ad.extract_signature(doc)
     pk, note = ad.resolve_key(doc, key_provider)
     if pk is None:
-        return AxisResult("signature", crypto.SKIPPED, f"no key: {note}")
+        return _axis("signature", crypto.SKIPPED, f"no key: {note}")
     msg = ad.signing_input(doc)
     res, why = crypto.verify_signature(sm.alg, pk, msg, sm.sig)
-    return AxisResult("signature", res, why)
+    return _axis("signature", res, why)
 
 
 def _chain_axis(
@@ -76,18 +171,18 @@ def _chain_axis(
 ) -> AxisResult:
     step = ad.chain_step(doc)
     if step.is_genesis:
-        return AxisResult("chain", crypto.PASS, "genesis receipt (no predecessor link)")
+        return _axis("chain", crypto.PASS, "genesis receipt (no predecessor link)")
     if predecessor is None:
-        return AxisResult("chain", crypto.SKIPPED, "no predecessor supplied")
+        return _axis("chain", crypto.SKIPPED, "no predecessor supplied")
     # A chain link must stay within one format; a cross-format predecessor is not a valid link.
     pred_ad = detect(predecessor, adapters)
     if pred_ad is None or pred_ad.name != ad.name:
-        return AxisResult("chain", crypto.FAIL, "predecessor is a different receipt format")
+        return _axis("chain", crypto.FAIL, "predecessor is a different receipt format")
     actual = step.recompute(predecessor)
     if actual == step.prev_field:
-        return AxisResult("chain", crypto.PASS, "chain link rederives from predecessor")
+        return _axis("chain", crypto.PASS, "chain link rederives from predecessor")
     exp = str(step.prev_field)[:16]
-    return AxisResult("chain", crypto.FAIL, f"chain break: expected {exp}.. got {actual[:16]}..")
+    return _axis("chain", crypto.FAIL, f"chain break: expected {exp}.. got {actual[:16]}..")
 
 
 #: Max nesting the recursive JCS encoder tolerates, mirrors the standalone verifier cap.
@@ -123,42 +218,34 @@ def verify(
 ) -> VerifyResult:
     ad = detect(doc, adapters)
     if ad is None:
-        return VerifyResult(
-            fmt="unknown",
-            axes=[AxisResult("structure", crypto.FAIL, "no adapter recognises this receipt")],
-            verdict="FAIL",
-        )
+        axes = [_axis("structure", crypto.FAIL, "no adapter recognises this receipt")]
+        verdict, failure_class = fold_verdict(axes, keyed=False)
+        return VerifyResult(fmt="unknown", axes=axes, verdict=verdict, failure_class=failure_class)
     # An over-nested receipt would crash the recursive JCS encoder. Cap it here and
-    # report INCOMPLETE, never a PASS, matching the standalone verifier shape gate.
+    # report unverified/unverifiable, never a verified, matching the standalone gate.
     if _exceeds_depth(doc, MAX_NESTING_DEPTH) or (
         predecessor is not None and _exceeds_depth(predecessor, MAX_NESTING_DEPTH)
     ):
+        axes = [_axis("structure", crypto.FAIL, _TOO_DEEP_NOTE)]
+        verdict, failure_class = fold_verdict(axes, keyed=False)
         return VerifyResult(
-            fmt=ad.name,
-            axes=[AxisResult("structure", crypto.FAIL, _TOO_DEEP_NOTE)],
-            verdict="INCOMPLETE",
+            fmt=ad.name, axes=axes, verdict=verdict, failure_class=failure_class
         )
 
     axes = [
-        AxisResult("structure", *ad.schema(doc)),
+        _axis("structure", *ad.schema(doc)),
         _signature_axis(ad, doc, key_provider),
         _chain_axis(ad, doc, adapters, predecessor),
     ]
-    axes.extend(AxisResult(name, res, note) for name, res, note in ad.extra_axes(doc, key_provider))
+    axes.extend(_axis(name, res, note) for name, res, note in ad.extra_axes(doc, key_provider))
 
-    # Expiry reports on its own axis and never folds the verdict (criterion 426)
-    has_fail = any(a.result == crypto.FAIL and a.axis != "expiry" for a in axes)
-    # Any skipped axis except a missing-predecessor chain blocks PASS: an unchecked
-    # signature / counter-sign / PDP layer means INCOMPLETE, never a hiding PASS.
-    blocking_skip = any(a.result == crypto.SKIPPED and a.axis != "chain" for a in axes)
-    if has_fail:
-        verdict = "FAIL"
-    elif blocking_skip:
-        verdict = "INCOMPLETE"
-    else:
-        verdict = "PASS"
+    # Expiry reports on its own axis and never folds the verdict (criterion 426);
+    # a keyed digest reports verified_keyed, never plain verified (criterion 438).
+    verdict, failure_class = fold_verdict(axes, keyed=ad.keyed_digest(doc))
     signer = ad.attestation(doc).get("signer")
-    return VerifyResult(fmt=ad.name, axes=axes, verdict=verdict, signer=signer)
+    return VerifyResult(
+        fmt=ad.name, axes=axes, verdict=verdict, failure_class=failure_class, signer=signer
+    )
 
 
     # Lowercase hex SHA-256 - the chain primitive every format shares.

--- a/python/src/asqav/verifier/oracle/runner.py
+++ b/python/src/asqav/verifier/oracle/runner.py
@@ -1,16 +1,19 @@
 """Conformance-vector runner - drive the oracle over the vector corpus.
 
 The corpus uses the AERF dir-per-vector layout as a superset: a top-level
-``manifest.json`` lists ``{dir, format, outcome, reason_code, notes}`` and each
-``<NN-name>/`` directory carries ``receipt.json``, an ``expected.json``, optional
-``predecessor.json`` for chain vectors, and optional key material (``jwks.json``
-for Asqav-native, ``keys.json`` mapping key_id->hex for AERF).
+``manifest.json`` lists ``{dir, format, outcome, failure_class, reason_code,
+notes}`` and each ``<NN-name>/`` directory carries ``receipt.json``, an
+``expected.json``, optional ``predecessor.json`` for chain vectors, and optional
+key material (``jwks.json`` for Asqav-native, ``keys.json`` mapping key_id->hex
+for AERF).
 
-``outcome`` maps to the verdict one-for-one (PASS/FAIL/INCOMPLETE). INCOMPLETE
-lets the corpus carry a vector whose signature axis cannot be checked in CI (a
-real ML-DSA-65 prod receipt without dilithium-py), pinning that the verifier
-downgrades rather than false-PASSing. ``run_corpus`` returns one ``VectorOutcome``
-per vector so callers can assert counts.
+``outcome`` speaks the public verdict vocabulary (criteria 418/438):
+verified / verified_keyed / unverified, and an ``unverified`` entry pins its
+``failure_class`` (invalid / unverifiable) so the two classes are never
+collapsed. ``run_corpus`` returns one ``VectorOutcome`` per vector so callers
+can assert counts. Every receipt/record file is parsed with duplicate-member
+rejection (criterion 419); a receipt that fails to parse is a terminal
+unverified/unverifiable outcome, never verified.
 """
 from __future__ import annotations
 
@@ -19,11 +22,17 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import ADAPTERS
-from .core import verify
+from asqav import strict_json
 
-#: manifest outcome token -> the VerifyResult.verdict it must produce.
-_OUTCOME_TO_VERDICT = {"PASS": "PASS", "FAIL": "FAIL", "INCOMPLETE": "INCOMPLETE"}
+from . import ADAPTERS
+from .core import FAILURE_UNVERIFIABLE, VERDICT_UNVERIFIED, VERDICT_VERIFIED, verify
+
+#: manifest outcome tokens -> the VerifyResult.verdict they must produce.
+_OUTCOME_TO_VERDICT = {
+    "verified": "verified",
+    "verified_keyed": "verified_keyed",
+    "unverified": "unverified",
+}
 
 
 @dataclass(frozen=True)
@@ -32,11 +41,13 @@ class VectorOutcome:
 
     Fields:
       dir: the vector directory name.
-      expected_outcome: the manifest's PASS / FAIL / INCOMPLETE outcome.
-      actual_verdict: the oracle's PASS / FAIL / INCOMPLETE verdict.
-      ok: True when the actual verdict matches the expected outcome.
+      expected_outcome: the manifest's verified / verified_keyed / unverified.
+      actual_verdict: the oracle's verdict in the same vocabulary.
+      ok: True when the actual verdict (and pinned failure class) matches.
       reason_code: the manifest reason_code for this vector.
       detail: per-axis notes for a failing match.
+      expected_failure_class: the manifest failure_class pin ("" when unpinned).
+      actual_failure_class: the oracle failure_class ("" on a verified verdict).
     """
 
     dir: str
@@ -45,10 +56,13 @@ class VectorOutcome:
     ok: bool
     reason_code: str
     detail: str
+    expected_failure_class: str = ""
+    actual_failure_class: str = ""
 
 
 def _load(path: Path) -> dict | None:
-    return json.loads(path.read_text()) if path.exists() else None
+    # Strict ingest (419): a duplicated member name is a terminal parse failure.
+    return strict_json.loads(path.read_text()) if path.exists() else None
 
 
 def _key_provider(vec_dir: Path, fmt: str):
@@ -67,35 +81,86 @@ def _key_provider(vec_dir: Path, fmt: str):
     return None
 
 
+def _parse_failure_outcome(
+    name: str, expected_outcome: str, expected_failure_class: str, reason_code: str, exc: Exception
+) -> VectorOutcome:
+    # A terminal ingest failure: nothing was hashed, checked, or verified (419).
+    detail = f"ingest=FAIL(terminal parse failure before any hashing: {exc})"
+    ok = expected_outcome == VERDICT_UNVERIFIED and expected_failure_class in (
+        "",
+        FAILURE_UNVERIFIABLE,
+    )
+    return VectorOutcome(
+        name,
+        expected_outcome,
+        VERDICT_UNVERIFIED,
+        ok,
+        reason_code,
+        detail,
+        expected_failure_class,
+        FAILURE_UNVERIFIABLE,
+    )
+
+
     # Run a single vector directory and compare against its expected outcome.
-def run_one(vec_dir: Path, fmt: str, expected_outcome: str, reason_code: str = "") -> VectorOutcome:
-    receipt = _load(vec_dir / "receipt.json")
-    predecessor = _load(vec_dir / "predecessor.json")
-    key_provider = _key_provider(vec_dir, fmt)
+def run_one(
+    vec_dir: Path,
+    fmt: str,
+    expected_outcome: str,
+    reason_code: str = "",
+    expected_failure_class: str = "",
+) -> VectorOutcome:
+    try:
+        receipt = _load(vec_dir / "receipt.json")
+        predecessor = _load(vec_dir / "predecessor.json")
+        key_provider = _key_provider(vec_dir, fmt)
+    except (strict_json.DuplicateMemberError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        # Terminal ingest failure (419): nothing is hashed, checked, or verified.
+        return _parse_failure_outcome(
+            vec_dir.name, expected_outcome, expected_failure_class, reason_code, exc
+        )
     result = verify(receipt, ADAPTERS, key_provider=key_provider, predecessor=predecessor)
 
     want_verdict = _OUTCOME_TO_VERDICT.get(expected_outcome)
     ok = want_verdict is not None and result.verdict == want_verdict
+    actual_failure_class = result.failure_class or ""
+    if ok and expected_failure_class:
+        ok = actual_failure_class == expected_failure_class
     detail = "; ".join(f"{a.axis}={a.result}({a.note})" for a in result.axes)
-    return VectorOutcome(vec_dir.name, expected_outcome, result.verdict, ok, reason_code, detail)
+    return VectorOutcome(
+        vec_dir.name,
+        expected_outcome,
+        result.verdict,
+        ok,
+        reason_code,
+        detail,
+        expected_failure_class,
+        actual_failure_class,
+    )
 
 
     # Run every vector named in ``corpus_root/manifest.json``.
 def run_corpus(corpus_root: Path) -> list[VectorOutcome]:
-    manifest = json.loads((corpus_root / "manifest.json").read_text())
+    manifest = strict_json.loads((corpus_root / "manifest.json").read_text())
     out = []
     for entry in manifest:
         out.append(
-            run_one(corpus_root / entry["dir"], entry["format"], entry["outcome"], entry.get("reason_code", ""))
+            run_one(
+                corpus_root / entry["dir"],
+                entry["format"],
+                entry["outcome"],
+                entry.get("reason_code", ""),
+                entry.get("failure_class", ""),
+            )
         )
     return out
 
 
-    # Accept the stronger PASS only for the optional-dep ML-DSA skip vector, never broadly.
+    # Accept the stronger verified only for the optional-dep ML-DSA skip vector.
 def _tolerated(outcome: VectorOutcome) -> bool:
     return outcome.ok or (
-        outcome.expected_outcome == "INCOMPLETE"
-        and outcome.actual_verdict == "PASS"
+        outcome.expected_outcome == VERDICT_UNVERIFIED
+        and outcome.actual_verdict == VERDICT_VERIFIED
         and outcome.reason_code == "signature_skipped_no_dilithium"
     )
 
@@ -122,7 +187,10 @@ def main() -> int:
     results = run_corpus(root)
     for r in results:
         mark = "ok" if _tolerated(r) else "FAIL"
-        print(f"  [{mark:>4}] {r.dir:<28} expect={r.expected_outcome:<5} got={r.actual_verdict}")
+        got = r.actual_verdict
+        if r.actual_failure_class:
+            got += f" ({r.actual_failure_class})"
+        print(f"  [{mark:>4}] {r.dir:<38} expect={r.expected_outcome:<16} got={got}")
         if not _tolerated(r):
             print(f"         {r.detail}")
     passed = sum(1 for r in results if _tolerated(r))

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -209,6 +209,68 @@ _SHAPE_MESSAGES = {
     "too_deep": f"receipt nesting exceeds the supported depth (> {MAX_NESTING_DEPTH} levels)",
 }
 
+#: Public verdict vocabulary (criteria 418/438). The per-axis PASS/FAIL/SKIPPED
+#: tokens stay internal; the surface a caller reads speaks these three only.
+VERDICT_VERIFIED = "verified"
+VERDICT_UNVERIFIED = "unverified"
+
+#: Failure classes carried by every unverified verdict (criterion 418); the two
+#: are never collapsed - a proven binding failure is not an incomplete check.
+FAILURE_INVALID = "invalid"
+FAILURE_UNVERIFIABLE = "unverifiable"
+
+#: Axes whose FAIL proves a cryptographic/policy binding failure (invalid).
+_INVALID_FAIL_AXES = frozenset({"signature", "anchors", "issuer_bind", "key_status", "nonce"})
+
+
+def _axis_failure_class(axis: str, result: str, note: str) -> str | None:
+    """Map one axis outcome to its failure class (criterion 418).
+
+    PASS carries none; SKIPPED means recomputation could not complete
+    (unverifiable); a FAIL is invalid when a binding was proven broken and
+    unverifiable when the receipt's own bytes stopped the recompute. Mirrors
+    the oracle's ``core.axis_failure_class`` byte for byte; a FAIL the table
+    does not name reads unverifiable, never a proven binding failure.
+    """
+    if result == "PASS":
+        return None
+    if result == "SKIPPED":
+        return FAILURE_UNVERIFIABLE
+    if axis in _INVALID_FAIL_AXES:
+        return FAILURE_INVALID
+    if axis == "chain":
+        if note.startswith("chain break:"):
+            return FAILURE_INVALID
+        return FAILURE_UNVERIFIABLE
+    if axis == "skew":
+        if note.startswith("unparseable issued_at"):
+            return FAILURE_UNVERIFIABLE
+        return FAILURE_INVALID
+    if axis == "structure":
+        return FAILURE_UNVERIFIABLE
+    if axis == "expiry":
+        if note.startswith("unreadable expires_at"):
+            return FAILURE_UNVERIFIABLE
+        return FAILURE_INVALID
+    # issuer_key and anything unlisted: the recompute could not complete.
+    return FAILURE_UNVERIFIABLE
+
+
+    # Fold per-axis (name, result, note) rows into verdict + failure class.
+def _fold_verdict(results) -> tuple[str, str | None]:
+    # Expiry reports on its own axis and never folds the verdict (criterion 426).
+    failed = [(n, r, note) for n, r, note in results if r == "FAIL" and n != "expiry"]
+    # A skipped chain (no predecessor supplied) is expected and does not block a
+    # verified verdict; any other skip downgrades to unverified/unverifiable.
+    blocking_skip = any(r == "SKIPPED" and n != "chain" for n, r, _ in results)
+    if failed:
+        classes = {_axis_failure_class(n, r, note) for n, r, note in failed}
+        failure_class = FAILURE_INVALID if FAILURE_INVALID in classes else FAILURE_UNVERIFIABLE
+        return VERDICT_UNVERIFIED, failure_class
+    if blocking_skip:
+        return VERDICT_UNVERIFIED, FAILURE_UNVERIFIABLE
+    return VERDICT_VERIFIED, None
+
 
 class VerifierInputError(Exception):
     """A receipt or JWKS input was missing, empty, or not a JSON object.
@@ -218,16 +280,40 @@ class VerifierInputError(Exception):
     """
 
 
+class DuplicateMemberError(ValueError):
+    """A receipt or JWKS repeated a JSON member name (criterion 419).
+
+    The stdlib decoder is last-wins on duplicate members, which would hash the
+    bytes an attacker kept and drop the ones they replaced; a duplicated name
+    is therefore a terminal parse failure, raised before any hashing or
+    canonicalisation. Self-contained here (mirrors ``asqav/strict_json.py``)
+    because this file ships standalone in the exit artifact.
+    """
+
+
+    # object_pairs_hook: reject a repeated member name at any depth (419).
+def _reject_duplicate_members(pairs):
+    out = {}
+    for key, value in pairs:
+        if key in out:
+            raise DuplicateMemberError(f"duplicate JSON member name: {key!r}")
+        out[key] = value
+    return out
+
+
 def _parse_object(text: str, source: str) -> dict:
     """Parse ``text`` as a JSON object, or raise VerifierInputError.
 
-    Rejects empty input and any non-object (array/string/number/null) so a
-    later ``.get`` never lands on a non-dict.
+    Rejects empty input, any non-object (array/string/number/null), and any
+    duplicated member name at any depth (419), so a later ``.get`` never lands
+    on a non-dict and last-wins bytes never reach the canonicaliser.
     """
     if not text or not text.strip():
         raise VerifierInputError(f"{source}: empty input, expected a JSON object")
     try:
-        value = json.loads(text)
+        value = json.loads(text, object_pairs_hook=_reject_duplicate_members)
+    except DuplicateMemberError as exc:
+        raise VerifierInputError(f"{source}: {exc}") from exc
     except json.JSONDecodeError as exc:
         raise VerifierInputError(f"{source}: not valid JSON ({exc})") from exc
     except RecursionError as exc:
@@ -899,7 +985,7 @@ def run(
             f"  [FAIL] input       expected a JSON object receipt, got "
             f"{type(envelope).__name__}"
         )
-        print("\n  => INCOMPLETE (no receipt object to verify; never a PASS)")
+        print("\n  => unverified (failure_class: unverifiable; no receipt object to verify)")
         return 2
     envelope = normalise_envelope(envelope)
     payload = envelope.get("payload", envelope)
@@ -913,7 +999,7 @@ def run(
             f"Verify with a saved receipt instead: --receipt FILE from your "
             f"Audit Pack or SDK capture."
         )
-        print("\n  => INCOMPLETE (no payload to verify; never a PASS)")
+        print("\n  => unverified (failure_class: unverifiable; no payload to verify)")
         return 2
     shape = _scan_shape(envelope, max_depth=MAX_NESTING_DEPTH)
     if shape is None:
@@ -921,7 +1007,7 @@ def run(
     if shape is not None:
         print("Asqav receipt verification")
         print(f"  [FAIL] input       {_SHAPE_MESSAGES[shape]}")
-        print("\n  => INCOMPLETE (receipt not canonicalisable; never a PASS)")
+        print("\n  => unverified (failure_class: unverifiable; receipt not canonicalisable)")
         return 2
     sig_obj = envelope.get("signature", {})
     if isinstance(sig_obj, str):  # flat-string signature, derive the object
@@ -943,7 +1029,7 @@ def run(
         # this; this stops a bypassing caller from crashing here too.
         print("Asqav receipt verification")
         print(f"  [FAIL] input       {_SHAPE_MESSAGES['too_deep']}")
-        print("\n  => INCOMPLETE (receipt not canonicalisable; never a PASS)")
+        print("\n  => unverified (failure_class: unverifiable; receipt not canonicalisable)")
         return 2
 
     results = []
@@ -1001,19 +1087,28 @@ def run(
         mark = {"PASS": "ok", "FAIL": "FAIL", "SKIPPED": "skip"}[res]
         print(f"  [{mark:>4}] {name:<11} {note}")
 
-    # Expiry reports on its own axis and never folds the verdict (criterion 426)
-    has_fail = any(r == "FAIL" for n, r, _ in results if n != "expiry")
-    # A skipped chain (no predecessor supplied) is expected and does not block a
-    # PASS; any other skip - notably the signature - downgrades to INCOMPLETE.
-    has_blocking_skip = any(r == "SKIPPED" and n != "chain" for n, r, _ in results)
-    if has_fail:
-        verdict, code = "FAIL", 1
-    elif has_blocking_skip:
-        verdict, code = "INCOMPLETE (some checks skipped; never a PASS)", 2
+    # Expiry reports on its own axis and never folds the verdict (criterion 426).
+    verdict, failure_class = _fold_verdict(results)
+    if verdict == VERDICT_VERIFIED:
+        code = 0
+        print(f"\n  => {verdict}")
+    elif failure_class == FAILURE_INVALID:
+        code = 1
+        print(f"\n  => {verdict} (failure_class: invalid)")
     else:
-        verdict, code = "PASS", 0
-    print(f"\n  => {verdict}")
+        code = 2
+        print(f"\n  => {verdict} (failure_class: unverifiable; never reported verified)")
     return code
+
+
+    # One structured-axis row carrying its per-axis failure token (418/438).
+def _struct_axis(name: str, result: str, note: str) -> dict:
+    return {
+        "name": name,
+        "result": result,
+        "note": note,
+        "failure_class": _axis_failure_class(name, result, note),
+    }
 
 
 def run_structured(
@@ -1029,23 +1124,23 @@ def run_structured(
 
     Returns:
         dict with keys:
-          - ``"verdict"``: "PASS" | "FAIL" | "INCOMPLETE"
-          - ``"axes"``: list of ``{"name": str, "result": str, "note": str}``
+          - ``"verdict"``: "verified" | "unverified" (criteria 418/438)
+          - ``"failure_class"``: "invalid" | "unverifiable" when unverified,
+            else None; the two are never collapsed (criterion 418)
+          - ``"axes"``: list of ``{"name", "result", "note", "failure_class"}``
           - ``"canonical_sha256"``: hex SHA-256 of the canonical payload bytes
           - ``"kid"``: the signature key id resolved
     """
     if not isinstance(envelope, dict):
         return {
-            "verdict": "INCOMPLETE",
+            "verdict": VERDICT_UNVERIFIED,
+            "failure_class": FAILURE_UNVERIFIABLE,
             "axes": [
-                {
-                    "name": "input",
-                    "result": "FAIL",
-                    "note": (
-                        "expected a JSON object receipt, got "
-                        f"{type(envelope).__name__}"
-                    ),
-                }
+                _struct_axis(
+                    "input",
+                    "FAIL",
+                    f"expected a JSON object receipt, got {type(envelope).__name__}",
+                )
             ],
             "canonical_sha256": None,
             "kid": None,
@@ -1054,17 +1149,16 @@ def run_structured(
     payload = envelope.get("payload", envelope)
     if not isinstance(payload, dict):
         return {
-            "verdict": "INCOMPLETE",
+            "verdict": VERDICT_UNVERIFIED,
+            "failure_class": FAILURE_UNVERIFIABLE,
             "axes": [
-                {
-                    "name": "payload",
-                    "result": "FAIL",
-                    "note": (
-                        "receipt payload not available from this surface "
-                        f"(got {_describe_value(payload)} instead of an object). "
-                        "Verify with a saved receipt instead."
-                    ),
-                }
+                _struct_axis(
+                    "payload",
+                    "FAIL",
+                    "receipt payload not available from this surface "
+                    f"(got {_describe_value(payload)} instead of an object). "
+                    "Verify with a saved receipt instead.",
+                )
             ],
             "canonical_sha256": None,
             "kid": None,
@@ -1074,8 +1168,9 @@ def run_structured(
         shape = _scan_shape(predecessor_payload, max_depth=MAX_NESTING_DEPTH)
     if shape is not None:
         return {
-            "verdict": "INCOMPLETE",
-            "axes": [{"name": "input", "result": "FAIL", "note": _SHAPE_MESSAGES[shape]}],
+            "verdict": VERDICT_UNVERIFIED,
+            "failure_class": FAILURE_UNVERIFIABLE,
+            "axes": [_struct_axis("input", "FAIL", _SHAPE_MESSAGES[shape])],
             "canonical_sha256": None,
             "kid": None,
         }
@@ -1096,37 +1191,20 @@ def run_structured(
     except RecursionError:
         # Defense in depth; the shape gate above should already have caught this.
         return {
-            "verdict": "INCOMPLETE",
-            "axes": [{"name": "input", "result": "FAIL", "note": _SHAPE_MESSAGES["too_deep"]}],
+            "verdict": VERDICT_UNVERIFIED,
+            "failure_class": FAILURE_UNVERIFIABLE,
+            "axes": [_struct_axis("input", "FAIL", _SHAPE_MESSAGES["too_deep"])],
             "canonical_sha256": None,
             "kid": None,
         }
 
     axes: list[dict] = []
-    axes.append(
-        {
-            "name": "structure",
-            "result": check_structure(payload)[0],
-            "note": check_structure(payload)[1],
-        }
-    )
+    axes.append(_struct_axis("structure", *check_structure(payload)))
 
     pk, status, jwks_alg = resolve_key(jwks, kid)
     if pk is None:
-        axes.append(
-            {
-                "name": "issuer_key",
-                "result": "FAIL",
-                "note": f"kid {kid!r} not in jwks directory",
-            }
-        )
-        axes.append(
-            {
-                "name": "signature",
-                "result": "SKIPPED",
-                "note": "no issuer key to verify against",
-            }
-        )
+        axes.append(_struct_axis("issuer_key", "FAIL", f"kid {kid!r} not in jwks directory"))
+        axes.append(_struct_axis("signature", "SKIPPED", "no issuer key to verify against"))
     else:
         _raw_sig = sig_obj.get("sig", "")
         sig_bytes = _b64decode(_raw_sig) if isinstance(_raw_sig, str) else b""
@@ -1151,47 +1229,34 @@ def run_structured(
                     eff_issuer = issuer_a
                     eff_revoked_at = resolve_revoked_at(jwks, kid_a)
         axes.append(
-            {
-                "name": "issuer_key",
-                "result": "PASS",
-                "note": f"resolved signing key {eff_kid} (status={eff_status})",
-            }
+            _struct_axis(
+                "issuer_key", "PASS", f"resolved signing key {eff_kid} (status={eff_status})"
+            )
         )
         # kid picks the key and the attacker picks the kid, so bind the key that
         # actually verified back to the issuer the receipt claims.
-        bind_r, bind_n = check_issuer_binding(eff_issuer, payload.get("issuer_id"))
-        axes.append({"name": "issuer_bind", "result": bind_r, "note": bind_n})
+        axes.append(_struct_axis("issuer_bind", *check_issuer_binding(eff_issuer, payload.get("issuer_id"))))
         # Offline anchor presence is not trusted timing; pass False so a forged
-        # anchor never upgrades a revoked key to PASS (hosted /verify does).
-        ks_r, ks_n = check_key_status(
-            eff_status, payload.get("issued_at", ""), eff_revoked_at, False
+        # anchor never upgrades a revoked key to a verified verdict.
+        axes.append(
+            _struct_axis(
+                "key_status",
+                *check_key_status(eff_status, payload.get("issued_at", ""), eff_revoked_at, False),
+            )
         )
-        axes.append({"name": "key_status", "result": ks_r, "note": ks_n})
-        axes.append({"name": "signature", "result": sig_res[0], "note": sig_res[1]})
+        axes.append(_struct_axis("signature", sig_res[0], sig_res[1]))
 
-    chain_r, chain_n = check_chain(payload, predecessor_payload)
-    axes.append({"name": "chain", "result": chain_r, "note": chain_n})
-    anch_r, anch_n = check_anchors(envelope)
-    axes.append({"name": "anchors", "result": anch_r, "note": anch_n})
-    skew_r, skew_n = check_skew(payload.get("issued_at", ""))
-    axes.append({"name": "skew", "result": skew_r, "note": skew_n})
-    exp_r, exp_n = check_expiry(payload)
-    axes.append({"name": "expiry", "result": exp_r, "note": exp_n})
+    axes.append(_struct_axis("chain", *check_chain(payload, predecessor_payload)))
+    axes.append(_struct_axis("anchors", *check_anchors(envelope)))
+    axes.append(_struct_axis("skew", *check_skew(payload.get("issued_at", ""))))
+    axes.append(_struct_axis("expiry", *check_expiry(payload)))
 
-    # Expiry reports on its own axis and never folds the verdict (criterion 426)
-    has_fail = any(a["result"] == "FAIL" and a["name"] != "expiry" for a in axes)
-    has_blocking_skip = any(
-        a["result"] == "SKIPPED" and a["name"] != "chain" for a in axes
-    )
-    if has_fail:
-        verdict = "FAIL"
-    elif has_blocking_skip:
-        verdict = "INCOMPLETE"
-    else:
-        verdict = "PASS"
+    # Expiry reports on its own axis and never folds the verdict (criterion 426).
+    verdict, failure_class = _fold_verdict([(a["name"], a["result"], a["note"]) for a in axes])
 
     return {
         "verdict": verdict,
+        "failure_class": failure_class,
         "axes": axes,
         "canonical_sha256": hashlib.sha256(msg).hexdigest(),
         "kid": kid,

--- a/python/tests/test_attestation_offline.py
+++ b/python/tests/test_attestation_offline.py
@@ -2,8 +2,8 @@
 
 Prove the SDK re-derives the cloud's statementHash byte for byte from the
 original claim, that a tampered claim or receipt fails, and that a good
-receipt yields the distinct "verified, commitment not re-derivable" outcome
-rather than a plain PASS.
+receipt yields the distinct "verified_keyed" outcome (commitment not
+re-derivable) rather than a plain verified verdict.
 
 The golden statementHash below was captured from the cloud route's merged
 canonicalization (src/asqav_cloud/api/routes/attestations.py), not a live call.
@@ -19,8 +19,10 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from asqav.attestation import (
-    VERDICT_FAIL,
-    VERDICT_VERIFIED_NOT_REDERIVABLE,
+    FAILURE_INVALID,
+    FAILURE_UNVERIFIABLE,
+    VERDICT_UNVERIFIED,
+    VERDICT_VERIFIED_KEYED,
     compute_statement_hash,
     merkle_inclusion_proof,
     merkle_leaf_hash,
@@ -145,14 +147,15 @@ def test_tampered_claim_changes_hash_and_does_not_pass() -> None:
         verify_signature=verify,
         signed_tree_head=tree_head,
     )
-    assert result["verdict"] == VERDICT_FAIL
+    assert result["verdict"] == VERDICT_UNVERIFIED
+    assert result["failure_class"] == FAILURE_INVALID
     assert result["statementHash"] != _GOLDEN_HASH
     by_name = {a["name"]: a["result"] for a in result["axes"]}
     assert by_name["statement_hash"] == "FAIL"
 
 
-    # (d) A good receipt yields the distinct outcome, never a plain PASS.
-def test_good_receipt_is_not_rederivable_never_plain_pass() -> None:
+    # (d) A good receipt yields verified_keyed, never plain verified (438).
+def test_good_receipt_is_not_rederivable_never_plain_verified() -> None:
     receipt, message, verify, tree_head = _good_receipt()
     result = verify_attestation_offline(
         _CLAIM,
@@ -161,8 +164,9 @@ def test_good_receipt_is_not_rederivable_never_plain_pass() -> None:
         verify_signature=verify,
         signed_tree_head=tree_head,
     )
-    assert result["verdict"] == VERDICT_VERIFIED_NOT_REDERIVABLE
-    assert result["verdict"] != "PASS"
+    assert result["verdict"] == VERDICT_VERIFIED_KEYED
+    assert result["verdict"] != "verified"
+    assert result["failure_class"] is None
     by_name = {a["name"]: a["result"] for a in result["axes"]}
     assert by_name["statement_hash"] == "PASS"
     assert by_name["signature"] == "PASS"
@@ -184,7 +188,8 @@ def test_tampered_signature_fails() -> None:
         verify_signature=verify,
         signed_tree_head=tree_head,
     )
-    assert result["verdict"] == VERDICT_FAIL
+    assert result["verdict"] == VERDICT_UNVERIFIED
+    assert result["failure_class"] == FAILURE_INVALID
     by_name = {a["name"]: a["result"] for a in result["axes"]}
     assert by_name["signature"] == "FAIL"
     assert by_name["statement_hash"] == "PASS"
@@ -201,18 +206,19 @@ def test_tampered_inclusion_proof_fails() -> None:
         verify_signature=verify,
         signed_tree_head=wrong_head,
     )
-    assert result["verdict"] == VERDICT_FAIL
+    assert result["verdict"] == VERDICT_UNVERIFIED
+    assert result["failure_class"] == FAILURE_INVALID
     by_name = {a["name"]: a["result"] for a in result["axes"]}
     assert by_name["inclusion"] == "FAIL"
     assert by_name["signature"] == "PASS"
 
 
-    # Without a key or tree head the verdict is INCOMPLETE, still never PASS.
-def test_missing_optional_inputs_is_incomplete_not_pass() -> None:
+    # Without a key or tree head the verdict is unverified/unverifiable (418).
+def test_missing_optional_inputs_is_unverifiable_not_verified() -> None:
     receipt, _message, _verify, _tree_head = _good_receipt()
     result = verify_attestation_offline(_CLAIM, receipt)
-    assert result["verdict"] == "INCOMPLETE"
-    assert result["verdict"] != "PASS"
+    assert result["verdict"] == VERDICT_UNVERIFIED
+    assert result["failure_class"] == FAILURE_UNVERIFIABLE
     by_name = {a["name"]: a["result"] for a in result["axes"]}
     assert by_name["statement_hash"] == "PASS"
     assert by_name["signature"] == "SKIP"
@@ -225,4 +231,5 @@ def test_public_surface_exposed_at_package_root() -> None:
 
     assert asqav.verify_attestation_offline is verify_attestation_offline
     assert asqav.compute_statement_hash is compute_statement_hash
-    assert asqav.VERDICT_VERIFIED_NOT_REDERIVABLE == "VERIFIED_COMMITMENT_NOT_REDERIVABLE"
+    assert asqav.VERDICT_VERIFIED_KEYED == "verified_keyed"
+    assert asqav.VERDICT_UNVERIFIED == "unverified"

--- a/python/tests/test_axis_parity_cases.py
+++ b/python/tests/test_axis_parity_cases.py
@@ -108,6 +108,9 @@ def test_chain_prev_hash_case(case: dict) -> None:
     result = asqav.verify_receipt_offline(_pipelock_receipt(case), keys)
     axes = {a["name"]: a["result"] for a in result["axes"]}
     assert result["verdict"] == case["expect"]["verdict"], f"{case['name']}: axes {axes}"
+    assert result["failure_class"] == case["expect"]["failure_class"], (
+        f"{case['name']}: axes {axes}"
+    )
     assert axes["chain"] == case["expect"]["chain"], f"{case['name']}: axes {axes}"
     assert axes["signature"] == case["expect"]["signature"], f"{case['name']}: axes {axes}"
 

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -25,7 +25,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # and in the corpus READMEs. A regenerated lock that forgets to update these is
 # drift, not a refresh
 FINGERPRINT_LOCK_DIGEST = "aa4e38f19dd227ffd4f674a9e25298199769d40ade9be63417eb9432ccb5ba6d"
-VERIFIER_LOCK_DIGEST = "3206eaf283ef84c3e54ea5d860ecc08a792fbd316daec04ea64072d9b6e05503"
+VERIFIER_LOCK_DIGEST = "37fdb7564b54303dde937e6f3324321e108dcd3710367ca6b0cf19906d029103"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_cross_language_cases.py
+++ b/python/tests/test_cross_language_cases.py
@@ -32,6 +32,10 @@ def test_cross_language_case(case: dict) -> None:
     assert result["verdict"] == case["expect"]["verdict"], (
         f"{case['name']}: verdict {result['verdict']!r}, axes {axes}"
     )
+    # invalid and unverifiable are never collapsed (criterion 418).
+    assert result["failure_class"] == case["expect"]["failure_class"], (
+        f"{case['name']}: failure_class {result['failure_class']!r}, axes {axes}"
+    )
     for axis, expected in case["expect"]["axes"].items():
         assert axes.get(axis) == expected, (
             f"{case['name']}: axis {axis} is {axes.get(axis)!r}, expected {expected!r}"

--- a/python/tests/test_deserializer_guards.py
+++ b/python/tests/test_deserializer_guards.py
@@ -10,6 +10,7 @@ a random dict index (rule 3.9).
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -25,6 +26,8 @@ def _mock_httpx(payload: dict) -> MagicMock:
     response = MagicMock()
     response.status_code = 200
     response.json.return_value = payload
+    # The strict-ingest path parses response.text, not .json() (criterion 419).
+    response.text = json.dumps(payload)
     return response
 
 

--- a/python/tests/test_exit_artifact_cli.py
+++ b/python/tests/test_exit_artifact_cli.py
@@ -156,8 +156,8 @@ def test_exit_artifact_command_passes_an_intact_pair(tmp_path: Path) -> None:
     _lay_out_exit_artifact(tmp_path, receipt, jwks)
     proc = _run_documented_command(tmp_path)
     assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
-    assert "=> PASS" in proc.stdout, proc.stdout
-    # A PASS with a skipped signature axis would be the failure this test exists for.
+    assert "=> verified" in proc.stdout, proc.stdout
+    # A verified verdict with a skipped signature axis is the failure this test exists for.
     assert "[  ok] signature" in proc.stdout, proc.stdout
     assert "[  ok] anchors" in proc.stdout, proc.stdout
     assert "[  ok] expiry" in proc.stdout, proc.stdout
@@ -170,7 +170,7 @@ def test_exit_artifact_command_fails_a_tampered_receipt(tmp_path: Path) -> None:
     _lay_out_exit_artifact(tmp_path, receipt, jwks)
     proc = _run_documented_command(tmp_path)
     assert proc.returncode == 1, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
-    assert "=> FAIL" in proc.stdout, proc.stdout
+    assert "=> unverified (failure_class: invalid)" in proc.stdout, proc.stdout
     assert "[FAIL] signature" in proc.stdout, proc.stdout
 
 
@@ -183,7 +183,7 @@ def test_exit_artifact_command_fails_a_tampered_jwks(tmp_path: Path) -> None:
     _lay_out_exit_artifact(tmp_path, receipt, jwks)
     proc = _run_documented_command(tmp_path)
     assert proc.returncode == 1, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
-    assert "=> FAIL" in proc.stdout, proc.stdout
+    assert "=> unverified (failure_class: invalid)" in proc.stdout, proc.stdout
 
 
     # The exit artifact ships one file, so it must not import the rest of the SDK.

--- a/python/tests/test_offline_verify.py
+++ b/python/tests/test_offline_verify.py
@@ -79,7 +79,8 @@ def test_verify_receipt_offline_pass():
     receipt = _load(PASS_VECTOR / "receipt.json")
     jwks = _load(PASS_VECTOR / "jwks.json")
     result = asqav.verify_receipt_offline(receipt, jwks)
-    assert result["verdict"] == "PASS", f"axes: {result['axes']}"
+    assert result["verdict"] == "verified", f"axes: {result['axes']}"
+    assert result["failure_class"] is None
     sig_axis = next(a for a in result["axes"] if a["name"] == "signature")
     assert sig_axis["result"] == "PASS"
 
@@ -105,7 +106,8 @@ def test_verify_receipt_offline_tampered_receipt_fails():
     receipt = _load(TAMPER_VECTOR / "receipt.json")
     jwks = _load(TAMPER_VECTOR / "jwks.json")
     result = asqav.verify_receipt_offline(receipt, jwks)
-    assert result["verdict"] == "FAIL", f"axes: {result['axes']}"
+    assert result["verdict"] == "unverified", f"axes: {result['axes']}"
+    assert result["failure_class"] == "invalid"
     sig_axis = next((a for a in result["axes"] if a["name"] == "signature"), None)
     assert sig_axis is not None
     assert sig_axis["result"] == "FAIL"
@@ -118,7 +120,8 @@ def test_verify_receipt_offline_tampered_payload_directly():
     tampered = copy.deepcopy(receipt)
     tampered["payload"]["decision"] = "deny"
     result = asqav.verify_receipt_offline(tampered, jwks)
-    assert result["verdict"] == "FAIL"
+    assert result["verdict"] == "unverified"
+    assert result["failure_class"] == "invalid"
 
 
 # ---------------------------------------------------------------------------
@@ -126,13 +129,13 @@ def test_verify_receipt_offline_tampered_payload_directly():
 # ---------------------------------------------------------------------------
 
 
-    # Missing key in JWKS -> signature SKIPPED -> INCOMPLETE (never a PASS).
+    # Missing key in JWKS -> signature SKIPPED -> unverified/unverifiable (never verified).
 def test_verify_receipt_offline_no_key_in_jwks():
     receipt = _load(PASS_VECTOR / "receipt.json")
     result = asqav.verify_receipt_offline(receipt, {"keys": []})
-    # Oracle SKIPs the signature when the key is absent; verdict is INCOMPLETE.
-    assert result["verdict"] in ("FAIL", "INCOMPLETE")
-    assert result["verdict"] != "PASS"
+    # Oracle SKIPs the signature when the key is absent; the check cannot complete.
+    assert result["verdict"] == "unverified"
+    assert result["failure_class"] == "unverifiable"
     sig_axis = next((a for a in result["axes"] if a["name"] == "signature"), None)
     assert sig_axis is not None
     assert sig_axis["result"] in ("SKIPPED", "FAIL")
@@ -207,18 +210,20 @@ except ImportError:
 def test_verify_receipt_offline_mldsa65_pass():
     envelope, jwks = _make_mldsa_receipt_and_jwks()
     result = asqav.verify_receipt_offline(envelope, jwks)
-    assert result["verdict"] == "PASS", f"axes: {result['axes']}"
+    assert result["verdict"] == "verified", f"axes: {result['axes']}"
+    assert result["failure_class"] is None
     sig_axis = next(a for a in result["axes"] if a["name"] == "signature")
     assert sig_axis["result"] == "PASS"
 
 
-    # A tampered ML-DSA-65 receipt must return FAIL, never PASS.
+    # A tampered ML-DSA-65 receipt reads unverified/invalid, never verified.
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_verify_receipt_offline_mldsa65_tampered_fails():
     envelope, jwks = _make_mldsa_receipt_and_jwks()
     envelope["payload"]["decision"] = "deny"
     result = asqav.verify_receipt_offline(envelope, jwks)
-    assert result["verdict"] == "FAIL"
+    assert result["verdict"] == "unverified"
+    assert result["failure_class"] == "invalid"
     sig_axis = next(a for a in result["axes"] if a["name"] == "signature")
     assert sig_axis["result"] == "FAIL"
 
@@ -343,7 +348,8 @@ def test_verify_receipt_offline_rejects_hash_mode_claiming_another_org():
     }
     doc = _hash_mode_receipt(_VICTIM_ORG, "attacker-key", attacker_sk)
     result = asqav.verify_receipt_offline(doc, jwks)
-    assert result["verdict"] == "FAIL", f"axes: {result['axes']}"
+    assert result["verdict"] == "unverified", f"axes: {result['axes']}"
+    assert result["failure_class"] == "invalid"
     bind = next(a for a in result["axes"] if a["name"] == "issuer_bind")
     assert bind["result"] == "FAIL", f"issuer_bind axis: {bind}"
     sig_axis = next(a for a in result["axes"] if a["name"] == "signature")
@@ -373,14 +379,14 @@ def test_verify_receipt_offline_hash_mode_cannot_shed_axes_via_unsigned_fields()
     }
     clean = _hash_mode_receipt(_ATTACKER_ORG, "attacker-key", attacker_sk)
     # Control: the honest hash-mode receipt still verifies.
-    assert asqav.verify_receipt_offline(clean, jwks)["verdict"] == "PASS"
+    assert asqav.verify_receipt_offline(clean, jwks)["verdict"] == "verified"
 
     doc = dict(clean)
     # Unsigned in hash mode, so a consumer reading these fields sees a victim claim.
     doc["issuer_id"] = "org-victim"
     doc["previousReceiptHash"] = "0" * 64
     result = asqav.verify_receipt_offline(doc, jwks)
-    assert result["verdict"] == "FAIL", f"axes: {result['axes']}"
+    assert result["verdict"] == "unverified", f"axes: {result['axes']}"
     # The compliance rule set applied, so the doc is judged on the claim it displays.
     structure = next(a for a in result["axes"] if a["name"] == "structure")
     assert structure["result"] == "FAIL", f"structure axis: {structure}"
@@ -393,7 +399,8 @@ def test_verify_receipt_offline_rejects_a_key_from_another_issuer():
     issuer_id. The signature is genuine, so only the issuer bind can refuse it."""
     envelope, jwks = _cross_issuer_forgery_and_jwks()
     result = asqav.verify_receipt_offline(envelope, jwks)
-    assert result["verdict"] == "FAIL", f"axes: {result['axes']}"
+    assert result["verdict"] == "unverified", f"axes: {result['axes']}"
+    assert result["failure_class"] == "invalid"
     bind = next(a for a in result["axes"] if a["name"] == "issuer_bind")
     assert bind["result"] == "FAIL", f"issuer_bind axis: {bind}"
     sig_axis = next(a for a in result["axes"] if a["name"] == "signature")
@@ -424,8 +431,8 @@ def test_verify_receipt_offline_mldsa65_real_cloud_kat():
     assert "lapsed" in expiry_axis["note"], expiry_axis["note"]
     # Expiry never folds the verdict; the crypto axes decide it (criterion 426)
     assert (
-        result["verdict"] == "PASS"
-    ), f"Expected PASS with the lapsed window on its own axis, got {result['verdict']}; axes: {result['axes']}"
+        result["verdict"] == "verified"
+    ), f"Expected verified with the lapsed window on its own axis, got {result['verdict']}; axes: {result['axes']}"
 
 
     # Tampered KAT payload byte must return FAIL - anti-vacuous guard.
@@ -438,8 +445,9 @@ def test_verify_receipt_offline_mldsa65_real_cloud_kat_tamper_payload():
     tampered["payload"]["decision"] = "deny"
     result = asqav.verify_receipt_offline(tampered, jwks)
     assert (
-        result["verdict"] == "FAIL"
-    ), f"Tampered receipt must be FAIL, got {result['verdict']}; axes: {result['axes']}"
+        result["verdict"] == "unverified"
+    ), f"Tampered receipt must be unverified, got {result['verdict']}; axes: {result['axes']}"
+    assert result["failure_class"] == "invalid"
     sig_axis = next((a for a in result["axes"] if a["name"] == "signature"), None)
     assert sig_axis is not None
     assert (
@@ -463,8 +471,9 @@ def test_verify_receipt_offline_mldsa65_real_cloud_kat_tamper_sig():
     tampered["signature"]["sig"] = base64.b64encode(bad_sig).decode()
     result = asqav.verify_receipt_offline(tampered, jwks)
     assert (
-        result["verdict"] == "FAIL"
-    ), f"Corrupted-sig receipt must be FAIL, got {result['verdict']}; axes: {result['axes']}"
+        result["verdict"] == "unverified"
+    ), f"Corrupted-sig receipt must be unverified, got {result['verdict']}; axes: {result['axes']}"
+    assert result["failure_class"] == "invalid"
     sig_axis = next((a for a in result["axes"] if a["name"] == "signature"), None)
     assert sig_axis is not None
     assert sig_axis["result"] == "FAIL"
@@ -474,7 +483,7 @@ def test_verify_receipt_offline_mldsa65_real_cloud_kat_tamper_sig():
 # run_structured is also available directly on the verifier module.
 # run_structured uses the standalone verify_receipt engine (ML-DSA-65 only).
 # The Ed25519 vector has an unsupported alg for the standalone engine, so it
-# returns INCOMPLETE (not PASS); that is correct and expected behaviour.
+# returns unverified/unverifiable (not verified); correct and expected behaviour.
 # ---------------------------------------------------------------------------
 
 
@@ -483,8 +492,8 @@ def test_run_structured_directly():
     receipt = _load(PASS_VECTOR / "receipt.json")
     jwks = _load(PASS_VECTOR / "jwks.json")
     result = vr.run_structured(receipt, jwks)
-    # The standalone engine only verifies ML-DSA-65; Ed25519 is SKIPPED -> INCOMPLETE.
-    assert result["verdict"] in ("PASS", "INCOMPLETE")
+    # The standalone engine only verifies ML-DSA-65; Ed25519 is SKIPPED -> unverifiable.
+    assert result["verdict"] in ("verified", "unverified")
     assert isinstance(result["axes"], list)
     assert result["canonical_sha256"] is not None
 
@@ -500,7 +509,7 @@ def test_offline_api_missing_public_key_no_crash():
     kid = receipt["signature"]["kid"]
     jwks = {"keys": [{"kid": kid, "kty": "OKP", "crv": "Ed25519", "x": "abc"}]}
     result = asqav.verify_receipt_offline(receipt, jwks)
-    assert result["verdict"] in ("FAIL", "INCOMPLETE")
+    assert result["verdict"] == "unverified"
     sig_axis = next(a for a in result["axes"] if a["name"] == "signature")
     assert sig_axis["result"] in ("FAIL", "SKIPPED")
 
@@ -537,12 +546,13 @@ def test_hash_mode_org_with_a_legal_entity_does_not_false_fail():
     aliased = asqav.verify_receipt_offline(doc, _hash_mode_jwks("Acme Compliance Ltd", pk))
     bind = next(a for a in aliased["axes"] if a["name"] == "issuer_bind")
     assert bind["result"] == "SKIPPED", f"honest receipt false-FAILed: {bind}"
-    assert aliased["verdict"] == "INCOMPLETE", f"axes: {aliased['axes']}"
+    assert aliased["verdict"] == "unverified", f"axes: {aliased['axes']}"
+    assert aliased["failure_class"] == "unverifiable"
 
     published = asqav.verify_receipt_offline(
         doc, _hash_mode_jwks("Acme Compliance Ltd", pk, org_id=_ATTACKER_ORG)
     )
-    assert published["verdict"] == "PASS", f"axes: {published['axes']}"
+    assert published["verdict"] == "verified", f"axes: {published['axes']}"
 
 
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
@@ -558,7 +568,8 @@ def test_hash_mode_cross_org_still_fails_when_the_directory_names_an_org():
         _hash_mode_jwks("Acme Compliance Ltd", pk, org_id=_ATTACKER_ORG),
     ):
         result = asqav.verify_receipt_offline(doc, jwks)
-        assert result["verdict"] == "FAIL", f"cross-org forgery survived: {result['axes']}"
+        assert result["verdict"] == "unverified", f"cross-org forgery survived: {result['axes']}"
+        assert result["failure_class"] == "invalid"
 
 
 def test_unmodified_prod_vector_with_unsigned_claims_does_not_crash():
@@ -569,6 +580,6 @@ def test_unmodified_prod_vector_with_unsigned_claims_does_not_crash():
     doc["issuer_id"] = "org-victim"
     doc["previousReceiptHash"] = "0" * 64
     result = asqav.verify_receipt_offline(doc, _load(V / "jwks.json"))
-    assert result["verdict"] == "FAIL", f"axes: {result['axes']}"
+    assert result["verdict"] == "unverified", f"axes: {result['axes']}"
     structure = next(a for a in result["axes"] if a["name"] == "structure")
     assert "does not cover" in structure["note"], structure

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -89,7 +89,8 @@ def test_aerf_valid_receipt_passes() -> None:
     doc = _load("aerf-01-genesis", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("aerf-01-genesis", "aerf"))
     assert res.fmt == "aerf"
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
+    assert res.failure_class is None
     assert res.axis("signature").result == crypto.PASS
 
 
@@ -98,7 +99,8 @@ def test_aerf_chain_link_passes() -> None:
     doc = _load("aerf-02-chain-link", "receipt.json")
     pred = _load("aerf-02-chain-link", "predecessor.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("aerf-02-chain-link", "aerf"), predecessor=pred)
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
+    assert res.failure_class is None
     assert res.axis("chain").result == crypto.PASS
 
 
@@ -106,7 +108,8 @@ def test_aerf_chain_link_passes() -> None:
 def test_aerf_tampered_evidence_fails_signature() -> None:
     doc = _load("aerf-03-tamper-evidence", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("aerf-03-tamper-evidence", "aerf"))
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -115,7 +118,8 @@ def test_aerf_tampered_chain_fails_chain() -> None:
     doc = _load("aerf-04-tamper-chain", "receipt.json")
     pred = _load("aerf-04-tamper-chain", "predecessor.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("aerf-04-tamper-chain", "aerf"), predecessor=pred)
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("chain").result == crypto.FAIL
 
 
@@ -124,7 +128,8 @@ def test_aerf_tampered_chain_fails_chain() -> None:
 def test_aerf_impact_without_parent_sig_fails() -> None:
     doc = _load("aerf-up-05-impact-no-parent-sig", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("aerf-up-05-impact-no-parent-sig", "aerf"))
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.PASS
     assert res.axis("parent_signature").result == crypto.FAIL
 
@@ -134,20 +139,23 @@ def test_aerf_impact_without_parent_sig_fails() -> None:
 def test_aerf_pdp_split_context_fails() -> None:
     doc = _load("aerf-up-08-pdp-binding-split-context", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("aerf-up-08-pdp-binding-split-context", "aerf"))
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.PASS
     assert res.axis("pdp_signature").result == crypto.FAIL
 
 
-    # A required counter-sign axis whose key is not supplied SKIPs and downgrades to INCOMPLETE, never PASS.
+    # A required counter-sign axis whose key is not supplied SKIPs and downgrades to
+    # unverified/unverifiable, never a verified verdict.
 @requires_ed25519
-def test_aerf_required_layer_without_key_is_incomplete_never_pass() -> None:
+def test_aerf_required_layer_without_key_is_unverifiable_never_verified() -> None:
     doc = _load("aerf-up-07-pdp-binding-valid", "receipt.json")
     keys = dict(_provider("aerf-up-07-pdp-binding-valid", "aerf"))
     keys.pop("dfe937603b2f3312", None)  # drop the PDP key so the axis cannot be checked
     res = verify(doc, ADAPTERS, key_provider=keys)
     assert res.axis("pdp_signature").result == crypto.SKIPPED
-    assert res.verdict == "INCOMPLETE"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "unverifiable"
 
 
 @requires_ed25519
@@ -155,7 +163,8 @@ def test_asqav_native_valid_receipt_passes() -> None:
     doc = _load("asqav-01-genesis-permit", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("asqav-01-genesis-permit", "asqav-native"))
     assert res.fmt == "asqav-native"
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
+    assert res.failure_class is None
     assert res.axis("signature").result == crypto.PASS
 
 
@@ -166,7 +175,8 @@ def test_asqav_native_chain_link_passes() -> None:
     res = verify(
         doc, ADAPTERS, key_provider=_provider("asqav-03-chain-link", "asqav-native"), predecessor=pred
     )
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
+    assert res.failure_class is None
     assert res.axis("chain").result == crypto.PASS
 
 
@@ -174,7 +184,8 @@ def test_asqav_native_chain_link_passes() -> None:
 def test_asqav_native_tampered_signature_fails() -> None:
     doc = _load("asqav-04-tamper-sig", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_provider("asqav-04-tamper-sig", "asqav-native"))
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -191,15 +202,18 @@ def test_asqav_native_chain_break_fails_without_crypto() -> None:
 def test_unknown_format_fails_closed() -> None:
     res = verify({"hello": "world"}, ADAPTERS)
     assert res.fmt == "unknown"
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    # An unrecognised receipt cannot be recomputed at all (malformed member class).
+    assert res.failure_class == "unverifiable"
 
 
-    # No key provider means the signature cannot be checked; never a PASS.
-def test_signature_skips_downgrade_to_incomplete() -> None:
+    # No key provider means the signature cannot be checked; never a verified verdict.
+def test_signature_skips_downgrade_to_unverifiable() -> None:
     doc = _load("aerf-01-genesis", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider={})
     assert res.axis("signature").result == crypto.SKIPPED
-    assert res.verdict == "INCOMPLETE"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "unverifiable"
 
 
     # The CLI entrypoint runs the corpus, tolerates the optional-dep vector, exits 0.
@@ -215,12 +229,12 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 52
-    # asqav-05 (INCOMPLETE) upgrades to PASS when dilithium-py is present.
+    assert len(results) == 54
+    # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (
-            r.expected_outcome == "INCOMPLETE"
-            and r.actual_verdict == "PASS"
+            r.expected_outcome == "unverified"
+            and r.actual_verdict == "verified"
             and r.reason_code == "signature_skipped_no_dilithium"
         )
 
@@ -242,7 +256,7 @@ def test_acta_valid_genesis_passes() -> None:
     doc = _load("acta-01-genesis", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_acta_keys("acta-01-genesis"))
     assert res.fmt == "acta"
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
     assert res.axis("signature").result == crypto.PASS
 
 
@@ -251,7 +265,7 @@ def test_acta_chain_link_passes() -> None:
     doc = _load("acta-02-chain-link", "receipt.json")
     pred = _load("acta-02-chain-link", "predecessor.json")
     res = verify(doc, ADAPTERS, key_provider=_acta_keys("acta-02-chain-link"), predecessor=pred)
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
     assert res.axis("chain").result == crypto.PASS
 
 
@@ -259,7 +273,8 @@ def test_acta_chain_link_passes() -> None:
 def test_acta_tampered_signature_fails() -> None:
     doc = _load("acta-03-tamper-sig", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_acta_keys("acta-03-tamper-sig"))
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -268,7 +283,8 @@ def test_acta_tampered_signature_fails() -> None:
 def test_acta_commitment_mode_fails_not_false_passes() -> None:
     doc = _load("acta-05-commitment-mode-unsupported", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_acta_keys("acta-05-commitment-mode-unsupported"))
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -319,7 +335,7 @@ def test_acta_rev02_vectors_still_verify() -> None:
     for vec in ("acta-01-genesis",):
         doc = _load(vec, "receipt.json")
         res = verify(doc, ADAPTERS, key_provider=_acta_keys(vec))
-        assert res.verdict == "PASS", vec
+        assert res.verdict == "verified", vec
 
 
 @requires_ed25519
@@ -337,7 +353,7 @@ def test_acta_upstream_scopeblind_receipt_verifies() -> None:
     assert "issuer_id" not in doc["payload"] and "type" not in doc["payload"]
     res = verify(doc, ADAPTERS, key_provider=_acta_keys("acta-up-01-a2a-trusted-attestation"))
     assert res.fmt == "acta"
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
     assert res.axis("signature").result == crypto.PASS
 
 
@@ -346,7 +362,8 @@ def test_acta_upstream_scopeblind_receipt_verifies() -> None:
 def test_acta_upstream_tampered_receipt_fails() -> None:
     doc = _load("acta-up-03-a2a-tampered-sig", "receipt.json")
     res = verify(doc, ADAPTERS, key_provider=_acta_keys("acta-up-03-a2a-tampered-sig"))
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -363,7 +380,7 @@ def test_acta_malformed_signature_fails_does_not_crash() -> None:
         forged = json.loads(json.dumps(doc))
         forged["signature"] = {"sig": bad, "alg": "EdDSA", "kid": "k1"}
         res = verify(forged, ADAPTERS, key_provider=_acta_keys("acta-01-genesis"))
-        assert res.verdict != "PASS"
+        assert res.verdict == "unverified"
         assert ActaAdapter().extract_signature(forged).sig == b""
 
 
@@ -386,7 +403,9 @@ def test_cross_format_confusion_asqav_with_hex_sig_does_not_verify_as_native() -
     forged["signature"]["sig"] = "ab" * 64  # 128-char lowercase hex (ACTA-shaped)
     res = verify(forged, ADAPTERS, key_provider=_acta_keys("acta-01-genesis"))
     assert res.fmt == "acta"
-    assert res.verdict != "PASS"
+    assert res.verdict == "unverified"
+    # The ACTA route cannot resolve the native kid, so the check cannot complete.
+    assert res.failure_class == "unverifiable"
     # The unmodified native receipt still routes to asqav-native.
     assert verify(native, ADAPTERS, key_provider=_provider("asqav-01-genesis-permit", "asqav-native")).fmt == "asqav-native"
 
@@ -407,7 +426,8 @@ def test_acta_genesis_spoof_breaks_signature() -> None:
     spoof = json.loads(json.dumps(succ))
     del spoof["payload"]["previousReceiptHash"]
     res = verify(spoof, ADAPTERS, key_provider=_acta_keys("acta-02-chain-link"))
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -466,7 +486,7 @@ def test_asqav_native_agent_id_fallback_resolves_absent_kid() -> None:
     res = verify(doc, ADAPTERS, key_provider=jwks)
     assert res.fmt == "asqav-native"
     assert res.axis("signature").result == crypto.PASS
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
 
 
 @requires_ed25519
@@ -514,7 +534,8 @@ def test_asqav_native_agent_id_fallback_binds_issuer() -> None:
     }
     res = verify(doc, ADAPTERS, key_provider=jwks)
     assert res.fmt == "asqav-native"
-    assert res.verdict != "PASS"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "unverifiable"
     assert res.axis("signature").result in (crypto.FAIL, crypto.SKIPPED)
 
 
@@ -528,11 +549,12 @@ def test_wrong_key_resolution_fails_signature() -> None:
     swapped[kid] = other_raw.hex()
     res = verify(doc, ADAPTERS, key_provider=swapped)
     assert res.fmt == "aerf"
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
-    # An Ed25519 receipt relabelled to an alg the verifier does not check never PASSes.
+    # An Ed25519 receipt relabelled to an alg the verifier does not check never verifies.
 @requires_ed25519
 def test_algorithm_confusion_does_not_false_pass() -> None:
     doc = _load("acta-01-genesis", "receipt.json")
@@ -540,7 +562,9 @@ def test_algorithm_confusion_does_not_false_pass() -> None:
     forged["signature"]["alg"] = "ES256"
     res = verify(forged, ADAPTERS, key_provider=_acta_keys("acta-01-genesis"))
     assert res.fmt == "acta"
-    assert res.verdict != "PASS"
+    assert res.verdict == "unverified"
+    # An algorithm the format does not implement is an algorithm mismatch: invalid.
+    assert res.failure_class == "invalid"
     assert res.axis("structure").result == crypto.FAIL
     assert res.axis("signature").result in (crypto.FAIL, crypto.SKIPPED)
 
@@ -629,7 +653,7 @@ def test_agentreceipts_didkey_genesis_passes() -> None:
     doc = _ar("agentreceipts-01-didkey-genesis")
     res = verify(doc, ADAPTERS)
     assert res.fmt == "agentreceipts"
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
     assert res.axis("signature").result == crypto.PASS
 
 
@@ -638,7 +662,7 @@ def test_agentreceipts_chain_link_passes() -> None:
     doc = _ar("agentreceipts-02-didkey-chain-link")
     pred = _ar("agentreceipts-02-didkey-chain-link", "predecessor.json")
     res = verify(doc, ADAPTERS, predecessor=pred)
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
     assert res.axis("chain").result == crypto.PASS
 
 
@@ -646,7 +670,8 @@ def test_agentreceipts_chain_link_passes() -> None:
 def test_agentreceipts_tampered_payload_fails_signature() -> None:
     doc = _ar("agentreceipts-03-tamper-payload")
     res = verify(doc, ADAPTERS)
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -654,7 +679,8 @@ def test_agentreceipts_tampered_payload_fails_signature() -> None:
 def test_agentreceipts_tampered_proofvalue_fails_signature() -> None:
     doc = _ar("agentreceipts-04-tamper-proofvalue")
     res = verify(doc, ADAPTERS)
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -677,7 +703,8 @@ def test_agentreceipts_issuer_must_control_signing_key_no_impersonation() -> Non
     res = verify(forged, ADAPTERS, key_provider={vm: pk.hex()})
     assert res.axis("signature").result == crypto.PASS  # attacker's sig is cryptographically valid
     assert res.axis("structure").result == crypto.FAIL  # but signing-key DID != issuer
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
 
 
     # Genesis carries previous_receipt_hash present and null; omitting it is malformed.
@@ -689,7 +716,7 @@ def test_agentreceipts_genesis_explicit_null_is_genesis_missing_field_is_malform
 
     missing = _ar("agentreceipts-05-genesis-missing-prev-hash")
     assert ad.schema(missing)[0] == crypto.FAIL
-    assert verify(missing, ADAPTERS).verdict == "FAIL"
+    assert verify(missing, ADAPTERS).verdict == "unverified"
 
 
     # A verificationMethod resolved to a different key cannot verify the signature.
@@ -698,7 +725,8 @@ def test_agentreceipts_wrong_did_fails_signature() -> None:
     doc = _ar("agentreceipts-06-wrong-key")
     res = verify(doc, ADAPTERS, key_provider=_ar_provider("agentreceipts-06-wrong-key"))
     assert res.fmt == "agentreceipts"
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -707,7 +735,7 @@ def test_agentreceipts_wrong_did_fails_signature() -> None:
 def test_agentreceipts_upstream_valid_resigned_passes() -> None:
     doc = _ar("agentreceipts-up-00-valid-resigned")
     res = verify(doc, ADAPTERS, key_provider=_ar_provider("agentreceipts-up-00-valid-resigned"))
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
     assert res.axis("signature").result == crypto.PASS
 
 
@@ -792,8 +820,9 @@ def test_hash_mode_signature_skips_without_dilithium_never_false_pass() -> None:
     assert res.fmt == "asqav-native"
     assert res.axis("structure").result == crypto.PASS
     assert res.axis("signature").result in (crypto.PASS, crypto.SKIPPED)
-    assert res.verdict in ("PASS", "INCOMPLETE")
-    assert res.verdict != "FAIL"
+    assert res.verdict in ("verified", "unverified")
+    # A skipped post-quantum check is unverifiable, never a proven invalid.
+    assert res.failure_class in (None, "unverifiable")
 
 
     # A malformed hash-mode signature (non-string) verifies to a non-PASS, never raises.
@@ -804,7 +833,7 @@ def test_hash_mode_malformed_signature_fails_does_not_crash() -> None:
         forged.pop("signature_b64", None)
         forged["signature"] = bad
         res = verify(forged, ADAPTERS, key_provider=_provider("asqav-05-hash-mode-prod", "asqav-native"))
-        assert res.verdict != "PASS"
+        assert res.verdict == "unverified"
 
 
     # A malformed Asqav compliance-envelope signature decodes to b'' and FAILs, never raises.
@@ -814,7 +843,8 @@ def test_compliance_envelope_malformed_signature_fails_does_not_crash() -> None:
         forged = json.loads(json.dumps(doc))
         forged["signature"]["sig"] = bad
         res = verify(forged, ADAPTERS, key_provider=_provider("asqav-01-genesis-permit", "asqav-native"))
-        assert res.verdict != "PASS"
+        assert res.verdict == "unverified"
+        assert res.failure_class == "invalid"
 
 
     # A malformed AERF signature (non-hex or non-string) decodes to b'' and FAILs, never raises.
@@ -824,7 +854,8 @@ def test_aerf_malformed_signature_fails_does_not_crash() -> None:
         forged = json.loads(json.dumps(doc))
         forged["signature"] = bad
         res = verify(forged, ADAPTERS, key_provider=_provider("aerf-01-genesis", "aerf"))
-        assert res.verdict != "PASS"
+        assert res.verdict == "unverified"
+        assert res.failure_class == "invalid"
 
 
     # Malformed AERF parent/pdp counter-signatures decode to b'' and FAIL, never raise.
@@ -836,7 +867,8 @@ def test_aerf_malformed_parent_pdp_signature_fails_does_not_crash() -> None:
             forged = json.loads(json.dumps(doc))
             forged[field] = bad
             res = verify(forged, ADAPTERS, key_provider=_provider(vec, "aerf"))
-            assert res.verdict != "PASS"
+            assert res.verdict == "unverified"
+            assert res.failure_class == "invalid"
 
 
 # --- Authproof adapter (ES256 over insertion-order JSON.stringify) ---
@@ -853,7 +885,7 @@ def _authproof_receipt() -> dict:
 def test_authproof_real_sdk_receipt_verifies() -> None:
     res = verify(_authproof_receipt(), ADAPTERS)
     assert res.fmt == "authproof"
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
     assert res.axis("signature").result == crypto.PASS
 
 
@@ -871,13 +903,13 @@ def test_authproof_tamper_and_forge_fail_closed() -> None:
     base = _authproof_receipt()
     tampered = json.loads(json.dumps(base))
     tampered["scope"] = "Send all the emails."
-    assert verify(tampered, ADAPTERS).verdict == "FAIL"
+    assert verify(tampered, ADAPTERS).verdict == "unverified"
     forged = json.loads(json.dumps(base))
     forged["signature"] = "25" + base["signature"][2:]
-    assert verify(forged, ADAPTERS).verdict == "FAIL"
+    assert verify(forged, ADAPTERS).verdict == "unverified"
     wrong_key = json.loads(json.dumps(base))
     wrong_key["signerPublicKey"]["x"] = "AAAAXZILz_GGg8wwWuea3gOYkTvvYwzM42bgY5k_zgM"
-    assert verify(wrong_key, ADAPTERS).verdict == "FAIL"
+    assert verify(wrong_key, ADAPTERS).verdict == "unverified"
 
 
     # A malformed Authproof signature decodes to b'' and FAILs, never raises.
@@ -886,7 +918,7 @@ def test_authproof_malformed_signature_fails_does_not_crash() -> None:
     for bad in ("zz-not-hex", {"k": "v"}, 42, None, "abc"):
         forged = json.loads(json.dumps(base))
         forged["signature"] = bad
-        assert verify(forged, ADAPTERS).verdict != "PASS"
+        assert verify(forged, ADAPTERS).verdict == "unverified"
 
 
     # ES256 verify returns FAIL (never raises) on a bad point or a wrong-length signature.
@@ -903,7 +935,8 @@ def test_non_dict_receipt_fails_closed_never_crashes() -> None:
     for bad in ([1, 2, 3], "a-string", 42, None, True):
         assert detect(bad, ADAPTERS) is None
         res = verify(bad, ADAPTERS)
-        assert res.verdict != "PASS"
+        assert res.verdict == "unverified"
+        assert res.failure_class == "unverifiable"
 
 
 # --- Pipelock EvidenceReceipt v2 adapter ---
@@ -937,7 +970,7 @@ def test_pipelock_evidence_v2_valid_passes() -> None:
     doc = _pipelock("pipelock-ev2-01-proxy-decision")
     res = verify(doc, ADAPTERS, key_provider=_PIPELOCK_KEY_PROVIDER)
     assert res.fmt == "pipelock-evidence-v2"
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
     assert res.axis("structure").result == crypto.PASS
     assert res.axis("signature").result == crypto.PASS
 
@@ -953,7 +986,8 @@ def test_pipelock_evidence_v2_tampered_payload_fails() -> None:
     doc = _pipelock("pipelock-ev2-02-tamper-payload")
     res = verify(doc, ADAPTERS, key_provider=_PIPELOCK_KEY_PROVIDER)
     assert res.fmt == "pipelock-evidence-v2"
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
@@ -981,17 +1015,19 @@ def test_pipelock_wrong_key_fails_signature() -> None:
     wrong_provider = {"receipt-signing-test": "00" * 32}
     res = verify(doc, ADAPTERS, key_provider=wrong_provider)
     assert res.fmt == "pipelock-evidence-v2"
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert res.axis("signature").result == crypto.FAIL
 
 
-    # No key for signer_key_id: signature axis SKIPs; verdict is INCOMPLETE, never PASS.
-def test_pipelock_missing_key_skips_never_passes() -> None:
+    # No key for signer_key_id: signature axis SKIPs; unverified/unverifiable, never verified.
+def test_pipelock_missing_key_skips_never_verified() -> None:
     doc = _pipelock("pipelock-ev2-01-proxy-decision")
     res = verify(doc, ADAPTERS, key_provider={})
     assert res.fmt == "pipelock-evidence-v2"
     assert res.axis("signature").result == crypto.SKIPPED
-    assert res.verdict == "INCOMPLETE"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "unverifiable"
 
 
     # A Pipelock receipt carrying an unsupported algorithm token FAILs the structure axis.
@@ -1001,7 +1037,8 @@ def test_pipelock_schema_rejects_bad_algorithm() -> None:
     forged["signature"]["algorithm"] = "ecdsa-p256"
     res = verify(forged, ADAPTERS, key_provider=_PIPELOCK_KEY_PROVIDER)
     assert res.axis("structure").result == crypto.FAIL
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
 
 
     # Both 'genesis' and 'sha256:0' chain_prev_hash values are accepted as genesis.
@@ -1028,11 +1065,12 @@ def test_oracle_verify_signature_nonstring_alg_skips_clean() -> None:
         assert result == crypto.SKIPPED
 
 
-    # A non-dict top-level receipt returns a FAIL verdict, never raises in detect().
+    # A non-dict top-level receipt reads unverified/unverifiable, never raises in detect().
 def test_oracle_verify_nonobject_doc_fails_clean() -> None:
     for bad_doc in (None, "a string", 123, [1, 2]):
         res = verify(bad_doc, ADAPTERS)
-        assert res.verdict == "FAIL"
+        assert res.verdict == "unverified"
+        assert res.failure_class == "unverifiable"
 
 
 # A did:web signer resolved from an injected map, so the signature axis reaches the
@@ -1070,23 +1108,25 @@ def _deep_agentreceipt(depth: int, *, genesis: bool = True) -> dict:
     }
 
 
-def test_oracle_over_nested_receipt_is_incomplete_not_recursionerror() -> None:
-    """A receipt nested past the cap returns INCOMPLETE, never an unhandled RecursionError.
+def test_oracle_over_nested_receipt_is_unverifiable_not_recursionerror() -> None:
+    """A receipt nested past the cap returns unverified/unverifiable, never an unhandled RecursionError.
 
     The signer resolves so the signature axis reaches the recursive JCS
     canonicaliser, which overflows the stack without the depth gate in verify().
     """
     res = verify(_deep_agentreceipt(3000), ADAPTERS, key_provider=_SIGNER)
-    assert res.verdict == "INCOMPLETE"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "unverifiable"
     assert res.fmt == "agentreceipts"
     assert "depth" in (res.axis("structure").note or "")
 
 
     # A deeply nested predecessor is capped on the chain axis, never a RecursionError.
-def test_oracle_over_nested_predecessor_is_incomplete_not_recursionerror() -> None:
+def test_oracle_over_nested_predecessor_is_unverifiable_not_recursionerror() -> None:
     doc = _deep_agentreceipt(1, genesis=False)
     res = verify(doc, ADAPTERS, key_provider=_SIGNER, predecessor=_deep_agentreceipt(3000))
-    assert res.verdict == "INCOMPLETE"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "unverifiable"
     assert "depth" in (res.axis("structure").note or "")
 
 

--- a/python/tests/test_oracle_kid_shared_resolution.py
+++ b/python/tests/test_oracle_kid_shared_resolution.py
@@ -193,7 +193,9 @@ def test_rewritten_kid_cannot_flip_a_revoked_receipt_to_pass() -> None:
     assert honest_res.axis("signature").result == "PASS"
     assert rewritten_res.axis("signature").result == "PASS"
     # And the revoked status carries the verdict in both cases.
-    assert honest_res.verdict == "FAIL"
-    assert rewritten_res.verdict == "FAIL"
+    assert honest_res.verdict == "unverified"
+    assert rewritten_res.verdict == "unverified"
+    assert honest_res.failure_class == "invalid"
+    assert rewritten_res.failure_class == "invalid"
     assert rewritten_res.axis("key_status") is not None
     assert rewritten_res.axis("key_status").result == "FAIL"

--- a/python/tests/test_oracle_multikey_org_resolution.py
+++ b/python/tests/test_oracle_multikey_org_resolution.py
@@ -92,7 +92,8 @@ def test_last_sibling_receipt_resolves_the_actual_signer() -> None:
 
     result = verify(receipt, [AsqavNativeAdapter()], key_provider=jwks)
     assert result.axis("signature").result == "PASS", result.axes
-    assert result.verdict == "PASS", result.axes
+    assert result.verdict == "verified", result.axes
+    assert result.failure_class is None, result.axes
 
 
     # Whichever sibling signs, the agent bind resolves that sibling's key, never another.
@@ -108,7 +109,7 @@ def test_each_sibling_resolves_to_its_own_key() -> None:
         receipt = _sign(_flat(f"agt_{i}"), sk)
         pk, note = ad.resolve_key(receipt, jwks)
         assert pk == pks[i], (i, note)
-        assert verify(receipt, [ad], key_provider=jwks).verdict == "PASS"
+        assert verify(receipt, [ad], key_provider=jwks).verdict == "verified"
 
 
     # A signature from a key the directory does not publish fails, never a false PASS.
@@ -123,7 +124,8 @@ def test_forged_signature_against_the_org_still_fails() -> None:
     jwks = _sibling_jwks(2, pks)
 
     result = verify(receipt, [AsqavNativeAdapter()], key_provider=jwks)
-    assert result.verdict != "PASS", result.axes
+    assert result.verdict == "unverified", result.axes
+    assert result.failure_class == "invalid", result.axes
 
 
     # agent_id is attacker-controlled: a key from another org never resolves the claim.

--- a/python/tests/test_retry_async.py
+++ b/python/tests/test_retry_async.py
@@ -230,7 +230,7 @@ async def test_async_verify() -> None:
 
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {
+    _verify_payload = {
         "signature_id": "sigid_001",
         "agent_id": "agent_001",
         "agent_name": "test-agent",
@@ -243,6 +243,11 @@ async def test_async_verify() -> None:
         "verified": True,
         "verification_url": "https://api.asqav.com/verify/sigid_001",
     }
+    mock_response.json.return_value = _verify_payload
+    # The strict-ingest path parses response.text, not .json() (criterion 419).
+    import json as _json
+
+    mock_response.text = _json.dumps(_verify_payload)
 
     agent = AsyncAgent(
         agent_id="agent_001",

--- a/python/tests/test_signing_key_sibling.py
+++ b/python/tests/test_signing_key_sibling.py
@@ -212,7 +212,8 @@ def test_oracle_passes_a_receipt_signed_by_the_second_agent() -> None:
     assert axes["signature"] == "PASS", axes
     assert axes["key_status"] == "PASS"
     assert axes["issuer_bind"] == "PASS"
-    assert res.verdict == "PASS", axes
+    assert res.verdict == "verified", axes
+    assert res.failure_class is None
 
 
     # Naming a sibling in the payload never lends that sibling's key to a forgery.
@@ -231,7 +232,8 @@ def test_oracle_rejects_a_signature_from_the_wrong_agent() -> None:
     }
     assert forger_pk not in (one_pk, two_pk)
     res = verify(_receipt(payload, sig), [AsqavNativeAdapter()], key_provider=jwks)
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert {a.axis: a.result for a in res.axes}["signature"] == "FAIL"
 
 
@@ -249,5 +251,6 @@ def test_oracle_rejects_an_agent_key_from_another_org() -> None:
         ]
     }
     res = verify(_receipt(payload, sig), [AsqavNativeAdapter()], key_provider=jwks)
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
     assert {a.axis: a.result for a in res.axes}["signature"] == "FAIL"

--- a/python/tests/test_standalone_verifier_surface.py
+++ b/python/tests/test_standalone_verifier_surface.py
@@ -144,7 +144,7 @@ def test_standalone_file_verifies_the_published_receipt_without_asqav(tmp_path) 
         timeout=180,
     )
     assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
-    assert "=> PASS" in proc.stdout, proc.stdout
+    assert "=> verified" in proc.stdout, proc.stdout
     # The lapsed signed expiry reports on its own axis and never folds the verdict
     assert "[FAIL] expiry" in proc.stdout, proc.stdout
 
@@ -179,4 +179,4 @@ def test_standalone_file_rejects_a_tampered_published_receipt(tmp_path) -> None:
         timeout=180,
     )
     assert proc.returncode == 1, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
-    assert "=> FAIL" in proc.stdout, proc.stdout
+    assert "=> unverified" in proc.stdout, proc.stdout

--- a/python/tests/test_strict_json.py
+++ b/python/tests/test_strict_json.py
@@ -1,0 +1,110 @@
+"""Strict JSON ingest (criterion 419): duplicate members fail closed.
+
+Every receipt- and record-parsing path rejects a duplicated JSON member name at
+ANY nesting depth as a terminal parse failure, before any hashing,
+canonicalisation, or signature check. Last-wins ingest would hash the bytes an
+attacker kept and drop the ones they replaced; these tests pin the rejection.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from asqav import strict_json
+from asqav.verifier import verify_receipt as vr
+
+_CORPUS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+
+    # A duplicated member name at the top level raises the terminal error.
+def test_top_level_duplicate_member_rejected() -> None:
+    with pytest.raises(strict_json.DuplicateMemberError):
+        strict_json.loads('{"payload": {"a": 1}, "payload": {"a": 2}}')
+
+
+    # A duplicated member name nested inside an object raises too.
+def test_nested_duplicate_member_rejected() -> None:
+    with pytest.raises(strict_json.DuplicateMemberError):
+        strict_json.loads('{"payload": {"digest": {"hash": "x", "hash": "y"}}}')
+
+
+    # Depth does not weaken the gate: a duplicate five levels down is terminal.
+def test_deeply_nested_duplicate_member_rejected() -> None:
+    text = '{"a": {"b": {"c": {"d": [{"e": 1, "e": 2}]}}}}'
+    with pytest.raises(strict_json.DuplicateMemberError):
+        strict_json.loads(text)
+
+
+    # Duplicates inside an array element are rejected at any depth.
+def test_duplicate_member_inside_array_element_rejected() -> None:
+    with pytest.raises(strict_json.DuplicateMemberError):
+        strict_json.loads('{"list": [{"k": 1}, {"k": 2, "k": 3}]}')
+
+
+    # The same member name in SIBLING objects is legal; only one object scope matters.
+def test_same_name_in_sibling_objects_is_allowed() -> None:
+    out = strict_json.loads('{"list": [{"k": 1}, {"k": 2}]}')
+    assert out == {"list": [{"k": 1}, {"k": 2}]}
+
+
+    # Clean documents parse exactly like the stdlib decoder.
+def test_clean_documents_parse_like_stdlib() -> None:
+    samples = [
+        "{}",
+        '{"a": 1, "b": [true, false, null], "c": {"d": "e"}}',
+        '{"nested": [[[[1]]]], "mix": [{"x": [2, {"y": 3}]}]}',
+        '[1, 2, {"a": {"b": [3]}}]',
+    ]
+    for text in samples:
+        assert strict_json.loads(text) == json.loads(text), text
+
+
+    # The object_pairs_hook is reserved for duplicate rejection, never overridden.
+def test_loads_refuses_a_caller_object_pairs_hook() -> None:
+    with pytest.raises(ValueError):
+        strict_json.loads("{}", object_pairs_hook=dict)
+
+
+    # The standalone verifier parses with the same gate (self-contained copy).
+def test_standalone_verifier_rejects_duplicate_members() -> None:
+    with pytest.raises(vr.VerifierInputError, match="duplicate JSON member name"):
+        vr._parse_object('{"payload": 1, "payload": 2}', "receipt.json")
+
+
+    # A duplicate key in the standalone path raises before any hashing runs.
+def test_standalone_duplicate_member_is_terminal_before_hashing() -> None:
+    text = '{"payload": {"type": "protectmcp:decision"}, "payload": {"type": "evil"}}'
+    with pytest.raises(vr.DuplicateMemberError):
+        json.loads(text, object_pairs_hook=vr._reject_duplicate_members)
+
+
+    # The OTel GenAI door recovers a receipt only when its JSON is duplicate-free.
+def test_doors_otel_receipt_rejects_duplicate_members() -> None:
+    from asqav import doors
+
+    attrs = {doors.OTEL_RECEIPT_ATTR: '{"a": 1, "a": 2}'}
+    with pytest.raises(strict_json.DuplicateMemberError):
+        doors.receipt_from_otel_genai_attributes(attrs)
+
+
+    # Both corpus duplicate-member vectors are terminal parse failures.
+@pytest.mark.parametrize("vec", ["asqav-11-dup-member-toplevel", "asqav-13-dup-member-nested"])
+def test_corpus_duplicate_member_vectors_never_parse(vec: str) -> None:
+    raw = (_CORPUS / vec / "receipt.json").read_text()
+    with pytest.raises(strict_json.DuplicateMemberError):
+        strict_json.loads(raw)
+
+
+    # A mutated receipt with a duplicated member never verifies through the runner.
+@pytest.mark.parametrize("vec", ["asqav-11-dup-member-toplevel", "asqav-13-dup-member-nested"])
+def test_corpus_duplicate_member_vectors_never_verify(vec: str) -> None:
+    from asqav.verifier.oracle.runner import run_one
+
+    outcome = run_one(_CORPUS / vec, "asqav-native", "unverified", "duplicate_member", "unverifiable")
+    assert outcome.ok
+    assert outcome.actual_verdict == "unverified"
+    assert outcome.actual_failure_class == "unverifiable"
+    assert "terminal parse failure before any hashing" in outcome.detail

--- a/python/tests/test_time_edge_vectors.py
+++ b/python/tests/test_time_edge_vectors.py
@@ -138,7 +138,7 @@ def test_time_edge_corpus_vector_expiry_never_folds_the_verdict() -> None:
     jwks = json.loads((TIME_EDGE_VECTOR / "jwks.json").read_text())
     result = vr.run_structured(receipt, jwks)
     axes = {a["name"]: a for a in result["axes"]}
-    assert result["verdict"] == "PASS", result["axes"]
+    assert result["verdict"] == "verified", result["axes"]
     assert axes["skew"]["result"] == "PASS", axes["skew"]
     assert axes["expiry"]["result"] == "FAIL", axes["expiry"]
     assert "lapsed" in axes["expiry"]["note"], axes["expiry"]
@@ -149,7 +149,7 @@ def test_time_edge_corpus_vector_expiry_never_folds_the_verdict() -> None:
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_time_edge_corpus_vector_matches_its_expected_outcome() -> None:
     expected = json.loads((TIME_EDGE_VECTOR / "expected.json").read_text())
-    assert expected["outcome"] == "PASS"
+    assert expected["outcome"] == "verified"
     from asqav.verifier.oracle.runner import run_one
 
     outcome = run_one(

--- a/python/tests/test_v2_signer.py
+++ b/python/tests/test_v2_signer.py
@@ -44,7 +44,8 @@ def test_v2_receipt_verifies_and_surfaces_signer() -> None:
     receipt, jwks = _v2()
     res = verify(receipt, ADAPTERS, key_provider=jwks)
     assert res.fmt == "asqav-native"
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
+    assert res.failure_class is None
     assert res.axis("signature").result == crypto.PASS
     # The v:2 origin attestation is surfaced from the signed body.
     assert res.signer == _SIGNER
@@ -62,7 +63,8 @@ def test_v2_tampered_in_body_signer_fails() -> None:
     receipt["payload"]["signer"] = "https://api.asqav.con"
     res = verify(receipt, ADAPTERS, key_provider=jwks)
     assert res.axis("signature").result == crypto.FAIL
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
 
 
     # signer as loose metadata outside the signed payload is neither surfaced nor trusted.
@@ -73,7 +75,8 @@ def test_v2_signer_moved_outside_signed_body_not_surfaced_and_fails() -> None:
     receipt["signer"] = _SIGNER  # loose, outside the canonical body
     res = verify(receipt, ADAPTERS, key_provider=jwks)
     assert res.signer is None
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
 
 
 @requires_ed25519
@@ -82,7 +85,8 @@ def test_v2_tampered_canary_corpus_vector_fails() -> None:
         "asqav-09-v2-signer-tampered", "jwks.json"
     )
     res = verify(receipt, ADAPTERS, key_provider=jwks)
-    assert res.verdict == "FAIL"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
 
 
     # A v:2 receipt without _asqav_tid still verifies; the neutral verifier never requires it.
@@ -102,7 +106,7 @@ def test_v1_vector_still_verifies_and_exposes_no_signer() -> None:
         "asqav-01-genesis-permit", "jwks.json"
     )
     res = verify(receipt, ADAPTERS, key_provider=jwks)
-    assert res.verdict == "PASS"
+    assert res.verdict == "verified"
     assert res.signer is None
 
 

--- a/python/tests/test_verdict_vocabulary.py
+++ b/python/tests/test_verdict_vocabulary.py
@@ -1,0 +1,147 @@
+"""Shipped verdict vocabulary + exit-code contract (criteria 418/438).
+
+The public surfaces speak verified / verified_keyed / unverified, and every
+unverified verdict carries a failure_class of invalid or unverifiable - the two
+are never collapsed. Exit codes keep the stable mapping: verified/verified_keyed
+-> 0, unverified+invalid -> 1, unverified+unverifiable -> 2 (the blocked state
+the old INCOMPLETE verdict carried).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from asqav.verifier.oracle.__main__ import _exit_code, run as cli_run
+from asqav.verifier.oracle import verify
+from asqav.verifier.oracle.adapters.asqav_native import AsqavNativeAdapter
+from asqav.verifier.oracle.canonical import asqav_jcs
+from asqav.verifier.oracle.core import (
+    FAILURE_INVALID,
+    FAILURE_UNVERIFIABLE,
+    VERDICT_UNVERIFIED,
+    VERDICT_VERIFIED,
+    VERDICT_VERIFIED_KEYED,
+)
+
+_CORPUS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+
+    # The exit-code mapping is the documented CLI contract.
+def test_exit_code_mapping() -> None:
+    assert _exit_code(VERDICT_VERIFIED, None) == 0
+    assert _exit_code(VERDICT_VERIFIED_KEYED, None) == 0
+    assert _exit_code(VERDICT_UNVERIFIED, FAILURE_INVALID) == 1
+    assert _exit_code(VERDICT_UNVERIFIED, FAILURE_UNVERIFIABLE) == 2
+
+
+    # A verified corpus vector exits 0 through the CLI entry point.
+def test_cli_exits_zero_for_verified() -> None:
+    vec = _CORPUS / "asqav-01-genesis-permit"
+    code = cli_run(str(vec / "receipt.json"), str(vec / "jwks.json"), None)
+    assert code == 0
+
+
+    # A tampered-signature vector exits 1 (a proven binding failure, invalid).
+def test_cli_exits_one_for_invalid() -> None:
+    vec = _CORPUS / "asqav-04-tamper-sig"
+    code = cli_run(str(vec / "receipt.json"), str(vec / "jwks.json"), None)
+    assert code == 1
+
+
+    # A duplicate-member receipt exits 2 (terminal parse failure, unverifiable).
+def test_cli_exits_two_for_unverifiable_parse_failure() -> None:
+    vec = _CORPUS / "asqav-11-dup-member-toplevel"
+    # The CLI raises SystemExit(2) from _load before any hashing runs.
+    with pytest.raises(SystemExit) as exc:
+        cli_run(str(vec / "receipt.json"), str(vec / "jwks.json"), None)
+    assert exc.value.code == 2
+
+
+    # The structured CLI report speaks the shipped vocabulary.
+def test_cli_report_uses_shipped_vocabulary(capsys: pytest.CaptureFixture) -> None:
+    vec = _CORPUS / "asqav-04-tamper-sig"
+    cli_run(str(vec / "receipt.json"), str(vec / "jwks.json"), None)
+    report = json.loads(capsys.readouterr().out)
+    assert report["verdict"] == "unverified"
+    assert report["failure_class"] == "invalid"
+    # Per-axis rows carry their failure token too.
+    for ax in report["axes"]:
+        assert "failure_class" in ax
+
+
+    # Build a signed hash-mode receipt whose digest is keyed (hmac-sha256).
+def _keyed_hash_mode_receipt():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    org = "f94f66c0-c580-432d-a041-29374f7aee07"
+    sk = Ed25519PrivateKey.generate()
+    pk = sk.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    flat = {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:" + "a" * 64,
+        "hash_algo": "hmac-sha256",
+        "metadata": {},
+        "server_timestamp": "2026-01-01T00:00:00Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": org,
+        "policy_digest": "sha256:" + "c" * 64,
+        "policy_decision": "allow",
+    }
+    doc = dict(flat)
+    doc["payload"] = None
+    doc["algorithm"] = "Ed25519"
+    doc["key_id"] = org
+    doc["signature_b64"] = base64.b64encode(sk.sign(asqav_jcs(flat))).decode()
+    jwks = {
+        "keys": [
+            {
+                "kid": "keyed-key",
+                "agent_id": "agt_1",
+                "issuer_id": org,
+                "org_id": org,
+                "alg": "Ed25519",
+                "public_key": base64.b64encode(pk).decode(),
+                "status": "active",
+            }
+        ]
+    }
+    return doc, jwks
+
+
+    # A keyed digest that fully checks reports verified_keyed, never verified (438).
+def test_keyed_digest_reports_verified_keyed_never_plain_verified() -> None:
+    pytest.importorskip("cryptography")
+    doc, jwks = _keyed_hash_mode_receipt()
+    res = verify(doc, [AsqavNativeAdapter()], key_provider=jwks)
+    assert res.verdict == VERDICT_VERIFIED_KEYED
+    assert res.failure_class is None
+
+
+    # The same receipt with a plain sha256 digest reports verified, not keyed.
+def test_plain_digest_reports_verified_not_keyed() -> None:
+    pytest.importorskip("cryptography")
+    doc, jwks = _keyed_hash_mode_receipt()
+    # Re-sign with hash_algo flipped to sha256 so the signature still binds.
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    flat = {k: v for k, v in doc.items() if k not in ("payload", "algorithm", "key_id", "signature_b64")}
+    flat["hash_algo"] = "sha256"
+    sk = Ed25519PrivateKey.generate()
+    pk = sk.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    flat_signed = dict(flat)
+    flat_signed["payload"] = None
+    flat_signed["algorithm"] = "Ed25519"
+    flat_signed["key_id"] = flat["org_id"]
+    flat_signed["signature_b64"] = base64.b64encode(sk.sign(asqav_jcs(flat))).decode()
+    jwks["keys"][0]["public_key"] = base64.b64encode(pk).decode()
+    res = verify(flat_signed, [AsqavNativeAdapter()], key_provider=jwks)
+    assert res.verdict == VERDICT_VERIFIED
+    assert res.failure_class is None

--- a/python/tests/test_verify_public_dict.py
+++ b/python/tests/test_verify_public_dict.py
@@ -9,6 +9,7 @@ path, and chain_hash must equal sha256(canonical_json(payload)).
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -44,6 +45,8 @@ def _mock_httpx(payload: dict) -> MagicMock:
     response = MagicMock()
     response.status_code = 200
     response.json.return_value = payload
+    # The strict-ingest path parses response.text, not .json() (criterion 419).
+    response.text = json.dumps(payload)
     return response
 
 

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -121,7 +121,7 @@ def test_run_payload_null_fails_clean(capsys) -> None:
     """A hosted /verify response with ``payload: null`` must not traceback.
 
     The published verifier crashed with a raw AttributeError here; it now
-    prints a readable message and returns the INCOMPLETE exit code (2).
+    prints a readable message and returns the unverifiable exit code (2).
     """
     envelope = {
         "signature_id": "sig_abc123",
@@ -133,8 +133,8 @@ def test_run_payload_null_fails_clean(capsys) -> None:
     out = capsys.readouterr().out
     assert code == 2
     assert "receipt payload not available from this surface" in out
-    assert "INCOMPLETE" in out
-    assert "PASS" not in out.replace("never a PASS", "")
+    assert "unverified" in out
+    assert "verified" not in out.replace("unverified", "").replace("never reported verified", "")
 
 
     # Same guard when the response carries only nulls.
@@ -142,7 +142,7 @@ def test_run_payload_null_without_signature_keys(capsys) -> None:
     code = v.run({"payload": None}, {"keys": []}, predecessor_payload=None)
     out = capsys.readouterr().out
     assert code == 2
-    assert "INCOMPLETE" in out
+    assert "unverified" in out
 
 
     # A non-string alg SKIPs cleanly instead of crashing on (alg or '').upper().
@@ -232,7 +232,9 @@ def test_agent_id_fallback_never_trusts_a_non_verifying_key() -> None:
         "anchors": [],
     }
     code = v.run(envelope, jwks, None)
-    assert code == 1  # FAIL: the agent key does not verify the forged signature
+    # The standalone surface only checks ML-DSA-65, so the Ed25519 signature axis
+    # SKIPs and the verdict is unverified/unverifiable (exit 2), never verified.
+    assert code == 2
 
 
 # === agent_id fallback must bind the resolved key to the claimed issuer ===
@@ -364,7 +366,7 @@ def test_run_tampered_payload_fails() -> None:
 
 def test_run_structured_agent_id_fallback_passes_legit_multi_agent() -> None:
     """run_structured mirrors run(): the issuer-kid resolves the wrong sibling, the
-    signature fails, and the agent_id fallback resolves the real signer -> PASS."""
+    signature fails, and the agent_id fallback resolves the real signer -> verified."""
     ml = _ml_dsa_65()
     a1_pk, _a1_sk = ml.keygen()
     a2_pk, a2_sk = ml.keygen()
@@ -378,15 +380,16 @@ def test_run_structured_agent_id_fallback_passes_legit_multi_agent() -> None:
     }
     out = v.run_structured(_envelope(payload, sig), jwks, None)
     axes = {a["name"]: a["result"] for a in out["axes"]}
-    assert out["verdict"] == "PASS"
+    assert out["verdict"] == "verified"
+    assert out["failure_class"] is None
     assert axes["signature"] == "PASS"
     assert axes["issuer_bind"] == "PASS"
 
 
 def test_run_structured_agent_id_fallback_rejects_forged_issuer() -> None:
     """run_structured inherits run()'s bind: a receipt signed by org-attacker's key
-    but claiming issuer_id=org-victim FAILs, since the fallback trusts only a key
-    whose issuer_id equals the claimed issuer."""
+    but claiming issuer_id=org-victim is unverified/invalid, since the fallback
+    trusts only a key whose issuer_id equals the claimed issuer."""
     ml = _ml_dsa_65()
     attacker_pk, attacker_sk = ml.keygen()
     victim_pk, _victim_sk = ml.keygen()
@@ -399,7 +402,8 @@ def test_run_structured_agent_id_fallback_rejects_forged_issuer() -> None:
         ]
     }
     out = v.run_structured(_envelope(payload, sig), jwks, None)
-    assert out["verdict"] == "FAIL"
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "invalid"
 
 
 # === the kid path must bind the verifying key to the claimed issuer too ===
@@ -447,18 +451,19 @@ def test_run_rejects_attacker_kid_claiming_another_issuer() -> None:
     assert by_org_id == 1, f"attacker org id verified a receipt claiming org-victim (exit {by_org_id})"
 
 
-    # Same forgery through run_structured: FAIL on issuer_bind, signature PASS.
+    # Same forgery through run_structured: issuer_bind FAIL (invalid), signature PASS.
 def test_run_structured_rejects_attacker_kid_claiming_another_issuer() -> None:
     payload, sig, jwks = _cross_issuer_forgery()
     result = v.run_structured(_envelope(payload, sig, kid="attacker-key"), jwks, None)
-    assert result["verdict"] == "FAIL", f"axes: {result['axes']}"
+    assert result["verdict"] == "unverified", f"axes: {result['axes']}"
+    assert result["failure_class"] == "invalid", f"axes: {result['axes']}"
     bind = next(a for a in result["axes"] if a["name"] == "issuer_bind")
     assert bind["result"] == "FAIL", f"issuer_bind axis: {bind}"
     sig_axis = next(a for a in result["axes"] if a["name"] == "signature")
     assert sig_axis["result"] == "PASS", "the forged signature itself verifies; the bind rejects it"
 
 
-    # LEGIT: the claimed issuer's own key still PASSes, so real verifies work.
+    # LEGIT: the claimed issuer's own key still verifies, so real verifies work.
 def test_run_structured_passes_a_receipt_signed_by_the_claimed_issuer() -> None:
     ml = _ml_dsa_65()
     pk, sk = ml.keygen()
@@ -466,7 +471,8 @@ def test_run_structured_passes_a_receipt_signed_by_the_claimed_issuer() -> None:
     sig = ml.sign(sk, v.canonical_json(payload))
     jwks = {"keys": [_jwks_key("agent-one", "agt_one", "org-legit", pk)]}
     result = v.run_structured(_envelope(payload, sig, kid="agent-one"), jwks, None)
-    assert result["verdict"] == "PASS", f"axes: {result['axes']}"
+    assert result["verdict"] == "verified", f"axes: {result['axes']}"
+    assert result["failure_class"] is None, f"axes: {result['axes']}"
 
 
 def test_extended_offset_rejects_out_of_range_minute() -> None:

--- a/python/tests/test_verify_receipt_failclean.py
+++ b/python/tests/test_verify_receipt_failclean.py
@@ -19,13 +19,14 @@ from asqav.verifier import verify_receipt as vr
 
 
 def test_run_rejects_non_object_envelope() -> None:
-    # A JSON array (non-object) must not crash run(); it returns 2 (INCOMPLETE).
+    # A JSON array (non-object) must not crash run(); unverified/unverifiable -> 2.
     assert vr.run([], {"keys": []}, None) == 2
 
 
 def test_run_structured_rejects_non_object() -> None:
     out = vr.run_structured("not-an-object", {"keys": []})
-    assert out["verdict"] == "INCOMPLETE"
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "unverifiable"
     assert out["canonical_sha256"] is None
 
 
@@ -86,13 +87,15 @@ def test_run_structured_handles_malformed_anchors_string() -> None:
     # printf '{"anchors":"str"}' | verify_receipt --receipt - must not raise.
     envelope = {"payload": {"type": "x"}, "anchors": "str"}
     out = vr.run_structured(envelope, {"keys": []})
-    assert out["verdict"] in ("FAIL", "INCOMPLETE")
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "invalid"
 
 
 def test_run_structured_handles_malformed_anchor_entries() -> None:
     envelope = {"payload": {"type": "x"}, "anchors": ["x"]}
     out = vr.run_structured(envelope, {"keys": []})
-    assert out["verdict"] in ("FAIL", "INCOMPLETE")
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "invalid"
 
 
 # === criterion 446: complete the fail-clean surface ===
@@ -136,7 +139,8 @@ def test_run_infinity_in_payload_fails_clean(capsys) -> None:
 def test_run_structured_nan_fails_clean() -> None:
     env = {"payload": {**_payload(), "score": float("nan")}, "signature": _sig(), "anchors": []}
     out = vr.run_structured(env, {"keys": []})
-    assert out["verdict"] == "INCOMPLETE"
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "unverifiable"
 
 
 # S2: non-dict "signature" on a flat receipt (no payload wrapper) -> kid = sig_obj.get(...)
@@ -151,7 +155,7 @@ def test_run_non_dict_signature_fails_clean(capsys) -> None:
 def test_run_structured_non_dict_signature_fails_clean() -> None:
     env = {**_payload(), "signature": [1, 2, 3]}
     out = vr.run_structured(env, {"keys": []})
-    assert out["verdict"] in ("FAIL", "INCOMPLETE")
+    assert out["verdict"] == "unverified"
 
 
 # S3: malformed JWKS "keys" (string / list of non-dicts) -> resolve_key must not crash
@@ -197,7 +201,7 @@ def test_run_non_string_sig_fails_clean(capsys) -> None:
 def test_run_structured_non_string_sig_fails_clean() -> None:
     env = {"payload": _payload(), "signature": {"alg": "ML-DSA-65", "kid": "kid-x", "sig": 123}, "anchors": []}
     out = vr.run_structured(env, _resolvable_jwks())
-    assert out["verdict"] in ("FAIL", "INCOMPLETE")
+    assert out["verdict"] == "unverified"
 
 
 # S6: binary / non-UTF8 --receipt file -> VerifierInputError, not a raw UnicodeDecodeError
@@ -331,7 +335,8 @@ def test_run_deep_nesting_no_recursion_error(capsys) -> None:
 def test_run_structured_deep_nesting_no_recursion_error() -> None:
     env = {"payload": {"a": _deep_dict(1500)}, "signature": _sig(), "anchors": []}
     out = vr.run_structured(env, {"keys": []})
-    assert out["verdict"] == "INCOMPLETE"
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "unverifiable"
     assert "nesting exceeds" in out["axes"][0]["note"]
 
 
@@ -346,7 +351,7 @@ def test_run_deep_predecessor_no_recursion_error() -> None:
 def test_parse_object_recursion_error_becomes_input_error(monkeypatch) -> None:
     # Defense-in-depth: json.loads itself raising RecursionError (a pure-Python
     # decoder fallback) must surface as VerifierInputError, not crash the CLI.
-    def _boom(text):
+    def _boom(text, **kwargs):
         raise RecursionError("maximum recursion depth exceeded")
 
     monkeypatch.setattr(vr.json, "loads", _boom)
@@ -354,7 +359,7 @@ def test_parse_object_recursion_error_becomes_input_error(monkeypatch) -> None:
         vr._parse_object('{"a": 1}', "stdin")
 
 
-def test_canonical_json_recursion_error_becomes_incomplete(monkeypatch, capsys) -> None:
+def test_canonical_json_recursion_error_becomes_unverifiable(monkeypatch, capsys) -> None:
     # Defense-in-depth: even if canonical_json itself raises RecursionError
     # (a bypassed or future call path), run() must still report cleanly.
     def _boom(*a, **kw):
@@ -397,6 +402,7 @@ def test_run_payload_string_names_actual_type(capsys) -> None:
 
 def test_run_structured_payload_list_names_actual_type() -> None:
     out = vr.run_structured({"payload": [1, 2, 3], "signature": "x"}, {"keys": []})
-    assert out["verdict"] == "INCOMPLETE"
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "unverifiable"
     note = out["axes"][0]["note"]
     assert "list" in note

--- a/python/tests/test_verify_receipt_revoked_key.py
+++ b/python/tests/test_verify_receipt_revoked_key.py
@@ -82,7 +82,7 @@ def test_check_key_status_revoked_after_issuance_passes_with_anchor():
 # --- standalone verify_receipt.run ---
 
 
-    # A revoked-key receipt yields a FAIL verdict, never PASS, from run().
+    # A revoked-key receipt yields unverified (invalid), never verified, from run().
 def test_run_revoked_key_does_not_pass(capsys):
     envelope = {
         "payload": _payload(),
@@ -93,7 +93,7 @@ def test_run_revoked_key_does_not_pass(capsys):
     out = capsys.readouterr().out
     assert "FAIL" in out
     assert "key_status" in out
-    assert code == 1  # FAIL dominates; never 0 (PASS)
+    assert code == 1  # invalid dominates; never 0 (verified)
 
 
     # An active key contributes a key_status PASS line.
@@ -190,9 +190,10 @@ def test_run_structured_forged_anchor_does_not_upgrade_revoked_key():
 
 
 def test_offline_forged_anchor_revoked_key_verdict_not_pass():
-    """End-to-end: a revoked key cannot mint a PASS by appending a forged anchor.
-    A real ML-DSA-65 signature over a backdated payload verifies (the holder keeps
-    the key), but the forged anchor must not upgrade it, so verdict is INCOMPLETE."""
+    """End-to-end: a revoked key cannot mint a verified verdict by appending a
+    forged anchor. A real ML-DSA-65 signature over a backdated payload verifies
+    (the holder keeps the key), but the forged anchor must not upgrade it, so the
+    verdict is unverified/unverifiable (pending anchor without cryptographic proof)."""
     import base64
 
     pytest.importorskip("dilithium_py")
@@ -209,7 +210,8 @@ def test_offline_forged_anchor_revoked_key_verdict_not_pass():
         "anchors": [{"type": "rfc3161", "value": "dGVzdA=="}],
     }
     result = v.run_structured(envelope, jwks, None)
-    assert result["verdict"] == "INCOMPLETE", f"revoked key produced verdict {result['verdict']!r}"
+    assert result["verdict"] == "unverified", f"revoked key produced verdict {result['verdict']!r}"
+    assert result["failure_class"] == "unverifiable"
 
 
 # --- oracle adapter path ---

--- a/python/tests/test_verify_response_fields.py
+++ b/python/tests/test_verify_response_fields.py
@@ -11,6 +11,7 @@ that the SDK parser populates the dataclasses with all of them.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -83,6 +84,8 @@ def _mock_httpx(payload: dict) -> MagicMock:
     response = MagicMock()
     response.status_code = 200
     response.json.return_value = payload
+    # The strict-ingest path parses response.text, not .json() (criterion 419).
+    response.text = json.dumps(payload)
     return response
 
 

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -43,6 +43,7 @@ import {
   saveCredentials,
 } from "./credentials.js";
 import { SDK_VERSION, userAgentHeaders } from "./userAgent.js";
+import { parseJsonStrict } from "./verifier/canonical.js";
 
 export const CLI_VERSION = SDK_VERSION;
 
@@ -372,11 +373,12 @@ async function readJsonInput(value: string): Promise<unknown> {
     for await (const chunk of process.stdin) {
       chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : (chunk as Buffer));
     }
-    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    // Strict ingest (419): a duplicated member name is a terminal parse failure.
+    return parseJsonStrict(Buffer.concat(chunks).toString("utf8"));
   }
   const fs = await import("node:fs/promises");
   const text = await fs.readFile(value, "utf8");
-  return JSON.parse(text);
+  return parseJsonStrict(text);
 }
 
 /** Parsed shape of `asqav sign` flags; bundles raw strings without
@@ -613,7 +615,8 @@ async function cmdAuditPackVerify(args: string[]): Promise<void> {
       const fs = await import("node:fs/promises");
       raw = await fs.readFile(bundlePath, "utf8");
     }
-    bundle = JSON.parse(raw);
+    // Strict ingest (419): a duplicated member name is a terminal parse failure.
+    bundle = parseJsonStrict(raw);
   } catch (err) {
     die(`Error reading bundle: ${(err as Error).message}`);
   }

--- a/typescript/src/doors.ts
+++ b/typescript/src/doors.ts
@@ -4,6 +4,7 @@
 import { createHash } from "node:crypto";
 
 import { canonicalJson } from "./jcs.js";
+import { parseJsonStrict } from "./verifier/canonical.js";
 
 export type Receipt = Record<string, unknown>;
 
@@ -213,7 +214,8 @@ export function receiptFromCloudEvent(event: Receipt): Receipt {
 }
 
 export function receiptFromOtelGenaiAttributes(attrs: Receipt): Receipt {
-  return JSON.parse(attrs[OTEL_RECEIPT_ATTR] as string) as Receipt;
+  // Strict ingest (419): a duplicated member name never reaches the caller.
+  return parseJsonStrict(attrs[OTEL_RECEIPT_ATTR] as string) as Receipt;
 }
 
 export function receiptFromC2paAssertion(assertion: Receipt): Receipt {

--- a/typescript/src/verifier/adapter.ts
+++ b/typescript/src/verifier/adapter.ts
@@ -87,4 +87,14 @@ export abstract class FormatAdapter {
   attestation(_doc: Record<string, unknown>): Record<string, unknown> {
     return {};
   }
+
+  /**
+   * True when the receipt's digest is keyed (criterion 438). A keyed digest
+   * (e.g. HMAC-SHA256) is internally consistent but not third-party
+   * re-derivable, so a fully-checked receipt reports `verified_keyed`, never
+   * plain `verified`. Default is false.
+   */
+  keyedDigest(_doc: Record<string, unknown>): boolean {
+    return false;
+  }
 }

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -270,4 +270,14 @@ export class AsqavNativeAdapter extends FormatAdapter {
     const signer = payloadOf(doc).signer;
     return signer !== undefined && signer !== null ? { signer } : {};
   }
+
+  /**
+   * A hash-mode digest sealed with the org salt is keyed (criterion 438).
+   * hash_algo hmac-sha256 is internally consistent but not third-party
+   * re-derivable, so a fully-checked receipt reports verified_keyed, never
+   * plain verified. Read from the signed field set only.
+   */
+  keyedDigest(doc: Record<string, unknown>): boolean {
+    return isHashMode(doc) && doc.hash_algo === "hmac-sha256";
+  }
 }

--- a/typescript/src/verifier/canonical.ts
+++ b/typescript/src/verifier/canonical.ts
@@ -59,6 +59,11 @@ type JsonValue =
  */
 export class RawFloat {
   constructor(public readonly value: number) {}
+
+  // JSON.stringify re-emits the number itself, never the wrapper shape.
+  toJSON(): number {
+    return this.value;
+  }
 }
 
 function isRawFloat(v: unknown): v is RawFloat {
@@ -74,10 +79,28 @@ function isRawFloat(v: unknown): v is RawFloat {
  */
 export class RawBigInt {
   constructor(public readonly source: string) {}
+
+  // JSON.stringify collapses exactly like JSON.parse would (nearest double).
+  toJSON(): number {
+    return Number(this.source);
+  }
 }
 
 function isRawBigInt(v: unknown): v is RawBigInt {
   return v instanceof RawBigInt;
+}
+
+/**
+ * A JSON object repeated a member name (criterion 419). ECMAScript object
+ * semantics are last-wins on duplicate keys, which would hash the bytes an
+ * attacker kept and drop the ones they replaced; the strict parser therefore
+ * throws this before any hashing, canonicalisation, or signature check.
+ */
+export class DuplicateMemberError extends SyntaxError {
+  constructor(message: string) {
+    super(message);
+    this.name = "DuplicateMemberError";
+  }
 }
 
 /** ECMAScript-shortest decimal of a float, forced to carry a `.0` when whole. */
@@ -96,6 +119,10 @@ function floatToString(n: number): string {
  * integers as `RawBigInt`, so the canonicalisers re-emit `500.0` rather than the
  * collapsed `500` and never let two distinct big integers share one signature.
  * Mirrors what Python's `json.load` preserves implicitly.
+ *
+ * Strict ingest (criterion 419): a duplicated object member name at ANY depth
+ * throws `DuplicateMemberError` before the value returns, so last-wins bytes
+ * never reach a hash, canonicaliser, or signature check.
  *
  * Hand-rolled recursive descent rather than a `JSON.parse` reviver: the reviver's
  * raw-literal `context.source` is only available on Node 21.1+, and this package
@@ -128,6 +155,8 @@ export function parseJsonPreservingFloats(text: string): unknown {
   };
   const object = (): Record<string, unknown> => {
     const out: Record<string, unknown> = {};
+    // Strict ingest (419): a repeated member name at any depth is terminal.
+    const seen = new Set<string>();
     i++; // {
     ws();
     if (text[i] === "}") return i++, out;
@@ -135,6 +164,12 @@ export function parseJsonPreservingFloats(text: string): unknown {
       ws();
       if (text[i] !== '"') err("expected object key");
       const k = str();
+      if (seen.has(k)) {
+        throw new DuplicateMemberError(
+          `duplicate JSON member name: ${JSON.stringify(k)} at position ${i}`,
+        );
+      }
+      seen.add(k);
       ws();
       if (text[i++] !== ":") err("expected ':'");
       out[k] = value();
@@ -209,6 +244,37 @@ export function parseJsonPreservingFloats(text: string): unknown {
   ws();
   if (i !== text.length) err("trailing content after JSON value");
   return result;
+}
+
+/**
+ * Strip the `RawFloat` / `RawBigInt` wrappers back to plain JS values, the
+ * exact shapes `JSON.parse` produces (whole floats collapse to `500`, big
+ * integers to the nearest double). Callers that canonicalise with the
+ * float-preserving dialects keep the wrappers; callers that need the plain
+ * wire shape (doors parity, sign inputs, bundle re-post) unwrap them.
+ */
+export function unwrapPreservedFloats(value: unknown): unknown {
+  if (isRawFloat(value)) return value.value;
+  if (isRawBigInt(value)) return Number(value.source);
+  if (Array.isArray(value)) return value.map(unwrapPreservedFloats);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = unwrapPreservedFloats(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Strict ingest with `JSON.parse`-compatible values (criterion 419): rejects a
+ * duplicated member name at ANY depth as a terminal `DuplicateMemberError` and
+ * returns plain values, so it replaces `JSON.parse` at every receipt/record
+ * parse site that does not canonicalise with the float-preserving dialects.
+ */
+export function parseJsonStrict(text: string): unknown {
+  return unwrapPreservedFloats(parseJsonPreservingFloats(text));
 }
 
 /** Recursively NFC-normalise every string key and value (mirrors `_nfc`). */

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -12,17 +12,34 @@
 import type { FormatAdapter, KeyProvider } from "./adapter.js";
 import { FAIL, PASS, SKIPPED, verifySignature, type VerifyState } from "./crypto.js";
 
+/**
+ * Public verdict vocabulary (criteria 418/438). The per-axis PASS/FAIL/SKIPPED
+ * tokens stay internal; the surface a caller reads speaks these three only.
+ */
+export const VERDICT_VERIFIED = "verified";
+export const VERDICT_VERIFIED_KEYED = "verified_keyed";
+export const VERDICT_UNVERIFIED = "unverified";
+export type Verdict = "verified" | "verified_keyed" | "unverified";
+
+/**
+ * Failure classes carried by every unverified verdict (criterion 418); the two
+ * are never collapsed - a proven binding failure is not an incomplete check.
+ */
+export const FAILURE_INVALID = "invalid";
+export const FAILURE_UNVERIFIABLE = "unverifiable";
+export type FailureClass = "invalid" | "unverifiable";
+
 /** One verification axis outcome. */
 export interface AxisResult {
   /** Which check (structure / signature / chain / extra). */
   axis: string;
-  /** PASS / FAIL / SKIPPED. */
+  /** PASS / FAIL / SKIPPED (internal token). */
   result: VerifyState;
   /** Human-readable detail for the report. */
   note: string;
+  /** invalid / unverifiable for a non-PASS axis, null on PASS. */
+  failureClass: FailureClass | null;
 }
-
-export type Verdict = "PASS" | "FAIL" | "INCOMPLETE";
 
 /** The aggregate outcome of verifying one receipt. */
 export interface VerifyResult {
@@ -30,13 +47,96 @@ export interface VerifyResult {
   fmt: string;
   axes: AxisResult[];
   /**
-   * PASS only when every non-skipped axis passed AND the signature was actually
-   * checked; a skipped signature downgrades to INCOMPLETE, never a PASS.
+   * `verified` only when every non-skipped axis passed AND the signature was
+   * actually checked; `verified_keyed` when the digest is keyed (internally
+   * consistent but not third-party re-derivable). A skipped signature
+   * downgrades to `unverified` with failureClass `unverifiable`, never a
+   * verified. Defaults fail closed: an unfolded result reads unverified.
    */
   verdict: Verdict;
+  /** invalid / unverifiable when unverified, else null. */
+  failureClass: FailureClass | null;
   // In-body origin attestation (v:2 signer) from the signed payload.
   // null for v:1. Never gates the verdict.
   signer: string | null;
+}
+
+/** Axes whose FAIL proves a cryptographic/policy binding failure (invalid). */
+const INVALID_FAIL_AXES = new Set([
+  "signature",
+  "anchors",
+  "issuer_bind",
+  "key_status",
+  "nonce",
+  "parent_signature",
+  "pdp_signature",
+]);
+
+/**
+ * Map one axis outcome to its failure class (criterion 418). A port of the
+ * Python `axis_failure_class`: PASS carries none; SKIPPED means recomputation
+ * could not complete (unverifiable); a FAIL is invalid when a binding was
+ * proven broken and unverifiable when the receipt's own bytes stopped the
+ * recompute. A FAIL this table does not name reads unverifiable, never a
+ * proven binding failure.
+ */
+export function axisFailureClass(axis: string, result: VerifyState, note: string): FailureClass | null {
+  if (result === PASS) return null;
+  if (result === SKIPPED) return FAILURE_UNVERIFIABLE;
+  if (INVALID_FAIL_AXES.has(axis)) return FAILURE_INVALID;
+  if (axis === "chain") {
+    // A mismatched link or a cross-format predecessor is a proven break; a
+    // predecessor the canonicaliser cannot walk stops the recompute instead.
+    if (note.startsWith("chain break:") || note === "predecessor is a different receipt format") {
+      return FAILURE_INVALID;
+    }
+    return FAILURE_UNVERIFIABLE;
+  }
+  if (axis === "skew") {
+    if (note.startsWith("unparseable issued_at")) return FAILURE_UNVERIFIABLE;
+    return FAILURE_INVALID;
+  }
+  if (axis === "structure") {
+    if (note.startsWith("unsupported ACTA alg") || note.startsWith("unsupported signature algorithm")) {
+      return FAILURE_INVALID;
+    }
+    if (note.startsWith("key_purpose mismatch")) return FAILURE_INVALID;
+    if (note.includes("signing-key DID != issuer DID")) return FAILURE_INVALID;
+    return FAILURE_UNVERIFIABLE;
+  }
+  if (axis === "expiry") {
+    if (note.startsWith("unreadable expires_at")) return FAILURE_UNVERIFIABLE;
+    return FAILURE_INVALID;
+  }
+  // issuer_key / ingest and anything unlisted: the recompute could not complete.
+  return FAILURE_UNVERIFIABLE;
+}
+
+function axis(axis: string, result: VerifyState, note: string): AxisResult {
+  return { axis, result, note, failureClass: axisFailureClass(axis, result, note) };
+}
+
+/**
+ * Fold per-axis outcomes into the public verdict + failure class (418/438).
+ * A port of the Python `fold_verdict`.
+ */
+export function foldVerdict(
+  axes: AxisResult[],
+  keyed: boolean,
+): readonly [Verdict, FailureClass | null] {
+  const failed = axes.filter((a) => a.result === FAIL && a.axis !== "expiry");
+  const blockingSkip = axes.some((a) => a.result === SKIPPED && a.axis !== "chain");
+  if (failed.length > 0) {
+    // A proven binding failure dominates a malformed-member failure: the
+    // receipt is invalid on the strongest ground the axes established.
+    const failureClass = failed.some((a) => a.failureClass === FAILURE_INVALID)
+      ? FAILURE_INVALID
+      : FAILURE_UNVERIFIABLE;
+    return [VERDICT_UNVERIFIED, failureClass];
+  }
+  if (blockingSkip) return [VERDICT_UNVERIFIED, FAILURE_UNVERIFIABLE];
+  if (keyed) return [VERDICT_VERIFIED_KEYED, null];
+  return [VERDICT_VERIFIED, null];
 }
 
 /** Return the first adapter whose structural fingerprint matches `doc`. */
@@ -56,11 +156,11 @@ function signatureAxis(
   const sm = ad.extractSignature(doc);
   const [pk, note] = ad.resolveKey(doc, keyProvider);
   if (pk === null) {
-    return { axis: "signature", result: SKIPPED, note: `no key: ${note}` };
+    return axis("signature", SKIPPED, `no key: ${note}`);
   }
   const msg = ad.signingInput(doc);
   const { result, note: why } = verifySignature(sm.alg, pk, msg, sm.sig);
-  return { axis: "signature", result, note: why };
+  return axis("signature", result, why);
 }
 
 function chainAxis(
@@ -71,22 +171,22 @@ function chainAxis(
 ): AxisResult {
   const step = ad.chainStep(doc);
   if (step.isGenesis) {
-    return { axis: "chain", result: PASS, note: "genesis receipt (no predecessor link)" };
+    return axis("chain", PASS, "genesis receipt (no predecessor link)");
   }
   if (predecessor === null) {
-    return { axis: "chain", result: SKIPPED, note: "no predecessor supplied" };
+    return axis("chain", SKIPPED, "no predecessor supplied");
   }
   // A chain link must stay within one format; a cross-format predecessor is not a valid link.
   const predAd = detect(predecessor, adapters);
   if (predAd === null || predAd.name !== ad.name) {
-    return { axis: "chain", result: FAIL, note: "predecessor is a different receipt format" };
+    return axis("chain", FAIL, "predecessor is a different receipt format");
   }
   const actual = step.recompute(predecessor);
   if (actual === step.prevField) {
-    return { axis: "chain", result: PASS, note: "chain link rederives from predecessor" };
+    return axis("chain", PASS, "chain link rederives from predecessor");
   }
   const exp = String(step.prevField).slice(0, 16);
-  return { axis: "chain", result: FAIL, note: `chain break: expected ${exp}.. got ${actual.slice(0, 16)}..` };
+  return axis("chain", FAIL, `chain break: expected ${exp}.. got ${actual.slice(0, 16)}..`);
 }
 
 /** Max nesting the recursive JCS encoder tolerates, mirrors the Python core cap. */
@@ -124,51 +224,35 @@ export function verify(
 ): VerifyResult {
   const ad = detect(doc, adapters);
   if (ad === null) {
-    return {
-      fmt: "unknown",
-      axes: [{ axis: "structure", result: FAIL, note: "no adapter recognises this receipt" }],
-      verdict: "FAIL",
-      signer: null,
-    };
+    const axes = [axis("structure", FAIL, "no adapter recognises this receipt")];
+    const [verdict, failureClass] = foldVerdict(axes, false);
+    return { fmt: "unknown", axes, verdict, failureClass, signer: null };
   }
   // An over-nested receipt would crash the recursive JCS encoder. Cap it here and
-  // report INCOMPLETE, never a PASS, matching the Python core's shape gate.
+  // report unverified/unverifiable, never a verified, matching the Python gate.
   if (
     exceedsDepth(doc, MAX_NESTING_DEPTH) ||
     (predecessor !== null && exceedsDepth(predecessor, MAX_NESTING_DEPTH))
   ) {
-    return {
-      fmt: ad.name,
-      axes: [{ axis: "structure", result: FAIL, note: TOO_DEEP_NOTE }],
-      verdict: "INCOMPLETE",
-      signer: null,
-    };
+    const axes = [axis("structure", FAIL, TOO_DEEP_NOTE)];
+    const [verdict, failureClass] = foldVerdict(axes, false);
+    return { fmt: ad.name, axes, verdict, failureClass, signer: null };
   }
 
   const [structResult, structNote] = ad.schema(doc);
   const axes: AxisResult[] = [
-    { axis: "structure", result: structResult, note: structNote },
+    axis("structure", structResult, structNote),
     signatureAxis(ad, doc, keyProvider),
     chainAxis(ad, doc, adapters, predecessor),
   ];
   for (const [name, res, note] of ad.extraAxes(doc, keyProvider)) {
-    axes.push({ axis: name, result: res, note });
+    axes.push(axis(name, res, note));
   }
 
-  // Expiry reports on its own axis and never folds the verdict (criterion 426)
-  const hasFail = axes.some((a) => a.result === FAIL && a.axis !== "expiry");
-  // Any skipped axis except a missing-predecessor chain blocks PASS: an unchecked
-  // signature / counter-sign / PDP layer means INCOMPLETE, never a hiding PASS.
-  const blockingSkip = axes.some((a) => a.result === SKIPPED && a.axis !== "chain");
-  let verdict: Verdict;
-  if (hasFail) {
-    verdict = "FAIL";
-  } else if (blockingSkip) {
-    verdict = "INCOMPLETE";
-  } else {
-    verdict = "PASS";
-  }
+  // Expiry reports on its own axis and never folds the verdict (criterion 426);
+  // a keyed digest reports verified_keyed, never plain verified (criterion 438).
+  const [verdict, failureClass] = foldVerdict(axes, ad.keyedDigest(doc));
   const signerVal = ad.attestation(doc).signer;
   const signer = typeof signerVal === "string" ? signerVal : null;
-  return { fmt: ad.name, axes, verdict, signer };
+  return { fmt: ad.name, axes, verdict, failureClass, signer };
 }

--- a/typescript/src/verifier/dsse.ts
+++ b/typescript/src/verifier/dsse.ts
@@ -22,6 +22,7 @@
  */
 
 import { verifySignature } from "./crypto.js";
+import { DuplicateMemberError, parseJsonStrict } from "./canonical.js";
 import { b64decode, resolveKey, resolveRevokedAt } from "./vrShim.js";
 
 /** DSSE payloadType for an in-toto Statement (mirrors `core/dsse.py`). */
@@ -167,8 +168,10 @@ function checkAttestationStructure(envelope: unknown, expectedType: string): Str
   }
   let statement: unknown;
   try {
-    statement = JSON.parse(new TextDecoder().decode(payloadBytes));
-  } catch {
+    // Strict ingest (419): a duplicated member name is a terminal parse failure.
+    statement = parseJsonStrict(new TextDecoder().decode(payloadBytes));
+  } catch (exc) {
+    if (exc instanceof DuplicateMemberError) return bad(`payload rejected: ${exc.message}`);
     return bad("payload does not decode to a JSON document");
   }
   if (!isRecord(statement)) return bad("decoded payload is not a JSON object");

--- a/typescript/src/verifier/index.ts
+++ b/typescript/src/verifier/index.ts
@@ -48,8 +48,19 @@ export { AgentReceiptsAdapter } from "./adapters/agentreceipts.js";
 export { AsqavNativeAdapter } from "./adapters/asqavNative.js";
 export { AuthproofAdapter } from "./adapters/authproof.js";
 export { PipelockEvidenceAdapter } from "./adapters/pipelock.js";
-export { detect, MAX_NESTING_DEPTH, verify } from "./core.js";
-export type { AxisResult, Verdict, VerifyResult } from "./core.js";
+export {
+  detect,
+  FAILURE_INVALID,
+  FAILURE_UNVERIFIABLE,
+  MAX_NESTING_DEPTH,
+  VERDICT_UNVERIFIED,
+  VERDICT_VERIFIED,
+  VERDICT_VERIFIED_KEYED,
+  axisFailureClass,
+  foldVerdict,
+  verify,
+} from "./core.js";
+export type { AxisResult, FailureClass, Verdict, VerifyResult } from "./core.js";
 // The axes the oracle leaves out by design, so a TypeScript caller runs what a
 // Python caller runs. normaliseEnvelope ships too: skip it and you digest other bytes.
 export {
@@ -60,7 +71,15 @@ export {
   normaliseEnvelope,
   SKEW_BOUND_SECONDS,
 } from "./vrShim.js";
-export { asqavJcs, jcs, jcsRfc8785, parseJsonPreservingFloats, RawFloat } from "./canonical.js";
+export {
+  asqavJcs,
+  DuplicateMemberError,
+  jcs,
+  jcsRfc8785,
+  parseJsonPreservingFloats,
+  parseJsonStrict,
+  RawFloat,
+} from "./canonical.js";
 export {
   FAIL,
   PASS,

--- a/typescript/src/verifier/parity-check.ts
+++ b/typescript/src/verifier/parity-check.ts
@@ -32,7 +32,8 @@ export function runParity(corpusRoot = defaultCorpusRoot()): ParityReport {
   for (const r of results) {
     const ok = tolerated(r);
     const mark = ok ? "ok" : "FAIL";
-    lines.push(`  [${mark.padStart(4)}] ${r.dir.padEnd(38)} expect=${r.expectedOutcome.padEnd(11)} got=${r.actualVerdict}`);
+    const got = r.actualFailureClass !== "" ? `${r.actualVerdict} (${r.actualFailureClass})` : r.actualVerdict;
+    lines.push(`  [${mark.padStart(4)}] ${r.dir.padEnd(38)} expect=${r.expectedOutcome.padEnd(16)} got=${got}`);
     if (!ok) lines.push(`         ${r.detail}`);
   }
   const passed = results.filter(tolerated).length;

--- a/typescript/src/verifier/runner.ts
+++ b/typescript/src/verifier/runner.ts
@@ -3,45 +3,45 @@
  * A port of the Python oracle's `verifier/oracle/runner.py`.
  *
  * The corpus uses the AERF dir-per-vector layout: a top-level `manifest.json`
- * lists `{dir, format, outcome, reason_code, notes}` and each `<NN-name>/`
- * directory carries `receipt.json`, an `expected.json`, optional
+ * lists `{dir, format, outcome, failure_class, reason_code, notes}` and each
+ * `<NN-name>/` directory carries `receipt.json`, an `expected.json`, optional
  * `predecessor.json`, and optional key material (`jwks.json` for Asqav-native,
- * `keys.json` for AERF, `acta-keys.json` for ACTA, `did_map.json` for agentreceipts).
+ * `keys.json` for AERF, `acta-keys.json` for ACTA, `did_map.json` for
+ * agentreceipts).
  *
- * `outcome` maps to the verdict one-for-one (PASS/FAIL/INCOMPLETE). INCOMPLETE
- * lets the corpus carry a vector whose signature axis cannot be checked (a real
- * ML-DSA-65 receipt without an ML-DSA library), pinning that the verifier
- * downgrades rather than false-PASSing.
+ * `outcome` speaks the public verdict vocabulary (criteria 418/438):
+ * verified / verified_keyed / unverified, and an `unverified` entry pins its
+ * `failure_class` (invalid / unverifiable) so the two classes are never
+ * collapsed. Every receipt/record file is parsed with duplicate-member
+ * rejection (criterion 419); a receipt that fails to parse is a terminal
+ * unverified/unverifiable outcome, never verified.
  */
 
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 import { ADAPTERS } from "./index.js";
-import { verify, type Verdict } from "./core.js";
-import { parseJsonPreservingFloats } from "./canonical.js";
+import { verify, VERDICT_UNVERIFIED, VERDICT_VERIFIED, FAILURE_UNVERIFIABLE } from "./core.js";
+import { parseJsonPreservingFloats, parseJsonStrict } from "./canonical.js";
 import type { KeyProvider } from "./adapter.js";
-
-const OUTCOME_TO_VERDICT: Record<string, Verdict> = {
-  PASS: "PASS",
-  FAIL: "FAIL",
-  INCOMPLETE: "INCOMPLETE",
-};
 
 /** The result of running one corpus vector against the oracle. */
 export interface VectorOutcome {
   dir: string;
   expectedOutcome: string;
-  actualVerdict: Verdict | string;
+  actualVerdict: string;
   ok: boolean;
   reasonCode: string;
   detail: string;
+  expectedFailureClass: string;
+  actualFailureClass: string;
 }
 
 interface ManifestEntry {
   dir: string;
   format: string;
   outcome: string;
+  failure_class?: string;
   reason_code?: string;
   notes?: string;
 }
@@ -49,6 +49,7 @@ interface ManifestEntry {
 function loadJson(path: string): Record<string, unknown> | null {
   // Receipts and predecessors are parsed float-preserving so a `500.0` literal
   // survives to the canonicaliser (JSON.parse otherwise collapses it to `500`).
+  // The same parser rejects a duplicated member name at any depth (419).
   return existsSync(path)
     ? (parseJsonPreservingFloats(readFileSync(path, "utf-8")) as Record<string, unknown>)
     : null;
@@ -63,39 +64,94 @@ function keyProviderFor(vecDir: string, fmt: string): KeyProvider {
   return null;
 }
 
+function parseFailureOutcome(
+  name: string,
+  expectedOutcome: string,
+  expectedFailureClass: string,
+  reasonCode: string,
+  exc: unknown,
+): VectorOutcome {
+  // A terminal ingest failure: nothing was hashed, checked, or verified (419).
+  const detail = `ingest=FAIL(terminal parse failure before any hashing: ${(exc as Error).message})`;
+  const ok = expectedOutcome === VERDICT_UNVERIFIED && (expectedFailureClass === "" || expectedFailureClass === FAILURE_UNVERIFIABLE);
+  return {
+    dir: name,
+    expectedOutcome,
+    actualVerdict: VERDICT_UNVERIFIED,
+    ok,
+    reasonCode,
+    detail,
+    expectedFailureClass,
+    actualFailureClass: FAILURE_UNVERIFIABLE,
+  };
+}
+
 /** Run a single vector directory and compare against its expected outcome. */
 export function runOne(
   vecDir: string,
   fmt: string,
   expectedOutcome: string,
   reasonCode = "",
+  expectedFailureClass = "",
 ): VectorOutcome {
-  const receipt = loadJson(join(vecDir, "receipt.json")) ?? {};
-  const predecessor = loadJson(join(vecDir, "predecessor.json"));
-  const keyProvider = keyProviderFor(vecDir, fmt);
+  const name = vecDir.split(/[/\\]/).pop() ?? vecDir;
+  let receipt: Record<string, unknown>;
+  let predecessor: Record<string, unknown> | null;
+  let keyProvider: KeyProvider;
+  try {
+    receipt = loadJson(join(vecDir, "receipt.json")) ?? {};
+    predecessor = loadJson(join(vecDir, "predecessor.json"));
+    keyProvider = keyProviderFor(vecDir, fmt);
+  } catch (exc) {
+    if (exc instanceof SyntaxError) {
+      // Terminal ingest failure (419): never hash, check, or verify the bytes.
+      return parseFailureOutcome(name, expectedOutcome, expectedFailureClass, reasonCode, exc);
+    }
+    throw exc;
+  }
   const result = verify(receipt, ADAPTERS, keyProvider, predecessor);
 
-  const wantVerdict = OUTCOME_TO_VERDICT[expectedOutcome];
-  const ok = wantVerdict !== undefined && result.verdict === wantVerdict;
+  let ok = result.verdict === expectedOutcome;
+  const actualFailureClass = result.failureClass ?? "";
+  if (ok && expectedFailureClass !== "") {
+    ok = actualFailureClass === expectedFailureClass;
+  }
   const detail = result.axes.map((a) => `${a.axis}=${a.result}(${a.note})`).join("; ");
-  const name = vecDir.split(/[/\\]/).pop() ?? vecDir;
-  return { dir: name, expectedOutcome, actualVerdict: result.verdict, ok, reasonCode, detail };
+  return {
+    dir: name,
+    expectedOutcome,
+    actualVerdict: result.verdict,
+    ok,
+    reasonCode,
+    detail,
+    expectedFailureClass,
+    actualFailureClass,
+  };
 }
 
 /** Run every vector named in `corpusRoot/manifest.json`. */
 export function runCorpus(corpusRoot: string): VectorOutcome[] {
-  const manifest = JSON.parse(readFileSync(join(corpusRoot, "manifest.json"), "utf-8")) as ManifestEntry[];
+  // The manifest rides the same strict parser (419): duplicates fail the run.
+  const manifest = parseJsonStrict(
+    readFileSync(join(corpusRoot, "manifest.json"), "utf-8"),
+  ) as ManifestEntry[];
   return manifest.map((entry) =>
-    runOne(join(corpusRoot, entry.dir), entry.format, entry.outcome, entry.reason_code ?? ""),
+    runOne(
+      join(corpusRoot, entry.dir),
+      entry.format,
+      entry.outcome,
+      entry.reason_code ?? "",
+      entry.failure_class ?? "",
+    ),
   );
 }
 
-/** Accept the stronger PASS only for the optional-dep ML-DSA skip vector, never broadly. */
+/** Accept the stronger verified only for the optional-dep ML-DSA skip vector. */
 export function tolerated(outcome: VectorOutcome): boolean {
   return (
     outcome.ok ||
-    (outcome.expectedOutcome === "INCOMPLETE" &&
-      outcome.actualVerdict === "PASS" &&
+    (outcome.expectedOutcome === VERDICT_UNVERIFIED &&
+      outcome.actualVerdict === VERDICT_VERIFIED &&
       outcome.reasonCode === "signature_skipped_no_dilithium")
   );
 }

--- a/typescript/tests/cross-language-cases.test.ts
+++ b/typescript/tests/cross-language-cases.test.ts
@@ -17,7 +17,7 @@ interface Case {
   name: string;
   receipt: Record<string, unknown>;
   jwks: Record<string, unknown>;
-  expect: { verdict: string; axes: Record<string, string> };
+  expect: { verdict: string; failure_class: string | null; axes: Record<string, string> };
 }
 
 const CASES_FILE = resolve(__dirname, "..", "..", "verifier", "cross-language-cases.json");
@@ -34,6 +34,10 @@ describe("cross-language adversarial case table", () => {
       const axes: Record<string, string> = {};
       for (const a of result.axes) axes[a.axis] = a.result;
       expect(result.verdict, `${c.name}: axes ${JSON.stringify(axes)}`).toBe(c.expect.verdict);
+      // invalid and unverifiable are never collapsed (criterion 418).
+      expect(result.failureClass, `${c.name}: axes ${JSON.stringify(axes)}`).toBe(
+        c.expect.failure_class,
+      );
       for (const [axis, expected] of Object.entries(c.expect.axes)) {
         expect(axes[axis], `${c.name}: axis ${axis}`).toBe(expected);
       }

--- a/typescript/tests/offline-verify.test.ts
+++ b/typescript/tests/offline-verify.test.ts
@@ -82,7 +82,8 @@ describe("verifyReceiptOffline - Ed25519 path (no network)", () => {
     const receipt = loadJson(PASS_DIR, "receipt.json");
     const jwks = loadJson(PASS_DIR, "jwks.json");
     const result = verifyReceiptOffline(receipt, jwks);
-    expect(result.verdict).toBe("PASS");
+    expect(result.verdict).toBe("verified");
+    expect(result.failureClass).toBeNull();
     const sigAxis = result.axes.find((a) => a.axis === "signature");
     expect(sigAxis?.result).toBe("PASS");
   });
@@ -103,6 +104,7 @@ describe("verifyReceiptOffline - Ed25519 path (no network)", () => {
       expect(ax).toHaveProperty("axis");
       expect(ax).toHaveProperty("result");
       expect(ax).toHaveProperty("note");
+      expect(ax).toHaveProperty("failureClass");
     }
   });
 });
@@ -118,7 +120,8 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     const receipt = loadJson(REVOKED_DIR, "receipt.json");
     const jwks = loadJson(REVOKED_DIR, "jwks.json");
     const result = verifyReceiptOffline(receipt, jwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
+    expect(result.failureClass).toBe("invalid");
     const keyAxis = result.axes.find((a) => a.axis === "key_status");
     expect(keyAxis, "key_status axis must be present").toBeDefined();
     expect(keyAxis?.result).toBe("FAIL");
@@ -147,7 +150,7 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     const activeJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
     ((activeJwks.keys as Array<Record<string, unknown>>)[0]).status = "active";
     const result = verifyReceiptOffline(receipt, activeJwks);
-    expect(result.verdict).toBe("PASS");
+    expect(result.verdict).toBe("verified");
   });
 
   it("suspended key also FAILs the key_status axis (REVOKED_KEY_STATUSES parity)", () => {
@@ -156,7 +159,7 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     const suspJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
     ((suspJwks.keys as Array<Record<string, unknown>>)[0]).status = "suspended";
     const result = verifyReceiptOffline(receipt, suspJwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     const keyAxis = result.axes.find((a) => a.axis === "key_status");
     expect(keyAxis?.result).toBe("FAIL");
   });
@@ -167,7 +170,7 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     const compJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
     ((compJwks.keys as Array<Record<string, unknown>>)[0]).status = "compromised";
     const result = verifyReceiptOffline(receipt, compJwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     const keyAxis = result.axes.find((a) => a.axis === "key_status");
     expect(keyAxis?.result).toBe("FAIL");
   });
@@ -182,7 +185,8 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     const futureJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
     ((futureJwks.keys as Array<Record<string, unknown>>)[0]).revoked_at = "2026-12-01T00:00:00+00:00";
     const result = verifyReceiptOffline(receipt, futureJwks);
-    expect(result.verdict).toBe("INCOMPLETE");
+    expect(result.verdict).toBe("unverified");
+    expect(result.failureClass).toBe("unverifiable");
     const keyAxis = result.axes.find((a) => a.axis === "key_status");
     expect(keyAxis?.result).toBe("SKIPPED");
     expect(keyAxis?.note).toMatch(/no anchor/i);
@@ -198,8 +202,8 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     const anchored = JSON.parse(JSON.stringify(receipt)) as Record<string, unknown>;
     anchored.anchors = [{ type: "rfc3161", value: "dGVzdC10c3ItY29va2ll", tsa_url: "https://tsa.example/timestamp" }];
     const result = verifyReceiptOffline(anchored, futureJwks);
-    expect(result.verdict).not.toBe("PASS");
-    expect(result.verdict).toBe("INCOMPLETE");
+    expect(result.verdict).not.toBe("verified");
+    expect(result.verdict).toBe("unverified");
     const keyAxis = result.axes.find((a) => a.axis === "key_status");
     expect(keyAxis?.result).toBe("SKIPPED");
     expect(keyAxis?.note).toMatch(/no anchor|self-attested/i);
@@ -214,8 +218,8 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     ((compromisedJwks.keys as Array<Record<string, unknown>>)[0]).status = "compromised";
     ((compromisedJwks.keys as Array<Record<string, unknown>>)[0]).revoked_at = "2026-12-01T00:00:00+00:00";
     const result = verifyReceiptOffline(receipt, compromisedJwks);
-    expect(result.verdict).not.toBe("PASS");
-    expect(result.verdict).toBe("INCOMPLETE");
+    expect(result.verdict).not.toBe("verified");
+    expect(result.verdict).toBe("unverified");
     const keyAxis = result.axes.find((a) => a.axis === "key_status");
     expect(keyAxis?.result).toBe("SKIPPED");
   });
@@ -227,7 +231,7 @@ describe("verifyReceiptOffline - revoked key (CRIT-167, no network)", () => {
     const atJwks = JSON.parse(JSON.stringify(revokedJwks)) as Record<string, unknown>;
     ((atJwks.keys as Array<Record<string, unknown>>)[0]).revoked_at = "2026-06-01T12:00:00+00:00";
     const result = verifyReceiptOffline(receipt, atJwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     const keyAxis = result.axes.find((a) => a.axis === "key_status");
     expect(keyAxis?.result).toBe("FAIL");
     expect(keyAxis?.note).toMatch(/on\/before issuance/i);
@@ -243,7 +247,8 @@ describe("verifyReceiptOffline - tamper detection (no network)", () => {
     const receipt = loadJson(TAMPER_DIR, "receipt.json");
     const jwks = loadJson(TAMPER_DIR, "jwks.json");
     const result = verifyReceiptOffline(receipt, jwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
+    expect(result.failureClass).toBe("invalid");
     const sigAxis = result.axes.find((a) => a.axis === "signature");
     expect(sigAxis?.result).toBe("FAIL");
   });
@@ -254,7 +259,8 @@ describe("verifyReceiptOffline - tamper detection (no network)", () => {
     const tampered = JSON.parse(JSON.stringify(receipt)) as Record<string, unknown>;
     (tampered.payload as Record<string, unknown>).decision = "deny";
     const result = verifyReceiptOffline(tampered, jwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
+    expect(result.failureClass).toBe("invalid");
   });
 });
 
@@ -266,7 +272,8 @@ describe("verifyReceiptOffline - missing key (no network)", () => {
   it("never returns PASS when key is absent from JWKS", () => {
     const receipt = loadJson(PASS_DIR, "receipt.json");
     const result = verifyReceiptOffline(receipt, { keys: [] });
-    expect(result.verdict).not.toBe("PASS");
+    expect(result.verdict).toBe("unverified");
+    expect(result.failureClass).toBe("unverifiable");
     // Signature must be SKIPPED (key not found) not FAIL
     const sigAxis = result.axes.find((a) => a.axis === "signature");
     expect(sigAxis?.result).toBe("SKIPPED");
@@ -332,7 +339,7 @@ describe("verifyReceiptOffline - ML-DSA-65 path (@noble/post-quantum)", () => {
     };
 
     const result = oracleVerify(envelope, ADAPTERS, jwks);
-    expect(result.verdict).toBe("PASS");
+    expect(result.verdict).toBe("verified");
     const sigAxis = result.axes.find((a) => a.axis === "signature");
     expect(sigAxis?.result).toBe("PASS");
   });
@@ -371,7 +378,7 @@ describe("verifyReceiptOffline - ML-DSA-65 path (@noble/post-quantum)", () => {
       keys: [{ kid, issuer_id: kid, alg: "ML-DSA-65", status: "active", public_key: pk_b64 }],
     };
     const result = verifyReceiptOffline(envelope, jwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     const sigAxis = result.axes.find((a) => a.axis === "signature");
     expect(sigAxis?.result).toBe("FAIL");
   });
@@ -394,7 +401,7 @@ describe("verifyReceiptOffline - ML-DSA-65 path (@noble/post-quantum)", () => {
     expect(result.axes.filter((a) => a.axis !== "expiry").map((a) => a.result)).toEqual(
       result.axes.filter((a) => a.axis !== "expiry").map(() => "PASS"),
     );
-    expect(result.verdict).toBe("PASS");
+    expect(result.verdict).toBe("verified");
   });
 
   it("returns FAIL for a tampered real-cloud ML-DSA-65 KAT receipt (anti-vacuous)", () => {
@@ -404,7 +411,7 @@ describe("verifyReceiptOffline - ML-DSA-65 path (@noble/post-quantum)", () => {
     // Flip one payload field - ML-DSA sig over canonical bytes must not match.
     (tampered.payload as Record<string, unknown>).decision = "deny";
     const result = verifyReceiptOffline(tampered, jwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     const sigAxis = result.axes.find((a) => a.axis === "signature");
     expect(sigAxis?.result).toBe("FAIL");
   });
@@ -421,7 +428,7 @@ describe("verifyReceiptOffline - ML-DSA-65 path (@noble/post-quantum)", () => {
     bad.fill(0, 0, 16);
     sig.sig = Buffer.from(bad).toString("base64");
     const result = verifyReceiptOffline(tampered, jwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     const sigAxis = result.axes.find((a) => a.axis === "signature");
     expect(sigAxis?.result).toBe("FAIL");
   });
@@ -474,7 +481,7 @@ describe("verifyReceiptOffline - issuer binding (no network)", () => {
   it("refuses a receipt signed by a key published under another issuer", () => {
     const [envelope, jwks] = crossIssuerForgery();
     const result = verifyReceiptOffline(envelope, jwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     const bind = result.axes.find((a) => a.axis === "issuer_bind");
     expect(bind?.result).toBe("FAIL");
     // The forged signature itself verifies; the bind is what refuses it.
@@ -513,7 +520,7 @@ describe("verifyReceiptOffline - issuer binding (no network)", () => {
         },
       ],
     };
-    expect(verifyReceiptOffline(envelope, jwks).verdict).toBe("PASS");
+    expect(verifyReceiptOffline(envelope, jwks).verdict).toBe("verified");
   });
 });
 
@@ -565,7 +572,7 @@ describe("verifyReceiptOffline - hash mode (no network)", () => {
     const { publicKey, secretKey } = ml_dsa65.keygen();
     const doc = hashModeReceipt(VICTIM_ORG, secretKey);
     const result = verifyReceiptOffline(doc, hashModeJwks(ATTACKER_ORG, publicKey));
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     expect(result.axes.find((a) => a.axis === "issuer_bind")?.result).toBe("FAIL");
     // The signature itself verifies; the bind is what refuses it.
     expect(result.axes.find((a) => a.axis === "signature")?.result).toBe("PASS");
@@ -575,11 +582,11 @@ describe("verifyReceiptOffline - hash mode (no network)", () => {
     const { publicKey, secretKey } = ml_dsa65.keygen();
     const clean = hashModeReceipt(ATTACKER_ORG, secretKey);
     const jwks = hashModeJwks(ATTACKER_ORG, publicKey);
-    expect(verifyReceiptOffline(clean, jwks).verdict).toBe("PASS");
+    expect(verifyReceiptOffline(clean, jwks).verdict).toBe("verified");
 
     const doc = { ...clean, issuer_id: "org-victim", previousReceiptHash: "0".repeat(64) };
     const result = verifyReceiptOffline(doc, jwks);
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     expect(result.axes.find((a) => a.axis === "structure")?.note).toContain("does not cover");
   });
 
@@ -588,12 +595,12 @@ describe("verifyReceiptOffline - hash mode (no network)", () => {
     const doc = hashModeReceipt(ATTACKER_ORG, secretKey);
     const aliased = verifyReceiptOffline(doc, hashModeJwks("Acme Compliance Ltd", publicKey));
     expect(aliased.axes.find((a) => a.axis === "issuer_bind")?.result).toBe("SKIPPED");
-    expect(aliased.verdict).toBe("INCOMPLETE");
+    expect(aliased.verdict).toBe("unverified");
     const published = verifyReceiptOffline(
       doc,
       hashModeJwks("Acme Compliance Ltd", publicKey, ATTACKER_ORG),
     );
-    expect(published.verdict).toBe("PASS");
+    expect(published.verdict).toBe("verified");
   });
 
   it("gives a clean FAIL, not a crash, on the prod vector plus unsigned claims", () => {
@@ -602,7 +609,7 @@ describe("verifyReceiptOffline - hash mode (no network)", () => {
     doc.issuer_id = "org-victim";
     doc.previousReceiptHash = "0".repeat(64);
     const result = verifyReceiptOffline(doc, loadJson(dir, "jwks.json"));
-    expect(result.verdict).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
     expect(result.axes.find((a) => a.axis === "structure")?.note).toContain("does not cover");
   });
 });

--- a/typescript/tests/signing-key-sibling-hashmode.test.ts
+++ b/typescript/tests/signing-key-sibling-hashmode.test.ts
@@ -67,7 +67,18 @@ describe("hash-mode resolution across three org siblings", () => {
     const res = verify(hashReceipt(f, sig), [new AsqavNativeAdapter()], jwks);
     const axes = axesOf(res);
     expect(axes.signature, JSON.stringify(axes)).toBe("PASS");
-    expect(res.verdict, JSON.stringify(axes)).toBe("PASS");
+    expect(res.verdict, JSON.stringify(axes)).toBe("verified");
+    expect(res.failureClass).toBeNull();
+  });
+
+  it("reports verified_keyed, never plain verified, for an hmac-sha256 digest (criterion 438)", () => {
+    const kp = ml_dsa65.keygen();
+    const f = { ...flat("agt_1"), hash_algo: "hmac-sha256" };
+    const sig = Buffer.from(ml_dsa65.sign(asqavJcs(f), kp.secretKey)).toString("base64");
+    const jwks = { keys: [siblingKey(1, kp.publicKey)] };
+    const res = verify(hashReceipt(f, sig), [new AsqavNativeAdapter()], jwks);
+    expect(res.verdict).toBe("verified_keyed");
+    expect(res.failureClass).toBeNull();
   });
 
   it("resolves each sibling to its own key", () => {

--- a/typescript/tests/signing-key-sibling.test.ts
+++ b/typescript/tests/signing-key-sibling.test.ts
@@ -130,7 +130,8 @@ describe("end to end over a real ML-DSA-65 signature", () => {
     expect(axes.signature, JSON.stringify(axes)).toBe("PASS");
     expect(axes.key_status).toBe("PASS");
     expect(axes.issuer_bind).toBe("PASS");
-    expect(res.verdict, JSON.stringify(axes)).toBe("PASS");
+    expect(res.verdict, JSON.stringify(axes)).toBe("verified");
+    expect(res.failureClass).toBeNull();
   });
 
   it("rejects a signature from a key the directory never published", () => {
@@ -148,7 +149,8 @@ describe("end to end over a real ML-DSA-65 signature", () => {
     const axes: Record<string, string> = {};
     for (const a of res.axes) axes[a.axis] = a.result;
     expect(axes.signature).toBe("FAIL");
-    expect(res.verdict).toBe("FAIL");
+    expect(res.verdict).toBe("unverified");
+    expect(res.failureClass).toBe("invalid");
   });
 
   it("rejects an agent key published under another org", () => {
@@ -165,6 +167,7 @@ describe("end to end over a real ML-DSA-65 signature", () => {
     const axes: Record<string, string> = {};
     for (const a of res.axes) axes[a.axis] = a.result;
     expect(axes.signature).toBe("FAIL");
-    expect(res.verdict).toBe("FAIL");
+    expect(res.verdict).toBe("unverified");
+    expect(res.failureClass).toBe("invalid");
   });
 });

--- a/typescript/tests/strict-ingest.test.ts
+++ b/typescript/tests/strict-ingest.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Strict JSON ingest (criterion 419): duplicate members fail closed.
+ *
+ * Every receipt- and record-parsing path rejects a duplicated JSON member name
+ * at ANY nesting depth as a terminal parse failure, before any hashing,
+ * canonicalisation, or signature check. Last-wins ingest would hash the bytes an
+ * attacker kept and drop the ones they replaced; these tests pin the rejection.
+ */
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  DuplicateMemberError,
+  parseJsonPreservingFloats,
+  parseJsonStrict,
+} from "../src/verifier/canonical.js";
+import { receiptFromOtelGenaiAttributes, OTEL_RECEIPT_ATTR } from "../src/doors.js";
+import { runOne } from "../src/verifier/runner.js";
+
+const CORPUS_ROOT = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
+
+describe("strict ingest rejects duplicate members at any depth (criterion 419)", () => {
+  it("rejects a duplicated member at the top level", () => {
+    expect(() => parseJsonPreservingFloats('{"payload": {"a": 1}, "payload": {"a": 2}}')).toThrow(
+      DuplicateMemberError,
+    );
+    expect(() => parseJsonStrict('{"payload": {"a": 1}, "payload": {"a": 2}}')).toThrow(
+      DuplicateMemberError,
+    );
+  });
+
+  it("rejects a duplicated member nested inside an object", () => {
+    expect(() =>
+      parseJsonPreservingFloats('{"payload": {"digest": {"hash": "x", "hash": "y"}}}'),
+    ).toThrow(DuplicateMemberError);
+  });
+
+  it("rejects a duplicate five levels down", () => {
+    expect(() => parseJsonStrict('{"a": {"b": {"c": {"d": [{"e": 1, "e": 2}]}}}}')).toThrow(
+      DuplicateMemberError,
+    );
+  });
+
+  it("rejects a duplicate inside an array element", () => {
+    expect(() => parseJsonStrict('{"list": [{"k": 1}, {"k": 2, "k": 3}]}')).toThrow(
+      DuplicateMemberError,
+    );
+  });
+
+  it("allows the same name in sibling objects (one object scope only)", () => {
+    expect(parseJsonStrict('{"list": [{"k": 1}, {"k": 2}]}')).toEqual({
+      list: [{ k: 1 }, { k: 2 }],
+    });
+  });
+
+  it("clean documents still parse to plain values", () => {
+    expect(parseJsonStrict('{"a": 1, "b": [true, false, null]}')).toEqual({
+      a: 1,
+      b: [true, false, null],
+    });
+  });
+
+  it("DuplicateMemberError is a SyntaxError so existing catch sites stay fail-closed", () => {
+    try {
+      parseJsonStrict('{"a": 1, "a": 2}');
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(SyntaxError);
+      expect((e as Error).name).toBe("DuplicateMemberError");
+    }
+  });
+
+  it("the OTel GenAI door rejects a duplicate-member receipt string", () => {
+    const attrs = { [OTEL_RECEIPT_ATTR]: '{"a": 1, "a": 2}' };
+    expect(() => receiptFromOtelGenaiAttributes(attrs)).toThrow(DuplicateMemberError);
+  });
+});
+
+describe("corpus duplicate-member vectors never verify (criteria 419/418)", () => {
+  it("both vectors are terminal parse failures in the raw files", () => {
+    for (const dir of ["asqav-11-dup-member-toplevel", "asqav-13-dup-member-nested"]) {
+      const raw = readFileSync(join(CORPUS_ROOT, dir, "receipt.json"), "utf-8");
+      expect(() => parseJsonPreservingFloats(raw)).toThrow(DuplicateMemberError);
+    }
+  });
+
+  it("the runner reports them unverified/unverifiable, never verified", () => {
+    for (const dir of ["asqav-11-dup-member-toplevel", "asqav-13-dup-member-nested"]) {
+      const r = runOne(join(CORPUS_ROOT, dir), "asqav-native", "unverified", "duplicate_member", "unverifiable");
+      expect(r.ok, r.detail).toBe(true);
+      expect(r.actualVerdict).toBe("unverified");
+      expect(r.actualFailureClass).toBe("unverifiable");
+      expect(r.detail).toContain("terminal parse failure before any hashing");
+    }
+  });
+});

--- a/typescript/tests/v2-signer.test.ts
+++ b/typescript/tests/v2-signer.test.ts
@@ -28,7 +28,8 @@ describe("v:2 signer + canary acceptance (neutral verifier)", () => {
     const { receipt, jwks } = v2();
     const res = verify(receipt, ADAPTERS, jwks);
     expect(res.fmt).toBe("asqav-native");
-    expect(res.verdict).toBe("PASS");
+    expect(res.verdict).toBe("verified");
+    expect(res.failureClass).toBeNull();
     expect(res.axes.find((a) => a.axis === "signature")?.result).toBe("PASS");
     expect(res.signer).toBe(SIGNER);
   });
@@ -38,7 +39,8 @@ describe("v:2 signer + canary acceptance (neutral verifier)", () => {
     (receipt.payload as Record<string, unknown>).signer = "https://api.asqav.con";
     const res = verify(receipt, ADAPTERS, jwks);
     expect(res.axes.find((a) => a.axis === "signature")?.result).toBe("FAIL");
-    expect(res.verdict).toBe("FAIL");
+    expect(res.verdict).toBe("unverified");
+    expect(res.failureClass).toBe("invalid");
   });
 
   it("does not surface or trust a signer moved outside the signed body", () => {
@@ -47,14 +49,16 @@ describe("v:2 signer + canary acceptance (neutral verifier)", () => {
     receipt.signer = SIGNER; // loose, outside the canonical body
     const res = verify(receipt, ADAPTERS, jwks);
     expect(res.signer).toBeNull();
-    expect(res.verdict).toBe("FAIL");
+    expect(res.verdict).toBe("unverified");
+    expect(res.failureClass).toBe("invalid");
   });
 
   it("fails the tampered-canary corpus vector", () => {
     const receipt = load("asqav-09-v2-signer-tampered", "receipt.json");
     const jwks = load("asqav-09-v2-signer-tampered", "jwks.json");
     const res = verify(receipt, ADAPTERS, jwks);
-    expect(res.verdict).toBe("FAIL");
+    expect(res.verdict).toBe("unverified");
+    expect(res.failureClass).toBe("invalid");
   });
 
   it("does not add a canary axis (neutral verifier cannot recompute _asqav_tid)", () => {
@@ -67,7 +71,7 @@ describe("v:2 signer + canary acceptance (neutral verifier)", () => {
     const receipt = load("asqav-01-genesis-permit", "receipt.json");
     const jwks = load("asqav-01-genesis-permit", "jwks.json");
     const res = verify(receipt, ADAPTERS, jwks);
-    expect(res.verdict).toBe("PASS");
+    expect(res.verdict).toBe("verified");
     expect(res.signer).toBeNull();
   });
 

--- a/typescript/tests/verifier-axis-parity.test.ts
+++ b/typescript/tests/verifier-axis-parity.test.ts
@@ -273,7 +273,8 @@ describe("nesting-depth gate parity", () => {
 
   it("caps a receipt one level past it", () => {
     const r = verifyReceiptOffline(nestedReceipt(MAX_NESTING_DEPTH - 1), JWKS);
-    expect(r.verdict).toBe("INCOMPLETE");
+    expect(r.verdict).toBe("unverified");
+    expect(r.failureClass).toBe("unverifiable");
     expect(r.axes).toHaveLength(1);
     expect(r.axes[0].axis).toBe("structure");
     expect(r.axes[0].result).toBe("FAIL");
@@ -282,7 +283,8 @@ describe("nesting-depth gate parity", () => {
 
   it("caps an over-nested predecessor", () => {
     const r = verifyReceiptOffline(nestedReceipt(0), JWKS, nestedReceipt(5000));
-    expect(r.verdict).toBe("INCOMPLETE");
+    expect(r.verdict).toBe("unverified");
+    expect(r.failureClass).toBe("unverifiable");
     expect(r.axes[0].note).toBe("receipt nesting exceeds the supported depth (> 200 levels)");
   });
 
@@ -294,6 +296,6 @@ describe("nesting-depth gate parity", () => {
     const receipt = nestedReceipt(0);
     (receipt.payload as Record<string, unknown>).junk = node;
     expect(() => verifyReceiptOffline(receipt, JWKS)).not.toThrow();
-    expect(verifyReceiptOffline(receipt, JWKS).verdict).toBe("INCOMPLETE");
+    expect(verifyReceiptOffline(receipt, JWKS).verdict).toBe("unverified");
   });
 });

--- a/typescript/tests/verifier-fail-clean.test.ts
+++ b/typescript/tests/verifier-fail-clean.test.ts
@@ -9,10 +9,11 @@ import { verify as oracleVerify } from "../src/verifier/core.js";
 import { verifySignature } from "../src/verifier/crypto.js";
 
 describe("verifier fail-clean on malformed input", () => {
-  it("returns FAIL (no throw) on a non-object top-level receipt", () => {
+  it("returns unverified (no throw) on a non-object top-level receipt", () => {
     for (const doc of [null, "a string", 123, [1, 2]] as unknown[]) {
       const r = oracleVerify(doc as Record<string, unknown>, ADAPTERS);
-      expect(r.verdict).toBe("FAIL");
+      expect(r.verdict).toBe("unverified");
+      expect(r.failureClass).toBe("unverifiable");
     }
   });
 

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -78,7 +78,6 @@ describe("verifier parity gate (THE GATE)", () => {
       expect(r.actualFailureClass).toBe("unverifiable");
       expect(r.detail).toContain("terminal parse failure before any hashing");
     }
->>>>>>> 795f0b7 (feat(verifier): strict JSON ingest and tri-state verdict vocabulary (criteria 419, 418, 438))
   });
 });
 

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from "vitest";
 import { asqavJcs, jcsRfc8785, parseJsonPreservingFloats } from "../src/verifier/canonical.js";
 import { verify } from "../src/verifier/core.js";
 import { ADAPTERS } from "../src/verifier/index.js";
-import { runCorpus, tolerated } from "../src/verifier/runner.js";
+import { runCorpus, runOne, tolerated } from "../src/verifier/runner.js";
 
 // typescript/tests -> repo root -> verifier/conformance-vectors
 const CORPUS_ROOT = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
@@ -27,7 +27,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 52 corpus vectors", () => {
+  it("matches every manifest outcome across all 54 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -36,16 +36,49 @@ describe("verifier parity gate (THE GATE)", () => {
     const report = results
       .map((r) => {
         const mark = tolerated(r) ? "ok" : "FAIL";
-        const line = `  [${mark.padStart(4)}] ${r.dir.padEnd(38)} expect=${r.expectedOutcome.padEnd(11)} got=${r.actualVerdict}`;
+        const got = r.actualFailureClass !== "" ? `${r.actualVerdict} (${r.actualFailureClass})` : r.actualVerdict;
+        const line = `  [${mark.padStart(4)}] ${r.dir.padEnd(38)} expect=${r.expectedOutcome.padEnd(16)} got=${got}`;
         return tolerated(r) ? line : `${line}\n         ${r.detail}`;
       })
       .join("\n");
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(52);
+    expect(results.length).toBe(54);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(52);
+    expect(passed).toBe(54);
+  });
+
+  it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {
+    // Criteria 418/438: invalid and unverifiable must never collapse, and the two
+    // languages must agree on which class each failing vector lands in. The
+    // optional-dep ML-DSA vector is skipped: with a crypto library present it
+    // upgrades to verified, which the tolerance rule above already covers.
+    const results = runCorpus(CORPUS_ROOT);
+    const unverified = results.filter(
+      (r) => r.expectedOutcome === "unverified" && r.reasonCode !== "signature_skipped_no_dilithium",
+    );
+    expect(unverified.length).toBeGreaterThanOrEqual(2);
+    for (const r of unverified) {
+      expect(r.actualVerdict, r.dir).toBe("unverified");
+      expect(r.expectedFailureClass, `${r.dir} pins a failure_class`).not.toBe("");
+      expect(r.actualFailureClass, `${r.dir}: ${r.detail}`).toBe(r.expectedFailureClass);
+    }
+    // Both criteria-418 classes are exercised by the corpus.
+    const classes = new Set(unverified.map((r) => r.actualFailureClass));
+    expect(classes).toContain("invalid");
+    expect(classes).toContain("unverifiable");
+  });
+
+  it("rejects the duplicate-member vectors at ingest; they never verify (criterion 419)", () => {
+    for (const dir of ["asqav-11-dup-member-toplevel", "asqav-13-dup-member-nested"]) {
+      const r = runOne(join(CORPUS_ROOT, dir), "asqav-native", "unverified", "duplicate_member", "unverifiable");
+      expect(r.ok, `${dir}: ${r.detail}`).toBe(true);
+      expect(r.actualVerdict).toBe("unverified");
+      expect(r.actualFailureClass).toBe("unverifiable");
+      expect(r.detail).toContain("terminal parse failure before any hashing");
+    }
+>>>>>>> 795f0b7 (feat(verifier): strict JSON ingest and tri-state verdict vocabulary (criteria 419, 418, 438))
   });
 });
 
@@ -66,15 +99,16 @@ describe("jcs_rfc8785 byte-parity vs upstream canonicalization vectors", () => {
   });
 });
 
-describe("real Authproof receipt verifies PASS (ES256 path)", () => {
-  it("authproof-01-genesis-real-sdk -> PASS", () => {
+describe("real Authproof receipt verifies (ES256 path)", () => {
+  it("authproof-01-genesis-real-sdk -> verified", () => {
     const dir = join(CORPUS_ROOT, "authproof-01-genesis-real-sdk");
     const receipt = loadJson(join(dir, "receipt.json"));
     const result = verify(receipt, ADAPTERS);
     // eslint-disable-next-line no-console
     console.log(`\n  authproof-01-genesis-real-sdk: fmt=${result.fmt} verdict=${result.verdict}\n`);
     expect(result.fmt).toBe("authproof");
-    expect(result.verdict).toBe("PASS");
+    expect(result.verdict).toBe("verified");
+    expect(result.failureClass).toBeNull();
   });
 });
 

--- a/typescript/tests/verifier-time-edge-cases.test.ts
+++ b/typescript/tests/verifier-time-edge-cases.test.ts
@@ -142,7 +142,7 @@ describe("the expiry axis at the frozen clock", () => {
 });
 
 describe("the time-edge corpus vector keeps expiry on its own axis", () => {
-  it("verdict stays PASS while the lapsed expires_at FAILs alone", () => {
+  it("verdict stays verified while the lapsed expires_at FAILs alone", () => {
     const result = verify(loadVector("receipt.json"), ADAPTERS, loadVector("jwks.json"));
     expect(result.fmt).toBe("asqav-native");
     const expiry = result.axes.find((a) => a.axis === "expiry");
@@ -150,7 +150,7 @@ describe("the time-edge corpus vector keeps expiry on its own axis", () => {
     expect(expiry?.note).toContain("lapsed");
     const nonExpiry = result.axes.filter((a) => a.axis !== "expiry");
     expect(nonExpiry.map((a) => a.result)).not.toContain("FAIL");
-    expect(result.verdict).toBe("PASS");
+    expect(result.verdict).toBe("verified");
   });
 
   it("matches its expected outcome through the corpus runner", () => {

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -26,8 +26,8 @@ pip install dilithium-py
 `dilithium-py` is a pure-python FIPS 204 implementation; its verify path uses
 only stdlib SHAKE, so nothing compiles. If you skip it, every other check still
 runs and the signature axis reports `SKIPPED`; the overall verdict is then
-`INCOMPLETE`. The tool never prints `PASS` unless the signature was actually
-verified.
+`unverified` with `failure_class=unverifiable`. The tool never reports
+`verified` unless the signature was actually verified.
 
 ## Verify a live receipt
 
@@ -46,10 +46,10 @@ python -m asqav.verifier.verify_receipt --id sig_example_regulator_cold_verify_2
 This pulls `https://api.asqav.com/api/v1/verify/<id>` and
 `https://api.asqav.com/.well-known/jwks.json`, then prints a per-axis report.
 This is a public documentation fixture. Its signing key is a reserved example
-identity that is not published in the public JWKS, so the offline verdict is a
-FAIL on issuer-key resolution rather than a green PASS. Point `--id` at one of
-your own signed receipts, whose agent key is in the JWKS, to run the full
-cryptographic path through to a PASS.
+identity that is not published in the public JWKS, so the offline verdict is
+`unverified` (issuer-key resolution cannot complete) rather than a `verified`
+outcome. Point `--id` at one of your own signed receipts, whose agent key is in
+the JWKS, to run the full cryptographic path through to `verified`.
 
 ## Verify fully offline
 
@@ -92,8 +92,30 @@ This file is Python. The TypeScript SDK reaches the same axes through
 snippets and the measured list of stamp spellings the two halves read differently.
 There is no single-file TypeScript download equivalent to this script.
 
+## Verdict vocabulary
+
+The verifier reports one of three verdicts (criteria 418/438):
+
+| Verdict | Meaning |
+|---|---|
+| `verified` | Every non-skipped axis passed and the signature was actually checked. |
+| `verified_keyed` | Same as `verified`, but the digest is keyed (e.g. HMAC-SHA256) and so is internally consistent yet not third-party re-derivable. Never reported as plain `verified`. |
+| `unverified` | The receipt is not verified. Carries a `failure_class` of `invalid` or `unverifiable`. |
+
+Every `unverified` verdict names why, and the two classes are never collapsed:
+
+- `invalid` - a check ran and a cryptographic/policy binding failed: signature
+  mismatch, chain-link mismatch, anchor invalid, counterparty binding mismatch,
+  signer key revoked/changed, algorithm mismatch, or `issued_at` future-skew
+  bound violation.
+- `unverifiable` - recomputation could not complete: unresolvable key, missing
+  or broken chain predecessor, malformed member, canonicalisation or parse
+  failure (including a duplicated JSON member name), or a pending anchor without
+  cryptographic proof.
+
 ## Exit codes
 
-- `0` - PASS (every non-skipped axis passed, signature verified)
-- `1` - FAIL (at least one axis failed)
-- `2` - INCOMPLETE (a blocking axis, typically the signature, was skipped)
+- `0` - `verified` or `verified_keyed`
+- `1` - `unverified`, `failure_class=invalid` (a binding was proven broken)
+- `2` - `unverified`, `failure_class=unverifiable` (verification could not
+  complete; a blocked check is never reported as verified)

--- a/verifier/axis-parity-cases.json
+++ b/verifier/axis-parity-cases.json
@@ -1,132 +1,1769 @@
 {
- "note": "Anchor-binding and clock-skew axis parity table. Expectations are the output of the Python check_anchors / check_skew in python/src/asqav/verifier/verify_receipt.py, and both suites feed every case through their own implementation. The anchors notes are deterministic so they are pinned whole; a skew note carries a live wall-clock reading, so only the stable fragment is pinned.",
- "anchors": [
-  {"name":"absent","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"}},"expect":{"result":"SKIPPED","note":"no anchors on this receipt"}},
-  {"name":"null","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":null},"expect":{"result":"SKIPPED","note":"no anchors on this receipt"}},
-  {"name":"empty list","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[]},"expect":{"result":"SKIPPED","note":"no anchors on this receipt"}},
-  {"name":"dict","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":{}},"expect":{"result":"FAIL","note":"anchors field is not a list (got dict)"}},
-  {"name":"nonempty dict","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":{"a":1}},"expect":{"result":"FAIL","note":"anchors field is not a list (got dict)"}},
-  {"name":"empty string","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":""},"expect":{"result":"FAIL","note":"anchors field is not a list (got str)"}},
-  {"name":"string","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":"rfc3161"},"expect":{"result":"FAIL","note":"anchors field is not a list (got str)"}},
-  {"name":"int zero","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":0},"expect":{"result":"FAIL","note":"anchors field is not a list (got int)"}},
-  {"name":"float","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":1.5},"expect":{"result":"FAIL","note":"anchors field is not a list (got float)"}},
-  {"name":"bool","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":true},"expect":{"result":"FAIL","note":"anchors field is not a list (got bool)"}},
-  {"name":"good entry","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"MTIzNA=="}]},"expect":{"result":"PASS","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"}},
-  {"name":"empty value","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":""}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"null value","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":null}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"missing value","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161"}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value one char","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"a"}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value five chars","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"xxxxx"}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value punctuation only","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"!!!!"}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value pad only","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"===="}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value junk after group","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"YQ==!!!!"}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value whitespace only","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":" "}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value with interior junk","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"a!bc"}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value urlsafe","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"-_-_"}]},"expect":{"result":"PASS","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"}},
-  {"name":"value surplus padding","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"AAAA===="}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value one surplus pad","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"AAAA="}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value urlsafe surplus padding","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"YW5j-aG9y-IHBh-eWxv-YWQg-aGVy-ZQ=="}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value mime line wrapped","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"TVRJek5BPT0K\nTVRJek5BPT0K\n"}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value junk laundering","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"QU!JD"}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value whitespace split","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"MTIz NA=="}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value trailing newline","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"MTIzNA==\n"}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value homoglyph","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"MTIzN\u0410=="}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value interior padding","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"AA=AA="}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value unpadded","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"MTIzNA"}]},"expect":{"result":"PASS","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"}},
-  {"name":"value urlsafe sha256","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"5vJx0_qZ8dHc1nOa-bTfLmQwXyE2rZgKpVuHjNdCsAI"}]},"expect":{"result":"PASS","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"}},
-  {"name":"value is a number","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":12}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value is an empty list","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":[]}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"value is an empty dict","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":{}}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"}},
-  {"name":"entry is a string","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":["rfc3161"]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - malformed anchor entry (got str, expected an object)"}},
-  {"name":"entry is a list","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[[]]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - malformed anchor entry (got list, expected an object)"}},
-  {"name":"entry is null","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[null]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - malformed anchor entry (got NoneType, expected an object)"}},
-  {"name":"entry is a number","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[7]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - malformed anchor entry (got int, expected an object)"}},
-  {"name":"type absent","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"value":"MTIzNA=="}]},"expect":{"result":"PASS","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - ?: value present, base64-ok"}},
-  {"name":"type null","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":null,"value":"MTIzNA=="}]},"expect":{"result":"PASS","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - None: value present, base64-ok"}},
-  {"name":"type bool","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":true,"value":"MTIzNA=="}]},"expect":{"result":"PASS","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - True: value present, base64-ok"}},
-  {"name":"two entries one bad","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"MTIzNA=="},{"type":"merkle","value":""}]},"expect":{"result":"FAIL","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok;     - merkle: value MISSING or malformed"}},
-  {"name":"two entries both good","envelope":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[{"type":"rfc3161","value":"MTIzNA=="},{"type":"merkle","value":"YWJjZA=="}]},"expect":{"result":"PASS","note":"anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok;     - merkle: value present, base64-ok"}}
- ],
- "skew": [
-  {"name":"2020-01-01T00:00:00+00:00","issued_at":"2020-01-01T00:00:00+00:00","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00:00Z","issued_at":"2020-01-01T00:00:00Z","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00:00z","issued_at":"2020-01-01T00:00:00z","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"20200101T000000Z basic form","issued_at":"20200101T000000Z","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-01-01T00:00:00.123456Z","issued_at":"2020-01-01T00:00:00.123456Z","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00:00.123456+00:00","issued_at":"2020-01-01T00:00:00.123456+00:00","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00","issued_at":"2020-01-01T00:00","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00:00","issued_at":"2020-01-01T00:00:00","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01","issued_at":"2020-01-01","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01 00:00:00+00:00","issued_at":"2020-01-01 00:00:00+00:00","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00:00+02:00","issued_at":"2020-01-01T00:00:00+02:00","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00:00-05:00","issued_at":"2020-01-01T00:00:00-05:00","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00:00+0200","issued_at":"2020-01-01T00:00:00+0200","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2099-01-01T00:00:00+00:00","issued_at":"2099-01-01T00:00:00+00:00","expect":{"result":"FAIL","note_contains":"ahead of wall clock (> 300s)"}},
-  {"name":"2099-01-01T00:00:00Z","issued_at":"2099-01-01T00:00:00Z","expect":{"result":"FAIL","note_contains":"ahead of wall clock (> 300s)"}},
-  {"name":"empty string","issued_at":"","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"not-a-date","issued_at":"not-a-date","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-13-01T00:00:00Z","issued_at":"2020-13-01T00:00:00Z","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"May 4 2026","issued_at":"May 4 2026","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"1700000000","issued_at":"1700000000","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-01-01T00:00:00+99:00","issued_at":"2020-01-01T00:00:00+99:00","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-01-01T00:00:00+02","issued_at":"2020-01-01T00:00:00+02","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00:00-0500","issued_at":"2020-01-01T00:00:00-0500","expect":{"result":"PASS","note_contains":"within bound"}},
-  {"name":"2020-01-01T00:00:00+0260","issued_at":"2020-01-01T00:00:00+0260","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-01-01T00:00:00+02:60","issued_at":"2020-01-01T00:00:00+02:60","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-01-01T00:00:00-0060","issued_at":"2020-01-01T00:00:00-0060","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-01-01T00:00:00+9999","issued_at":"2020-01-01T00:00:00+9999","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-01-01T24:00:00Z","issued_at":"2020-01-01T24:00:00Z","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-01-01T00:60:00Z","issued_at":"2020-01-01T00:60:00Z","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}},
-  {"name":"2020-01-01T00:00:60Z","issued_at":"2020-01-01T00:00:60Z","expect":{"result":"FAIL","note_contains":"unparseable issued_at"}}
- ],
- "normalise": [
-  {"name":"canonical envelope","raw":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00","issuer_id":"Asqav Ltd","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[]},"expect":{"digest":"fefda3fe6acef8e83c8910f5b351843d2e005c82938495ddee6179ed89d354a0","anchors_axis":"SKIPPED"}},
-  {"name":"hosted response, flat signature","raw":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00","issuer_id":"Asqav Ltd","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":"AAAA","algorithm":"ML-DSA-65","anchors":[{"type":"rfc3161","value":"MTIzNA=="}]},"expect":{"digest":"39a39f4279c02b1e6e38e35f16238c6da0d14d42ad44377b60056d318f4727af","anchors_axis":"PASS"}},
-  {"name":"hosted response, signature_envelope","raw":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00","issuer_id":"Asqav Ltd","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature_envelope":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"signature":"AAAA"},"expect":{"digest":"fefda3fe6acef8e83c8910f5b351843d2e005c82938495ddee6179ed89d354a0","anchors_axis":"SKIPPED"}},
-  {"name":"hosted response, malformed anchors object","raw":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00","issuer_id":"Asqav Ltd","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":"AAAA","algorithm":"ML-DSA-65","anchors":{}},"expect":{"digest":"39a39f4279c02b1e6e38e35f16238c6da0d14d42ad44377b60056d318f4727af","anchors_axis":"FAIL"}},
-  {"name":"hosted response, anchors as a string","raw":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00","issuer_id":"Asqav Ltd","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":"AAAA","algorithm":"ML-DSA-65","anchors":"rfc3161"},"expect":{"digest":"39a39f4279c02b1e6e38e35f16238c6da0d14d42ad44377b60056d318f4727af","anchors_axis":"FAIL"}},
-  {"name":"hosted response, anchors absent","raw":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00","issuer_id":"Asqav Ltd","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":"AAAA","algorithm":"ML-DSA-65"},"expect":{"digest":"39a39f4279c02b1e6e38e35f16238c6da0d14d42ad44377b60056d318f4727af","anchors_axis":"SKIPPED"}},
-  {"name":"bare payload, no envelope","raw":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00+00:00","issuer_id":"Asqav Ltd","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"expect":{"digest":"6e9ea8a909f02ad89fc51aa3bbacc9052c6e9bc87dcb402fc4faedf7185482c0","anchors_axis":"SKIPPED"}}
- ],
- "expiry_note": "Expiry cases mirror the hosted signature_expired verdict: the window is read from inside the signed bytes and an unreadable value fails closed. An expiry note carries a live wall-clock delta, so only the stable fragment is pinned.",
- "expiry": [
- {"name":"no expires_at key","payload":{},"expect":{"result":"PASS","note_contains":"receipt declares no expiry"}},
- {"name":"past ISO Z","payload":{"expires_at":"2020-01-01T00:00:00Z"},"expect":{"result":"FAIL","note_contains":"expires_at 2020-01-01T00:00:00Z lapsed"}},
- {"name":"past with space separator","payload":{"expires_at":"2020-01-01 00:00:00+00:00"},"expect":{"result":"FAIL","note_contains":"lapsed"}},
- {"name":"real prod receipt value","payload":{"expires_at":"2026-06-20T22:23:57.045786Z"},"expect":{"result":"FAIL","note_contains":"expires_at 2026-06-20T22:23:57.045786Z lapsed"}},
- {"name":"future ISO Z","payload":{"expires_at":"2099-01-01T00:00:00Z"},"expect":{"result":"PASS","note_contains":"expires_at 2099-01-01T00:00:00Z is"}},
- {"name":"future extended offset","payload":{"expires_at":"2099-01-01T00:00:00+02:00"},"expect":{"result":"PASS","note_contains":"is"}},
- {"name":"future basic offset","payload":{"expires_at":"2099-01-01T00:00:00+0200"},"expect":{"result":"PASS","note_contains":"is"}},
- {"name":"future date only","payload":{"expires_at":"2099-01-01"},"expect":{"result":"PASS","note_contains":"is"}},
- {"name":"future naive reads as utc","payload":{"expires_at":"2099-01-01T00:00:00"},"expect":{"result":"PASS","note_contains":"is"}},
- {"name":"far future","payload":{"expires_at":"9999-12-31T23:59:59Z"},"expect":{"result":"PASS","note_contains":"is"}},
- {"name":"null","payload":{"expires_at":null},"expect":{"result":"FAIL","note_contains":"unreadable expires_at None"}},
- {"name":"empty string","payload":{"expires_at":""},"expect":{"result":"FAIL","note_contains":"unreadable expires_at ''"}},
- {"name":"not a date","payload":{"expires_at":"not-a-date"},"expect":{"result":"FAIL","note_contains":"unreadable expires_at 'not-a-date'"}},
- {"name":"lowercase z zone","payload":{"expires_at":"2099-01-01T00:00:00z"},"expect":{"result":"FAIL","note_contains":"unreadable expires_at '2099-01-01T00:00:00z'"}},
- {"name":"offset minute 60","payload":{"expires_at":"2099-01-01T00:00:00+0260"},"expect":{"result":"FAIL","note_contains":"unreadable expires_at"}},
- {"name":"offset minute 60 extended","payload":{"expires_at":"2099-01-01T00:00:00+02:60"},"expect":{"result":"FAIL","note_contains":"unreadable expires_at"}},
- {"name":"hour 24","payload":{"expires_at":"2099-01-01T24:00:00Z"},"expect":{"result":"FAIL","note_contains":"unreadable expires_at"}},
- {"name":"posix seconds","payload":{"expires_at":1700000000},"expect":{"result":"FAIL","note_contains":"unreadable expires_at"}},
- {"name":"boolean","payload":{"expires_at":true},"expect":{"result":"FAIL","note_contains":"unreadable expires_at"}},
- {"name":"object","payload":{"expires_at":{}},"expect":{"result":"FAIL","note_contains":"unreadable expires_at"}},
- {"name":"list","payload":{"expires_at":[]},"expect":{"result":"FAIL","note_contains":"unreadable expires_at"}}
- ],
- "chain_prev_hash_note": "pipelock-evidence-v2 chain_prev_hash cases, run over verifier/conformance-vectors/pipelock-ev2-01-proxy-decision with the field substituted. Expectations are the output of the Python oracle. Only an absent, null, or sentinel string is a genesis link; every other value is producer-set and must not read as an absent link. The field sits inside the signed preimage, so any substitution also FAILs the signature.",
- "chain_prev_hash": [
- {"name":"untouched sentinel sha256:0","expect":{"verdict":"PASS","chain":"PASS","signature":"PASS"}},
- {"name":"sentinel genesis","value":"genesis","expect":{"verdict":"FAIL","chain":"PASS","signature":"FAIL"}},
- {"name":"field absent","omit":true,"expect":{"verdict":"FAIL","chain":"PASS","signature":"FAIL"}},
- {"name":"explicit null","value":null,"expect":{"verdict":"FAIL","chain":"PASS","signature":"FAIL"}},
- {"name":"empty string","value":"","expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}},
- {"name":"arbitrary hex string","value":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}},
- {"name":"int zero","value":0,"expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}},
- {"name":"int one","value":1,"expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}},
- {"name":"bool true","value":true,"expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}},
- {"name":"float","value":1.5,"expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}},
- {"name":"empty list","value":[],"expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}},
- {"name":"empty object","value":{},"expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}},
- {"name":"list of sentinel","value":["sha256:0"],"expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}},
- {"name":"object with sentinel","value":{"v":"sha256:0"},"expect":{"verdict":"FAIL","chain":"SKIPPED","signature":"FAIL"}}
- ]
+  "note": "Anchor-binding and clock-skew axis parity table. Expectations are the output of the Python check_anchors / check_skew in python/src/asqav/verifier/verify_receipt.py, and both suites feed every case through their own implementation. The anchors notes are deterministic so they are pinned whole; a skew note carries a live wall-clock reading, so only the stable fragment is pinned.",
+  "anchors": [
+    {
+      "name": "absent",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        }
+      },
+      "expect": {
+        "result": "SKIPPED",
+        "note": "no anchors on this receipt"
+      }
+    },
+    {
+      "name": "null",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": null
+      },
+      "expect": {
+        "result": "SKIPPED",
+        "note": "no anchors on this receipt"
+      }
+    },
+    {
+      "name": "empty list",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": []
+      },
+      "expect": {
+        "result": "SKIPPED",
+        "note": "no anchors on this receipt"
+      }
+    },
+    {
+      "name": "dict",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": {}
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors field is not a list (got dict)"
+      }
+    },
+    {
+      "name": "nonempty dict",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": {
+          "a": 1
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors field is not a list (got dict)"
+      }
+    },
+    {
+      "name": "empty string",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": ""
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors field is not a list (got str)"
+      }
+    },
+    {
+      "name": "string",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": "rfc3161"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors field is not a list (got str)"
+      }
+    },
+    {
+      "name": "int zero",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": 0
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors field is not a list (got int)"
+      }
+    },
+    {
+      "name": "float",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": 1.5
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors field is not a list (got float)"
+      }
+    },
+    {
+      "name": "bool",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": true
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors field is not a list (got bool)"
+      }
+    },
+    {
+      "name": "good entry",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MTIzNA=="
+          }
+        ]
+      },
+      "expect": {
+        "result": "PASS",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"
+      }
+    },
+    {
+      "name": "empty value",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": ""
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "null value",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": null
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "missing value",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161"
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value one char",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "a"
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value five chars",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "xxxxx"
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value punctuation only",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "!!!!"
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value pad only",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "===="
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value junk after group",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "YQ==!!!!"
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value whitespace only",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": " "
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value with interior junk",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "a!bc"
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value urlsafe",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "-_-_"
+          }
+        ]
+      },
+      "expect": {
+        "result": "PASS",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"
+      }
+    },
+    {
+      "name": "value surplus padding",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "AAAA===="
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value one surplus pad",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "AAAA="
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value urlsafe surplus padding",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "YW5j-aG9y-IHBh-eWxv-YWQg-aGVy-ZQ=="
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value mime line wrapped",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "TVRJek5BPT0K\nTVRJek5BPT0K\n"
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value junk laundering",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "QU!JD"
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value whitespace split",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MTIz NA=="
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value trailing newline",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MTIzNA==\n"
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value homoglyph",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MTIzN\u0410=="
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value interior padding",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "AA=AA="
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value unpadded",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MTIzNA"
+          }
+        ]
+      },
+      "expect": {
+        "result": "PASS",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"
+      }
+    },
+    {
+      "name": "value urlsafe sha256",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "5vJx0_qZ8dHc1nOa-bTfLmQwXyE2rZgKpVuHjNdCsAI"
+          }
+        ]
+      },
+      "expect": {
+        "result": "PASS",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"
+      }
+    },
+    {
+      "name": "value is a number",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": 12
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value is an empty list",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": []
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "value is an empty dict",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": {}
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "entry is a string",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          "rfc3161"
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - malformed anchor entry (got str, expected an object)"
+      }
+    },
+    {
+      "name": "entry is a list",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          []
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - malformed anchor entry (got list, expected an object)"
+      }
+    },
+    {
+      "name": "entry is null",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          null
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - malformed anchor entry (got NoneType, expected an object)"
+      }
+    },
+    {
+      "name": "entry is a number",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          7
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - malformed anchor entry (got int, expected an object)"
+      }
+    },
+    {
+      "name": "type absent",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "value": "MTIzNA=="
+          }
+        ]
+      },
+      "expect": {
+        "result": "PASS",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - ?: value present, base64-ok"
+      }
+    },
+    {
+      "name": "type null",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": null,
+            "value": "MTIzNA=="
+          }
+        ]
+      },
+      "expect": {
+        "result": "PASS",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - None: value present, base64-ok"
+      }
+    },
+    {
+      "name": "type bool",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": true,
+            "value": "MTIzNA=="
+          }
+        ]
+      },
+      "expect": {
+        "result": "PASS",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - True: value present, base64-ok"
+      }
+    },
+    {
+      "name": "two entries one bad",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MTIzNA=="
+          },
+          {
+            "type": "merkle",
+            "value": ""
+          }
+        ]
+      },
+      "expect": {
+        "result": "FAIL",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok;     - merkle: value MISSING or malformed"
+      }
+    },
+    {
+      "name": "two entries both good",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MTIzNA=="
+          },
+          {
+            "type": "merkle",
+            "value": "YWJjZA=="
+          }
+        ]
+      },
+      "expect": {
+        "result": "PASS",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok;     - merkle: value present, base64-ok"
+      }
+    }
+  ],
+  "skew": [
+    {
+      "name": "2020-01-01T00:00:00+00:00",
+      "issued_at": "2020-01-01T00:00:00+00:00",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00Z",
+      "issued_at": "2020-01-01T00:00:00Z",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00z",
+      "issued_at": "2020-01-01T00:00:00z",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "20200101T000000Z basic form",
+      "issued_at": "20200101T000000Z",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00.123456Z",
+      "issued_at": "2020-01-01T00:00:00.123456Z",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00.123456+00:00",
+      "issued_at": "2020-01-01T00:00:00.123456+00:00",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00",
+      "issued_at": "2020-01-01T00:00",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00",
+      "issued_at": "2020-01-01T00:00:00",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01",
+      "issued_at": "2020-01-01",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01 00:00:00+00:00",
+      "issued_at": "2020-01-01 00:00:00+00:00",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00+02:00",
+      "issued_at": "2020-01-01T00:00:00+02:00",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00-05:00",
+      "issued_at": "2020-01-01T00:00:00-05:00",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00+0200",
+      "issued_at": "2020-01-01T00:00:00+0200",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2099-01-01T00:00:00+00:00",
+      "issued_at": "2099-01-01T00:00:00+00:00",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "ahead of wall clock (> 300s)"
+      }
+    },
+    {
+      "name": "2099-01-01T00:00:00Z",
+      "issued_at": "2099-01-01T00:00:00Z",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "ahead of wall clock (> 300s)"
+      }
+    },
+    {
+      "name": "empty string",
+      "issued_at": "",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "not-a-date",
+      "issued_at": "not-a-date",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-13-01T00:00:00Z",
+      "issued_at": "2020-13-01T00:00:00Z",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "May 4 2026",
+      "issued_at": "May 4 2026",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "1700000000",
+      "issued_at": "1700000000",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00+99:00",
+      "issued_at": "2020-01-01T00:00:00+99:00",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00+02",
+      "issued_at": "2020-01-01T00:00:00+02",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00-0500",
+      "issued_at": "2020-01-01T00:00:00-0500",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00+0260",
+      "issued_at": "2020-01-01T00:00:00+0260",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00+02:60",
+      "issued_at": "2020-01-01T00:00:00+02:60",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00-0060",
+      "issued_at": "2020-01-01T00:00:00-0060",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:00+9999",
+      "issued_at": "2020-01-01T00:00:00+9999",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-01-01T24:00:00Z",
+      "issued_at": "2020-01-01T24:00:00Z",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-01-01T00:60:00Z",
+      "issued_at": "2020-01-01T00:60:00Z",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    },
+    {
+      "name": "2020-01-01T00:00:60Z",
+      "issued_at": "2020-01-01T00:00:60Z",
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unparseable issued_at"
+      }
+    }
+  ],
+  "normalise": [
+    {
+      "name": "canonical envelope",
+      "raw": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00",
+          "issuer_id": "Asqav Ltd",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": []
+      },
+      "expect": {
+        "digest": "fefda3fe6acef8e83c8910f5b351843d2e005c82938495ddee6179ed89d354a0",
+        "anchors_axis": "SKIPPED"
+      }
+    },
+    {
+      "name": "hosted response, flat signature",
+      "raw": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00",
+          "issuer_id": "Asqav Ltd",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": "AAAA",
+        "algorithm": "ML-DSA-65",
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MTIzNA=="
+          }
+        ]
+      },
+      "expect": {
+        "digest": "39a39f4279c02b1e6e38e35f16238c6da0d14d42ad44377b60056d318f4727af",
+        "anchors_axis": "PASS"
+      }
+    },
+    {
+      "name": "hosted response, signature_envelope",
+      "raw": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00",
+          "issuer_id": "Asqav Ltd",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature_envelope": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "signature": "AAAA"
+      },
+      "expect": {
+        "digest": "fefda3fe6acef8e83c8910f5b351843d2e005c82938495ddee6179ed89d354a0",
+        "anchors_axis": "SKIPPED"
+      }
+    },
+    {
+      "name": "hosted response, malformed anchors object",
+      "raw": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00",
+          "issuer_id": "Asqav Ltd",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": "AAAA",
+        "algorithm": "ML-DSA-65",
+        "anchors": {}
+      },
+      "expect": {
+        "digest": "39a39f4279c02b1e6e38e35f16238c6da0d14d42ad44377b60056d318f4727af",
+        "anchors_axis": "FAIL"
+      }
+    },
+    {
+      "name": "hosted response, anchors as a string",
+      "raw": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00",
+          "issuer_id": "Asqav Ltd",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": "AAAA",
+        "algorithm": "ML-DSA-65",
+        "anchors": "rfc3161"
+      },
+      "expect": {
+        "digest": "39a39f4279c02b1e6e38e35f16238c6da0d14d42ad44377b60056d318f4727af",
+        "anchors_axis": "FAIL"
+      }
+    },
+    {
+      "name": "hosted response, anchors absent",
+      "raw": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00",
+          "issuer_id": "Asqav Ltd",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": "AAAA",
+        "algorithm": "ML-DSA-65"
+      },
+      "expect": {
+        "digest": "39a39f4279c02b1e6e38e35f16238c6da0d14d42ad44377b60056d318f4727af",
+        "anchors_axis": "SKIPPED"
+      }
+    },
+    {
+      "name": "bare payload, no envelope",
+      "raw": {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-06-19T00:00:00+00:00",
+        "issuer_id": "Asqav Ltd",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "decision": "allow"
+      },
+      "expect": {
+        "digest": "6e9ea8a909f02ad89fc51aa3bbacc9052c6e9bc87dcb402fc4faedf7185482c0",
+        "anchors_axis": "SKIPPED"
+      }
+    }
+  ],
+  "expiry_note": "Expiry cases mirror the hosted signature_expired verdict: the window is read from inside the signed bytes and an unreadable value fails closed. An expiry note carries a live wall-clock delta, so only the stable fragment is pinned.",
+  "expiry": [
+    {
+      "name": "no expires_at key",
+      "payload": {},
+      "expect": {
+        "result": "PASS",
+        "note_contains": "receipt declares no expiry"
+      }
+    },
+    {
+      "name": "past ISO Z",
+      "payload": {
+        "expires_at": "2020-01-01T00:00:00Z"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "expires_at 2020-01-01T00:00:00Z lapsed"
+      }
+    },
+    {
+      "name": "past with space separator",
+      "payload": {
+        "expires_at": "2020-01-01 00:00:00+00:00"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "lapsed"
+      }
+    },
+    {
+      "name": "real prod receipt value",
+      "payload": {
+        "expires_at": "2026-06-20T22:23:57.045786Z"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "expires_at 2026-06-20T22:23:57.045786Z lapsed"
+      }
+    },
+    {
+      "name": "future ISO Z",
+      "payload": {
+        "expires_at": "2099-01-01T00:00:00Z"
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "expires_at 2099-01-01T00:00:00Z is"
+      }
+    },
+    {
+      "name": "future extended offset",
+      "payload": {
+        "expires_at": "2099-01-01T00:00:00+02:00"
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "is"
+      }
+    },
+    {
+      "name": "future basic offset",
+      "payload": {
+        "expires_at": "2099-01-01T00:00:00+0200"
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "is"
+      }
+    },
+    {
+      "name": "future date only",
+      "payload": {
+        "expires_at": "2099-01-01"
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "is"
+      }
+    },
+    {
+      "name": "future naive reads as utc",
+      "payload": {
+        "expires_at": "2099-01-01T00:00:00"
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "is"
+      }
+    },
+    {
+      "name": "far future",
+      "payload": {
+        "expires_at": "9999-12-31T23:59:59Z"
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "is"
+      }
+    },
+    {
+      "name": "null",
+      "payload": {
+        "expires_at": null
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at None"
+      }
+    },
+    {
+      "name": "empty string",
+      "payload": {
+        "expires_at": ""
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at ''"
+      }
+    },
+    {
+      "name": "not a date",
+      "payload": {
+        "expires_at": "not-a-date"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at 'not-a-date'"
+      }
+    },
+    {
+      "name": "lowercase z zone",
+      "payload": {
+        "expires_at": "2099-01-01T00:00:00z"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at '2099-01-01T00:00:00z'"
+      }
+    },
+    {
+      "name": "offset minute 60",
+      "payload": {
+        "expires_at": "2099-01-01T00:00:00+0260"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at"
+      }
+    },
+    {
+      "name": "offset minute 60 extended",
+      "payload": {
+        "expires_at": "2099-01-01T00:00:00+02:60"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at"
+      }
+    },
+    {
+      "name": "hour 24",
+      "payload": {
+        "expires_at": "2099-01-01T24:00:00Z"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at"
+      }
+    },
+    {
+      "name": "posix seconds",
+      "payload": {
+        "expires_at": 1700000000
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at"
+      }
+    },
+    {
+      "name": "boolean",
+      "payload": {
+        "expires_at": true
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at"
+      }
+    },
+    {
+      "name": "object",
+      "payload": {
+        "expires_at": {}
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at"
+      }
+    },
+    {
+      "name": "list",
+      "payload": {
+        "expires_at": []
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at"
+      }
+    }
+  ],
+  "chain_prev_hash_note": "pipelock-evidence-v2 chain_prev_hash cases, run over verifier/conformance-vectors/pipelock-ev2-01-proxy-decision with the field substituted. Expectations are the output of the Python oracle. Only an absent, null, or sentinel string is a genesis link; every other value is producer-set and must not read as an absent link. The field sits inside the signed preimage, so any substitution also FAILs the signature.",
+  "chain_prev_hash": [
+    {
+      "name": "untouched sentinel sha256:0",
+      "expect": {
+        "verdict": "verified",
+        "chain": "PASS",
+        "signature": "PASS",
+        "failure_class": null
+      }
+    },
+    {
+      "name": "sentinel genesis",
+      "value": "genesis",
+      "expect": {
+        "verdict": "unverified",
+        "chain": "PASS",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "field absent",
+      "omit": true,
+      "expect": {
+        "verdict": "unverified",
+        "chain": "PASS",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "explicit null",
+      "value": null,
+      "expect": {
+        "verdict": "unverified",
+        "chain": "PASS",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "empty string",
+      "value": "",
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "arbitrary hex string",
+      "value": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "int zero",
+      "value": 0,
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "int one",
+      "value": 1,
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "bool true",
+      "value": true,
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "float",
+      "value": 1.5,
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "empty list",
+      "value": [],
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "empty object",
+      "value": {},
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "list of sentinel",
+      "value": [
+        "sha256:0"
+      ],
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "object with sentinel",
+      "value": {
+        "v": "sha256:0"
+      },
+      "expect": {
+        "verdict": "unverified",
+        "chain": "SKIPPED",
+        "signature": "FAIL",
+        "failure_class": "invalid"
+      }
+    }
+  ]
 }

--- a/verifier/conformance-vectors/README.md
+++ b/verifier/conformance-vectors/README.md
@@ -7,10 +7,10 @@ top-level `manifest.json`, and per-vector key material plus an `expected.json`.
 ## Layout
 
 ```
-manifest.json                  array of {dir, format, outcome, reason_code, notes}
+manifest.json                  array of {dir, format, outcome, failure_class, reason_code, notes}
 <vector-dir>/
   receipt.json                 the receipt under test
-  expected.json                {format, outcome, reason_code, notes}
+  expected.json                {format, outcome, failure_class, reason_code, notes}
   predecessor.json             (chain vectors only) the prior receipt
   jwks.json                    (asqav-native) issuer key directory
   keys.json                    (aerf) {key_id: ed25519_pubkey_hex}
@@ -18,13 +18,21 @@ manifest.json                  array of {dir, format, outcome, reason_code, note
   did_map.json                 (agentreceipts) {did: ed25519_pubkey_hex} for did:agent / did:web
 ```
 
-`outcome` is `PASS`, `FAIL`, or `INCOMPLETE`; the runner maps it one-for-one to
-the oracle verdict and asserts equality. `INCOMPLETE` carries a vector whose
-signature axis cannot be checked in the CI environment (for example a real
-ML-DSA-65 prod receipt when `dilithium-py` is absent), pinning that the verifier
-downgrades to INCOMPLETE rather than emitting a false PASS. `reason_code` follows
-the shared taxonomy (`issuer_signature`, `chain`, `schema`, `key`,
-`signature_skipped_no_dilithium`).
+`outcome` speaks the shipped verdict vocabulary - `verified`, `verified_keyed`,
+or `unverified` - and the runner asserts the oracle verdict equals it. An
+`unverified` entry also pins `failure_class` (`invalid` or `unverifiable`), so
+the two are never collapsed and both languages agree byte for byte on each.
+`unverified`/`unverifiable` carries a vector whose signature axis cannot be
+checked in the CI environment (for example a real ML-DSA-65 prod receipt when
+`dilithium-py` is absent), pinning that the verifier downgrades rather than
+emitting a false `verified`. `reason_code` follows the shared taxonomy
+(`issuer_signature`, `chain`, `schema`, `key`, `signature_skipped_no_dilithium`,
+`duplicate_member`).
+
+Receipts are parsed with duplicate-member rejection (criterion 419): a receipt
+that repeats a JSON member name at any depth is a terminal parse failure,
+reported `unverified`/`unverifiable` before any hashing. `asqav-11` and
+`asqav-12` pin the top-level and nested cases.
 
 ## Run
 
@@ -41,8 +49,13 @@ python -m oracle.runner          # from the verifier/ directory
 - `asqav-05-hash-mode-prod` - a real default-mode prod `/sign` receipt (ML-DSA-65).
   The reconstructed signing input byte-matches the prod-signed message and the
   signature verifies with `dilithium-py`; absent that optional dep the signature
-  axis SKIPs, so the outcome is `INCOMPLETE`. Guards the production hash-mode path
-  against a false PASS on the post-quantum signature the CI base cannot check.
+  axis SKIPs, so the outcome is `unverified`/`unverifiable`. Guards the
+  production hash-mode path against a false `verified` on the post-quantum
+  signature the CI base cannot check.
+- `asqav-11-dup-member-toplevel` / `asqav-12-dup-member-nested` - the valid
+  genesis receipt with a duplicated JSON member name at the top level and two
+  levels down. Both are terminal parse failures (criterion 419): the strict
+  parser rejects them before any hashing, so they never verify.
 - `aerf-01..02` - valid AERF receipts (genesis, chain link). Genesis omits
   `previous_receipt_hash`; the chain hash excludes the signature, per the AERF
   spec.

--- a/verifier/conformance-vectors/acta-01-genesis/expected.json
+++ b/verifier/conformance-vectors/acta-01-genesis/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "acta",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Valid ACTA genesis; Ed25519 over JCS(payload) verifies."
 }

--- a/verifier/conformance-vectors/acta-02-chain-link/expected.json
+++ b/verifier/conformance-vectors/acta-02-chain-link/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "acta",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "ACTA successor links via SHA-256 of the JCS of the full predecessor receipt."
 }

--- a/verifier/conformance-vectors/acta-03-tamper-sig/expected.json
+++ b/verifier/conformance-vectors/acta-03-tamper-sig/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "acta",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "sig_mismatch",
-  "notes": "Flipped signature byte; Ed25519 verify fails."
+  "notes": "Flipped signature byte; Ed25519 verify fails.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/acta-05-commitment-mode-unsupported/expected.json
+++ b/verifier/conformance-vectors/acta-05-commitment-mode-unsupported/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "acta",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "sig_mismatch",
-  "notes": "Commitment-mode receipt (signs SHA-256(JCS)) fails the baseline JCS verifier - honest, never a false pass."
+  "notes": "Commitment-mode receipt (signs SHA-256(JCS)) fails the baseline JCS verifier - honest, never a false pass.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/acta-up-01-a2a-trusted-attestation/expected.json
+++ b/verifier/conformance-vectors/acta-up-01-a2a-trusted-attestation/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "acta",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Real ScopeBlind APS issuer attestation (a2a-trust-header/happy-path.json); the upstream Ed25519 signature over JCS(payload) verifies under our adapter. Inbound interop: we verify a producer we did not write."
 }

--- a/verifier/conformance-vectors/acta-up-02-a2a-trajectory-endpoint/expected.json
+++ b/verifier/conformance-vectors/acta-up-02-a2a-trajectory-endpoint/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "acta",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Real ScopeBlind trust-level-ascending endpoint attestation (the 'trusted' link); a second upstream payload whose Ed25519 signature verifies, confirming the interop is not a single-receipt fluke."
 }

--- a/verifier/conformance-vectors/acta-up-03-a2a-tampered-sig/expected.json
+++ b/verifier/conformance-vectors/acta-up-03-a2a-tampered-sig/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "acta",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "sig_mismatch",
-  "notes": "The real happy-path attestation with its first signature nibble flipped; Ed25519 verify fails, proving the oracle rejects a mutated third-party receipt rather than waving it through."
+  "notes": "The real happy-path attestation with its first signature nibble flipped; Ed25519 verify fails, proving the oracle rejects a mutated third-party receipt rather than waving it through.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/aerf-01-genesis/expected.json
+++ b/verifier/conformance-vectors/aerf-01-genesis/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "aerf",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Valid genesis: Ed25519 signature over JCS payload verifies; previous_receipt_hash omitted."
 }

--- a/verifier/conformance-vectors/aerf-02-chain-link/expected.json
+++ b/verifier/conformance-vectors/aerf-02-chain-link/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "aerf",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Second receipt; signature verifies and previous_receipt_hash rederives from the predecessor signable payload (signature excluded, per spec)."
 }

--- a/verifier/conformance-vectors/aerf-03-tamper-evidence/expected.json
+++ b/verifier/conformance-vectors/aerf-03-tamper-evidence/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "aerf",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "action field mutated after signing; Ed25519 signature no longer matches the canonical bytes."
+  "notes": "action field mutated after signing; Ed25519 signature no longer matches the canonical bytes.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/aerf-04-tamper-chain/expected.json
+++ b/verifier/conformance-vectors/aerf-04-tamper-chain/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "aerf",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "chain",
-  "notes": "previous_receipt_hash mutated; the link no longer rederives from the predecessor."
+  "notes": "previous_receipt_hash mutated; the link no longer rederives from the predecessor.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/aerf-up-01-genesis-happy-path/expected.json
+++ b/verifier/conformance-vectors/aerf-up-01-genesis-happy-path/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "aerf",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Upstream genesis happy path; Ed25519 over JCS payload verifies, previous_receipt_hash omitted."
 }

--- a/verifier/conformance-vectors/aerf-up-02-chain-happy-path/expected.json
+++ b/verifier/conformance-vectors/aerf-up-02-chain-happy-path/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "aerf",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Upstream three-receipt chain; the final link verifies its signature and rederives previous_receipt_hash from its predecessor (signature excluded from the chain hash)."
 }

--- a/verifier/conformance-vectors/aerf-up-03-tamper-evidence/expected.json
+++ b/verifier/conformance-vectors/aerf-up-03-tamper-evidence/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "aerf",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Upstream tamper vector; the action field was mutated after signing, so the issuer signature no longer matches."
+  "notes": "Upstream tamper vector; the action field was mutated after signing, so the issuer signature no longer matches.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/aerf-up-04-tamper-chain/expected.json
+++ b/verifier/conformance-vectors/aerf-up-04-tamper-chain/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "aerf",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Upstream tamper-in-chain vector; the middle receipt's evidence was mutated after signing, so that receipt's own issuer signature fails. Ingested as the mutated middle receipt with its valid predecessor; the chain link still rederives, the signature is what fails."
+  "notes": "Upstream tamper-in-chain vector; the middle receipt's evidence was mutated after signing, so that receipt's own issuer signature fails. Ingested as the mutated middle receipt with its valid predecessor; the chain link still rederives, the signature is what fails.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/aerf-up-05-impact-no-parent-sig/expected.json
+++ b/verifier/conformance-vectors/aerf-up-05-impact-no-parent-sig/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "aerf",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "parent_signature",
-  "notes": "Upstream impact receipt missing its required parent counter-signature; impact_tags is non-empty so the parent_signature axis fails closed even though the issuer signature is valid."
+  "notes": "Upstream impact receipt missing its required parent counter-signature; impact_tags is non-empty so the parent_signature axis fails closed even though the issuer signature is valid.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/aerf-up-06-impact-with-parent-sig/expected.json
+++ b/verifier/conformance-vectors/aerf-up-06-impact-with-parent-sig/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "aerf",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Upstream impact receipt with valid parent and PDP signatures; issuer, parent, and PDP axes all verify."
 }

--- a/verifier/conformance-vectors/aerf-up-07-pdp-binding-valid/expected.json
+++ b/verifier/conformance-vectors/aerf-up-07-pdp-binding-valid/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "aerf",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Upstream PDP-binding happy path; the PDP signature over the canonical {context_hash_sha256, in_policy, policy_hash} tuple verifies."
 }

--- a/verifier/conformance-vectors/aerf-up-08-pdp-binding-split-context/expected.json
+++ b/verifier/conformance-vectors/aerf-up-08-pdp-binding-split-context/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "aerf",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "pdp_signature",
-  "notes": "Upstream split-context vector; the PDP signed a verdict for one context but the receipt claims another, so the PDP-binding axis fails."
+  "notes": "Upstream split-context vector; the PDP signed a verdict for one context but the receipt claims another, so the PDP-binding axis fails.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/aerf-up-11-tag-stripped-known-limit/expected.json
+++ b/verifier/conformance-vectors/aerf-up-11-tag-stripped-known-limit/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "aerf",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Upstream documents this as a residual the receipt layer cannot close: an agent that controls receipt construction can strip impact_tags before signing, so no counter-sign is required and the issuer signature verifies. Our verifier reaches the same PASS the upstream verifier does; the defense is producer-side tag pinning, outside the receipt bytes. Mapped to PASS because that is the honest outcome the bytes produce, not a relabel."
 }

--- a/verifier/conformance-vectors/aerf-up-12-common-mode-known-limit/expected.json
+++ b/verifier/conformance-vectors/aerf-up-12-common-mode-known-limit/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "aerf",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Upstream documents this as a residual: all three signers (issuer, parent, PDP) saw the same poisoned upstream context and signed honestly, so every signature verifies. The receipt records what was attested, not whether the context was sound; our verifier reaches the same PASS the upstream verifier does. Mapped to PASS because every signature genuinely verifies, not a relabel."
 }

--- a/verifier/conformance-vectors/agentreceipts-01-didkey-genesis/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-01-didkey-genesis/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "agentreceipts",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "did:key genesis; key resolves inline, signature verifies, previous_receipt_hash explicit null."
 }

--- a/verifier/conformance-vectors/agentreceipts-02-didkey-chain-link/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-02-didkey-chain-link/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "agentreceipts",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Successor links via sha256:hex(JCS(predecessor without proof)); signature verifies."
 }

--- a/verifier/conformance-vectors/agentreceipts-03-tamper-payload/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-03-tamper-payload/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "action.type mutated after signing; canonical bytes no longer match the signature."
+  "notes": "action.type mutated after signing; canonical bytes no longer match the signature.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-04-tamper-proofvalue/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-04-tamper-proofvalue/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Single proofValue byte flipped; Ed25519 verification fails."
+  "notes": "Single proofValue byte flipped; Ed25519 verification fails.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-05-genesis-missing-prev-hash/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-05-genesis-missing-prev-hash/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "schema",
-  "notes": "previous_receipt_hash omitted; spec requires it present (null on genesis), so the receipt is malformed."
+  "notes": "previous_receipt_hash omitted; spec requires it present (null on genesis), so the receipt is malformed.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-06-wrong-key/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-06-wrong-key/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "verificationMethod resolves (via the injected map) to a different valid Ed25519 key than the signer; signature fails."
+  "notes": "verificationMethod resolves (via the injected map) to a different valid Ed25519 key than the signer; signature fails.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-up-00-valid-resigned/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-00-valid-resigned/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "agentreceipts",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Upstream malformed-corpus base receipt re-signed cleanly with the upstream keypair; signature verifies over jcs_rfc8785 bytes."
 }

--- a/verifier/conformance-vectors/agentreceipts-up-01-wrong-proof-type/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-01-wrong-proof-type/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "schema",
-  "notes": "Upstream malformed vector: proof.type is not Ed25519Signature2020."
+  "notes": "Upstream malformed vector: proof.type is not Ed25519Signature2020.",
+  "failure_class": "unverifiable"
 }

--- a/verifier/conformance-vectors/agentreceipts-up-02-mutated-action-type/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-02-mutated-action-type/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Upstream malformed vector: action.type mutated after signing."
+  "notes": "Upstream malformed vector: action.type mutated after signing.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-up-03-mutated-principal-id/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-03-mutated-principal-id/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Upstream malformed vector: principal.id mutated after signing."
+  "notes": "Upstream malformed vector: principal.id mutated after signing.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-up-04-truncated-proof-value/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-04-truncated-proof-value/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Upstream malformed vector: proofValue truncated to its multibase prefix; empty signature bytes."
+  "notes": "Upstream malformed vector: proofValue truncated to its multibase prefix; empty signature bytes.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-up-05-wrong-multibase-prefix/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-05-wrong-multibase-prefix/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Upstream malformed vector: proofValue uses base58 'z' not base64url 'u'; signature bytes do not decode to the real signature."
+  "notes": "Upstream malformed vector: proofValue uses base58 'z' not base64url 'u'; signature bytes do not decode to the real signature.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-up-06-flipped-proof-byte/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-06-flipped-proof-byte/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Upstream malformed vector: Single proofValue byte mutated; Ed25519 verification fails."
+  "notes": "Upstream malformed vector: Single proofValue byte mutated; Ed25519 verification fails.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-07-tampered-mid-chain/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "agentreceipts",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Upstream tampered-chain vector: the middle receipt was mutated after signing, so its own issuer signature no longer matches; ingested against its valid predecessor."
+  "notes": "Upstream tampered-chain vector: the middle receipt was mutated after signing, so its own issuer signature no longer matches; ingested against its valid predecessor.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/expected.json
+++ b/verifier/conformance-vectors/agentreceipts-up-08-valid-chain-link/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "agentreceipts",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Successor signed with the upstream keypair; previous_receipt_hash rederives from sha256:hex(JCS(genesis without proof))."
 }

--- a/verifier/conformance-vectors/asqav-01-genesis-permit/expected.json
+++ b/verifier/conformance-vectors/asqav-01-genesis-permit/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "asqav-native",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Valid genesis permit; Ed25519 signature over canonical payload verifies; all-zero previousReceiptHash seed."
 }

--- a/verifier/conformance-vectors/asqav-02-genesis-deny/expected.json
+++ b/verifier/conformance-vectors/asqav-02-genesis-deny/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "asqav-native",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Valid genesis deny decision; signature verifies."
 }

--- a/verifier/conformance-vectors/asqav-03-chain-link/expected.json
+++ b/verifier/conformance-vectors/asqav-03-chain-link/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "asqav-native",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Successor receipt; signature verifies and previousReceiptHash rederives from the predecessor canonical payload."
 }

--- a/verifier/conformance-vectors/asqav-04-tamper-sig/expected.json
+++ b/verifier/conformance-vectors/asqav-04-tamper-sig/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "asqav-native",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "decision flipped from allow to deny after signing; signature no longer matches the canonical payload."
+  "notes": "decision flipped from allow to deny after signing; signature no longer matches the canonical payload.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/asqav-05-hash-mode-prod/expected.json
+++ b/verifier/conformance-vectors/asqav-05-hash-mode-prod/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "asqav-native",
-  "outcome": "INCOMPLETE",
+  "outcome": "unverified",
   "reason_code": "signature_skipped_no_dilithium",
-  "notes": "Real prod hash-mode receipt (default /sign). payload is null so the signature axis is SKIPPED/INCOMPLETE here; no signing_input byte-match is asserted. This vector tests format detection and INCOMPLETE propagation only. A payload-mode prod receipt with ML-DSA-65 signature verification is a documented follow-up (real-cloud KAT vector)."
+  "notes": "Real prod hash-mode receipt (default /sign). payload is null so the signature axis is SKIPPED/INCOMPLETE here; no signing_input byte-match is asserted. This vector tests format detection and INCOMPLETE propagation only. A payload-mode prod receipt with ML-DSA-65 signature verification is a documented follow-up (real-cloud KAT vector).",
+  "failure_class": "unverifiable"
 }

--- a/verifier/conformance-vectors/asqav-06-mldsa65-payload-prod/expected.json
+++ b/verifier/conformance-vectors/asqav-06-mldsa65-payload-prod/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "asqav-native",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Real prod payload-mode receipt signed by ML-DSA-65 (FIPS 204). Agent agt_LBe47lJwgA0DfVom created 2026-06-19; action act_6Xm9cj3AgtPVqZaY8IJnLw signed with key mxYqaLBR_T76ThNw0Kiekw (issuer_id f94f66c0-c580-432d-a041-29374f7aee07). mode=payload so signing_input is canonical_json(full payload dict). ML-DSA-65 signature axis must be PASS, not SKIPPED or INCOMPLETE - this is the known-answer vector for offline ML-DSA-65 against a real cloud receipt. The signed expires_at 2026-06-20T22:23:57.045786Z has lapsed: the expiry axis FAILs on its own (hosted signature_expired label) but never folds the receipt-level verdict, matching hosted parity (criterion 426)."
 }

--- a/verifier/conformance-vectors/asqav-07-revoked-key/expected.json
+++ b/verifier/conformance-vectors/asqav-07-revoked-key/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "asqav-native",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "key_revoked",
-  "notes": "Valid Ed25519 signature but signing key status is 'revoked'; key_status axis FAILs the verdict."
+  "notes": "Valid Ed25519 signature but signing key status is 'revoked'; key_status axis FAILs the verdict.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/asqav-08-v2-signer-canary/expected.json
+++ b/verifier/conformance-vectors/asqav-08-v2-signer-canary/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "asqav-native",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Valid v:2 receipt; signer and _asqav_tid sit inside the signed body, Ed25519 over the canonical payload verifies, signer is surfaced in the verdict."
 }

--- a/verifier/conformance-vectors/asqav-09-v2-signer-tampered/expected.json
+++ b/verifier/conformance-vectors/asqav-09-v2-signer-tampered/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "asqav-native",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "signer flipped after signing; because signer is inside the signed body the Ed25519 signature over the canonical payload no longer matches and the verdict FAILs."
+  "notes": "signer flipped after signing; because signer is inside the signed body the Ed25519 signature over the canonical payload no longer matches and the verdict FAILs.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/asqav-10-hash-mode-multikey/expected.json
+++ b/verifier/conformance-vectors/asqav-10-hash-mode-multikey/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "asqav-native",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Hash-mode receipt signed by the LAST of three sibling keys that share issuer_id/org_id; signature.kid is the org id, so a kid-shaped match answers for every sibling and list position would pick the wrong one. The agent bind (agent_id plus the org_id the receipt signs) resolves the actual signer. ANTI-VACUOUS: pre-change kid-first resolution verifies the first sibling and FAILs. Parity vector: both PY and TS oracles must PASS."
 }

--- a/verifier/conformance-vectors/asqav-11-dup-member-toplevel/expected.json
+++ b/verifier/conformance-vectors/asqav-11-dup-member-toplevel/expected.json
@@ -1,0 +1,7 @@
+{
+  "format": "asqav-native",
+  "outcome": "unverified",
+  "failure_class": "unverifiable",
+  "reason_code": "duplicate_member",
+  "notes": "Top-level 'payload' member appears twice; strict ingest rejects it at parse time, before any hashing or signature check, so it never verifies."
+}

--- a/verifier/conformance-vectors/asqav-11-dup-member-toplevel/jwks.json
+++ b/verifier/conformance-vectors/asqav-11-dup-member-toplevel/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-oracle-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "oJql9HpnWYAv+VX43C0qFKXJnSO+l/hkEn/5ODRVpPA="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-11-dup-member-toplevel/receipt.json
+++ b/verifier/conformance-vectors/asqav-11-dup-member-toplevel/receipt.json
@@ -1,0 +1,38 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-05-04T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_demo_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-05-04T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_demo_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "deny",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-oracle-vec-key",
+    "sig": "WidJSxXAYyzn6WxgYV2CkMwfbcwkF5a7SPCuRVJqcMqND/86ew7XVM080W2isSxoDKe4o1YmWCcg+Ln9rbsQAA=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-12-time-edge-expiry/expected.json
+++ b/verifier/conformance-vectors/asqav-12-time-edge-expiry/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "asqav-native",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
-  "notes": "Deterministic ML-DSA-65 vector minted from the published corpus signing seed (criterion 420; dilithium-py deterministic=True, FIPS 204 pure variant), so the signature bytes reproduce exactly. Time-edge conformance (criterion 422): issued_at 2026-05-19T00:10:00+14:00 is an extreme positive UTC offset around midnight (UTC 2026-05-18T10:10:00, a past instant the skew axis accepts); the signed expires_at 2026-05-20T00:10:00Z has lapsed, so the expiry axis FAILs alone while the verdict stays PASS (criterion 426)."
+  "notes": "Deterministic ML-DSA-65 vector minted from the published corpus signing seed (criterion 420; dilithium-py deterministic=True, FIPS 204 pure variant), so the signature bytes reproduce exactly. Time-edge conformance (criterion 422): issued_at 2026-05-19T00:10:00+14:00 is an extreme positive UTC offset around midnight (UTC 2026-05-18T10:10:00, a past instant the skew axis accepts); the signed expires_at 2026-05-20T00:10:00Z has lapsed, so the expiry axis FAILs alone while the verdict stays verified (criterion 426)."
 }

--- a/verifier/conformance-vectors/asqav-13-dup-member-nested/expected.json
+++ b/verifier/conformance-vectors/asqav-13-dup-member-nested/expected.json
@@ -1,0 +1,7 @@
+{
+  "format": "asqav-native",
+  "outcome": "unverified",
+  "failure_class": "unverifiable",
+  "reason_code": "duplicate_member",
+  "notes": "The payload_digest.hash member is duplicated two levels down; strict ingest rejects duplicate members at any depth at parse time, before any hashing or signature check, so it never verifies."
+}

--- a/verifier/conformance-vectors/asqav-13-dup-member-nested/jwks.json
+++ b/verifier/conformance-vectors/asqav-13-dup-member-nested/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-oracle-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "oJql9HpnWYAv+VX43C0qFKXJnSO+l/hkEn/5ODRVpPA="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-13-dup-member-nested/receipt.json
+++ b/verifier/conformance-vectors/asqav-13-dup-member-nested/receipt.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-05-04T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_demo_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0,
+      "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    "policy_digest": "sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-oracle-vec-key",
+    "sig": "WidJSxXAYyzn6WxgYV2CkMwfbcwkF5a7SPCuRVJqcMqND/86ew7XVM080W2isSxoDKe4o1YmWCcg+Ln9rbsQAA=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/authproof-01-genesis-real-sdk/expected.json
+++ b/verifier/conformance-vectors/authproof-01-genesis-real-sdk/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "authproof",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Receipt minted by the real Authproof JS SDK (Commonguy25/authproof-sdk). ES256 over insertion-order JSON.stringify, hex raw r||s, embedded P-256 JWK. Cross-implementation interop proof."
 }

--- a/verifier/conformance-vectors/authproof-02-forged-sig/expected.json
+++ b/verifier/conformance-vectors/authproof-02-forged-sig/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "authproof",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Signature first byte flipped; ECDSA verify fails."
+  "notes": "Signature first byte flipped; ECDSA verify fails.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/authproof-03-tampered-scope/expected.json
+++ b/verifier/conformance-vectors/authproof-03-tampered-scope/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "authproof",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Scope changed after signing; signature no longer covers the bytes."
+  "notes": "Scope changed after signing; signature no longer covers the bytes.",
+  "failure_class": "invalid"
 }

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -2,357 +2,384 @@
   {
     "dir": "asqav-01-genesis-permit",
     "format": "asqav-native",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Valid Asqav-native genesis permit; Ed25519 over canonical payload verifies."
   },
   {
     "dir": "asqav-02-genesis-deny",
     "format": "asqav-native",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Valid Asqav-native genesis deny decision; signature verifies."
   },
   {
     "dir": "asqav-03-chain-link",
     "format": "asqav-native",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Successor receipt links to its predecessor via SHA-256 of the predecessor canonical payload."
   },
   {
     "dir": "asqav-04-tamper-sig",
     "format": "asqav-native",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "decision flipped after signing; signature no longer matches the canonical payload."
   },
   {
     "dir": "asqav-05-hash-mode-prod",
     "format": "asqav-native",
-    "outcome": "INCOMPLETE",
+    "outcome": "unverified",
+    "failure_class": "unverifiable",
     "reason_code": "signature_skipped_no_dilithium",
     "notes": "Real default-mode prod /sign receipt; the reconstructed signing input byte-matches the prod-signed message and ML-DSA-65 verifies with dilithium-py. Absent that optional dep the signature axis SKIPs, so the verdict is INCOMPLETE, proving the verifier never false-PASSes the post-quantum path it cannot check."
   },
   {
     "dir": "asqav-06-mldsa65-payload-prod",
     "format": "asqav-native",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Real payload-mode prod ML-DSA-65 receipt; the signing input byte-matches and ML-DSA-65 verifies with dilithium-py (proven in test_offline_verify.py's known-answer test). Its signed expires_at lapsed 2026-06-20: the expiry axis FAILs alone while the verdict stays PASS, matching hosted parity (criterion 426). asqav-05-hash-mode-prod carries the SKIP case."
   },
   {
     "dir": "asqav-07-revoked-key",
     "format": "asqav-native",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "key_revoked",
     "notes": "Valid Ed25519 signature from a key whose JWKS status is 'revoked'; the key_status axis FAILs the verdict even though the signature itself verifies. Parity vector: both PY and TS oracles must return FAIL."
   },
   {
     "dir": "aerf-01-genesis",
     "format": "aerf",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Valid AERF genesis; Ed25519 over JCS payload verifies; previous_receipt_hash omitted."
   },
   {
     "dir": "aerf-02-chain-link",
     "format": "aerf",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Second AERF receipt; previous_receipt_hash rederives from the predecessor signable payload (signature excluded, per AERF spec)."
   },
   {
     "dir": "aerf-03-tamper-evidence",
     "format": "aerf",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "action field mutated after signing; signature no longer matches the canonical bytes."
   },
   {
     "dir": "aerf-04-tamper-chain",
     "format": "aerf",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "chain",
     "notes": "previous_receipt_hash mutated; the link no longer rederives from the predecessor."
   },
   {
     "dir": "acta-01-genesis",
     "format": "acta",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Valid ACTA genesis; Ed25519 over JCS(payload) verifies."
   },
   {
     "dir": "acta-02-chain-link",
     "format": "acta",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "ACTA successor links via SHA-256 of the JCS of the full predecessor receipt."
   },
   {
     "dir": "acta-03-tamper-sig",
     "format": "acta",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "sig_mismatch",
     "notes": "Flipped signature byte; Ed25519 verify fails."
   },
   {
     "dir": "acta-05-commitment-mode-unsupported",
     "format": "acta",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "sig_mismatch",
     "notes": "Commitment-mode receipt (signs SHA-256(JCS)) fails the baseline JCS verifier - honest, never a false pass."
   },
   {
     "dir": "acta-up-01-a2a-trusted-attestation",
     "format": "acta",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Real ScopeBlind APS issuer attestation (a2a-trust-header/happy-path.json); the upstream Ed25519 signature over JCS(payload) verifies under our adapter. Inbound interop: we verify a producer we did not write."
   },
   {
     "dir": "acta-up-02-a2a-trajectory-endpoint",
     "format": "acta",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Real ScopeBlind trust-level-ascending endpoint attestation (the 'trusted' link); a second upstream payload whose Ed25519 signature verifies, confirming the interop is not a single-receipt fluke."
   },
   {
     "dir": "acta-up-03-a2a-tampered-sig",
     "format": "acta",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "sig_mismatch",
     "notes": "The real happy-path attestation with its first signature nibble flipped; Ed25519 verify fails, proving the oracle rejects a mutated third-party receipt rather than waving it through."
   },
   {
     "dir": "aerf-up-01-genesis-happy-path",
     "format": "aerf",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Upstream genesis happy path; Ed25519 over JCS payload verifies, previous_receipt_hash omitted."
   },
   {
     "dir": "aerf-up-02-chain-happy-path",
     "format": "aerf",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Upstream three-receipt chain; the final link verifies its signature and rederives previous_receipt_hash from its predecessor (signature excluded from the chain hash)."
   },
   {
     "dir": "aerf-up-03-tamper-evidence",
     "format": "aerf",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Upstream tamper vector; the action field was mutated after signing, so the issuer signature no longer matches."
   },
   {
     "dir": "aerf-up-04-tamper-chain",
     "format": "aerf",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Upstream tamper-in-chain vector; the middle receipt's evidence was mutated after signing, so that receipt's own issuer signature fails. Ingested as the mutated middle receipt with its valid predecessor; the chain link still rederives, the signature is what fails."
   },
   {
     "dir": "aerf-up-05-impact-no-parent-sig",
     "format": "aerf",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "parent_signature",
     "notes": "Upstream impact receipt missing its required parent counter-signature; impact_tags is non-empty so the parent_signature axis fails closed even though the issuer signature is valid."
   },
   {
     "dir": "aerf-up-06-impact-with-parent-sig",
     "format": "aerf",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Upstream impact receipt with valid parent and PDP signatures; issuer, parent, and PDP axes all verify."
   },
   {
     "dir": "aerf-up-07-pdp-binding-valid",
     "format": "aerf",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Upstream PDP-binding happy path; the PDP signature over the canonical {context_hash_sha256, in_policy, policy_hash} tuple verifies."
   },
   {
     "dir": "aerf-up-08-pdp-binding-split-context",
     "format": "aerf",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "pdp_signature",
     "notes": "Upstream split-context vector; the PDP signed a verdict for one context but the receipt claims another, so the PDP-binding axis fails."
   },
   {
     "dir": "aerf-up-11-tag-stripped-known-limit",
     "format": "aerf",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Upstream documents this as a residual the receipt layer cannot close: an agent that controls receipt construction can strip impact_tags before signing, so no counter-sign is required and the issuer signature verifies. Our verifier reaches the same PASS the upstream verifier does; the defense is producer-side tag pinning, outside the receipt bytes. Mapped to PASS because that is the honest outcome the bytes produce, not a relabel."
   },
   {
     "dir": "aerf-up-12-common-mode-known-limit",
     "format": "aerf",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Upstream documents this as a residual: all three signers (issuer, parent, PDP) saw the same poisoned upstream context and signed honestly, so every signature verifies. The receipt records what was attested, not whether the context was sound; our verifier reaches the same PASS the upstream verifier does. Mapped to PASS because every signature genuinely verifies, not a relabel."
   },
   {
     "dir": "agentreceipts-01-didkey-genesis",
     "format": "agentreceipts",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "did:key genesis; key resolves inline, signature verifies, previous_receipt_hash explicit null."
   },
   {
     "dir": "agentreceipts-02-didkey-chain-link",
     "format": "agentreceipts",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Successor links via sha256:hex(JCS(predecessor without proof)); signature verifies."
   },
   {
     "dir": "agentreceipts-03-tamper-payload",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "action.type mutated after signing; canonical bytes no longer match the signature."
   },
   {
     "dir": "agentreceipts-04-tamper-proofvalue",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Single proofValue byte flipped; Ed25519 verification fails."
   },
   {
     "dir": "agentreceipts-05-genesis-missing-prev-hash",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "schema",
     "notes": "previous_receipt_hash omitted; spec requires it present (null on genesis), so the receipt is malformed."
   },
   {
     "dir": "agentreceipts-06-wrong-key",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "verificationMethod resolves (via the injected map) to a different valid Ed25519 key than the signer; signature fails."
   },
   {
     "dir": "agentreceipts-up-00-valid-resigned",
     "format": "agentreceipts",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Upstream malformed-corpus base receipt re-signed cleanly with the upstream keypair; signature verifies over jcs_rfc8785 bytes."
   },
   {
     "dir": "agentreceipts-up-01-wrong-proof-type",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "unverifiable",
     "reason_code": "schema",
     "notes": "Upstream malformed vector: proof.type is not Ed25519Signature2020."
   },
   {
     "dir": "agentreceipts-up-02-mutated-action-type",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Upstream malformed vector: action.type mutated after signing."
   },
   {
     "dir": "agentreceipts-up-03-mutated-principal-id",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Upstream malformed vector: principal.id mutated after signing."
   },
   {
     "dir": "agentreceipts-up-04-truncated-proof-value",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Upstream malformed vector: proofValue truncated to its multibase prefix; empty signature bytes."
   },
   {
     "dir": "agentreceipts-up-05-wrong-multibase-prefix",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Upstream malformed vector: proofValue uses base58 'z' not base64url 'u'; signature bytes do not decode to the real signature."
   },
   {
     "dir": "agentreceipts-up-06-flipped-proof-byte",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Upstream malformed vector: Single proofValue byte mutated; Ed25519 verification fails."
   },
   {
     "dir": "agentreceipts-up-07-tampered-mid-chain",
     "format": "agentreceipts",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Upstream tampered-chain vector: the middle receipt was mutated after signing, so its own issuer signature no longer matches; ingested against its valid predecessor."
   },
   {
     "dir": "agentreceipts-up-08-valid-chain-link",
     "format": "agentreceipts",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Successor signed with the upstream keypair; previous_receipt_hash rederives from sha256:hex(JCS(genesis without proof))."
   },
   {
     "dir": "authproof-01-genesis-real-sdk",
     "format": "authproof",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Receipt minted by the real Authproof JS SDK; ES256 over insertion-order JSON.stringify, hex raw r||s, embedded P-256 JWK. Cross-implementation interop proof."
   },
   {
     "dir": "authproof-02-forged-sig",
     "format": "authproof",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Signature first byte flipped; ECDSA verify fails."
   },
   {
     "dir": "authproof-03-tampered-scope",
     "format": "authproof",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Scope changed after signing; signature no longer covers the bytes."
   },
   {
     "dir": "pipelock-ev2-01-proxy-decision",
     "format": "pipelock-evidence-v2",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Valid proxy_decision EvidenceReceipt v2 from Go reference implementation; signed with RFC 8032 section 7.1 test-1 key (d75a98...). Verifies Ed25519 over JCS preimage (signature zeroed out) and chain genesis sha256:0. Source: luckyPipewrench/pipelock-verify-python commit 9eaff72."
   },
   {
     "dir": "pipelock-ev2-02-tamper-payload",
     "format": "pipelock-evidence-v2",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "Same receipt with payload.verdict changed from 'allow' to 'block' after signing; JCS preimage diverges, Ed25519 verify fails."
   },
   {
     "dir": "asqav-08-v2-signer-canary",
     "format": "asqav-native",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Valid v:2 Asqav receipt; signer and _asqav_tid are ordinary keys inside the signed payload, so JCS sorts them into place and Ed25519 over the canonical body verifies. The neutral verifier surfaces signer and does not require the canary. Parity vector: both PY and TS must PASS and expose signer."
   },
   {
     "dir": "asqav-09-v2-signer-tampered",
     "format": "asqav-native",
-    "outcome": "FAIL",
+    "outcome": "unverified",
+    "failure_class": "invalid",
     "reason_code": "issuer_signature",
     "notes": "The v:2 receipt with signer flipped after signing; because signer sits inside the signed body the canonical bytes diverge and Ed25519 verify FAILs. Parity vector: both PY and TS must FAIL, proving signer is inside the signed coverage, not loose metadata."
   },
   {
     "dir": "asqav-10-hash-mode-multikey",
     "format": "asqav-native",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
     "notes": "Hash-mode receipt signed by the LAST of three sibling keys that share issuer_id/org_id; signature.kid is the org id, so a kid-shaped match answers for every sibling and list position would pick the wrong one. The agent bind (agent_id plus the org_id the receipt signs) resolves the actual signer. ANTI-VACUOUS: pre-change kid-first resolution verifies the first sibling and FAILs. Parity vector: both PY and TS oracles must PASS."
   },
@@ -362,5 +389,21 @@
     "outcome": "PASS",
     "reason_code": "",
     "notes": "Deterministic ML-DSA-65 vector minted from the published corpus signing seed (criterion 420), so its signature bytes reproduce exactly. Time-edge conformance (criterion 422): issued_at 2026-05-19T00:10:00+14:00 is an extreme positive UTC offset around midnight (UTC 2026-05-18T10:10:00, a past instant); the signed expires_at 2026-05-20T00:10:00Z lapsed, so the expiry axis FAILs alone while the verdict stays PASS (criterion 426). Parity vector: both PY and TS oracles must PASS."
+  },
+  {
+    "dir": "asqav-11-dup-member-toplevel",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "failure_class": "unverifiable",
+    "reason_code": "duplicate_member",
+    "notes": "Top-level 'payload' member appears twice (the second flips decision to deny); strict ingest rejects the duplicate at parse time, before any hashing or signature check, so the mutated receipt never verifies (criterion 419)."
+  },
+  {
+    "dir": "asqav-13-dup-member-nested",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "failure_class": "unverifiable",
+    "reason_code": "duplicate_member",
+    "notes": "payload_digest.hash is duplicated two levels down; strict ingest rejects duplicate members at ANY depth at parse time, before any hashing or signature check, so the mutated receipt never verifies (criterion 419)."
   }
 ]

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -386,9 +386,9 @@
   {
     "dir": "asqav-12-time-edge-expiry",
     "format": "asqav-native",
-    "outcome": "PASS",
+    "outcome": "verified",
     "reason_code": "",
-    "notes": "Deterministic ML-DSA-65 vector minted from the published corpus signing seed (criterion 420), so its signature bytes reproduce exactly. Time-edge conformance (criterion 422): issued_at 2026-05-19T00:10:00+14:00 is an extreme positive UTC offset around midnight (UTC 2026-05-18T10:10:00, a past instant); the signed expires_at 2026-05-20T00:10:00Z lapsed, so the expiry axis FAILs alone while the verdict stays PASS (criterion 426). Parity vector: both PY and TS oracles must PASS."
+    "notes": "Deterministic ML-DSA-65 vector minted from the published corpus signing seed (criterion 420), so its signature bytes reproduce exactly. Time-edge conformance (criterion 422): issued_at 2026-05-19T00:10:00+14:00 is an extreme positive UTC offset around midnight (UTC 2026-05-18T10:10:00, a past instant); the signed expires_at 2026-05-20T00:10:00Z lapsed, so the expiry axis FAILs alone while the verdict stays verified (criterion 426). Parity vector: both PY and TS oracles must verify."
   },
   {
     "dir": "asqav-11-dup-member-toplevel",

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -6,8 +6,8 @@
   "files": [
     {
       "path": "README.md",
-      "sha256": "8d18411427b5973837ff247e35c8eba03b7046ad496d8e092c921ada83b02240",
-      "bytes": 5694
+      "sha256": "42fb019594b3ce9f50c69e90664adfd0254ea873060c54522f061e65510abf97",
+      "bytes": 6529
     },
     {
       "path": "UPSTREAM.md",
@@ -21,8 +21,8 @@
     },
     {
       "path": "acta-01-genesis/expected.json",
-      "sha256": "99b62cf28438863dc7938819a1b8b7515ac835a8991c1c589924cc2142d19c7a",
-      "bytes": 135
+      "sha256": "6a25002b43ea3f4c7133a31bbaf95e45df248ca2378df6d02c14b332a22c648a",
+      "bytes": 139
     },
     {
       "path": "acta-01-genesis/receipt.json",
@@ -36,8 +36,8 @@
     },
     {
       "path": "acta-02-chain-link/expected.json",
-      "sha256": "6fbdd1f49c75448df503372da7ab0517da70eb3bbbdd792d5b295b611c14de99",
-      "bytes": 156
+      "sha256": "038c708ecb2ccbda46730be02d62ae287c74964b4a348fe3f6716c27fb25aa62",
+      "bytes": 160
     },
     {
       "path": "acta-02-chain-link/predecessor.json",
@@ -56,8 +56,8 @@
     },
     {
       "path": "acta-03-tamper-sig/expected.json",
-      "sha256": "a001b63f6391091af2e4d0024cf34d681366abcac2b3c861d57c7d1ae52ddb7c",
-      "bytes": 137
+      "sha256": "690bdc3a878e37a45d609bcff3d896cf2a8284d0f84c5e198af4c669e37bd6cd",
+      "bytes": 173
     },
     {
       "path": "acta-03-tamper-sig/receipt.json",
@@ -71,8 +71,8 @@
     },
     {
       "path": "acta-05-commitment-mode-unsupported/expected.json",
-      "sha256": "357cf87008e82e413a1eea26847122fef5d2756e89401af92443d6a62309594d",
-      "bytes": 198
+      "sha256": "6a3bdeb40b636e93a2d5a240f7516e5a8aac5413191b57f14d7ca78a9d89a586",
+      "bytes": 234
     },
     {
       "path": "acta-05-commitment-mode-unsupported/receipt.json",
@@ -86,8 +86,8 @@
     },
     {
       "path": "acta-up-01-a2a-trusted-attestation/expected.json",
-      "sha256": "c0b5da9bcc9d4f13202f771bcca3bef0de472dfcbfd157a4d958eb0b35ada38c",
-      "bytes": 287
+      "sha256": "0937e4c63aacc8f2cdfbf19febb7396d6d79a0d9ee25821186c51fcdba395cf1",
+      "bytes": 291
     },
     {
       "path": "acta-up-01-a2a-trusted-attestation/receipt.json",
@@ -101,8 +101,8 @@
     },
     {
       "path": "acta-up-02-a2a-trajectory-endpoint/expected.json",
-      "sha256": "8fd6f11b4eeae748ec7d172cb8d49e7f66de376c529b9c944310caf81822258e",
-      "bytes": 274
+      "sha256": "165a84bfc0a25acb20cd92cd2fad2db69f5633005acef8e68e1e883b5cc4ae32",
+      "bytes": 278
     },
     {
       "path": "acta-up-02-a2a-trajectory-endpoint/receipt.json",
@@ -116,8 +116,8 @@
     },
     {
       "path": "acta-up-03-a2a-tampered-sig/expected.json",
-      "sha256": "f08c863e3a3bbd928c3d5666cb3f68944e29b182f3a2e7ba5f3861ad68748738",
-      "bytes": 274
+      "sha256": "5b210fd3d6ff95170783b76a52b15526cf38c038d830d3db675b0dcb34fa1be3",
+      "bytes": 310
     },
     {
       "path": "acta-up-03-a2a-tampered-sig/receipt.json",
@@ -126,8 +126,8 @@
     },
     {
       "path": "aerf-01-genesis/expected.json",
-      "sha256": "a486cf37d3d072b02d707ea25889dd59f13d53703941439b9840e4f467ce2937",
-      "bytes": 169
+      "sha256": "89d99a28c0874f4f862133061b62ec9586b386c060ca35616bc14584f62b5451",
+      "bytes": 174
     },
     {
       "path": "aerf-01-genesis/keys.json",
@@ -141,8 +141,8 @@
     },
     {
       "path": "aerf-02-chain-link/expected.json",
-      "sha256": "f805c0e74ba8f4a933e4add20506f1333198cb0f75defd346170b803ddbefc1c",
-      "bytes": 219
+      "sha256": "1974ea665cc50b746a1cbc82171cee877b9139ecbb622ba5c78aaec6a325cd87",
+      "bytes": 224
     },
     {
       "path": "aerf-02-chain-link/keys.json",
@@ -161,8 +161,8 @@
     },
     {
       "path": "aerf-03-tamper-evidence/expected.json",
-      "sha256": "164e38806a7760adf64f60940f11b25bc9100ec1e8b1f6c758feea1a3241584d",
-      "bytes": 187
+      "sha256": "257c47fb07633e4114972ee55a58cc4e66f0c34da0a3f23cf54c3e33eed5f35e",
+      "bytes": 224
     },
     {
       "path": "aerf-03-tamper-evidence/keys.json",
@@ -176,8 +176,8 @@
     },
     {
       "path": "aerf-04-tamper-chain/expected.json",
-      "sha256": "f76e8630abf1b5f0c69130d37ecad70964fa92aa7b219099b2561865caedd390",
-      "bytes": 165
+      "sha256": "c8a91f0e16e80e05acb9d4c0ce42ced33b8a47e012b229a91553f9a0d6acefcf",
+      "bytes": 202
     },
     {
       "path": "aerf-04-tamper-chain/keys.json",
@@ -196,8 +196,8 @@
     },
     {
       "path": "aerf-up-01-genesis-happy-path/expected.json",
-      "sha256": "c4a3fc0688cb6a3063c2f49575607101a686467409b38828351c90b1af765118",
-      "bytes": 174
+      "sha256": "9d42a3d7cfdb3ce4c5a1ab4d3a15c0048387d1c5fb520339feff51a3e596cabe",
+      "bytes": 178
     },
     {
       "path": "aerf-up-01-genesis-happy-path/keys.json",
@@ -211,8 +211,8 @@
     },
     {
       "path": "aerf-up-02-chain-happy-path/expected.json",
-      "sha256": "c3cc9b015f8b5fb100740486889654c0b50765c8c5c5030bdd17c5d7aeed1973",
-      "bytes": 246
+      "sha256": "371d3060f1e68a5dd1e01515e6b1707a388174212d52974fa354a0abc354d786",
+      "bytes": 250
     },
     {
       "path": "aerf-up-02-chain-happy-path/keys.json",
@@ -231,8 +231,8 @@
     },
     {
       "path": "aerf-up-03-tamper-evidence/expected.json",
-      "sha256": "1043badf3d1a9d56bcaf486e35c8fc8df60fb252a9cff590bc1651b21767ce84",
-      "bytes": 206
+      "sha256": "27fa3d2a754f466fb0c9f1ae068000f712de98db8b95355c779e5a86cc46c30f",
+      "bytes": 242
     },
     {
       "path": "aerf-up-03-tamper-evidence/keys.json",
@@ -246,8 +246,8 @@
     },
     {
       "path": "aerf-up-04-tamper-chain/expected.json",
-      "sha256": "5929b7c89b9e269f7eb09c460309e36db1660beedcbe225ed2f5073096556562",
-      "bytes": 359
+      "sha256": "da30e4aaf1b4ffa5c5a3141dd934616d1aa6ac160ac77f069d0949aa47bce2d2",
+      "bytes": 395
     },
     {
       "path": "aerf-up-04-tamper-chain/keys.json",
@@ -266,8 +266,8 @@
     },
     {
       "path": "aerf-up-05-impact-no-parent-sig/expected.json",
-      "sha256": "f4e3fbc926e8cbe3ee6c8e115566eff26f320c06f24ecb29779a7ed4dd519b1c",
-      "bytes": 276
+      "sha256": "ad6bc0f55b104446de4e3e7e905b31e2e60217f973021681c9c5a515168c8fd3",
+      "bytes": 312
     },
     {
       "path": "aerf-up-05-impact-no-parent-sig/keys.json",
@@ -281,8 +281,8 @@
     },
     {
       "path": "aerf-up-06-impact-with-parent-sig/expected.json",
-      "sha256": "5b039fadaf8a4e1fc56d2580b84ebc5b17349557ee8171945a7bc51bff9c8e4d",
-      "bytes": 182
+      "sha256": "cb4363bab841905c73dd2a07f5bb8f24a34c79d088c7504c1fedb5e7af03a4d9",
+      "bytes": 186
     },
     {
       "path": "aerf-up-06-impact-with-parent-sig/keys.json",
@@ -296,8 +296,8 @@
     },
     {
       "path": "aerf-up-07-pdp-binding-valid/expected.json",
-      "sha256": "e7e313ef88b11a36f938c51c542242a69ec365840bda06c6757e4588d0874583",
-      "bytes": 211
+      "sha256": "5a8f2cce61d983c128b977b814f30be971577324d4f928d1dadd121c2b924630",
+      "bytes": 215
     },
     {
       "path": "aerf-up-07-pdp-binding-valid/keys.json",
@@ -311,8 +311,8 @@
     },
     {
       "path": "aerf-up-08-pdp-binding-split-context/expected.json",
-      "sha256": "99c9f38881e2f4967c5b5d68023ee0acab2626a3b3894404644179dbe488ed0a",
-      "bytes": 227
+      "sha256": "b0f659bfa564c748a144858df4aa6af341e2e7be81f99c44a6d1c636ca438dc6",
+      "bytes": 263
     },
     {
       "path": "aerf-up-08-pdp-binding-split-context/keys.json",
@@ -326,8 +326,8 @@
     },
     {
       "path": "aerf-up-11-tag-stripped-known-limit/expected.json",
-      "sha256": "d48eb91f8604a69135836b092df92c0a920c45b31cb3cb94f67ecd04368cb083",
-      "bytes": 513
+      "sha256": "06d475243ae1f96a28befbe68f68c56e4ccc80087dd8284b319a4c6d2becaa2a",
+      "bytes": 517
     },
     {
       "path": "aerf-up-11-tag-stripped-known-limit/keys.json",
@@ -341,8 +341,8 @@
     },
     {
       "path": "aerf-up-12-common-mode-known-limit/expected.json",
-      "sha256": "7d68aefeef2c18d987bc031c61a80eb148bdc2a6ad7699fd6e443fc3afb10726",
-      "bytes": 458
+      "sha256": "d0f1e8d5ec2f8f9995e82067a0e0dd49353dde06234734c2b50d088cb00c7f21",
+      "bytes": 462
     },
     {
       "path": "aerf-up-12-common-mode-known-limit/keys.json",
@@ -356,8 +356,8 @@
     },
     {
       "path": "agentreceipts-01-didkey-genesis/expected.json",
-      "sha256": "72f549f84a2176765bc22ba599ffd9c97473bb5157a309be43a790a18d005a3e",
-      "bytes": 183
+      "sha256": "e50179dfe636d4016925f23e7e47c5238b567fdd839113be022e23a8734c8409",
+      "bytes": 187
     },
     {
       "path": "agentreceipts-01-didkey-genesis/receipt.json",
@@ -366,8 +366,8 @@
     },
     {
       "path": "agentreceipts-02-didkey-chain-link/expected.json",
-      "sha256": "1877f683b6e1dbe44471b34bea433207ce67523ba77b9660bba62eff4d699f82",
-      "bytes": 172
+      "sha256": "326535c27cf95119859c03c8ac56bfb92cdfb1dd59d3388cade623d127e3cbe2",
+      "bytes": 176
     },
     {
       "path": "agentreceipts-02-didkey-chain-link/predecessor.json",
@@ -381,8 +381,8 @@
     },
     {
       "path": "agentreceipts-03-tamper-payload/expected.json",
-      "sha256": "bc99103abe21b52238b0833b0194d8411b1ac9476b6b631245bd9352b205cc68",
-      "bytes": 186
+      "sha256": "e990dc0c4b5d040c6549f63c86ecebee9056e9cbc1e9f34f85777bd946ecbce4",
+      "bytes": 222
     },
     {
       "path": "agentreceipts-03-tamper-payload/receipt.json",
@@ -391,8 +391,8 @@
     },
     {
       "path": "agentreceipts-04-tamper-proofvalue/expected.json",
-      "sha256": "c194000c50895c7fdeaef387ab96f46dbb18297dec0589d0a13d97e4f861ce62",
-      "bytes": 164
+      "sha256": "de4564e9bbde52ef7a19cf048e857335c0b4093a9d1a514812fc48db04c94b72",
+      "bytes": 200
     },
     {
       "path": "agentreceipts-04-tamper-proofvalue/receipt.json",
@@ -401,8 +401,8 @@
     },
     {
       "path": "agentreceipts-05-genesis-missing-prev-hash/expected.json",
-      "sha256": "db385f7b2841e206f727a65dfe4bb4d5ddd906810fbc5b8e1c5c62a371826b67",
-      "bytes": 198
+      "sha256": "a3458ed921c4bba2257e16d34947ec8d6c6719eb47504716aa15ac75214250f0",
+      "bytes": 234
     },
     {
       "path": "agentreceipts-05-genesis-missing-prev-hash/receipt.json",
@@ -416,8 +416,8 @@
     },
     {
       "path": "agentreceipts-06-wrong-key/expected.json",
-      "sha256": "8934b13f5ee03c4c67dd57edbe2085b3c9c40ed8d7dbd02451a74903cad8710f",
-      "bytes": 222
+      "sha256": "cb520e3e87f841ccecf6f991389d01baa090e5f7ea7ad508fe9a36e1966ec5a2",
+      "bytes": 258
     },
     {
       "path": "agentreceipts-06-wrong-key/receipt.json",
@@ -431,8 +431,8 @@
     },
     {
       "path": "agentreceipts-up-00-valid-resigned/expected.json",
-      "sha256": "2ca31042a3cf16a15aceab7e06bf6582370916249aa7b5a795a707d7aaa704a0",
-      "bytes": 215
+      "sha256": "59bf41070a56fafc0934e095baed6a5fc0370c82aa5c8d68cb3fee367ee9125c",
+      "bytes": 219
     },
     {
       "path": "agentreceipts-up-00-valid-resigned/receipt.json",
@@ -446,8 +446,8 @@
     },
     {
       "path": "agentreceipts-up-01-wrong-proof-type/expected.json",
-      "sha256": "09d7950118a6dc8a82b86e35e8ca5397b41b3e25897e9296b0981e46045e5c6d",
-      "bytes": 161
+      "sha256": "b829a976dc33fec0335d98253c853ad219e776e00beb0eb4469ce074010a6415",
+      "bytes": 202
     },
     {
       "path": "agentreceipts-up-01-wrong-proof-type/receipt.json",
@@ -461,8 +461,8 @@
     },
     {
       "path": "agentreceipts-up-02-mutated-action-type/expected.json",
-      "sha256": "7813674efe4a9e6c2084924d68c2e8a035183259bf4ac67bb0245e0546dbfb30",
-      "bytes": 166
+      "sha256": "4113fabc0d39c54c7e9fc51a7315db87ea6d36c1d37000125a673893017868c7",
+      "bytes": 202
     },
     {
       "path": "agentreceipts-up-02-mutated-action-type/receipt.json",
@@ -476,8 +476,8 @@
     },
     {
       "path": "agentreceipts-up-03-mutated-principal-id/expected.json",
-      "sha256": "5161e679b9e4862f63169143a01c6c72833f7d85778533c38cb264db75c1a694",
-      "bytes": 167
+      "sha256": "d00140aa3b9b3c2bace16b65cf91bf96c624ba0618b1c7c0ab31c048a5ecd3ca",
+      "bytes": 203
     },
     {
       "path": "agentreceipts-up-03-mutated-principal-id/receipt.json",
@@ -491,8 +491,8 @@
     },
     {
       "path": "agentreceipts-up-04-truncated-proof-value/expected.json",
-      "sha256": "6f1b74ab8054bc2e95f1cd9a7912c5da812fefa4aa64a7bb7dddfcc0b9c2c182",
-      "bytes": 200
+      "sha256": "563a653523fbc1ed5a09edad717d50fb9c763e1747425f5d54166da0897da1bc",
+      "bytes": 236
     },
     {
       "path": "agentreceipts-up-04-truncated-proof-value/receipt.json",
@@ -506,8 +506,8 @@
     },
     {
       "path": "agentreceipts-up-05-wrong-multibase-prefix/expected.json",
-      "sha256": "7a5a14cc4884408d752f9f206ebb4173d7d7d7b3041f33d7bb2e8d4d2c3fe2ad",
-      "bytes": 230
+      "sha256": "53bca5c4d78f90697799c7c5a49b518b4c026f30b2a7083403851c3eac4ce77c",
+      "bytes": 266
     },
     {
       "path": "agentreceipts-up-05-wrong-multibase-prefix/receipt.json",
@@ -521,8 +521,8 @@
     },
     {
       "path": "agentreceipts-up-06-flipped-proof-byte/expected.json",
-      "sha256": "90e5f431e94c70a04893d8771b15a8a144a8eb04beceddddf9d935e798ef58f7",
-      "bytes": 191
+      "sha256": "da5b4f740244d276ae9ace47b72e9513b64c0edb50468e164e7d00dd4fd3efb3",
+      "bytes": 227
     },
     {
       "path": "agentreceipts-up-06-flipped-proof-byte/receipt.json",
@@ -536,8 +536,8 @@
     },
     {
       "path": "agentreceipts-up-07-tampered-mid-chain/expected.json",
-      "sha256": "48cb4f051fd6e68d62b87b624cb3eb4f98305241cb66b61ebf02685c551519f4",
-      "bytes": 269
+      "sha256": "13ca80f61e8e19551f39135435ed28be9cb4d6973fca1ca200fcb7eaa5780273",
+      "bytes": 305
     },
     {
       "path": "agentreceipts-up-07-tampered-mid-chain/predecessor.json",
@@ -556,8 +556,8 @@
     },
     {
       "path": "agentreceipts-up-08-valid-chain-link/expected.json",
-      "sha256": "b81cd0c6bec7ad3866310c692cb18d7ffa37f978d6b81843deb64cc193531683",
-      "bytes": 209
+      "sha256": "7715606674350e64bb3a23467af8dda0280030a5b00dd1e82c3457b24fa6828e",
+      "bytes": 213
     },
     {
       "path": "agentreceipts-up-08-valid-chain-link/predecessor.json",
@@ -581,8 +581,8 @@
     },
     {
       "path": "asqav-01-genesis-permit/expected.json",
-      "sha256": "ea08d1e6100bc038107e1ea5e32e256a2e8af1adc783d14358d102dc23beb10c",
-      "bytes": 194
+      "sha256": "72257a48afe336d13b589dccbcdf83743d80437dee729954d0a9494e915e9fbf",
+      "bytes": 199
     },
     {
       "path": "asqav-01-genesis-permit/jwks.json",
@@ -596,8 +596,8 @@
     },
     {
       "path": "asqav-02-genesis-deny/expected.json",
-      "sha256": "d358e6e162047ac41403d7845440014774611080ed8b932a00701592ebed5e50",
-      "bytes": 135
+      "sha256": "4e2a3e0e0fbae67a1e243b82c0e240401cefe7fc6d33b84f479ff8f086cded5f",
+      "bytes": 140
     },
     {
       "path": "asqav-02-genesis-deny/jwks.json",
@@ -611,8 +611,8 @@
     },
     {
       "path": "asqav-03-chain-link/expected.json",
-      "sha256": "add238f86c1b8e66b4963f49593e8bc49d89212594f781d34bafbe53b9eee755",
-      "bytes": 198
+      "sha256": "59cf35472dcc75f090840ba3b126bc963f41783d27192f21ffdb93aae905446d",
+      "bytes": 203
     },
     {
       "path": "asqav-03-chain-link/jwks.json",
@@ -631,8 +631,8 @@
     },
     {
       "path": "asqav-04-tamper-sig/expected.json",
-      "sha256": "23209e25b6062db14985955d6ae5d56c3ba0b1be22c46f9aee2b8d5fb7999ec4",
-      "bytes": 204
+      "sha256": "6a546ffe7d28449a75606be56610780b9e4dd0cdf98526e9ac3a89ed885ed584",
+      "bytes": 241
     },
     {
       "path": "asqav-04-tamper-sig/jwks.json",
@@ -646,8 +646,8 @@
     },
     {
       "path": "asqav-05-hash-mode-prod/expected.json",
-      "sha256": "491556e6f28d91888bcfb3b1708b20e6ac33c6501a606c3af22ee7c1be40d563",
-      "bytes": 460
+      "sha256": "095cf2c05f0348f4d7e606c88fe5594850b4ef775357a21643c8ab75511950d0",
+      "bytes": 495
     },
     {
       "path": "asqav-05-hash-mode-prod/jwks.json",
@@ -666,8 +666,8 @@
     },
     {
       "path": "asqav-06-mldsa65-payload-prod/expected.json",
-      "sha256": "be06af1e40aac7d0e822fbe8a3c30de0f2eb680cf8d69252567d261656fe8eba",
-      "bytes": 750
+      "sha256": "bb2b199ca610f13b136496ff84b832d4aabfefddb38d482d50dc155d19592b7e",
+      "bytes": 754
     },
     {
       "path": "asqav-06-mldsa65-payload-prod/jwks.json",
@@ -681,8 +681,8 @@
     },
     {
       "path": "asqav-07-revoked-key/expected.json",
-      "sha256": "0f55827533ead2e3f457966d937abd235da72fdc6068677c2b455f441d55bd17",
-      "bytes": 194
+      "sha256": "15add9bbb4e86a185ea211370dba29f68367aa7eac1c787edc272d5b2f46b19a",
+      "bytes": 230
     },
     {
       "path": "asqav-07-revoked-key/jwks.json",
@@ -696,8 +696,8 @@
     },
     {
       "path": "asqav-08-v2-signer-canary/expected.json",
-      "sha256": "0ac0f0545fbf14ed5e81f8b380db03cf313eaca01a364a81ab70cace048630f6",
-      "bytes": 236
+      "sha256": "2095b072b9b21f4ce386c8e4ac982936b5a4e1a26b112b3f2494d06c4fa072e0",
+      "bytes": 240
     },
     {
       "path": "asqav-08-v2-signer-canary/jwks.json",
@@ -711,8 +711,8 @@
     },
     {
       "path": "asqav-09-v2-signer-tampered/expected.json",
-      "sha256": "34cd093e4a4eb05e290754464886cd20055175c3bca6ed253e4f4ac8bce74ed8",
-      "bytes": 264
+      "sha256": "4c8855d8e17c9d7a294d0be39bff6d8d536646ad18c56574af3a7b9a22123167",
+      "bytes": 300
     },
     {
       "path": "asqav-09-v2-signer-tampered/jwks.json",
@@ -726,8 +726,8 @@
     },
     {
       "path": "asqav-10-hash-mode-multikey/expected.json",
-      "sha256": "3f5466a35fe4f2e7a17ea89f291a61b919c001897c55165c480fef8f37104128",
-      "bytes": 517
+      "sha256": "3c98c29f46c49dec9682e9d5f0d404b4afcfdda452b3be795e899d6271e0274a",
+      "bytes": 521
     },
     {
       "path": "asqav-10-hash-mode-multikey/jwks.json",
@@ -740,9 +740,24 @@
       "bytes": 603
     },
     {
+      "path": "asqav-11-dup-member-toplevel/expected.json",
+      "sha256": "c624641d5affc05afdfaf00f366b1f7af0780268f894601e272c2863975ad7ac",
+      "bytes": 287
+    },
+    {
+      "path": "asqav-11-dup-member-toplevel/jwks.json",
+      "sha256": "233a208e9564acea9f24faa2ffaa8bebce04d752bee685e581eef16c2b9c51a4",
+      "bytes": 217
+    },
+    {
+      "path": "asqav-11-dup-member-toplevel/receipt.json",
+      "sha256": "1b1e78eb0189a0d28eeb1820158bbbf48d39f1ad4a677141afe9518fd6ce08ea",
+      "bytes": 1464
+    },
+    {
       "path": "asqav-12-time-edge-expiry/expected.json",
-      "sha256": "115a8bc53cc423c3753da34fe788ab3182e3b893a527a153f2e96c34b51ebcae",
-      "bytes": 601
+      "sha256": "4ee238d716051a55e735e89f7aa8724826245f7d65b6356746d8266ba9fde53e",
+      "bytes": 609
     },
     {
       "path": "asqav-12-time-edge-expiry/jwks.json",
@@ -755,9 +770,24 @@
       "bytes": 5308
     },
     {
+      "path": "asqav-13-dup-member-nested/expected.json",
+      "sha256": "31ea22ea00a547260cf8f8c6b0cb997a1af0180b4c03c4108ca702633727d4c8",
+      "bytes": 335
+    },
+    {
+      "path": "asqav-13-dup-member-nested/jwks.json",
+      "sha256": "233a208e9564acea9f24faa2ffaa8bebce04d752bee685e581eef16c2b9c51a4",
+      "bytes": 217
+    },
+    {
+      "path": "asqav-13-dup-member-nested/receipt.json",
+      "sha256": "2c973720a1e939a89a172374a58069bbce7328a6e0cf9bd8a29dcd2b9c5df8fe",
+      "bytes": 915
+    },
+    {
       "path": "authproof-01-genesis-real-sdk/expected.json",
-      "sha256": "bb2b3ab0cc45e1e940ede89af2e80291e6cd6531d5c04e12c336932d87777a39",
-      "bytes": 269
+      "sha256": "5599a2e6341d4194186cd5c43be8c271c2dd40d8a382f1be536d89488e6378a8",
+      "bytes": 274
     },
     {
       "path": "authproof-01-genesis-real-sdk/receipt.json",
@@ -766,8 +796,8 @@
     },
     {
       "path": "authproof-02-forged-sig/expected.json",
-      "sha256": "7d94ad2c0dceed59730f931fedfe69a7de067985c38679f87895df473cd43336",
-      "bytes": 149
+      "sha256": "e8b42e53a622ba9251d48c5ec975e357e5ad26f9d4e0e2e54b1ae739dbd8183e",
+      "bytes": 186
     },
     {
       "path": "authproof-02-forged-sig/receipt.json",
@@ -776,8 +806,8 @@
     },
     {
       "path": "authproof-03-tampered-scope/expected.json",
-      "sha256": "8fc68fac0298b037a3ac821e8607cb4211af08e496eacb6bc35a637b8ca22730",
-      "bytes": 166
+      "sha256": "727543274ada80070b9242064bd7d554f1d02a0f0df566a3f4ce0a53812c68fc",
+      "bytes": 203
     },
     {
       "path": "authproof-03-tampered-scope/receipt.json",
@@ -821,13 +851,13 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "cfddfb6b8c74f16be2ecf076ef98575460729aa09391ba4444a76fd213d28ea0",
-      "bytes": 15773
+      "sha256": "86d4450636912ae97ec1a00e1aa7009f5f45b79f734890ae5e7d8f3cd3813be9",
+      "bytes": 17747
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
-      "sha256": "c650f44e272ffa298037143ebdc291304467158b8edf5c703dc9ee5a72da749e",
-      "bytes": 375
+      "sha256": "c9023914bba62a4bf23e512b401f6af931eb0dfc90d25efd9e4d4f98a91a6bcd",
+      "bytes": 379
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/keys.json",
@@ -841,8 +871,8 @@
     },
     {
       "path": "pipelock-ev2-02-tamper-payload/expected.json",
-      "sha256": "daf3dcccc23043df60b61170db73a9bbf66ffc0afab8324bfed248d8e561dfae",
-      "bytes": 237
+      "sha256": "a19aa73082502ad4a484e7f189cd69fa7834dc61b364f576312c0c0716a3016a",
+      "bytes": 273
     },
     {
       "path": "pipelock-ev2-02-tamper-payload/keys.json",
@@ -885,5 +915,5 @@
       ]
     }
   },
-  "digest": "3206eaf283ef84c3e54ea5d860ecc08a792fbd316daec04ea64072d9b6e05503"
+  "digest": "37fdb7564b54303dde937e6f3324321e108dcd3710367ca6b0cf19906d029103"
 }

--- a/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/expected.json
+++ b/verifier/conformance-vectors/pipelock-ev2-01-proxy-decision/expected.json
@@ -1,6 +1,6 @@
 {
   "format": "pipelock-evidence-v2",
-  "outcome": "PASS",
+  "outcome": "verified",
   "reason_code": "",
   "notes": "Valid proxy_decision EvidenceReceipt v2 from Go reference implementation; signed with RFC 8032 section 7.1 test-1 key (d75a98...). Verifies Ed25519 over JCS preimage (signature zeroed out) and chain genesis sha256:0. Source: luckyPipewrench/pipelock-verify-python commit 9eaff72."
 }

--- a/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/expected.json
+++ b/verifier/conformance-vectors/pipelock-ev2-02-tamper-payload/expected.json
@@ -1,6 +1,7 @@
 {
   "format": "pipelock-evidence-v2",
-  "outcome": "FAIL",
+  "outcome": "unverified",
   "reason_code": "issuer_signature",
-  "notes": "Same receipt with payload.verdict changed from 'allow' to 'block' after signing; JCS preimage diverges, Ed25519 verify fails."
+  "notes": "Same receipt with payload.verdict changed from 'allow' to 'block' after signing; JCS preimage diverges, Ed25519 verify fails.",
+  "failure_class": "invalid"
 }

--- a/verifier/cross-language-cases.json
+++ b/verifier/cross-language-cases.json
@@ -1,40 +1,1850 @@
 {
   "note": "Cross-language adversarial case table. Both the Python and the TypeScript suites feed every case through their own verifier and assert the same verdict and the same result for each named axis. The signature axis is not the subject: the public keys resolve but never verify, so most cases end in FAIL and the per-axis assertions carry the meaning.",
   "cases": [
-    {"name":"hash org matches canonical uuid issuer","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"PASS","structure":"PASS"}}},
-    {"name":"hash org differs from canonical uuid issuer","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"FAIL"}}},
-    {"name":"issuer is the same uuid undashed","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0c580432da04129374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"issuer is a urn uuid","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"urn:uuid:f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"issuer is a brace wrapped uuid","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"{f94f66c0-c580-432d-a041-29374f7aee07}","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"issuer is an arbitrarily dashed uuid","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"issuer is an uppercase canonical uuid","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"0B6C2B1E-9F7A-4D3C-8A11-5C2E7D904F38","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"FAIL"}}},
-    {"name":"issuer is a number","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":12345,"alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"issuer is a legal entity label","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"Acme Compliance Ltd","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"label issuer with org_id published and matching","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"Acme Compliance Ltd","alg":"ML-DSA-65","status":"active","public_key":"AAAA","org_id":"f94f66c0-c580-432d-a041-29374f7aee07"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"PASS"}}},
-    {"name":"label issuer with org_id published and differing","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"Acme Compliance Ltd","alg":"ML-DSA-65","status":"active","public_key":"AAAA","org_id":"0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"FAIL"}}},
-    {"name":"org_id published as a number","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"Acme Compliance Ltd","alg":"ML-DSA-65","status":"active","public_key":"AAAA","org_id":99}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"receipt org_id absent","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":null,"policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"structure":"FAIL"}}},
-    {"name":"receipt org_id is a number","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":7,"policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"FAIL"}}},
-    {"name":"hash receipt displaying issuer_id","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA","issuer_id":"0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"structure":"FAIL"}}},
-    {"name":"hash receipt displaying previousReceiptHash","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"structure":"FAIL"}}},
-    {"name":"compliance issuer matches","receipt":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00.000000Z","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","agent_id":"agt_1","action_ref":"sha256:8888888888888888888888888888888888888888888888888888888888888888","payload_digest":{"hash":"8888888888888888888888888888888888888888888888888888888888888888","size":512},"policy_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[]},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"PASS","structure":"PASS"}}},
-    {"name":"compliance issuer differs","receipt":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00.000000Z","issuer_id":"0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38","agent_id":"agt_1","action_ref":"sha256:8888888888888888888888888888888888888888888888888888888888888888","payload_digest":{"hash":"8888888888888888888888888888888888888888888888888888888888888888","size":512},"policy_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[]},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"FAIL"}}},
-    {"name":"compliance issuer is a number","receipt":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00.000000Z","issuer_id":5,"agent_id":"agt_1","action_ref":"sha256:8888888888888888888888888888888888888888888888888888888888888888","payload_digest":{"hash":"8888888888888888888888888888888888888888888888888888888888888888","size":512},"policy_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[]},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"FAIL"}}},
-    {"name":"jwks keys is not a list","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":"nope"},"expect":{"verdict":"INCOMPLETE","axes":{"signature":"SKIPPED"}}},
-    {"name":"jwks keys holds non objects","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[1,2]},"expect":{"verdict":"INCOMPLETE","axes":{"signature":"SKIPPED"}}},
-    {"name":"issuer is the claimed uuid plus a trailing newline","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07\n","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"issuer is a different uuid plus a trailing newline","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38\n","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"issuer is the claimed uuid plus a carriage return","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07\r","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"issuer is the claimed uuid with a leading newline","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"\nf94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"org_id published as the claimed uuid plus a newline","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"Acme Compliance Ltd","alg":"ML-DSA-65","status":"active","public_key":"AAAA","org_id":"f94f66c0-c580-432d-a041-29374f7aee07\n"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"SKIPPED"}}},
-    {"name":"issuer is the claimed uuid in uppercase","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"F94F66C0-C580-432D-A041-29374F7AEE07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"PASS"}}},
-    {"name":"issuer is the claimed uuid in mixed case","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"F94F66c0-C580-432D-a041-29374F7AEE07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"PASS"}}},
-    {"name":"receipt claims the org id in uppercase","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"F94F66C0-C580-432D-A041-29374F7AEE07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"PASS"}}},
-    {"name":"org_id published in uppercase","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"Acme Compliance Ltd","alg":"ML-DSA-65","status":"active","public_key":"AAAA","org_id":"F94F66C0-C580-432D-A041-29374F7AEE07"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"PASS"}}},
-    {"name":"uppercase issuer naming a different org","receipt":{"v":1,"mode":"hash","hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","hash_algo":"sha256","metadata":{},"server_timestamp":"2026-06-19T00:00:00.000000Z","action_id":"act_1","agent_id":"agt_1","org_id":"f94f66c0-c580-432d-a041-29374f7aee07","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","policy_decision":"allow","key_id":"k1","algorithm":"ML-DSA-65","payload":null,"anchors":[],"signature_b64":"AAAA"},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"0B6C2B1E-9F7A-4D3C-8A11-5C2E7D904F38","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"issuer_bind":"FAIL"}}},
-    {"name":"receipt nested past the depth cap outside the signed payload","receipt":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00.000000Z","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","agent_id":"agt_1","action_ref":"sha256:8888888888888888888888888888888888888888888888888888888888888888","payload_digest":{"hash":"8888888888888888888888888888888888888888888888888888888888888888","size":512},"policy_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":{"alg":"ML-DSA-65","kid":"k1","sig":"AAAA"},"anchors":[],"junk":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"n":{"leaf":1}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}},"jwks":{"keys":[{"kid":"k1","agent_id":"agt_1","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"INCOMPLETE","axes":{"structure":"FAIL"}}},
-    {"name":"org kid resolves the agent the receipt names, sibling listed first","receipt":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00.000000Z","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","agent_id":"agt_two","action_ref":"sha256:8888888888888888888888888888888888888888888888888888888888888888","payload_digest":{"hash":"8888888888888888888888888888888888888888888888888888888888888888","size":512},"policy_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":{"alg":"ML-DSA-65","kid":"f94f66c0-c580-432d-a041-29374f7aee07","sig":"AAAA"},"anchors":[]},"jwks":{"keys":[{"kid":"k-agent-one","agent_id":"agt_one","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"revoked","public_key":"AAAA"},{"kid":"k-agent-two","agent_id":"agt_two","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"key_status":"PASS","issuer_bind":"PASS"}}},
-    {"name":"org kid reports the revoked signer rather than its active sibling","receipt":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00.000000Z","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","agent_id":"agt_two","action_ref":"sha256:8888888888888888888888888888888888888888888888888888888888888888","payload_digest":{"hash":"8888888888888888888888888888888888888888888888888888888888888888","size":512},"policy_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":{"alg":"ML-DSA-65","kid":"f94f66c0-c580-432d-a041-29374f7aee07","sig":"AAAA"},"anchors":[]},"jwks":{"keys":[{"kid":"k-agent-one","agent_id":"agt_one","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"active","public_key":"AAAA"},{"kid":"k-agent-two","agent_id":"agt_two","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","alg":"ML-DSA-65","status":"revoked","public_key":"AAAA"}]},"expect":{"verdict":"FAIL","axes":{"key_status":"FAIL","issuer_bind":"PASS"}}},
-    {"name":"org kid keeps the issuer bind when the agent key belongs to another org","receipt":{"payload":{"type":"protectmcp:decision","issued_at":"2026-06-19T00:00:00.000000Z","issuer_id":"f94f66c0-c580-432d-a041-29374f7aee07","agent_id":"agt_two","action_ref":"sha256:8888888888888888888888888888888888888888888888888888888888888888","payload_digest":{"hash":"8888888888888888888888888888888888888888888888888888888888888888","size":512},"policy_digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333","previousReceiptHash":"0000000000000000000000000000000000000000000000000000000000000000","decision":"allow"},"signature":{"alg":"ML-DSA-65","kid":"f94f66c0-c580-432d-a041-29374f7aee07","sig":"AAAA"},"anchors":[]},"jwks":{"keys":[{"kid":"k-foreign","agent_id":"agt_two","issuer_id":"0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38","alg":"ML-DSA-65","status":"active","public_key":"AAAA"}]},"expect":{"verdict":"INCOMPLETE","axes":{"signature":"SKIPPED"}}}
+    {
+      "name": "hash org matches canonical uuid issuer",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "PASS",
+          "structure": "PASS"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "hash org differs from canonical uuid issuer",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is the same uuid undashed",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0c580432da04129374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is a urn uuid",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "urn:uuid:f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is a brace wrapped uuid",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "{f94f66c0-c580-432d-a041-29374f7aee07}",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is an arbitrarily dashed uuid",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is an uppercase canonical uuid",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "0B6C2B1E-9F7A-4D3C-8A11-5C2E7D904F38",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is a number",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": 12345,
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is a legal entity label",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "Acme Compliance Ltd",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "label issuer with org_id published and matching",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "Acme Compliance Ltd",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA",
+            "org_id": "f94f66c0-c580-432d-a041-29374f7aee07"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "PASS"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "label issuer with org_id published and differing",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "Acme Compliance Ltd",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA",
+            "org_id": "0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "org_id published as a number",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "Acme Compliance Ltd",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA",
+            "org_id": 99
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "receipt org_id absent",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": null,
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "structure": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "receipt org_id is a number",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": 7,
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "hash receipt displaying issuer_id",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA",
+        "issuer_id": "0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "structure": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "hash receipt displaying previousReceiptHash",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "structure": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "compliance issuer matches",
+      "receipt": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00.000000Z",
+          "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "agent_id": "agt_1",
+          "action_ref": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "payload_digest": {
+            "hash": "8888888888888888888888888888888888888888888888888888888888888888",
+            "size": 512
+          },
+          "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": []
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "PASS",
+          "structure": "PASS"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "compliance issuer differs",
+      "receipt": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00.000000Z",
+          "issuer_id": "0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38",
+          "agent_id": "agt_1",
+          "action_ref": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "payload_digest": {
+            "hash": "8888888888888888888888888888888888888888888888888888888888888888",
+            "size": 512
+          },
+          "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": []
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "compliance issuer is a number",
+      "receipt": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00.000000Z",
+          "issuer_id": 5,
+          "agent_id": "agt_1",
+          "action_ref": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "payload_digest": {
+            "hash": "8888888888888888888888888888888888888888888888888888888888888888",
+            "size": 512
+          },
+          "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": []
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "jwks keys is not a list",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": "nope"
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "signature": "SKIPPED"
+        },
+        "failure_class": "unverifiable"
+      }
+    },
+    {
+      "name": "jwks keys holds non objects",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          1,
+          2
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "signature": "SKIPPED"
+        },
+        "failure_class": "unverifiable"
+      }
+    },
+    {
+      "name": "issuer is the claimed uuid plus a trailing newline",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07\n",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is a different uuid plus a trailing newline",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38\n",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is the claimed uuid plus a carriage return",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07\r",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is the claimed uuid with a leading newline",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "\nf94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "org_id published as the claimed uuid plus a newline",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "Acme Compliance Ltd",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA",
+            "org_id": "f94f66c0-c580-432d-a041-29374f7aee07\n"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "SKIPPED"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is the claimed uuid in uppercase",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "F94F66C0-C580-432D-A041-29374F7AEE07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "PASS"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "issuer is the claimed uuid in mixed case",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "F94F66c0-C580-432D-a041-29374F7AEE07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "PASS"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "receipt claims the org id in uppercase",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "F94F66C0-C580-432D-A041-29374F7AEE07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "PASS"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "org_id published in uppercase",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "Acme Compliance Ltd",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA",
+            "org_id": "F94F66C0-C580-432D-A041-29374F7AEE07"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "PASS"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "uppercase issuer naming a different org",
+      "receipt": {
+        "v": 1,
+        "mode": "hash",
+        "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-06-19T00:00:00.000000Z",
+        "action_id": "act_1",
+        "agent_id": "agt_1",
+        "org_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+        "policy_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "policy_decision": "allow",
+        "key_id": "k1",
+        "algorithm": "ML-DSA-65",
+        "payload": null,
+        "anchors": [],
+        "signature_b64": "AAAA"
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "0B6C2B1E-9F7A-4D3C-8A11-5C2E7D904F38",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "issuer_bind": "FAIL"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "receipt nested past the depth cap outside the signed payload",
+      "receipt": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00.000000Z",
+          "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "agent_id": "agt_1",
+          "action_ref": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "payload_digest": {
+            "hash": "8888888888888888888888888888888888888888888888888888888888888888",
+            "size": 512
+          },
+          "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [],
+        "junk": {
+          "n": {
+            "n": {
+              "n": {
+                "n": {
+                  "n": {
+                    "n": {
+                      "n": {
+                        "n": {
+                          "n": {
+                            "n": {
+                              "n": {
+                                "n": {
+                                  "n": {
+                                    "n": {
+                                      "n": {
+                                        "n": {
+                                          "n": {
+                                            "n": {
+                                              "n": {
+                                                "n": {
+                                                  "n": {
+                                                    "n": {
+                                                      "n": {
+                                                        "n": {
+                                                          "n": {
+                                                            "n": {
+                                                              "n": {
+                                                                "n": {
+                                                                  "n": {
+                                                                    "n": {
+                                                                      "n": {
+                                                                        "n": {
+                                                                          "n": {
+                                                                            "n": {
+                                                                              "n": {
+                                                                                "n": {
+                                                                                  "n": {
+                                                                                    "n": {
+                                                                                      "n": {
+                                                                                        "n": {
+                                                                                          "n": {
+                                                                                            "n": {
+                                                                                              "n": {
+                                                                                                "n": {
+                                                                                                  "n": {
+                                                                                                    "n": {
+                                                                                                      "n": {
+                                                                                                        "n": {
+                                                                                                          "n": {
+                                                                                                            "n": {
+                                                                                                              "n": {
+                                                                                                                "n": {
+                                                                                                                  "n": {
+                                                                                                                    "n": {
+                                                                                                                      "n": {
+                                                                                                                        "n": {
+                                                                                                                          "n": {
+                                                                                                                            "n": {
+                                                                                                                              "n": {
+                                                                                                                                "n": {
+                                                                                                                                  "n": {
+                                                                                                                                    "n": {
+                                                                                                                                      "n": {
+                                                                                                                                        "n": {
+                                                                                                                                          "n": {
+                                                                                                                                            "n": {
+                                                                                                                                              "n": {
+                                                                                                                                                "n": {
+                                                                                                                                                  "n": {
+                                                                                                                                                    "n": {
+                                                                                                                                                      "n": {
+                                                                                                                                                        "n": {
+                                                                                                                                                          "n": {
+                                                                                                                                                            "n": {
+                                                                                                                                                              "n": {
+                                                                                                                                                                "n": {
+                                                                                                                                                                  "n": {
+                                                                                                                                                                    "n": {
+                                                                                                                                                                      "n": {
+                                                                                                                                                                        "n": {
+                                                                                                                                                                          "n": {
+                                                                                                                                                                            "n": {
+                                                                                                                                                                              "n": {
+                                                                                                                                                                                "n": {
+                                                                                                                                                                                  "n": {
+                                                                                                                                                                                    "n": {
+                                                                                                                                                                                      "n": {
+                                                                                                                                                                                        "n": {
+                                                                                                                                                                                          "n": {
+                                                                                                                                                                                            "n": {
+                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                            "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                              "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                                "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                                  "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                                    "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                                      "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                                        "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                                          "n": {
+                                                                                                                                                                                                                                                                                                                                                                                                                            "leaf": 1
+                                                                                                                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                                }
+                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                            }
+                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                        }
+                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                    }
+                                                                                                                                                                                                                  }
+                                                                                                                                                                                                                }
+                                                                                                                                                                                                              }
+                                                                                                                                                                                                            }
+                                                                                                                                                                                                          }
+                                                                                                                                                                                                        }
+                                                                                                                                                                                                      }
+                                                                                                                                                                                                    }
+                                                                                                                                                                                                  }
+                                                                                                                                                                                                }
+                                                                                                                                                                                              }
+                                                                                                                                                                                            }
+                                                                                                                                                                                          }
+                                                                                                                                                                                        }
+                                                                                                                                                                                      }
+                                                                                                                                                                                    }
+                                                                                                                                                                                  }
+                                                                                                                                                                                }
+                                                                                                                                                                              }
+                                                                                                                                                                            }
+                                                                                                                                                                          }
+                                                                                                                                                                        }
+                                                                                                                                                                      }
+                                                                                                                                                                    }
+                                                                                                                                                                  }
+                                                                                                                                                                }
+                                                                                                                                                              }
+                                                                                                                                                            }
+                                                                                                                                                          }
+                                                                                                                                                        }
+                                                                                                                                                      }
+                                                                                                                                                    }
+                                                                                                                                                  }
+                                                                                                                                                }
+                                                                                                                                              }
+                                                                                                                                            }
+                                                                                                                                          }
+                                                                                                                                        }
+                                                                                                                                      }
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k1",
+            "agent_id": "agt_1",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "structure": "FAIL"
+        },
+        "failure_class": "unverifiable"
+      }
+    },
+    {
+      "name": "org kid resolves the agent the receipt names, sibling listed first",
+      "receipt": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00.000000Z",
+          "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "agent_id": "agt_two",
+          "action_ref": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "payload_digest": {
+            "hash": "8888888888888888888888888888888888888888888888888888888888888888",
+            "size": 512
+          },
+          "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "sig": "AAAA"
+        },
+        "anchors": []
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k-agent-one",
+            "agent_id": "agt_one",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "revoked",
+            "public_key": "AAAA"
+          },
+          {
+            "kid": "k-agent-two",
+            "agent_id": "agt_two",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "key_status": "PASS",
+          "issuer_bind": "PASS"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "org kid reports the revoked signer rather than its active sibling",
+      "receipt": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00.000000Z",
+          "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "agent_id": "agt_two",
+          "action_ref": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "payload_digest": {
+            "hash": "8888888888888888888888888888888888888888888888888888888888888888",
+            "size": 512
+          },
+          "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "sig": "AAAA"
+        },
+        "anchors": []
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k-agent-one",
+            "agent_id": "agt_one",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          },
+          {
+            "kid": "k-agent-two",
+            "agent_id": "agt_two",
+            "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+            "alg": "ML-DSA-65",
+            "status": "revoked",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "key_status": "FAIL",
+          "issuer_bind": "PASS"
+        },
+        "failure_class": "invalid"
+      }
+    },
+    {
+      "name": "org kid keeps the issuer bind when the agent key belongs to another org",
+      "receipt": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00.000000Z",
+          "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "agent_id": "agt_two",
+          "action_ref": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "payload_digest": {
+            "hash": "8888888888888888888888888888888888888888888888888888888888888888",
+            "size": 512
+          },
+          "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "sig": "AAAA"
+        },
+        "anchors": []
+      },
+      "jwks": {
+        "keys": [
+          {
+            "kid": "k-foreign",
+            "agent_id": "agt_two",
+            "issuer_id": "0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38",
+            "alg": "ML-DSA-65",
+            "status": "active",
+            "public_key": "AAAA"
+          }
+        ]
+      },
+      "expect": {
+        "verdict": "unverified",
+        "axes": {
+          "signature": "SKIPPED"
+        },
+        "failure_class": "unverifiable"
+      }
+    }
   ]
 }


### PR DESCRIPTION
Implements three security criteria for the compliance-receipt verifier.

## Criterion 419 - strict ingest (high stakes)
Every receipt- and record-parsing path rejects a **duplicated JSON member name at any depth** as a terminal parse failure, **before any hashing, canonicalisation, or signature check**. No last-wins fallback.
- Python: `asqav/strict_json.py` (`DuplicateMemberError` + an `object_pairs_hook`), plus a self-contained copy inside the standalone `verify_receipt.py` (it ships as one file).
- TypeScript: `DuplicateMemberError` + seen-key tracking in `parseJsonPreservingFloats`, and a plain-value `parseJsonStrict`.
- Routed through: `verify_receipt` ingest, oracle runner + CLI, attestation signed-message re-parse, doors OTel recovery, CLI JSON args + signing-log records, the sync/async API response parsers, and the TS receipt/bundle/doors/DSSE loaders.
- New corpus vectors `asqav-11-dup-member-toplevel` / `asqav-12-dup-member-nested` prove a mutated receipt never verifies (top-level + nested).

## Criteria 418 + 438 - tri-state verdict vocabulary (high stakes)
Public verifier surfaces now report **`verified` | `verified_keyed` | `unverified`** instead of PASS | FAIL | INCOMPLETE, and every `unverified` verdict carries a **`failure_class`** of `invalid` or `unverifiable` — **never collapsed**, and a receipt is **never reported verified when recomputation failed**.
- `invalid` = a check ran and a cryptographic/policy binding failed (signature mismatch, chain-link mismatch, invalid anchor, counterparty binding mismatch, revoked/changed signer key, algorithm mismatch, `issued_at` future-skew).
- `unverifiable` = recomputation could not complete (unresolvable key, missing/broken predecessor, malformed member, canonicalisation/parse failure incl. the 419 duplicate rejection, unresolvable policy digest, pending anchor without proof).
- A keyed digest (`hmac-sha256`) that fully checks reports **`verified_keyed`**, never plain `verified` (also `verify_attestation_offline`).
- Per-axis PASS/FAIL/SKIPPED tokens stay internal. Exit codes keep the stable mapping: `0` verified/verified_keyed, `1` invalid, `2` unverifiable.
- Surfaces changed: `verify_receipt.py` (text + structured + exit codes), oracle `core.py`/`VerifyResult`, oracle runner outcome mapping, TS `core.ts`/`runner.ts`, `attestation.py _verdict`.

## Parity & corpus
- Manifest + all `expected.json` move to the new vocabulary with a per-vector `failure_class`.
- Verifier-parity gates (Python + TS) now assert **verdict + failure_class byte-for-byte** for every corpus vector, and both classes are exercised (`asqav-04` invalid, `asqav-11/12` + `asqav-05` unverifiable).

## Docs
`verifier/README.md`, the oracle README, `docs/offline-verification.md`, and the conformance-vectors README updated to the new vocabulary. (`python/docs/CLI.md` documents the hosted `asqav` CLI and has no offline-verdict table, so nothing changed there.)

## Verification
- Full Python suite: 2738 passed, 2 skipped.
- Verifier CI job command: 1429 passed.
- TypeScript suite: 970 passed; `tsc --noEmit` and `npm run build` clean.
- `ruff check python/src`: clean.