### PR TITLE
release: 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-26
+
 ### Changed
 
 - **BREAKING: the verifier speaks a three-verdict vocabulary and never collapses

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.8.3"
+version = "0.9.0"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -186,7 +186,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.8.3"
+__version__ = "0.9.0"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "LicenseRef-Elastic-License-2.0",
       "dependencies": {
         "@noble/post-quantum": "^0.6.1"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.8.3";
+export const SDK_VERSION = "0.9.0";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Ships the work merged since 0.8.3 (2026-07-20): tri-state verdict vocabulary + failure_class axis (criteria 418/438), strict duplicate-member ingest (419), corpus freeze v1 + standalone verifier (420), litellm integration docs (422). Changelog already written in [Unreleased]; this stamps it 0.9.0 and bumps both halves (pyproject, __init__, package.json/lock, userAgent).

Generated with Qwen Code (16-shotted by Qwen-Coder)