### PR TITLE
feat(verifier): W3C VC 2.0 eddsa-jcs-2022 adapter with offline did:web resolution

### DIFF
--- a/python/src/asqav/verifier/oracle/__init__.py
+++ b/python/src/asqav/verifier/oracle/__init__.py
@@ -21,6 +21,7 @@ from .adapters.agentreceipts import AgentReceiptsAdapter
 from .adapters.asqav_native import AsqavNativeAdapter
 from .adapters.authproof import AuthproofAdapter
 from .adapters.pipelock import PipelockEvidenceAdapter
+from .adapters.w3c_vc import W3cVcAdapter
 from .core import AxisResult, VerifyResult, verify
 
 #: Detection fingerprints are mutually exclusive, so registration order is not load-bearing.
@@ -29,6 +30,7 @@ ADAPTERS: list[FormatAdapter] = [
     AerfAdapter(),
     ActaAdapter(),
     AgentReceiptsAdapter(),
+    W3cVcAdapter(),
     AuthproofAdapter(),
     PipelockEvidenceAdapter(),
 ]
@@ -46,5 +48,6 @@ __all__ = [
     "PipelockEvidenceAdapter",
     "SignatureMaterial",
     "VerifyResult",
+    "W3cVcAdapter",
     "verify",
 ]

--- a/python/src/asqav/verifier/oracle/adapters/w3c_vc.py
+++ b/python/src/asqav/verifier/oracle/adapters/w3c_vc.py
@@ -1,0 +1,201 @@
+"""W3C VC 2.0 adapter - DataIntegrityProof with the eddsa-jcs-2022 cryptosuite.
+
+A Verifiable Credential 2.0 envelope (``@context`` starting with the credentials/v2
+URL, ``type`` including ``VerifiableCredential``, ``issuer``, ``credentialSubject``)
+secured by a ``DataIntegrityProof`` whose ``cryptosuite`` is ``eddsa-jcs-2022``
+(W3C TR vc-di-eddsa): Ed25519 (RFC 8032) signs
+``SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecuredDocument))`` where JCS is
+strict RFC 8785, proofOptions is ``proof`` with ``proofValue`` removed, and
+unsecuredDocument is the credential with ``proof`` removed. ``proofValue`` is the
+raw 64-byte signature multibase base58btc ('z') encoded.
+
+When the proof options carry their own ``@context`` the spec's transform requires
+the document ``@context`` to start with it in order and canonicalises the document
+with the proof's ``@context`` substituted; both rules are enforced here.
+
+The oracle performs NO network DID resolution: ``proof.verificationMethod``
+resolves through the shared DID resolver (did:key inline; did:web and every other
+method from the injected map, either a raw key or the DID document the fetch would
+have returned). Structure is intentionally stricter than the suite spec, which does
+not normatively check proofPurpose: this adapter requires ``assertionMethod`` and
+binds the verificationMethod DID to the issuer DID, fail-closed, mirroring the
+agentreceipts adapter. A W3C VC carries no in-band chain link, so the chain axis
+reports genesis.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Any
+
+from ..adapter import ChainStep, FormatAdapter, SignatureMaterial
+from ..canonical import jcs_rfc8785
+from ..did import b58btc_decode, resolve_ed25519_key
+
+#: First @context value a VC 2.0 credential must carry.
+_VC_V2_CONTEXT = "https://www.w3.org/ns/credentials/v2"
+_PROOF_TYPE = "DataIntegrityProof"
+_CRYPTOSUITE = "eddsa-jcs-2022"
+
+
+    # The doc's proof member when it is a single object; {} for absent/list proofs.
+def _proof(doc: dict) -> dict:
+    proof = doc.get("proof")
+    return proof if isinstance(proof, dict) else {}
+
+
+    # The issuer DID whether issuer is a bare string or an object with an id.
+def _issuer_did(doc: dict) -> str | None:
+    issuer = doc.get("issuer")
+    if isinstance(issuer, str):
+        return issuer
+    if isinstance(issuer, dict) and isinstance(issuer.get("id"), str):
+        return issuer["id"]
+    return None
+
+
+    # xsd:datetime (RFC 3339 profile) -> aware datetime; None when unparseable.
+def _parse_datetime(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed
+
+
+    # proof minus proofValue - the exact object the spec canonicalises for hash one.
+def _proof_options(doc: dict) -> dict:
+    return {k: v for k, v in _proof(doc).items() if k != "proofValue"}
+
+
+    # Document minus proof; the proof's @context substitutes the document's when present.
+def _unsecured(doc: dict) -> dict:
+    body = {k: v for k, v in doc.items() if k != "proof"}
+    ctx = _proof(doc).get("@context")
+    if ctx is not None:
+        body["@context"] = ctx
+    return body
+
+
+    # True when the proof's @context is absent or prefixes the document @context in order.
+def _context_prefix_ok(doc: dict) -> bool:
+    ctx = _proof(doc).get("@context")
+    if ctx is None:
+        return True
+    if not isinstance(ctx, list):
+        return False
+    doc_ctx = doc.get("@context")
+    return isinstance(doc_ctx, list) and doc_ctx[: len(ctx)] == ctx
+
+
+    # Decode a multibase 'z' (base58btc) proofValue to raw signature bytes.
+def _multibase_z_decode(value: str) -> bytes:
+    if not value or value[0] != "z":
+        raise ValueError("proofValue is not multibase 'z' (base58btc) encoded")
+    return b58btc_decode(value[1:])
+
+
+    # W3C VC 2.0 - DataIntegrityProof eddsa-jcs-2022, Ed25519 over RFC 8785 JCS.
+class W3cVcAdapter(FormatAdapter):
+
+    name = "w3c-vc"
+
+    def detect(self, doc: dict) -> bool:
+        types = doc.get("type")
+        if not isinstance(types, list) or "VerifiableCredential" not in types:
+            return False
+        proof = doc.get("proof")
+        candidates = [proof] if isinstance(proof, dict) else (proof if isinstance(proof, list) else [])
+        # Any DataIntegrityProof on a VC routes here; the cryptosuite check belongs
+        # to the schema axis so a sibling suite reports as an algorithm mismatch
+        return any(isinstance(p, dict) and p.get("type") == _PROOF_TYPE for p in candidates)
+
+    def extract_signature(self, doc: dict) -> SignatureMaterial:
+        proof = _proof(doc)
+        value = proof.get("proofValue")
+        try:
+            sig = _multibase_z_decode(value if isinstance(value, str) else "")
+        except ValueError:
+            sig = b""
+        vm = proof.get("verificationMethod")
+        return SignatureMaterial(sig=sig, alg="EdDSA", kid=vm if isinstance(vm, str) else "")
+
+    def resolve_key(self, doc: dict, key_provider: Any) -> tuple[bytes | None, str]:
+        vm = _proof(doc).get("verificationMethod")
+        return resolve_ed25519_key(vm if isinstance(vm, str) else "", key_provider)
+
+    def signing_input(self, doc: dict) -> bytes:
+        # hashData = SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecured)) (TR vc-di-eddsa)
+        options_hash = hashlib.sha256(jcs_rfc8785(_proof_options(doc))).digest()
+        document_hash = hashlib.sha256(jcs_rfc8785(_unsecured(doc))).digest()
+        return options_hash + document_hash
+
+    def chain_step(self, doc: dict) -> ChainStep:
+        # A W3C VC carries no in-band chain link of its own.
+        return ChainStep(prev_field=None, is_genesis=True, recompute=lambda _pred: "")
+
+    def schema(self, doc: dict) -> tuple[str, str]:
+        ctx = doc.get("@context")
+        if not isinstance(ctx, list) or not ctx or ctx[0] != _VC_V2_CONTEXT:
+            return "FAIL", "first @context must be the W3C VC 2.0 credentials context"
+        types = doc.get("type")
+        if not isinstance(types, list) or "VerifiableCredential" not in types:
+            return "FAIL", "type must include VerifiableCredential"
+        proof = doc.get("proof")
+        if isinstance(proof, list):
+            return "FAIL", "proof sets are not supported; exactly one proof object is required"
+        if not isinstance(proof, dict):
+            return "FAIL", "missing required VC fields: proof"
+        if proof.get("type") != _PROOF_TYPE:
+            return "FAIL", "proof.type must be DataIntegrityProof"
+        suite = proof.get("cryptosuite")
+        if suite != _CRYPTOSUITE:
+            return (
+                "FAIL",
+                f"unsupported signature algorithm: cryptosuite {suite!r} "
+                f"(this verifier checks {_CRYPTOSUITE!r})",
+            )
+        vm = proof.get("verificationMethod")
+        if not isinstance(vm, str) or not vm.startswith("did:"):
+            return "FAIL", "proof.verificationMethod must be a DID URL"
+        if proof.get("proofPurpose") != "assertionMethod":
+            return "FAIL", "proof.proofPurpose must be assertionMethod"
+        issuer = _issuer_did(doc)
+        if issuer is None or not issuer.startswith("did:"):
+            return "FAIL", "issuer must be a DID"
+        if vm.split("#", 1)[0] != issuer:
+            # bind the signing key to the issuer or anyone self-signs as a victim
+            return "FAIL", "proof.verificationMethod is not controlled by issuer (signing-key DID != issuer DID)"
+        subject = doc.get("credentialSubject")
+        if not isinstance(subject, dict) and not (isinstance(subject, list) and subject):
+            return "FAIL", "missing required VC fields: credentialSubject"
+        created = proof.get("created")
+        if created is not None and _parse_datetime(created) is None:
+            return "FAIL", f"unreadable proof.created: {created!r}"
+        if not _context_prefix_ok(doc):
+            return "FAIL", "proof @context is not a prefix of the document @context"
+        return "PASS", "required VC 2.0 fields present; DataIntegrityProof eddsa-jcs-2022"
+
+    def extra_axes(self, doc: dict, key_provider: Any) -> list[tuple[str, str, str]]:
+        """validFrom/validUntil bound validity; the expiry axis never folds the verdict (426)."""
+        now = datetime.now(timezone.utc)
+        valid_from = doc.get("validFrom")
+        if valid_from is not None:
+            parsed = _parse_datetime(valid_from)
+            if parsed is None:
+                return [("expiry", "FAIL", f"unreadable expires_at (validFrom {valid_from!r})")]
+            if now < parsed:
+                return [("expiry", "FAIL", f"not yet valid: validFrom {valid_from}")]
+        valid_until = doc.get("validUntil")
+        if valid_until is not None:
+            parsed = _parse_datetime(valid_until)
+            if parsed is None:
+                return [("expiry", "FAIL", f"unreadable expires_at (validUntil {valid_until!r})")]
+            if now >= parsed:
+                return [("expiry", "FAIL", f"expired at {valid_until}")]
+        return [("expiry", "PASS", "no validFrom/validUntil constraint breached")]

--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -117,6 +117,8 @@ def axis_failure_class(axis: str, result: str, note: str) -> str | None:
             return FAILURE_INVALID
         if "signing-key DID != issuer DID" in note:
             return FAILURE_INVALID
+        if note.startswith("proof @context is not a prefix"):
+            return FAILURE_INVALID
         return FAILURE_UNVERIFIABLE
     if axis == "expiry":
         if note.startswith("unreadable expires_at"):

--- a/python/src/asqav/verifier/oracle/did.py
+++ b/python/src/asqav/verifier/oracle/did.py
@@ -2,14 +2,18 @@
 
 ``resolve_ed25519_key(did_url, injected)`` returns the raw 32-byte Ed25519 public
 key for a signer, or None when it cannot resolve without a network the oracle is
-forbidden from touching. Two methods are supported:
+forbidden from touching. Two resolution shapes are supported:
 
   - ``did:key`` - self-contained. The multibase ``z`` (base58btc) identifier
     decodes to a multicodec frame: the two-byte ``0xed 0x01`` Ed25519 prefix
     followed by the 32 raw key bytes. No network, no injected map needed.
   - ``did:agent`` / ``did:web`` (and any other method) - resolved from an injected
-    ``{did_or_kid: hex_or_raw}`` map the caller supplies. The oracle NEVER fetches
-    a DID document over the network; an unmapped DID returns None.
+    map the caller supplies. A value is either a raw key (hex string or bytes,
+    32 bytes) or the DID DOCUMENT the method's network fetch would have returned;
+    the resolver then walks ``verificationMethod`` / ``assertionMethod`` and
+    extracts an Ed25519 key (publicKeyMultibase Multikey, publicKeyJwk OKP, or
+    legacy publicKeyBase58). The oracle NEVER fetches a DID document over the
+    network; an unmapped DID returns None (fail closed).
 
 This resolver is adapter-agnostic so a later ERC-8004 / DID hook reuses it. base58
 is an encoding, not crypto, so the base58btc decoder is implemented here and pinned
@@ -17,6 +21,8 @@ by a unit test against the upstream did:key reference vectors; the Ed25519 verif
 itself stays in ``crypto.py`` behind the ``cryptography`` library.
 """
 from __future__ import annotations
+
+import base64
 
 #: Bitcoin base58 alphabet - the base58btc encoding multibase 'z' uses.
 _B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
@@ -66,13 +72,74 @@ def _coerce_raw(material: object) -> bytes | None:
     return raw if len(raw) == 32 else None
 
 
+    # OKP/Ed25519 JWK -> raw 32-byte key; None for any other curve or bad encoding.
+def _raw_from_jwk(jwk: object) -> bytes | None:
+    if not isinstance(jwk, dict) or jwk.get("kty") != "OKP" or jwk.get("crv") != "Ed25519":
+        return None
+    x = jwk.get("x")
+    if not isinstance(x, str):
+        return None
+    try:
+        raw = base64.urlsafe_b64decode(x + "=" * (-len(x) % 4))
+    except (ValueError, base64.binascii.Error):
+        return None
+    return raw if len(raw) == 32 else None
+
+
+    # Extract the raw Ed25519 key one DID-document verificationMethod publishes.
+def _raw_from_verification_method(vm: object) -> bytes | None:
+    if not isinstance(vm, dict):
+        return None
+    multibase = vm.get("publicKeyMultibase")
+    if isinstance(multibase, str):
+        # A Multikey multibase value is shaped exactly like a did:key identifier.
+        key = _decode_did_key(multibase)
+        if key is not None:
+            return key
+    jwk = _raw_from_jwk(vm.get("publicKeyJwk"))
+    if jwk is not None:
+        return jwk
+    b58 = vm.get("publicKeyBase58")
+    if isinstance(b58, str):
+        try:
+            raw = b58btc_decode(b58)
+        except ValueError:
+            return None
+        return raw if len(raw) == 32 else None
+    return None
+
+
+    # Walk an injected DID document like the fetched one: exact fragment match first,
+    # else assertionMethod-authorized Ed25519 methods, then any remaining method.
+def _key_from_did_document(did_doc: dict, did_url: str) -> tuple[bytes | None, str]:
+    methods = did_doc.get("verificationMethod")
+    methods = [vm for vm in methods if isinstance(vm, dict)] if isinstance(methods, list) else []
+    assertion = did_doc.get("assertionMethod")
+    assertion = assertion if isinstance(assertion, list) else []
+    pool = methods + [vm for vm in assertion if isinstance(vm, dict)]
+    if "#" in did_url:
+        pool = [vm for vm in pool if vm.get("id") == did_url]
+        if not pool:
+            return None, f"no verificationMethod {did_url!r} in injected DID document"
+    else:
+        refs = {vm for vm in assertion if isinstance(vm, str)}
+        pool.sort(key=lambda vm: 0 if vm.get("id") in refs else 1)
+    for vm in pool:
+        key = _raw_from_verification_method(vm)
+        if key is not None:
+            return key, f"resolved {vm.get('id', did_url)} from injected DID document"
+    return None, f"no Ed25519 verificationMethod for {did_url!r} in injected DID document"
+
+
 def resolve_ed25519_key(
     did_url: str, injected: dict | None = None
 ) -> tuple[bytes | None, str]:
     """Resolve a verificationMethod DID URL to ``(raw_key_or_None, note)``.
 
     did:key resolves inline; every other method resolves from ``injected`` keyed by
-    the full DID URL first, then by the bare DID (fragment stripped). No network.
+    the full DID URL first, then by the bare DID (fragment stripped). An injected
+    value is a raw 32-byte key (bytes or hex) or the DID document the method's
+    fetch would have returned. No network.
     """
     if not isinstance(did_url, str) or not did_url.startswith("did:"):
         return None, f"not a DID URL: {did_url!r}"
@@ -85,7 +152,10 @@ def resolve_ed25519_key(
     keys = injected or {}
     for candidate in (did_url, bare):
         if candidate in keys:
-            raw = _coerce_raw(keys[candidate])
+            material = keys[candidate]
+            if isinstance(material, dict):
+                return _key_from_did_document(material, did_url)
+            raw = _coerce_raw(material)
             if raw is None:
                 return None, f"injected key for {candidate!r} is not a 32-byte Ed25519 key"
             return raw, f"resolved {candidate} from injected map"

--- a/python/src/asqav/verifier/oracle/runner.py
+++ b/python/src/asqav/verifier/oracle/runner.py
@@ -75,6 +75,9 @@ def _key_provider(vec_dir: Path, fmt: str):
     if fmt == "agentreceipts":
         # did:key receipts self-resolve (no file); did:agent/web carry an injected map.
         return _load(vec_dir / "did_map.json")
+    if fmt == "w3c-vc":
+        # did:web resolves from an injected DID-document map; the oracle never fetches.
+        return _load(vec_dir / "did_map.json")
     if fmt == "pipelock-evidence-v2":
         # keys.json: {signer_key_id: hex_32_bytes} - the raw Ed25519 key, no embedding.
         return _load(vec_dir / "keys.json")

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -25,7 +25,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # and in the corpus READMEs. A regenerated lock that forgets to update these is
 # drift, not a refresh
 FINGERPRINT_LOCK_DIGEST = "aa4e38f19dd227ffd4f674a9e25298199769d40ade9be63417eb9432ccb5ba6d"
-VERIFIER_LOCK_DIGEST = "37fdb7564b54303dde937e6f3324321e108dcd3710367ca6b0cf19906d029103"
+VERIFIER_LOCK_DIGEST = "8a8904f0b496b0ecb2580212f9cc59d3edd27e5292eaa0a15a5ba1f7bf4ee3b9"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -72,7 +72,15 @@ def test_verifier_ships_inside_the_asqav_package() -> None:
 
 def test_adapters_registered() -> None:
     names = [a.name for a in ADAPTERS]
-    assert names == ["asqav-native", "aerf", "acta", "agentreceipts", "authproof", "pipelock-evidence-v2"]
+    assert names == [
+        "asqav-native",
+        "aerf",
+        "acta",
+        "agentreceipts",
+        "w3c-vc",
+        "authproof",
+        "pipelock-evidence-v2",
+    ]
 
 
 def test_detection_picks_the_right_adapter() -> None:
@@ -229,7 +237,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 54
+    assert len(results) == 62
     # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/python/tests/test_oracle_w3c_vc.py
+++ b/python/tests/test_oracle_w3c_vc.py
@@ -1,0 +1,299 @@
+"""W3C VC 2.0 eddsa-jcs-2022 adapter tests.
+
+Covers the DataIntegrityProof path: did:web resolution from an injected DID
+document (offline, fail-closed), did:key self-resolution, the hashData signing
+construction, tamper rejection, the @context prefix transform, and the validity
+window. Corpus vectors w3c-vc-01..08 run through the shared runner; the tests
+here pin the axis-level behaviour behind them.
+"""
+from __future__ import annotations
+
+import json
+from base64 import urlsafe_b64encode
+from pathlib import Path
+
+import pytest
+
+from asqav.verifier.oracle import ADAPTERS, crypto, verify
+from asqav.verifier.oracle.adapters.agentreceipts import AgentReceiptsAdapter
+from asqav.verifier.oracle.adapters.w3c_vc import W3cVcAdapter
+from asqav.verifier.oracle.did import resolve_ed25519_key
+
+_CORPUS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+_ED25519_AVAILABLE = crypto.verify_ed25519(b"\x00" * 32, b"m", b"\x00" * 64)[0] != crypto.SKIPPED
+
+requires_ed25519 = pytest.mark.skipif(
+    not _ED25519_AVAILABLE, reason="cryptography not installed; Ed25519 verify SKIPs"
+)
+
+
+def _load(vec: str, name: str) -> dict:
+    return json.loads((_CORPUS / vec / name).read_text())
+
+
+def _provider(vec: str):
+    path = _CORPUS / vec / "did_map.json"
+    return json.loads(path.read_text()) if path.exists() else None
+
+
+    # A did:web credential verifies against the injected DID document, offline.
+@requires_ed25519
+def test_w3c_vc_didweb_happy_path_verifies() -> None:
+    doc = _load("w3c-vc-01-didweb-happy-path", "receipt.json")
+    res = verify(doc, ADAPTERS, key_provider=_provider("w3c-vc-01-didweb-happy-path"))
+    assert res.fmt == "w3c-vc"
+    assert res.verdict == "verified"
+    assert res.failure_class is None
+    assert res.axis("signature").result == crypto.PASS
+    assert res.axis("expiry").result == crypto.PASS
+
+
+    # A did:key credential self-resolves; no injected map is consulted.
+@requires_ed25519
+def test_w3c_vc_didkey_self_resolves() -> None:
+    doc = _load("w3c-vc-08-didkey-happy-path", "receipt.json")
+    res = verify(doc, ADAPTERS)
+    assert res.verdict == "verified"
+    assert res.axis("signature").result == crypto.PASS
+
+
+@requires_ed25519
+def test_w3c_vc_tampered_subject_fails_signature() -> None:
+    doc = _load("w3c-vc-02-tamper-subject", "receipt.json")
+    res = verify(doc, ADAPTERS, key_provider=_provider("w3c-vc-02-tamper-subject"))
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
+    assert res.axis("signature").result == crypto.FAIL
+
+
+@requires_ed25519
+def test_w3c_vc_tampered_proofvalue_fails_signature() -> None:
+    doc = _load("w3c-vc-03-tamper-proofvalue", "receipt.json")
+    res = verify(doc, ADAPTERS, key_provider=_provider("w3c-vc-03-tamper-proofvalue"))
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
+    assert res.axis("signature").result == crypto.FAIL
+
+
+    # A DID document publishing the wrong key fails the signature, never a false pass.
+@requires_ed25519
+def test_w3c_vc_wrong_published_key_fails() -> None:
+    doc = _load("w3c-vc-04-wrong-key-injected", "receipt.json")
+    res = verify(doc, ADAPTERS, key_provider=_provider("w3c-vc-04-wrong-key-injected"))
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
+    assert res.axis("signature").result == crypto.FAIL
+
+
+    # No injected DID document -> the oracle never fetches; fail closed, not verified.
+@requires_ed25519
+def test_w3c_vc_no_did_document_fails_closed() -> None:
+    doc = _load("w3c-vc-05-no-did-document", "receipt.json")
+    res = verify(doc, ADAPTERS)
+    assert res.axis("signature").result == crypto.SKIPPED
+    assert res.verdict == "unverified"
+    assert res.failure_class == "unverifiable"
+
+
+    # A lapsed validUntil FAILs the expiry axis alone; the verdict stays verified (426).
+@requires_ed25519
+def test_w3c_vc_expired_keeps_verified_verdict() -> None:
+    doc = _load("w3c-vc-06-expired", "receipt.json")
+    res = verify(doc, ADAPTERS, key_provider=_provider("w3c-vc-06-expired"))
+    assert res.verdict == "verified"
+    expiry = res.axis("expiry")
+    assert expiry.result == crypto.FAIL
+    assert expiry.note.startswith("expired at ")
+
+
+    # Proof sets are not supported: a list of proofs FAILs the structure axis.
+def test_w3c_vc_proof_set_is_rejected() -> None:
+    doc = _load("w3c-vc-01-didweb-happy-path", "receipt.json")
+    doc["proof"] = [doc["proof"]]
+    ad = W3cVcAdapter()
+    assert ad.detect(doc) is True
+    result, note = ad.schema(doc)
+    assert result == "FAIL" and "proof sets are not supported" in note
+    res = verify(doc, ADAPTERS, key_provider=_provider("w3c-vc-01-didweb-happy-path"))
+    assert res.verdict == "unverified"
+
+
+    # A sibling cryptosuite routes to the adapter and FAILs as an algorithm mismatch.
+def test_w3c_vc_other_cryptosuite_is_algorithm_mismatch() -> None:
+    doc = _load("w3c-vc-01-didweb-happy-path", "receipt.json")
+    doc["proof"]["cryptosuite"] = "eddsa-rdfc-2022"
+    ad = W3cVcAdapter()
+    assert ad.detect(doc) is True
+    result, note = ad.schema(doc)
+    assert result == "FAIL"
+    assert note.startswith("unsupported signature algorithm")
+    res = verify(doc, ADAPTERS, key_provider=_provider("w3c-vc-01-didweb-happy-path"))
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
+
+
+    # proofPurpose must be assertionMethod for a credential assertion (fail closed).
+def test_w3c_vc_proofpurpose_must_be_assertion_method() -> None:
+    doc = _load("w3c-vc-01-didweb-happy-path", "receipt.json")
+    doc["proof"]["proofPurpose"] = "authentication"
+    result, note = W3cVcAdapter().schema(doc)
+    assert result == "FAIL" and "proofPurpose" in note
+
+
+    # An attacker's valid signature under a key the issuer does not control must not verify.
+@requires_ed25519
+def test_w3c_vc_issuer_must_control_signing_key_no_impersonation() -> None:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    sk = Ed25519PrivateKey.generate()
+    pk = sk.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    attacker_did = "did:key:z" + _b58_encode(b"\xed\x01" + pk)
+    doc = _load("w3c-vc-01-didweb-happy-path", "receipt.json")
+    doc["issuer"] = "did:web:victim.example"
+    doc["proof"]["verificationMethod"] = attacker_did + "#key-1"
+    doc["proof"].pop("proofValue", None)
+    ad = W3cVcAdapter()
+    doc["proof"]["proofValue"] = "z" + _b58_encode(sk.sign(ad.signing_input(doc)))
+    res = verify(doc, ADAPTERS)
+    assert res.axis("signature").result == crypto.PASS  # attacker's sig is cryptographically valid
+    assert res.axis("structure").result == crypto.FAIL  # but signing-key DID != issuer
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
+
+
+_B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+    # base58btc encoder for test fixtures (mirrors the decoder pinned in test_oracle).
+def _b58_encode(data: bytes) -> str:
+    num = int.from_bytes(data, "big")
+    out = []
+    while num:
+        num, rem = divmod(num, 58)
+        out.append(_B58_ALPHABET[rem])
+    pad = len(data) - len(data.lstrip(b"\x00"))
+    return "1" * pad + "".join(reversed(out))
+
+
+    # A proof @context that prefixes the document @context is signed and verifies.
+@requires_ed25519
+def test_w3c_vc_proof_context_prefix_transform() -> None:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    # Re-issue under a fresh did:key issuer (the corpus private key is not recoverable).
+    sk = Ed25519PrivateKey.generate()
+    pk = sk.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    issuer = "did:key:z" + _b58_encode(b"\xed\x01" + pk)
+    doc = _load("w3c-vc-01-didweb-happy-path", "receipt.json")
+    doc["issuer"] = issuer
+    doc["proof"]["verificationMethod"] = issuer + "#key-1"
+    doc["proof"]["@context"] = ["https://www.w3.org/ns/credentials/v2"]
+    doc["proof"].pop("proofValue", None)
+    ad = W3cVcAdapter()
+    doc["proof"]["proofValue"] = "z" + _b58_encode(sk.sign(ad.signing_input(doc)))
+    res = verify(doc, ADAPTERS)
+    assert res.axis("structure").result == crypto.PASS
+    assert res.verdict == "verified"
+
+    # A proof @context the document does not start with is a proven mismatch: invalid.
+    bad = json.loads(json.dumps(doc))
+    bad["proof"]["@context"] = ["https://example.org/other-context"]
+    result, note = ad.schema(bad)
+    assert result == "FAIL"
+    assert note.startswith("proof @context is not a prefix")
+    res = verify(bad, ADAPTERS)
+    assert res.verdict == "unverified"
+    assert res.failure_class == "invalid"
+
+
+    # A malformed proofValue fails closed through verify() and never crashes.
+def test_w3c_vc_malformed_proofvalue_fails_closed() -> None:
+    doc = _load("w3c-vc-01-didweb-happy-path", "receipt.json")
+    for bad in ("u-not-base58btc", "", {"k": "v"}, None):
+        forged = json.loads(json.dumps(doc))
+        forged["proof"]["proofValue"] = bad
+        res = verify(forged, ADAPTERS, key_provider=_provider("w3c-vc-01-didweb-happy-path"))
+        assert res.verdict == "unverified"
+        assert W3cVcAdapter().extract_signature(forged).sig == b""
+
+
+    # An unreadable validFrom FAILs the expiry axis but never folds the verdict (426).
+def test_w3c_vc_unreadable_valid_from_reports_on_expiry_axis() -> None:
+    doc = _load("w3c-vc-01-didweb-happy-path", "receipt.json")
+    doc["validFrom"] = "not-a-date"
+    axes = W3cVcAdapter().extra_axes(doc, None)
+    assert axes == [("expiry", "FAIL", "unreadable expires_at (validFrom 'not-a-date')")]
+
+
+# --- DID-document resolution (the offline did:web path) ---
+
+
+def _did_doc_with(*methods: dict, assertion_refs: list | None = None) -> dict:
+    return {
+        "id": "did:web:example.com",
+        "verificationMethod": list(methods),
+        "assertionMethod": assertion_refs or [],
+    }
+
+
+def test_did_document_fragment_match_resolves() -> None:
+    raw = bytes(range(32))
+    doc = _did_doc_with(
+        {"id": "did:web:example.com#key-1", "publicKeyMultibase": "z" + _b58_encode(b"\xed\x01" + raw)}
+    )
+    key, note = resolve_ed25519_key("did:web:example.com#key-1", {"did:web:example.com": doc})
+    assert key == raw and "injected DID document" in note
+
+
+def test_did_document_missing_fragment_fails_closed() -> None:
+    doc = _did_doc_with({"id": "did:web:example.com#other", "publicKeyBase58": _b58_encode(bytes(range(32)))})
+    key, note = resolve_ed25519_key("did:web:example.com#key-1", {"did:web:example.com": doc})
+    assert key is None and "no verificationMethod" in note
+
+
+def test_did_document_prefers_assertion_method_reference() -> None:
+    key_a = bytes([1] * 32)
+    key_b = bytes([2] * 32)
+    doc = _did_doc_with(
+        {"id": "did:web:example.com#key-a", "publicKeyBase58": _b58_encode(key_a)},
+        {"id": "did:web:example.com#key-b", "publicKeyBase58": _b58_encode(key_b)},
+        assertion_refs=["did:web:example.com#key-b"],
+    )
+    key, _note = resolve_ed25519_key("did:web:example.com", {"did:web:example.com": doc})
+    assert key == key_b
+
+
+def test_did_document_public_key_jwk_resolves() -> None:
+    raw = bytes(range(32, 64))
+    x = urlsafe_b64encode(raw).decode().rstrip("=")
+    doc = _did_doc_with({"id": "did:web:example.com#jwk", "publicKeyJwk": {"kty": "OKP", "crv": "Ed25519", "x": x}})
+    key, _note = resolve_ed25519_key("did:web:example.com#jwk", {"did:web:example.com": doc})
+    assert key == raw
+
+
+def test_did_document_non_ed25519_multikey_fails_closed() -> None:
+    # 0xe7 0x01 is the secp256k1 multicodec prefix; not an Ed25519 key
+    doc = _did_doc_with({"id": "did:web:example.com#k", "publicKeyMultibase": "z" + _b58_encode(b"\xe7\x01" + bytes(32))})
+    key, note = resolve_ed25519_key("did:web:example.com#k", {"did:web:example.com": doc})
+    assert key is None and "no Ed25519 verificationMethod" in note
+
+
+    # The raw-key injection shape stays fully backwards compatible.
+def test_did_map_raw_hex_still_resolves() -> None:
+    raw = bytes(range(32))
+    key, note = resolve_ed25519_key("did:agent:x#k1", {"did:agent:x": raw.hex()})
+    assert key == raw and "injected map" in note
+
+
+# --- detection exclusion against the sibling VC format ---
+
+
+def test_w3c_vc_and_agentreceipts_are_mutually_exclusive() -> None:
+    vc = _load("w3c-vc-01-didweb-happy-path", "receipt.json")
+    ar = _load("agentreceipts-01-didkey-genesis", "receipt.json")
+    w, g = W3cVcAdapter(), AgentReceiptsAdapter()
+    assert (w.detect(vc), g.detect(vc)) == (True, False)
+    assert (w.detect(ar), g.detect(ar)) == (False, True)

--- a/typescript/src/verifier/adapters/w3cVc.ts
+++ b/typescript/src/verifier/adapters/w3cVc.ts
@@ -1,0 +1,247 @@
+/**
+ * W3C VC 2.0 adapter - DataIntegrityProof with the eddsa-jcs-2022 cryptosuite.
+ * A port of the Python oracle's `verifier/oracle/adapters/w3c_vc.py`.
+ *
+ * A Verifiable Credential 2.0 envelope secured by a `DataIntegrityProof` whose
+ * `cryptosuite` is `eddsa-jcs-2022` (W3C TR vc-di-eddsa): Ed25519 (RFC 8032)
+ * signs `SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecuredDocument))` where
+ * JCS is strict RFC 8785, proofOptions is `proof` with `proofValue` removed,
+ * and unsecuredDocument is the credential with `proof` removed. `proofValue` is
+ * the raw 64-byte signature multibase base58btc ('z') encoded.
+ *
+ * When the proof options carry their own `@context` the spec's transform
+ * requires the document `@context` to start with it in order and canonicalises
+ * the document with the proof's `@context` substituted; both rules are enforced.
+ *
+ * Structure is intentionally stricter than the suite spec: proofPurpose must be
+ * `assertionMethod` and the verificationMethod DID must equal the issuer DID,
+ * fail-closed, mirroring the agentreceipts adapter. A W3C VC carries no in-band
+ * chain link, so the chain axis reports genesis.
+ */
+
+import { createHash } from "node:crypto";
+
+import {
+  FormatAdapter,
+  type AxisCheck,
+  type ChainStep,
+  type ExtraAxis,
+  type KeyProvider,
+  type SignatureMaterial,
+} from "../adapter.js";
+import { jcsRfc8785 } from "../canonical.js";
+import { b58btcDecode, resolveEd25519Key } from "../did.js";
+
+/** First @context value a VC 2.0 credential must carry. */
+const VC_V2_CONTEXT = "https://www.w3.org/ns/credentials/v2";
+const PROOF_TYPE = "DataIntegrityProof";
+const CRYPTOSUITE = "eddsa-jcs-2022";
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+/** The doc's proof member when it is a single object; {} for absent/list proofs. */
+function proofOf(doc: Record<string, unknown>): Record<string, unknown> {
+  return asRecord(doc.proof);
+}
+
+/** The issuer DID whether issuer is a bare string or an object with an id. */
+function issuerDid(doc: Record<string, unknown>): string | null {
+  const issuer = doc.issuer;
+  if (typeof issuer === "string") return issuer;
+  if (issuer !== null && typeof issuer === "object" && !Array.isArray(issuer)) {
+    const id = (issuer as Record<string, unknown>).id;
+    if (typeof id === "string") return id;
+  }
+  return null;
+}
+
+/** xsd:datetime (RFC 3339 profile) -> epoch ms, or null when unparseable. */
+function parseDatetime(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|z|[+-]\d{2}:\d{2})$/.test(text)) return null;
+  const ms = Date.parse(text);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** proof minus proofValue - the exact object the spec canonicalises for hash one. */
+function proofOptions(doc: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(proofOf(doc))) {
+    if (k !== "proofValue") out[k] = v;
+  }
+  return out;
+}
+
+/** Document minus proof; the proof's @context substitutes the document's when present. */
+function unsecured(doc: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(doc)) {
+    if (k !== "proof") out[k] = v;
+  }
+  const ctx = proofOf(doc)["@context"];
+  if (ctx !== undefined) out["@context"] = ctx;
+  return out;
+}
+
+/** True when the proof's @context is absent or prefixes the document @context in order. */
+function contextPrefixOk(doc: Record<string, unknown>): boolean {
+  const ctx = proofOf(doc)["@context"];
+  if (ctx === undefined) return true;
+  if (!Array.isArray(ctx)) return false;
+  const docCtx = doc["@context"];
+  if (!Array.isArray(docCtx)) return false;
+  return ctx.every((v, i) => docCtx[i] !== undefined && JSON.stringify(docCtx[i]) === JSON.stringify(v));
+}
+
+/** Decode a multibase 'z' (base58btc) proofValue to raw signature bytes. */
+function multibaseZDecode(value: string): Uint8Array {
+  if (!value || value[0] !== "z") {
+    throw new Error("proofValue is not multibase 'z' (base58btc) encoded");
+  }
+  return b58btcDecode(value.slice(1));
+}
+
+function sha256(data: Uint8Array): Uint8Array {
+  return new Uint8Array(createHash("sha256").update(Buffer.from(data)).digest());
+}
+
+/** W3C VC 2.0 - DataIntegrityProof eddsa-jcs-2022, Ed25519 over RFC 8785 JCS. */
+export class W3cVcAdapter extends FormatAdapter {
+  readonly name = "w3c-vc";
+
+  detect(doc: Record<string, unknown>): boolean {
+    const types = doc.type;
+    if (!Array.isArray(types) || !types.includes("VerifiableCredential")) return false;
+    const proof = doc.proof;
+    const candidates = Array.isArray(proof)
+      ? proof
+      : proof !== null && typeof proof === "object"
+        ? [proof]
+        : [];
+    // Any DataIntegrityProof on a VC routes here; the cryptosuite check belongs
+    // to the schema axis so a sibling suite reports as an algorithm mismatch
+    return candidates.some(
+      (p) => p !== null && typeof p === "object" && (p as Record<string, unknown>).type === PROOF_TYPE,
+    );
+  }
+
+  extractSignature(doc: Record<string, unknown>): SignatureMaterial {
+    const proof = proofOf(doc);
+    const value = typeof proof.proofValue === "string" ? proof.proofValue : "";
+    let sig: Uint8Array;
+    try {
+      sig = multibaseZDecode(value);
+    } catch {
+      sig = new Uint8Array(0);
+    }
+    const vm = typeof proof.verificationMethod === "string" ? proof.verificationMethod : "";
+    return { sig, alg: "EdDSA", kid: vm };
+  }
+
+  resolveKey(
+    doc: Record<string, unknown>,
+    keyProvider: KeyProvider,
+  ): readonly [Uint8Array | null, string] {
+    const vm = proofOf(doc).verificationMethod;
+    return resolveEd25519Key(typeof vm === "string" ? vm : "", keyProvider);
+  }
+
+  signingInput(doc: Record<string, unknown>): Uint8Array {
+    // hashData = SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecured)) (TR vc-di-eddsa)
+    const optionsHash = sha256(jcsRfc8785(proofOptions(doc)));
+    const documentHash = sha256(jcsRfc8785(unsecured(doc)));
+    return Uint8Array.from([...optionsHash, ...documentHash]);
+  }
+
+  chainStep(_doc: Record<string, unknown>): ChainStep {
+    // A W3C VC carries no in-band chain link of its own
+    return { prevField: null, isGenesis: true, recompute: () => "" };
+  }
+
+  schema(doc: Record<string, unknown>): AxisCheck {
+    const ctx = doc["@context"];
+    if (!Array.isArray(ctx) || ctx.length === 0 || ctx[0] !== VC_V2_CONTEXT) {
+      return ["FAIL", "first @context must be the W3C VC 2.0 credentials context"];
+    }
+    const types = doc.type;
+    if (!Array.isArray(types) || !types.includes("VerifiableCredential")) {
+      return ["FAIL", "type must include VerifiableCredential"];
+    }
+    const proof = doc.proof;
+    if (Array.isArray(proof)) {
+      return ["FAIL", "proof sets are not supported; exactly one proof object is required"];
+    }
+    if (proof === null || typeof proof !== "object") {
+      return ["FAIL", "missing required VC fields: proof"];
+    }
+    const p = proof as Record<string, unknown>;
+    if (p.type !== PROOF_TYPE) {
+      return ["FAIL", "proof.type must be DataIntegrityProof"];
+    }
+    if (p.cryptosuite !== CRYPTOSUITE) {
+      return [
+        "FAIL",
+        `unsupported signature algorithm: cryptosuite '${p.cryptosuite}' ` +
+          `(this verifier checks '${CRYPTOSUITE}')`,
+      ];
+    }
+    const vm = p.verificationMethod;
+    if (typeof vm !== "string" || !vm.startsWith("did:")) {
+      return ["FAIL", "proof.verificationMethod must be a DID URL"];
+    }
+    if (p.proofPurpose !== "assertionMethod") {
+      return ["FAIL", "proof.proofPurpose must be assertionMethod"];
+    }
+    const issuer = issuerDid(doc);
+    if (issuer === null || !issuer.startsWith("did:")) {
+      return ["FAIL", "issuer must be a DID"];
+    }
+    if (vm.split("#")[0] !== issuer) {
+      // bind the signing key to the issuer or anyone self-signs as a victim
+      return [
+        "FAIL",
+        "proof.verificationMethod is not controlled by issuer (signing-key DID != issuer DID)",
+      ];
+    }
+    const subject = doc.credentialSubject;
+    if (!(subject !== null && typeof subject === "object" && (!Array.isArray(subject) || subject.length > 0))) {
+      return ["FAIL", "missing required VC fields: credentialSubject"];
+    }
+    if (p.created !== undefined && parseDatetime(p.created) === null) {
+      return ["FAIL", `unreadable proof.created: '${p.created}'`];
+    }
+    if (!contextPrefixOk(doc)) {
+      return ["FAIL", "proof @context is not a prefix of the document @context"];
+    }
+    return ["PASS", "required VC 2.0 fields present; DataIntegrityProof eddsa-jcs-2022"];
+  }
+
+  /** validFrom/validUntil bound validity; the expiry axis never folds the verdict (426). */
+  extraAxes(doc: Record<string, unknown>, _keyProvider: KeyProvider): ExtraAxis[] {
+    const now = Date.now();
+    const validFrom = doc.validFrom;
+    if (validFrom !== undefined) {
+      const parsed = parseDatetime(validFrom);
+      if (parsed === null) {
+        return [["expiry", "FAIL", `unreadable expires_at (validFrom '${validFrom}')`]];
+      }
+      if (now < parsed) {
+        return [["expiry", "FAIL", `not yet valid: validFrom ${validFrom}`]];
+      }
+    }
+    const validUntil = doc.validUntil;
+    if (validUntil !== undefined) {
+      const parsed = parseDatetime(validUntil);
+      if (parsed === null) {
+        return [["expiry", "FAIL", `unreadable expires_at (validUntil '${validUntil}')`]];
+      }
+      if (now >= parsed) {
+        return [["expiry", "FAIL", `expired at ${validUntil}`]];
+      }
+    }
+    return [["expiry", "PASS", "no validFrom/validUntil constraint breached"]];
+  }
+}

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -102,6 +102,7 @@ export function axisFailureClass(axis: string, result: VerifyState, note: string
     }
     if (note.startsWith("key_purpose mismatch")) return FAILURE_INVALID;
     if (note.includes("signing-key DID != issuer DID")) return FAILURE_INVALID;
+    if (note.startsWith("proof @context is not a prefix")) return FAILURE_INVALID;
     return FAILURE_UNVERIFIABLE;
   }
   if (axis === "expiry") {

--- a/typescript/src/verifier/did.ts
+++ b/typescript/src/verifier/did.ts
@@ -9,8 +9,13 @@
  *   - `did:key`  : self-contained. The multibase `z` (base58btc) identifier
  *                  decodes to a multicodec frame: the two-byte 0xed 0x01 Ed25519
  *                  prefix followed by the 32 raw key bytes. No network.
- *   - other      : resolved from an injected `{didOrKid: hexOrRaw}` map. The
- *                  oracle NEVER fetches a DID document over the network.
+ *   - other      : resolved from an injected map. A value is either a raw key
+ *                  (hex string or bytes, 32 bytes) or the DID DOCUMENT the
+ *                  method's network fetch would have returned; the resolver then
+ *                  walks `verificationMethod` / `assertionMethod` and extracts an
+ *                  Ed25519 key (publicKeyMultibase Multikey, publicKeyJwk OKP, or
+ *                  legacy publicKeyBase58). The oracle NEVER fetches a DID
+ *                  document over the network; an unmapped DID returns null.
  */
 
 /** Bitcoin base58 alphabet - the base58btc encoding multibase 'z' uses. */
@@ -88,11 +93,95 @@ function coerceRaw(material: unknown): Uint8Array | null {
   return raw !== null && raw.length === 32 ? raw : null;
 }
 
+/** Decode a base64url string to bytes (JWK coordinate form). */
+function b64urlDecode(value: string): Uint8Array {
+  const body = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = body + "=".repeat((-body.length % 4 + 4) % 4);
+  return new Uint8Array(Buffer.from(padded, "base64"));
+}
+
+/** OKP/Ed25519 JWK -> raw 32-byte key; null for any other curve or bad encoding. */
+function rawFromJwk(jwk: unknown): Uint8Array | null {
+  if (jwk === null || typeof jwk !== "object" || Array.isArray(jwk)) return null;
+  const rec = jwk as Record<string, unknown>;
+  if (rec.kty !== "OKP" || rec.crv !== "Ed25519" || typeof rec.x !== "string") return null;
+  let raw: Uint8Array;
+  try {
+    raw = b64urlDecode(rec.x);
+  } catch {
+    return null;
+  }
+  return raw.length === 32 ? raw : null;
+}
+
+/** Extract the raw Ed25519 key one DID-document verificationMethod publishes. */
+function rawFromVerificationMethod(vm: unknown): Uint8Array | null {
+  if (vm === null || typeof vm !== "object" || Array.isArray(vm)) return null;
+  const rec = vm as Record<string, unknown>;
+  if (typeof rec.publicKeyMultibase === "string") {
+    // A Multikey multibase value is shaped exactly like a did:key identifier
+    const key = decodeDidKey(rec.publicKeyMultibase);
+    if (key !== null) return key;
+  }
+  const jwk = rawFromJwk(rec.publicKeyJwk);
+  if (jwk !== null) return jwk;
+  if (typeof rec.publicKeyBase58 === "string") {
+    let raw: Uint8Array;
+    try {
+      raw = b58btcDecode(rec.publicKeyBase58);
+    } catch {
+      return null;
+    }
+    return raw.length === 32 ? raw : null;
+  }
+  return null;
+}
+
+/**
+ * Walk an injected DID document like the fetched one: exact fragment match first,
+ * else assertionMethod-authorized Ed25519 methods, then any remaining method.
+ */
+function keyFromDidDocument(
+  didDoc: Record<string, unknown>,
+  didUrl: string,
+): readonly [Uint8Array | null, string] {
+  const methods = Array.isArray(didDoc.verificationMethod)
+    ? didDoc.verificationMethod.filter(
+        (vm): vm is Record<string, unknown> => vm !== null && typeof vm === "object" && !Array.isArray(vm),
+      )
+    : [];
+  const assertion = Array.isArray(didDoc.assertionMethod) ? didDoc.assertionMethod : [];
+  let pool: Array<Record<string, unknown>> = [
+    ...methods,
+    ...assertion.filter(
+      (vm): vm is Record<string, unknown> => vm !== null && typeof vm === "object" && !Array.isArray(vm),
+    ),
+  ];
+  if (didUrl.includes("#")) {
+    pool = pool.filter((vm) => vm.id === didUrl);
+    if (pool.length === 0) {
+      return [null, `no verificationMethod '${didUrl}' in injected DID document`];
+    }
+  } else {
+    const refs = new Set(assertion.filter((vm): vm is string => typeof vm === "string"));
+    pool.sort((a, b) => (refs.has(a.id as string) ? 0 : 1) - (refs.has(b.id as string) ? 0 : 1));
+  }
+  for (const vm of pool) {
+    const key = rawFromVerificationMethod(vm);
+    if (key !== null) {
+      return [key, `resolved ${typeof vm.id === "string" ? vm.id : didUrl} from injected DID document`];
+    }
+  }
+  return [null, `no Ed25519 verificationMethod for '${didUrl}' in injected DID document`];
+}
+
 /**
  * Resolve a verificationMethod DID URL to `[rawKeyOrNull, note]`.
  *
  * did:key resolves inline; every other method resolves from `injected` keyed by
- * the full DID URL first, then by the bare DID (fragment stripped). No network.
+ * the full DID URL first, then by the bare DID (fragment stripped). An injected
+ * value is a raw 32-byte key (bytes or hex) or the DID document the method's
+ * fetch would have returned. No network.
  */
 export function resolveEd25519Key(
   didUrl: string,
@@ -112,7 +201,11 @@ export function resolveEd25519Key(
   const keys = injected || {};
   for (const candidate of [didUrl, bare]) {
     if (Object.prototype.hasOwnProperty.call(keys, candidate)) {
-      const raw = coerceRaw(keys[candidate]);
+      const material = keys[candidate];
+      if (material !== null && typeof material === "object" && !Array.isArray(material)) {
+        return keyFromDidDocument(material as Record<string, unknown>, didUrl);
+      }
+      const raw = coerceRaw(material);
       if (raw === null) {
         return [null, `injected key for '${candidate}' is not a 32-byte Ed25519 key`];
       }

--- a/typescript/src/verifier/index.ts
+++ b/typescript/src/verifier/index.ts
@@ -23,6 +23,7 @@ import { AgentReceiptsAdapter } from "./adapters/agentreceipts.js";
 import { AsqavNativeAdapter } from "./adapters/asqavNative.js";
 import { AuthproofAdapter } from "./adapters/authproof.js";
 import { PipelockEvidenceAdapter } from "./adapters/pipelock.js";
+import { W3cVcAdapter } from "./adapters/w3cVc.js";
 
 /** Detection fingerprints are mutually exclusive, so registration order is not load-bearing. */
 export const ADAPTERS: FormatAdapter[] = [
@@ -30,6 +31,7 @@ export const ADAPTERS: FormatAdapter[] = [
   new AerfAdapter(),
   new ActaAdapter(),
   new AgentReceiptsAdapter(),
+  new W3cVcAdapter(),
   new AuthproofAdapter(),
   new PipelockEvidenceAdapter(),
 ];
@@ -48,6 +50,7 @@ export { AgentReceiptsAdapter } from "./adapters/agentreceipts.js";
 export { AsqavNativeAdapter } from "./adapters/asqavNative.js";
 export { AuthproofAdapter } from "./adapters/authproof.js";
 export { PipelockEvidenceAdapter } from "./adapters/pipelock.js";
+export { W3cVcAdapter } from "./adapters/w3cVc.js";
 export {
   detect,
   FAILURE_INVALID,

--- a/typescript/src/verifier/parity-check.ts
+++ b/typescript/src/verifier/parity-check.ts
@@ -6,7 +6,7 @@
  * Python verifier without dilithium-py).
  *
  * Run directly:  node --import tsx typescript/src/verifier/parity-check.ts
- * or via the test `tests/verifier-parity.test.ts`, which asserts 44/44.
+ * or via the test `tests/verifier-parity.test.ts`, which asserts 62/62.
  */
 
 import { resolve } from "node:path";

--- a/typescript/src/verifier/runner.ts
+++ b/typescript/src/verifier/runner.ts
@@ -7,7 +7,7 @@
  * `<NN-name>/` directory carries `receipt.json`, an `expected.json`, optional
  * `predecessor.json`, and optional key material (`jwks.json` for Asqav-native,
  * `keys.json` for AERF, `acta-keys.json` for ACTA, `did_map.json` for
- * agentreceipts).
+ * agentreceipts and w3c-vc).
  *
  * `outcome` speaks the public verdict vocabulary (criteria 418/438):
  * verified / verified_keyed / unverified, and an `unverified` entry pins its
@@ -60,6 +60,8 @@ function keyProviderFor(vecDir: string, fmt: string): KeyProvider {
   if (fmt === "aerf") return loadJson(join(vecDir, "keys.json"));
   if (fmt === "acta") return loadJson(join(vecDir, "acta-keys.json"));
   if (fmt === "agentreceipts") return loadJson(join(vecDir, "did_map.json"));
+  // did:web resolves from an injected DID-document map; the oracle never fetches
+  if (fmt === "w3c-vc") return loadJson(join(vecDir, "did_map.json"));
   if (fmt === "pipelock-evidence-v2") return loadJson(join(vecDir, "keys.json"));
   return null;
 }

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -27,7 +27,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 54 corpus vectors", () => {
+  it("matches every manifest outcome across all 62 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -44,9 +44,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(54);
+    expect(results.length).toBe(62);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(54);
+    expect(passed).toBe(62);
   });
 
   it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {
@@ -126,6 +126,14 @@ describe("canonical-bytes cross-check (TS signing_input sha256 == Python)", () =
     "agentreceipts-01-didkey-genesis": {
       fmt: "agentreceipts",
       sha: "eb5fd119afbd399658e615cd4687c0047c72dd3bb3c59bbf40f69b7a12e66a34",
+    },
+    "w3c-vc-01-didweb-happy-path": {
+      fmt: "w3c-vc",
+      sha: "8bc6f6def30bde0132b272f99efdf583d49129f1c0f34291840525ed8802aed6",
+    },
+    "w3c-vc-08-didkey-happy-path": {
+      fmt: "w3c-vc",
+      sha: "969b993f84624dd9f47bba5baa2be7601a07c94bcea4369f7059d53502567c29",
     },
     "asqav-01-genesis-permit": {
       fmt: "asqav-native",

--- a/typescript/tests/verifier-w3c-vc.test.ts
+++ b/typescript/tests/verifier-w3c-vc.test.ts
@@ -1,0 +1,195 @@
+/**
+ * W3C VC 2.0 eddsa-jcs-2022 adapter tests (TS half).
+ *
+ * Mirrors the Python `tests/test_oracle_w3c_vc.py` negatives: proof sets,
+ * sibling cryptosuites, proofPurpose, issuer binding, the @context prefix
+ * transform, and the offline DID-document resolution. Corpus verdicts are
+ * gated in verifier-parity.test.ts; here the axis-level behaviour is pinned.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { FAIL, PASS, SKIPPED } from "../src/verifier/crypto.js";
+import { verify, FAILURE_INVALID, FAILURE_UNVERIFIABLE } from "../src/verifier/core.js";
+import { ADAPTERS } from "../src/verifier/index.js";
+import { W3cVcAdapter } from "../src/verifier/adapters/w3cVc.js";
+import { AgentReceiptsAdapter } from "../src/verifier/adapters/agentreceipts.js";
+import { resolveEd25519Key } from "../src/verifier/did.js";
+import { parseJsonPreservingFloats } from "../src/verifier/canonical.js";
+
+const CORPUS_ROOT = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
+
+function load(vec: string, name: string): Record<string, unknown> {
+  return parseJsonPreservingFloats(readFileSync(join(CORPUS_ROOT, vec, name), "utf-8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function provider(vec: string): Record<string, unknown> | null {
+  const path = join(CORPUS_ROOT, vec, "did_map.json");
+  return existsSync(path) ? (JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>) : null;
+}
+
+const b58 = (data: Uint8Array): string => {
+  const ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  let num = 0n;
+  for (const byte of data) num = num * 256n + BigInt(byte);
+  let out = "";
+  while (num > 0n) {
+    out = ALPHABET[Number(num % 58n)] + out;
+    num /= 58n;
+  }
+  let pad = 0;
+  for (const byte of data) {
+    if (byte === 0) pad++;
+    else break;
+  }
+  return "1".repeat(pad) + out;
+};
+
+describe("w3c-vc corpus verdicts (axis-level)", () => {
+  it("w3c-vc-01 did:web happy path verifies offline", () => {
+    const res = verify(load("w3c-vc-01-didweb-happy-path", "receipt.json"), ADAPTERS, provider("w3c-vc-01-didweb-happy-path"));
+    expect(res.fmt).toBe("w3c-vc");
+    expect(res.verdict).toBe("verified");
+    expect(res.axes.find((a) => a.axis === "signature")?.result).toBe(PASS);
+    expect(res.axes.find((a) => a.axis === "expiry")?.result).toBe(PASS);
+  });
+
+  it("w3c-vc-05 no injected DID document fails closed (never fetches)", () => {
+    const res = verify(load("w3c-vc-05-no-did-document", "receipt.json"), ADAPTERS);
+    expect(res.axes.find((a) => a.axis === "signature")?.result).toBe(SKIPPED);
+    expect(res.verdict).toBe("unverified");
+    expect(res.failureClass).toBe(FAILURE_UNVERIFIABLE);
+  });
+
+  it("w3c-vc-06 expired keeps the verified verdict (criterion 426)", () => {
+    const res = verify(load("w3c-vc-06-expired", "receipt.json"), ADAPTERS, provider("w3c-vc-06-expired"));
+    expect(res.verdict).toBe("verified");
+    const expiry = res.axes.find((a) => a.axis === "expiry");
+    expect(expiry?.result).toBe(FAIL);
+    expect(expiry?.note.startsWith("expired at ")).toBe(true);
+  });
+});
+
+describe("w3c-vc structure negatives", () => {
+  const ad = new W3cVcAdapter();
+
+  it("rejects proof sets", () => {
+    const doc = load("w3c-vc-01-didweb-happy-path", "receipt.json");
+    doc.proof = [doc.proof];
+    expect(ad.detect(doc)).toBe(true);
+    const [result, note] = ad.schema(doc);
+    expect(result).toBe(FAIL);
+    expect(note).toContain("proof sets are not supported");
+    const res = verify(doc, ADAPTERS, provider("w3c-vc-01-didweb-happy-path"));
+    expect(res.verdict).toBe("unverified");
+  });
+
+  it("reports a sibling cryptosuite as an algorithm mismatch (invalid)", () => {
+    const doc = load("w3c-vc-01-didweb-happy-path", "receipt.json");
+    (doc.proof as Record<string, unknown>).cryptosuite = "eddsa-rdfc-2022";
+    expect(ad.detect(doc)).toBe(true);
+    const [result, note] = ad.schema(doc);
+    expect(result).toBe(FAIL);
+    expect(note.startsWith("unsupported signature algorithm")).toBe(true);
+    const res = verify(doc, ADAPTERS, provider("w3c-vc-01-didweb-happy-path"));
+    expect(res.verdict).toBe("unverified");
+    expect(res.failureClass).toBe(FAILURE_INVALID);
+  });
+
+  it("requires proofPurpose assertionMethod", () => {
+    const doc = load("w3c-vc-01-didweb-happy-path", "receipt.json");
+    (doc.proof as Record<string, unknown>).proofPurpose = "authentication";
+    const [result, note] = ad.schema(doc);
+    expect(result).toBe(FAIL);
+    expect(note).toContain("proofPurpose");
+  });
+
+  it("rejects a malformed proofValue without crashing", () => {
+    const doc = load("w3c-vc-01-didweb-happy-path", "receipt.json");
+    for (const bad of ["u-not-base58btc", "", { k: "v" }, null]) {
+      const forged = JSON.parse(JSON.stringify(doc)) as Record<string, unknown>;
+      (forged.proof as Record<string, unknown>).proofValue = bad;
+      const res = verify(forged, ADAPTERS, provider("w3c-vc-01-didweb-happy-path"));
+      expect(res.verdict).toBe("unverified");
+      expect(ad.extractSignature(forged).sig.length).toBe(0);
+    }
+  });
+});
+
+describe("offline DID-document resolution (the did:web path)", () => {
+  const DID = "did:web:example.com";
+  const keyA = new Uint8Array(32).fill(1);
+  const keyB = new Uint8Array(32).fill(2);
+
+  function docWith(...methods: Array<Record<string, unknown>>): Record<string, unknown> {
+    return { id: DID, verificationMethod: methods, assertionMethod: [] };
+  }
+
+  it("resolves a fragment-matched publicKeyMultibase Multikey", () => {
+    const doc = docWith({
+      id: `${DID}#key-1`,
+      publicKeyMultibase: "z" + b58(Uint8Array.from([0xed, 0x01, ...keyA])),
+    });
+    const [key, note] = resolveEd25519Key(`${DID}#key-1`, { [DID]: doc });
+    expect(key).toEqual(keyA);
+    expect(note).toContain("injected DID document");
+  });
+
+  it("fails closed on a missing fragment", () => {
+    const doc = docWith({ id: `${DID}#other`, publicKeyBase58: b58(keyA) });
+    const [key, note] = resolveEd25519Key(`${DID}#key-1`, { [DID]: doc });
+    expect(key).toBeNull();
+    expect(note).toContain("no verificationMethod");
+  });
+
+  it("prefers the assertionMethod-referenced key", () => {
+    const doc = docWith(
+      { id: `${DID}#key-a`, publicKeyBase58: b58(keyA) },
+      { id: `${DID}#key-b`, publicKeyBase58: b58(keyB) },
+    );
+    doc.assertionMethod = [`${DID}#key-b`];
+    const [key] = resolveEd25519Key(DID, { [DID]: doc });
+    expect(key).toEqual(keyB);
+  });
+
+  it("resolves a publicKeyJwk OKP/Ed25519 key", () => {
+    const x = Buffer.from(keyA).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const doc = docWith({ id: `${DID}#jwk`, publicKeyJwk: { kty: "OKP", crv: "Ed25519", x } });
+    const [key] = resolveEd25519Key(`${DID}#jwk`, { [DID]: doc });
+    expect(key).toEqual(keyA);
+  });
+
+  it("fails closed on a non-Ed25519 multikey (secp256k1 prefix)", () => {
+    const doc = docWith({
+      id: `${DID}#k`,
+      publicKeyMultibase: "z" + b58(Uint8Array.from([0xe7, 0x01, ...keyA])),
+    });
+    const [key, note] = resolveEd25519Key(`${DID}#k`, { [DID]: doc });
+    expect(key).toBeNull();
+    expect(note).toContain("no Ed25519 verificationMethod");
+  });
+
+  it("keeps the raw-hex injection shape backwards compatible", () => {
+    const [key, note] = resolveEd25519Key("did:agent:x#k1", {
+      "did:agent:x": Buffer.from(keyA).toString("hex"),
+    });
+    expect(key).toEqual(keyA);
+    expect(note).toContain("injected map");
+  });
+});
+
+describe("detection exclusion against the sibling VC format", () => {
+  it("w3c-vc and agentreceipts never claim each other's receipts", () => {
+    const vc = load("w3c-vc-01-didweb-happy-path", "receipt.json");
+    const ar = load("agentreceipts-01-didkey-genesis", "receipt.json");
+    const w = new W3cVcAdapter();
+    const g = new AgentReceiptsAdapter();
+    expect([w.detect(vc), g.detect(vc)]).toEqual([true, false]);
+    expect([w.detect(ar), g.detect(ar)]).toEqual([false, true]);
+  });
+});

--- a/verifier/conformance-vectors/README.md
+++ b/verifier/conformance-vectors/README.md
@@ -15,7 +15,8 @@ manifest.json                  array of {dir, format, outcome, failure_class, re
   jwks.json                    (asqav-native) issuer key directory
   keys.json                    (aerf) {key_id: ed25519_pubkey_hex}
   acta-keys.json               (acta) JWKS-shaped key set
-  did_map.json                 (agentreceipts) {did: ed25519_pubkey_hex} for did:agent / did:web
+  did_map.json                 (agentreceipts, w3c-vc) {did: ed25519_pubkey_hex} or
+                               {did: did_document} for did:agent / did:web
 ```
 
 `outcome` speaks the shipped verdict vocabulary - `verified`, `verified_keyed`,
@@ -52,10 +53,24 @@ python -m oracle.runner          # from the verifier/ directory
   axis SKIPs, so the outcome is `unverified`/`unverifiable`. Guards the
   production hash-mode path against a false `verified` on the post-quantum
   signature the CI base cannot check.
-- `asqav-11-dup-member-toplevel` / `asqav-12-dup-member-nested` - the valid
+- `asqav-06-mldsa65-payload-prod` - a real payload-mode prod ML-DSA-65 receipt;
+  its signed `expires_at` lapsed, so the expiry axis FAILs alone while the
+  verdict stays verified (criterion 426).
+- `asqav-07-revoked-key` - a valid signature from a key whose JWKS status is
+  `revoked`; the key_status axis FAILs the verdict (parity vector).
+- `asqav-08-v2-signer-canary` / `asqav-09-v2-signer-tampered` - a v:2 receipt
+  whose in-signed-body `signer` the neutral verifier surfaces, and its tampered
+  twin proving `signer` sits inside the signed coverage (parity vectors).
+- `asqav-10-hash-mode-multikey` - hash-mode receipt signed by the last of three
+  sibling keys sharing issuer/org ids; the agent bind resolves the actual signer
+  (anti-vacuous parity vector).
+- `asqav-11-dup-member-toplevel` / `asqav-13-dup-member-nested` - the valid
   genesis receipt with a duplicated JSON member name at the top level and two
   levels down. Both are terminal parse failures (criterion 419): the strict
   parser rejects them before any hashing, so they never verify.
+- `asqav-12-time-edge-expiry` - deterministic ML-DSA-65 vector with an extreme
+  positive UTC offset around midnight and a lapsed signed `expires_at`
+  (time-edge conformance, criterion 422; parity vector).
 - `aerf-01..02` - valid AERF receipts (genesis, chain link). Genesis omits
   `previous_receipt_hash`; the chain hash excludes the signature, per the AERF
   spec.
@@ -75,6 +90,26 @@ python -m oracle.runner          # from the verifier/ directory
   cross-implementation interop PASS. `authproof-02/03` are its forged-signature
   and tampered-scope negatives. The signer key is embedded, so no key file. See
   `UPSTREAM.md`.
+- `pipelock-ev2-01-proxy-decision` / `pipelock-ev2-02-tamper-payload` - a valid
+  Pipelock evidence-v2 receipt and its verdict-flipped twin (keys.json carries
+  the signer key id -> raw Ed25519 hex).
+- `w3c-vc-01-didweb-happy-path` - a W3C VC 2.0 credential with a
+  DataIntegrityProof `eddsa-jcs-2022` signature (W3C TR vc-di-eddsa): Ed25519
+  over `SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecuredDocument))`. The
+  did:web issuer resolves from the injected DID document (offline mode).
+- `w3c-vc-02-tamper-subject` / `w3c-vc-03-tamper-proofvalue` - credentialSubject
+  flipped and one proofValue base58 character replaced after signing; both fail
+  the signature axis.
+- `w3c-vc-04-wrong-key-injected` - the injected DID document publishes an
+  unrelated key; verification fails against the published key, never a false pass.
+- `w3c-vc-05-no-did-document` - no injected DID document and the oracle never
+  fetches, so the signature axis SKIPs: `unverified`/`unverifiable`, fail closed.
+- `w3c-vc-06-expired` - signature verifies but signed `validUntil` lapsed; the
+  expiry axis FAILs alone while the verdict stays verified (criterion 426).
+- `w3c-vc-07-dup-member` - `credentialSubject` appears twice; strict ingest
+  rejects the duplicate at parse time (criterion 419).
+- `w3c-vc-08-didkey-happy-path` - a did:key issuer self-resolves inline from
+  the multicodec frame; no key file needed.
 
 The keys are generated from fixed seeds so the vectors are reproducible. AERF
 public keys are derived per spec as the first 16 hex of `SHA-256(pubkey)`.

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -405,5 +405,66 @@
     "failure_class": "unverifiable",
     "reason_code": "duplicate_member",
     "notes": "payload_digest.hash is duplicated two levels down; strict ingest rejects duplicate members at ANY depth at parse time, before any hashing or signature check, so the mutated receipt never verifies (criterion 419)."
+  },
+  {
+    "dir": "w3c-vc-01-didweb-happy-path",
+    "format": "w3c-vc",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "Valid W3C VC 2.0 with DataIntegrityProof eddsa-jcs-2022; the did:web issuer resolves from the injected DID document (offline mode) and Ed25519 verifies over SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecuredDocument)) per W3C TR vc-di-eddsa."
+  },
+  {
+    "dir": "w3c-vc-02-tamper-subject",
+    "format": "w3c-vc",
+    "outcome": "unverified",
+    "failure_class": "invalid",
+    "reason_code": "issuer_signature",
+    "notes": "credentialSubject.agentAction.outcome flipped from 'completed' to 'failed' after signing; the JCS document hash diverges and Ed25519 verify fails."
+  },
+  {
+    "dir": "w3c-vc-03-tamper-proofvalue",
+    "format": "w3c-vc",
+    "outcome": "unverified",
+    "failure_class": "invalid",
+    "reason_code": "issuer_signature",
+    "notes": "One base58btc character of proof.proofValue replaced after signing; the decoded signature no longer matches the signed hashData."
+  },
+  {
+    "dir": "w3c-vc-04-wrong-key-injected",
+    "format": "w3c-vc",
+    "outcome": "unverified",
+    "failure_class": "invalid",
+    "reason_code": "issuer_signature",
+    "notes": "Receipt signed by the real issuer key, but the injected DID document publishes an unrelated Ed25519 key; verification fails against the published key, never a false pass."
+  },
+  {
+    "dir": "w3c-vc-05-no-did-document",
+    "format": "w3c-vc",
+    "outcome": "unverified",
+    "failure_class": "unverifiable",
+    "reason_code": "signature_skipped_no_did_document",
+    "notes": "No injected DID document for the did:web issuer and the oracle never fetches, so the signature axis SKIPs and the verdict downgrades to unverified/unverifiable: fail-closed offline DID resolution."
+  },
+  {
+    "dir": "w3c-vc-06-expired",
+    "format": "w3c-vc",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "Signature verifies, but the signed validUntil 2026-01-01T00:00:00Z lapsed; the expiry axis FAILs alone while the verdict stays verified (criterion 426). Parity vector: both PY and TS oracles must verify."
+  },
+  {
+    "dir": "w3c-vc-07-dup-member",
+    "format": "w3c-vc",
+    "outcome": "unverified",
+    "failure_class": "unverifiable",
+    "reason_code": "duplicate_member",
+    "notes": "credentialSubject appears twice (the second flips outcome to failed); strict ingest rejects the duplicate at parse time, before any hashing or signature check, so the mutated credential never verifies (criterion 419)."
+  },
+  {
+    "dir": "w3c-vc-08-didkey-happy-path",
+    "format": "w3c-vc",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "did:key issuer self-resolves inline from the base58btc multicodec frame; no injected map needed and Ed25519 over hashData verifies."
   }
 ]

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -6,8 +6,8 @@
   "files": [
     {
       "path": "README.md",
-      "sha256": "42fb019594b3ce9f50c69e90664adfd0254ea873060c54522f061e65510abf97",
-      "bytes": 6529
+      "sha256": "69a8a270ca655b3e8f5cf8f1237ca43f257871169558f28443f5747d3aa76eb3",
+      "bytes": 8964
     },
     {
       "path": "UPSTREAM.md",
@@ -851,8 +851,8 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "86d4450636912ae97ec1a00e1aa7009f5f45b79f734890ae5e7d8f3cd3813be9",
-      "bytes": 17747
+      "sha256": "dcce074da806c01f83335172609efa7bda474d21d75ca7e378f92be4fe232e4b",
+      "bytes": 20564
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
@@ -883,6 +883,111 @@
       "path": "pipelock-ev2-02-tamper-payload/receipt.json",
       "sha256": "9bb3a0d9c98e7f6affa065cd5207f7ef89fb062e4bcf2da5e11f9847f764c866",
       "bytes": 730
+    },
+    {
+      "path": "w3c-vc-01-didweb-happy-path/did_map.json",
+      "sha256": "696b6045b08c96348fe563d15b49a54d2383d68c83ea7ed45aeb93979aac3763",
+      "bytes": 505
+    },
+    {
+      "path": "w3c-vc-01-didweb-happy-path/expected.json",
+      "sha256": "a859e48fc1b5d80d5294d966581dd1fa56defd0bbb9b6d66548a9c72c210f027",
+      "bytes": 301
+    },
+    {
+      "path": "w3c-vc-01-didweb-happy-path/receipt.json",
+      "sha256": "c116216553f9c94b8b2ab08505365b60a9c952b7ae6f5b2a17cb8a356e873a08",
+      "bytes": 903
+    },
+    {
+      "path": "w3c-vc-02-tamper-subject/did_map.json",
+      "sha256": "696b6045b08c96348fe563d15b49a54d2383d68c83ea7ed45aeb93979aac3763",
+      "bytes": 505
+    },
+    {
+      "path": "w3c-vc-02-tamper-subject/expected.json",
+      "sha256": "6e8b825f03e8004eb25c33c6a48d0994cdfb2e673a530be655e5039ec6c0e584",
+      "bytes": 221
+    },
+    {
+      "path": "w3c-vc-02-tamper-subject/receipt.json",
+      "sha256": "9170e637dab18e030a4bc2b714fbb86aeeaaee9df219b468ab91c851056d7f00",
+      "bytes": 900
+    },
+    {
+      "path": "w3c-vc-03-tamper-proofvalue/did_map.json",
+      "sha256": "696b6045b08c96348fe563d15b49a54d2383d68c83ea7ed45aeb93979aac3763",
+      "bytes": 505
+    },
+    {
+      "path": "w3c-vc-03-tamper-proofvalue/expected.json",
+      "sha256": "e3b48a3feb74e0b3ad1f3953e28ccecb004a39c500a1f9837a7a6358d542061d",
+      "bytes": 226
+    },
+    {
+      "path": "w3c-vc-03-tamper-proofvalue/receipt.json",
+      "sha256": "63f6061a51366d7b39bfb8dbf1862fbdbb09eb3d3c79b692d193a3fe24d8a9b9",
+      "bytes": 903
+    },
+    {
+      "path": "w3c-vc-04-wrong-key-injected/did_map.json",
+      "sha256": "f46792c0bd195d8139cac4ba406face71d8f1dce9195dfc05d75e96035e74819",
+      "bytes": 505
+    },
+    {
+      "path": "w3c-vc-04-wrong-key-injected/expected.json",
+      "sha256": "cb1929a9a2e99c50366235c1ec328e9bb9ddee011efb512ea45325621b9f1b63",
+      "bytes": 246
+    },
+    {
+      "path": "w3c-vc-04-wrong-key-injected/receipt.json",
+      "sha256": "c116216553f9c94b8b2ab08505365b60a9c952b7ae6f5b2a17cb8a356e873a08",
+      "bytes": 903
+    },
+    {
+      "path": "w3c-vc-05-no-did-document/expected.json",
+      "sha256": "bfa3c724fb68a3a46d5245aa612a32a7024cfde675e6b0f25d249e53db5aff2c",
+      "bytes": 278
+    },
+    {
+      "path": "w3c-vc-05-no-did-document/receipt.json",
+      "sha256": "c116216553f9c94b8b2ab08505365b60a9c952b7ae6f5b2a17cb8a356e873a08",
+      "bytes": 903
+    },
+    {
+      "path": "w3c-vc-06-expired/did_map.json",
+      "sha256": "696b6045b08c96348fe563d15b49a54d2383d68c83ea7ed45aeb93979aac3763",
+      "bytes": 505
+    },
+    {
+      "path": "w3c-vc-06-expired/expected.json",
+      "sha256": "cfa6511ce9c4a684f26b0d480b2ecaedac44f88a3c77fb3ea1a3f6dd6211f18c",
+      "bytes": 234
+    },
+    {
+      "path": "w3c-vc-06-expired/receipt.json",
+      "sha256": "4952d542d6bc5080b747472dfaa4fa8f2f74445724e64553bdc79115512b5a4c",
+      "bytes": 903
+    },
+    {
+      "path": "w3c-vc-07-dup-member/expected.json",
+      "sha256": "39dedc558c062a68e5c3f50ac9aac8c5661da9217de5c920be7cdba1aa1c8f49",
+      "bytes": 279
+    },
+    {
+      "path": "w3c-vc-07-dup-member/receipt.json",
+      "sha256": "e6209f19ae938c687533667a45ba3e68292b8f9c15bf1529986af05e76cfde06",
+      "bytes": 1064
+    },
+    {
+      "path": "w3c-vc-08-didkey-happy-path/expected.json",
+      "sha256": "f5acecb78db7fb0542ac54ef79be9c7978dc9b54e688189d091962960c9e7c79",
+      "bytes": 207
+    },
+    {
+      "path": "w3c-vc-08-didkey-happy-path/receipt.json",
+      "sha256": "6df9655344e7b87f5fc4a03ae097a6cd556acb7449c0df696dab6d66488e1aa4",
+      "bytes": 1005
     }
   ],
   "signing": {
@@ -915,5 +1020,5 @@
       ]
     }
   },
-  "digest": "37fdb7564b54303dde937e6f3324321e108dcd3710367ca6b0cf19906d029103"
+  "digest": "8a8904f0b496b0ecb2580212f9cc59d3edd27e5292eaa0a15a5ba1f7bf4ee3b9"
 }

--- a/verifier/conformance-vectors/w3c-vc-01-didweb-happy-path/did_map.json
+++ b/verifier/conformance-vectors/w3c-vc-01-didweb-happy-path/did_map.json
@@ -1,0 +1,20 @@
+{
+  "did:web:issuer.example": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/multikey/v1"
+    ],
+    "id": "did:web:issuer.example",
+    "verificationMethod": [
+      {
+        "id": "did:web:issuer.example#key-1",
+        "type": "Multikey",
+        "controller": "did:web:issuer.example",
+        "publicKeyMultibase": "z6MkeuQC5jHWAmno182wY9QpqQpmnQ4iaYfr5ZXbM3moHtKo"
+      }
+    ],
+    "assertionMethod": [
+      "did:web:issuer.example#key-1"
+    ]
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-01-didweb-happy-path/expected.json
+++ b/verifier/conformance-vectors/w3c-vc-01-didweb-happy-path/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "w3c-vc",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "Valid W3C VC 2.0 with DataIntegrityProof eddsa-jcs-2022; did:web issuer resolves from the injected DID document (offline mode) and Ed25519 verifies over SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecuredDocument))."
+}

--- a/verifier/conformance-vectors/w3c-vc-01-didweb-happy-path/receipt.json
+++ b/verifier/conformance-vectors/w3c-vc-01-didweb-happy-path/receipt.json
@@ -1,0 +1,30 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "id": "urn:asqav-test:w3c-vc-01",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "did:web:issuer.example",
+  "validFrom": "2026-08-01T00:00:00Z",
+  "validUntil": "2027-08-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:counterparty.example",
+    "agentAction": {
+      "type": "AgentAction",
+      "agent": "did:web:issuer.example#agent-payments",
+      "task": "invoice-settlement-run-2026-08",
+      "outcome": "completed",
+      "timestamp": "2026-08-01T09:30:00Z"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "created": "2026-08-01T09:30:05Z",
+    "verificationMethod": "did:web:issuer.example#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5ppJn6ZTw4faN4cCqcf2YVA9GDEqADvNQveEmEVb7pcDFrgmZoHkxHcbuWmLoqGKR4aj6MTQLfRmjHXFgEkszVBj"
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-02-tamper-subject/did_map.json
+++ b/verifier/conformance-vectors/w3c-vc-02-tamper-subject/did_map.json
@@ -1,0 +1,20 @@
+{
+  "did:web:issuer.example": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/multikey/v1"
+    ],
+    "id": "did:web:issuer.example",
+    "verificationMethod": [
+      {
+        "id": "did:web:issuer.example#key-1",
+        "type": "Multikey",
+        "controller": "did:web:issuer.example",
+        "publicKeyMultibase": "z6MkeuQC5jHWAmno182wY9QpqQpmnQ4iaYfr5ZXbM3moHtKo"
+      }
+    ],
+    "assertionMethod": [
+      "did:web:issuer.example#key-1"
+    ]
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-02-tamper-subject/expected.json
+++ b/verifier/conformance-vectors/w3c-vc-02-tamper-subject/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "w3c-vc",
+  "outcome": "unverified",
+  "reason_code": "issuer_signature",
+  "notes": "credentialSubject.agentAction.outcome flipped after signing; the JCS document hash diverges and Ed25519 verify fails."
+}

--- a/verifier/conformance-vectors/w3c-vc-02-tamper-subject/receipt.json
+++ b/verifier/conformance-vectors/w3c-vc-02-tamper-subject/receipt.json
@@ -1,0 +1,30 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "id": "urn:asqav-test:w3c-vc-01",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "did:web:issuer.example",
+  "validFrom": "2026-08-01T00:00:00Z",
+  "validUntil": "2027-08-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:counterparty.example",
+    "agentAction": {
+      "type": "AgentAction",
+      "agent": "did:web:issuer.example#agent-payments",
+      "task": "invoice-settlement-run-2026-08",
+      "outcome": "failed",
+      "timestamp": "2026-08-01T09:30:00Z"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "created": "2026-08-01T09:30:05Z",
+    "verificationMethod": "did:web:issuer.example#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5ppJn6ZTw4faN4cCqcf2YVA9GDEqADvNQveEmEVb7pcDFrgmZoHkxHcbuWmLoqGKR4aj6MTQLfRmjHXFgEkszVBj"
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-03-tamper-proofvalue/did_map.json
+++ b/verifier/conformance-vectors/w3c-vc-03-tamper-proofvalue/did_map.json
@@ -1,0 +1,20 @@
+{
+  "did:web:issuer.example": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/multikey/v1"
+    ],
+    "id": "did:web:issuer.example",
+    "verificationMethod": [
+      {
+        "id": "did:web:issuer.example#key-1",
+        "type": "Multikey",
+        "controller": "did:web:issuer.example",
+        "publicKeyMultibase": "z6MkeuQC5jHWAmno182wY9QpqQpmnQ4iaYfr5ZXbM3moHtKo"
+      }
+    ],
+    "assertionMethod": [
+      "did:web:issuer.example#key-1"
+    ]
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-03-tamper-proofvalue/expected.json
+++ b/verifier/conformance-vectors/w3c-vc-03-tamper-proofvalue/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "w3c-vc",
+  "outcome": "unverified",
+  "reason_code": "issuer_signature",
+  "notes": "One base58btc character of proofValue replaced after signing; the decoded signature no longer matches the signed hashData."
+}

--- a/verifier/conformance-vectors/w3c-vc-03-tamper-proofvalue/receipt.json
+++ b/verifier/conformance-vectors/w3c-vc-03-tamper-proofvalue/receipt.json
@@ -1,0 +1,30 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "id": "urn:asqav-test:w3c-vc-01",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "did:web:issuer.example",
+  "validFrom": "2026-08-01T00:00:00Z",
+  "validUntil": "2027-08-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:counterparty.example",
+    "agentAction": {
+      "type": "AgentAction",
+      "agent": "did:web:issuer.example#agent-payments",
+      "task": "invoice-settlement-run-2026-08",
+      "outcome": "completed",
+      "timestamp": "2026-08-01T09:30:00Z"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "created": "2026-08-01T09:30:05Z",
+    "verificationMethod": "did:web:issuer.example#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5ppJn6ZTw4faN4cCqcf3YVA9GDEqADvNQveEmEVb7pcDFrgmZoHkxHcbuWmLoqGKR4aj6MTQLfRmjHXFgEkszVBj"
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-04-wrong-key-injected/did_map.json
+++ b/verifier/conformance-vectors/w3c-vc-04-wrong-key-injected/did_map.json
@@ -1,0 +1,20 @@
+{
+  "did:web:issuer.example": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/multikey/v1"
+    ],
+    "id": "did:web:issuer.example",
+    "verificationMethod": [
+      {
+        "id": "did:web:issuer.example#key-1",
+        "type": "Multikey",
+        "controller": "did:web:issuer.example",
+        "publicKeyMultibase": "z6MkqSx2RutRZxLpVhnEjzXNPbP6DjV1A6hHA1L1ArzEDJSR"
+      }
+    ],
+    "assertionMethod": [
+      "did:web:issuer.example#key-1"
+    ]
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-04-wrong-key-injected/expected.json
+++ b/verifier/conformance-vectors/w3c-vc-04-wrong-key-injected/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "w3c-vc",
+  "outcome": "unverified",
+  "reason_code": "issuer_signature",
+  "notes": "Receipt signed by the real issuer key, but the injected DID document publishes an unrelated key; verification fails against the published key."
+}

--- a/verifier/conformance-vectors/w3c-vc-04-wrong-key-injected/receipt.json
+++ b/verifier/conformance-vectors/w3c-vc-04-wrong-key-injected/receipt.json
@@ -1,0 +1,30 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "id": "urn:asqav-test:w3c-vc-01",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "did:web:issuer.example",
+  "validFrom": "2026-08-01T00:00:00Z",
+  "validUntil": "2027-08-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:counterparty.example",
+    "agentAction": {
+      "type": "AgentAction",
+      "agent": "did:web:issuer.example#agent-payments",
+      "task": "invoice-settlement-run-2026-08",
+      "outcome": "completed",
+      "timestamp": "2026-08-01T09:30:00Z"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "created": "2026-08-01T09:30:05Z",
+    "verificationMethod": "did:web:issuer.example#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5ppJn6ZTw4faN4cCqcf2YVA9GDEqADvNQveEmEVb7pcDFrgmZoHkxHcbuWmLoqGKR4aj6MTQLfRmjHXFgEkszVBj"
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-05-no-did-document/expected.json
+++ b/verifier/conformance-vectors/w3c-vc-05-no-did-document/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "w3c-vc",
+  "outcome": "unverified",
+  "reason_code": "signature_skipped_no_did_document",
+  "notes": "No injected DID document for the did:web issuer; the oracle never fetches, so the signature axis SKIPs and the verdict downgrades to unverified/unverifiable."
+}

--- a/verifier/conformance-vectors/w3c-vc-05-no-did-document/receipt.json
+++ b/verifier/conformance-vectors/w3c-vc-05-no-did-document/receipt.json
@@ -1,0 +1,30 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "id": "urn:asqav-test:w3c-vc-01",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "did:web:issuer.example",
+  "validFrom": "2026-08-01T00:00:00Z",
+  "validUntil": "2027-08-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:counterparty.example",
+    "agentAction": {
+      "type": "AgentAction",
+      "agent": "did:web:issuer.example#agent-payments",
+      "task": "invoice-settlement-run-2026-08",
+      "outcome": "completed",
+      "timestamp": "2026-08-01T09:30:00Z"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "created": "2026-08-01T09:30:05Z",
+    "verificationMethod": "did:web:issuer.example#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5ppJn6ZTw4faN4cCqcf2YVA9GDEqADvNQveEmEVb7pcDFrgmZoHkxHcbuWmLoqGKR4aj6MTQLfRmjHXFgEkszVBj"
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-06-expired/did_map.json
+++ b/verifier/conformance-vectors/w3c-vc-06-expired/did_map.json
@@ -1,0 +1,20 @@
+{
+  "did:web:issuer.example": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/security/multikey/v1"
+    ],
+    "id": "did:web:issuer.example",
+    "verificationMethod": [
+      {
+        "id": "did:web:issuer.example#key-1",
+        "type": "Multikey",
+        "controller": "did:web:issuer.example",
+        "publicKeyMultibase": "z6MkeuQC5jHWAmno182wY9QpqQpmnQ4iaYfr5ZXbM3moHtKo"
+      }
+    ],
+    "assertionMethod": [
+      "did:web:issuer.example#key-1"
+    ]
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-06-expired/expected.json
+++ b/verifier/conformance-vectors/w3c-vc-06-expired/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "w3c-vc",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "Signature verifies, but signed validUntil 2026-01-01T00:00:00Z lapsed; the expiry axis FAILs alone while the verdict stays verified (criterion 426)."
+}

--- a/verifier/conformance-vectors/w3c-vc-06-expired/receipt.json
+++ b/verifier/conformance-vectors/w3c-vc-06-expired/receipt.json
@@ -1,0 +1,30 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "id": "urn:asqav-test:w3c-vc-06",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "did:web:issuer.example",
+  "validFrom": "2026-08-01T00:00:00Z",
+  "validUntil": "2026-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:counterparty.example",
+    "agentAction": {
+      "type": "AgentAction",
+      "agent": "did:web:issuer.example#agent-payments",
+      "task": "invoice-settlement-run-2026-08",
+      "outcome": "completed",
+      "timestamp": "2026-08-01T09:30:00Z"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "created": "2026-08-01T09:30:05Z",
+    "verificationMethod": "did:web:issuer.example#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z3a7ErrmBXteURzy64UwHfPYKZY4ieWwfkSNnqFo2fydKNziGGD64HcXFm3yWJKzPoa1PKoZtcSQZzZhS25cPbRt4"
+  }
+}

--- a/verifier/conformance-vectors/w3c-vc-07-dup-member/expected.json
+++ b/verifier/conformance-vectors/w3c-vc-07-dup-member/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "w3c-vc",
+  "outcome": "unverified",
+  "reason_code": "duplicate_member",
+  "notes": "credentialSubject appears twice (the second flips outcome to failed); strict ingest rejects the duplicate at parse time, before any hashing or signature check (criterion 419)."
+}

--- a/verifier/conformance-vectors/w3c-vc-07-dup-member/receipt.json
+++ b/verifier/conformance-vectors/w3c-vc-07-dup-member/receipt.json
@@ -1,0 +1,11 @@
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2"],
+  "id": "urn:asqav-test:w3c-vc-07",
+  "type": ["VerifiableCredential"],
+  "issuer": "did:web:issuer.example",
+  "validFrom": "2026-08-01T00:00:00Z",
+  "validUntil": "2027-08-01T00:00:00Z",
+  "credentialSubject": {"id": "did:web:counterparty.example", "agentAction": {"type": "AgentAction", "agent": "did:web:issuer.example#agent-payments", "task": "invoice-settlement-run-2026-08", "outcome": "completed", "timestamp": "2026-08-01T09:30:00Z"}},
+  "credentialSubject": {"id": "did:web:counterparty.example", "agentAction": {"type": "AgentAction", "agent": "did:web:issuer.example#agent-payments", "task": "invoice-settlement-run-2026-08", "outcome": "failed", "timestamp": "2026-08-01T09:30:00Z"}},
+  "proof": {"type": "DataIntegrityProof", "cryptosuite": "eddsa-jcs-2022", "created": "2026-08-01T09:30:05Z", "verificationMethod": "did:web:issuer.example#key-1", "proofPurpose": "assertionMethod", "proofValue": "z2LdUvYjrDGoWAjTCje8YVvyez41U3TzPrdigsLsdDNsGhi9dcFSYZADLPN3aA5V7qxsiQU8ePd8sTbSE7GmccLeL"}
+}

--- a/verifier/conformance-vectors/w3c-vc-08-didkey-happy-path/expected.json
+++ b/verifier/conformance-vectors/w3c-vc-08-didkey-happy-path/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "w3c-vc",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "did:key issuer self-resolves inline from the multicodec frame; no injected map needed and Ed25519 over hashData verifies."
+}

--- a/verifier/conformance-vectors/w3c-vc-08-didkey-happy-path/receipt.json
+++ b/verifier/conformance-vectors/w3c-vc-08-didkey-happy-path/receipt.json
@@ -1,0 +1,30 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "id": "urn:asqav-test:w3c-vc-08",
+  "type": [
+    "VerifiableCredential"
+  ],
+  "issuer": "did:key:z6MknDNKznvdxejiwnhKnj97qS3EX5QnyB9VwqahnpANazci",
+  "validFrom": "2026-08-01T00:00:00Z",
+  "validUntil": "2027-08-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:counterparty.example",
+    "agentAction": {
+      "type": "AgentAction",
+      "agent": "did:key:z6MknDNKznvdxejiwnhKnj97qS3EX5QnyB9VwqahnpANazci#agent-payments",
+      "task": "invoice-settlement-run-2026-08",
+      "outcome": "completed",
+      "timestamp": "2026-08-01T09:30:00Z"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "created": "2026-08-01T09:30:05Z",
+    "verificationMethod": "did:key:z6MknDNKznvdxejiwnhKnj97qS3EX5QnyB9VwqahnpANazci#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z2HHM5srjnYqHU8NYv3v2eUdVPbZo3ck4Q6rGBhMd3fDRXs4cDhjUXkukfYs6PKTHBdLWWeY3BQ1UtN5dUYMVUGPu"
+  }
+}


### PR DESCRIPTION
Seventh oracle format: W3C Verifiable Credentials 2.0 secured by DataIntegrityProof with the eddsa-jcs-2022 cryptosuite (W3C TR vc-di-eddsa).

## What it verifies
- Ed25519 over `SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecuredDocument))` - strict JCS canonicalization, proofOptions = proof minus proofValue, unsecuredDocument = credential minus proof
- `proofValue` multibase base58btc ('z'), proof.type DataIntegrityProof, cryptosuite eddsa-jcs-2022 (a sibling suite reports as an algorithm mismatch, invalid)
- the spec's proof @context prefix transform (document @context must start with the proof's, and the proof's substitutes it before canonicalization)
- fail-closed strictness beyond the suite spec: proofPurpose must be assertionMethod and the verificationMethod DID must equal the issuer DID (mirrors the agentreceipts adapter)
- validFrom/validUntil on the expiry axis, which never folds the verdict (criterion 426)

## did:web, offline and fail closed
The shared DID resolver now accepts an injected DID DOCUMENT (the bytes the did:web fetch would return) in the did_map.json slot and walks verificationMethod/assertionMethod for Ed25519 keys (publicKeyMultibase Multikey, publicKeyJwk OKP, publicKeyBase58). The oracle never fetches: an unmapped did:web reads unverified/unverifiable. Raw-key injection stays backwards compatible.

## Proof
- 8 new corpus vectors (w3c-vc-01..08): did:web happy path, did:key happy path, tampered subject, tampered proofValue, wrong published key, no DID document (fail closed), expired (expiry axis FAILs alone), duplicate member (criterion 419)
- corpus lock re-frozen at v1; both lock paths green (hashlib + sha256sum)
- Python: 2797 passed / 1 skipped; TypeScript: 1014 passed; 62/62 vectors in both language halves; signing-input SHAs pinned cross-language