### PR TITLE
release: 0.10.0 (W3C VC eddsa-jcs-2022 verifier format, shadow-ai CLI removal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-27
+
+### Added
+
+- **New oracle format: W3C Verifiable Credentials 2.0 secured by
+  DataIntegrityProof with the eddsa-jcs-2022 cryptosuite (W3C TR
+  vc-di-eddsa).** The seventh format the universal neutral verifier checks, in
+  both language halves together. The signature is Ed25519 over
+  `SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecuredDocument))` under strict
+  RFC 8785 JCS, with proofOptions the proof minus `proofValue` and the
+  unsecured document the credential minus `proof`; `proofValue` is the raw
+  signature multibase base58btc encoded. The cryptosuite's proof `@context`
+  prefix transform is enforced (the document `@context` must start with the
+  proof's, and the proof's substitutes it before canonicalization). The adapter
+  is fail-closed stricter than the suite spec: `proofPurpose` must be
+  `assertionMethod` and the verificationMethod DID must equal the issuer DID,
+  mirroring the agentreceipts adapter. `validFrom`/`validUntil` report on the
+  expiry axis, which never folds the verdict (criterion 426). A sibling
+  cryptosuite reports as an algorithm mismatch (`invalid`), never a silent
+  re-dispatch. Eight new conformance vectors (`w3c-vc-01..08`) pin the did:web
+  and did:key happy paths, tamper rejection, a wrong published key, fail-closed
+  offline resolution, the expiry rule, and strict ingest; the corpus lock is
+  re-frozen at v1 and both lock paths re-derive every pin.
+
+- **The shared DID resolver accepts an injected DID document** in the
+  `did_map.json` slot: the bytes the did:web fetch would have returned. The
+  resolver walks `verificationMethod` and `assertionMethod` and extracts an
+  Ed25519 key from `publicKeyMultibase` (Multikey), `publicKeyJwk`
+  (OKP/Ed25519), or `publicKeyBase58`. The oracle still never fetches a DID
+  document: an unmapped DID reads `unverified`/`unverifiable`, fail closed.
+  The raw-key injection shape (hex string or bytes) is unchanged.
+
+### Removed
+
+- **The `asqav shadow-ai` CLI subcommand, its templates, and its tests.**
+  Shadow-AI detection is retired as a product focus; platform observations and
+  SIEM ingest stay, unbranded.
+
 ## [0.9.0] - 2026-08-26
 
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.9.0"
+version = "0.10.0"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -186,7 +186,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "LicenseRef-Elastic-License-2.0",
       "dependencies": {
         "@noble/post-quantum": "^0.6.1"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.9.0";
+export const SDK_VERSION = "0.10.0";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Version bump only: CHANGELOG plus the five version fields (python pyproject + __init__, typescript package.json + package-lock + userAgent).

Carries the W3C VC 2.0 eddsa-jcs-2022 verifier format (the seventh oracle format, both language halves together), the injected-DID-document did:web resolution path, and the shadow-ai CLI removal. CHANGELOG records the full change set. Version consistency test green.

After merge: the py and ts release tags trigger the PyPI and npm publishes.