### PR TITLE
feat(verify): evaluate anchor cryptography and pin the cross-language divergence

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,7 @@
+# Secret scanning keeps the default ruleset; one corpus path is exempt.
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Parity corpus holds ML-DSA-65 public keys, signatures and SHA-384 digests only"
+paths = ['''verifier/axis-parity-cases\.json''']

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Autonomous coding agents open and merge their own pull requests, and a git autho
 
 Without governance, there is no record of what agents did, any agent can do anything, one person approves everything by hand, compliance reports are written manually, and the reasoning is lost once the run ends. Asqav changes each of those:
 
-* Every action is signed with ML-DSA (FIPS 204).
+* Every action is signed; the algorithm is per-receipt in `signature.alg` — ML-DSA-65 (FIPS 204) for cloud-issued receipts, Ed25519/ES256 for locally signed ones.
 * Policies block dangerous actions before they run.
 * Critical actions can require multi-party authorization.
 * EU AI Act and DORA reports are generated automatically.
@@ -289,7 +289,7 @@ From the command line, install the optional CLI extra (`pip install "asqav[cli]"
 asqav verify sig_example_regulator_cold_verify_2026
 ```
 
-Or open the receipt's `verification_url` in a browser. For a fully offline, zero-trust check that reproduces the ML-DSA-65 signature itself, use `asqav.verify_receipt_offline(receipt, jwks)` in Python or `verifyReceiptOffline()` in TypeScript, or run the standalone `python -m asqav.verifier.verify_receipt --offline`. Every hash rederives from the RFC 8785 canonical payload, so auditors do not need to trust Asqav's servers.
+Or open the receipt's `verification_url` in a browser. For a fully offline, zero-trust check that reproduces the receipt's signature itself (the algorithm is per-receipt from `signature.alg`: ML-DSA-65 for cloud-issued receipts, Ed25519/ES256 for locally signed), use `asqav.verify_receipt_offline(receipt, jwks)` in Python or `verifyReceiptOffline()` in TypeScript, or run the standalone `python -m asqav.verifier.verify_receipt --offline`. Every hash rederives from the RFC 8785 canonical payload, so auditors do not need to trust Asqav's servers.
 
 ## Verified by Asqav badge
 

--- a/docs/fingerprint-spec.md
+++ b/docs/fingerprint-spec.md
@@ -97,6 +97,15 @@ Signatures are NOT replay-stable: re-sending the same `(action_type, context)` p
 
 Each signed record has a `mode` field on `signature_records` with value `"hash"` or `"payload"`. Verifiers SHOULD read `signature_records.mode` to determine which form to expect, rather than inspecting the signed bytes. The hash-mode signing input includes `"v": 1` and `"mode": "hash"` for self-description; the payload-mode signing input keeps the flat shape unchanged.
 
+## Keyed vs unkeyed digests (`hash_algo`)
+
+A verifier CAN tell a keyed (salted) context digest from a plain one: the discriminator is the `hash_algo` member of the signed record, which sits inside the signed field set so it cannot be flipped without breaking the signature.
+
+- **`hash_algo: "hmac-sha256"`** means the context digest is keyed (HMAC-SHA256 under the org salt). It is internally consistent but not third-party re-derivable, so a fully-checked receipt reports the verdict `verified_keyed`, never plain `verified`.
+- **`hash_algo: "sha256"`** — or an absent `hash_algo`, which defaults to `sha256` — means the digest is the plain SHA-256 fingerprint above, re-derivable by anyone from the original `(action_type, context)` pair, and the verdict is `verified`.
+
+Verifiers MUST NOT report a keyed digest as plain `verified`: the two are different statements, and only the unkeyed one is independently reproducible.
+
 ## Test vectors
 
 See `conformance/vectors.json`. The hash-mode happy-path vectors (`minimal_read`, `tool_call_with_counterparty`, `traced_child_action`) are the ones that exercise this spec; the remaining vectors cover the agent-card verification feature, not GDPR hash signing.

--- a/docs/offline-verification.md
+++ b/docs/offline-verification.md
@@ -152,6 +152,20 @@ value carrying no bytes never reads as an anchor. `verifier/axis-parity-cases.js
 and `verifier/anchor-value-cases.json` pin the cases both languages answer alike, and
 both suites assert them.
 
+Presence is not proof, and the draft says an anchor must not yield a valid verdict
+without a successful cryptographic check. The Python verifier therefore evaluates the
+token itself: an RFC 3161 anchor PASSes only when its `messageImprint` commits
+`sha256(JCS(envelope minus anchors))` AND the TSA signature verifies against
+caller-pinned TSA key material (`trusted_tsa_keys`, or `--tsa-key` on the CLI);
+an OpenTimestamps anchor PASSes only when the proof commits the same digest and,
+when bitcoin headers are supplied (`bitcoin_headers` / `--bitcoin-headers`), its
+merkle path lands in the stated block. A token whose check runs and fails reports
+FAIL (`invalid`); one the check cannot complete offline — junk token, no pinned TSA
+key, no header source, `status: pending`/`failed`, unknown type — reports SKIPPED
+(`unverifiable`), never PASS. The TypeScript shim carries no CMS/ots evaluation, so
+every shape-valid entry reports unverifiable there; that residual is conservative,
+never permissive.
+
 An anchor value is one unwrapped base64 token. Whitespace is refused, including a
 trailing newline and MIME line wrapping, so a value piped from a shell base64 tool
 reports FAIL. `openssl base64` wraps at 64 characters, GNU `base64` wraps at 76, and

--- a/python/README.md
+++ b/python/README.md
@@ -129,7 +129,7 @@ The envelope extensions most callers reach for:
 
 ## Compliance receipts: the IETF profile
 
-Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 signature, JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `compliance_mode=False` if you want the older shape.
+Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): cloud-issued receipts carry an ML-DSA-65 signature (locally signed receipts carry Ed25519/ES256 — the algorithm is per-receipt in `signature.alg`), JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `compliance_mode=False` if you want the older shape.
 
 ### Shadow AI capture with passive_telemetry
 

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -250,8 +250,10 @@ class AsqavNativeAdapter(FormatAdapter):
             payload = _payload(doc)
             issued_at = payload.get("issued_at", "")
             bind = _vr.check_issuer_binding(key_issuer, payload.get("issuer_id"))
-        # Offline anchor presence is unverifiable (anchors are unsigned); pass
-        # False so a forged anchor never rides a revoked key to PASS.
+        # Only an anchor the caller cryptographically verified counts as trusted
+        # timing (verify_receipt.evaluate_anchors). This adapter pins no TSA key
+        # material, so it passes False: a forged anchor never rides a revoked key
+        # to PASS here.
         res, note = _vr.check_key_status(
             entry.get("status"), issued_at, _vr.revoked_at_of(entry), False
         )

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -1343,11 +1343,20 @@ def main() -> int:
         if args.predecessor:
             pred = _load(args.predecessor)
             predecessor_payload = pred.get("payload", pred)
+
+        trusted_tsa_keys = _load_tsa_keys(args.tsa_key)
+        bitcoin_headers = _load(args.bitcoin_headers) if args.bitcoin_headers else None
     except VerifierInputError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
-    return run(envelope, jwks, predecessor_payload)
+    return run(
+        envelope,
+        jwks,
+        predecessor_payload,
+        trusted_tsa_keys=trusted_tsa_keys,
+        bitcoin_headers=bitcoin_headers,
+    )
 
 
 if __name__ == "__main__":

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -22,33 +22,38 @@
 
 Verify an Asqav Compliance Receipt yourself, without the Asqav SDK or liboqs.
 
-WHAT THIS CHECKS (independently, on your machine):
+CHECKS (independently, on your machine):
   - ML-DSA-65 (FIPS 204) signature over the receipt's canonical bytes
   - canonical-bytes integrity (JCS / RFC8785 reproduction, stdlib json)
   - hash-chain link to a predecessor receipt
-  - anchor binding (which envelope each anchor commits to) plus anchor presence
-  - issuer public-key resolution from the public /.well-known/jwks.json
-  - issuer binding (the verifying key is published under the claimed issuer_id)
   - expiry (the expires_at the signer committed to inside the signed bytes)
+  - issuer key resolution from the public /.well-known/jwks.json, and issuer
+    binding (the verifying key is published under the claimed issuer_id)
+  - anchor binding AND each anchor's own proof: an RFC 3161 token must commit
+    sha256(JCS(envelope minus anchors)) in its messageImprint and verify against
+    caller-pinned TSA keys (--tsa-key); an OpenTimestamps proof must commit the
+    same digest and, given --bitcoin-headers, land its merkle path in the stated
+    block. Presence alone never PASSes the axis.
 
-WHAT THIS DOES NOT CHECK (needs server state or ASN.1; use the hosted /verify):
-  - full RFC3161 certificate-chain walk
-  - policy_digest artefact resolution
+DOES NOT CHECK (needs server state or extra trust material): a TSA
+certificate-chain walk to a public root - offline trust comes only from the TSA
+keys you pin, never from the unsigned envelope; OpenTimestamps block placement
+without a caller-supplied header source; policy_digest artefact resolution.
 
-The only non-stdlib dependency is the signature check:
+Only the signature checks need non-stdlib code:
   pip install dilithium-py        (pure python; verify path uses stdlib SHAKE)
-Without it, every other check still runs and the signature axis reports SKIPPED;
-the overall verdict is then INCOMPLETE, never a PASS. This tool will not emit a
-PASS unless the post-quantum signature was actually verified.
-
-Security note: dilithium-py is a pure-python FIPS 204 implementation that is not
-constant-time. For a verify-only tool this is acceptable: verification touches
-only public data (public key, signature, message), so there is no secret to leak
-through timing.
+  pip install cryptography        (pinned RSA/ECDSA/Ed25519 TSA certificates)
+Without either, the matching axis reports SKIPPED and the verdict is INCOMPLETE:
+this tool never emits a PASS on an unverified post-quantum signature, nor on
+anchor presence alone. dilithium-py is not constant-time, which is fine for a
+verify-only tool: it touches only public data (public key, signature, message),
+so there is no secret to leak through timing.
 
 Run:
   python verify_receipt.py --id sig_abc123
   python verify_receipt.py --receipt receipt.json --jwks jwks.json --offline
+  python verify_receipt.py --receipt receipt.json --jwks jwks.json --offline \
+      --tsa-key asqav-tsa-chain.pem   # pinned TSA material: anchors can verify
 """
 
 from __future__ import annotations
@@ -62,6 +67,7 @@ import re
 import sys
 import urllib.error
 import urllib.request
+from collections import namedtuple
 from datetime import datetime, timezone
 
 API_BASE = "https://api.asqav.com/api/v1"
@@ -173,10 +179,9 @@ def _scan_shape(obj, max_depth: int | None = None) -> str | None:
     """Iteratively walk ``obj``; returns "non_finite", "too_deep", or None (ok).
 
     Explicit stack, no recursion: depth alone cannot crash this walk. With
-    ``max_depth`` set, nesting past it stops the walk and reports "too_deep"
-    before the caller can hand the structure to the recursive stdlib json
-    encoder (canonical_json), which crashes past ~1000 levels on Python's C
-    encoder for versions <= 3.12.
+    ``max_depth``, nesting past it stops and reports "too_deep" before the caller
+    hands the structure to canonical_json's recursive stdlib encoder, which
+    crashes past ~1000 levels on CPython <= 3.12.
     """
     stack = [(obj, 0)]
     while stack:
@@ -245,11 +250,11 @@ _INVALID_FAIL_AXES = frozenset({"signature", "anchors", "issuer_bind", "key_stat
 def _axis_failure_class(axis: str, result: str, note: str) -> str | None:
     """Map one axis outcome to its failure class (criterion 418).
 
-    PASS carries none; SKIPPED means recomputation could not complete
+    PASS carries none; SKIPPED means the recompute could not complete
     (unverifiable); a FAIL is invalid when a binding was proven broken and
-    unverifiable when the receipt's own bytes stopped the recompute. Mirrors
-    the oracle's ``core.axis_failure_class`` byte for byte; a FAIL the table
-    does not name reads unverifiable, never a proven binding failure.
+    unverifiable when the receipt's own bytes stopped the recompute. Mirrors the
+    oracle's ``core.axis_failure_class`` byte for byte, and a FAIL the table does
+    not name reads unverifiable, never a proven binding failure.
     """
     if result == "PASS":
         return None
@@ -276,7 +281,7 @@ def _axis_failure_class(axis: str, result: str, note: str) -> str | None:
 
 
     # Fold per-axis (name, result, note) rows into verdict + failure class.
-def _fold_verdict(results) -> tuple[str, str | None]:
+def _fold_verdict(results, keyed: bool = False) -> tuple[str, str | None]:
     # Expiry reports on its own axis and never folds the verdict (criterion 426).
     failed = [(n, r, note) for n, r, note in results if r == "FAIL" and n != "expiry"]
     # A skipped chain (no predecessor supplied) is expected and does not block a
@@ -304,11 +309,10 @@ class VerifierInputError(Exception):
 class DuplicateMemberError(ValueError):
     """A receipt or JWKS repeated a JSON member name (criterion 419).
 
-    The stdlib decoder is last-wins on duplicate members, which would hash the
-    bytes an attacker kept and drop the ones they replaced; a duplicated name
-    is therefore a terminal parse failure, raised before any hashing or
-    canonicalisation. Self-contained here (mirrors ``asqav/strict_json.py``)
-    because this file ships standalone in the exit artifact.
+    The stdlib decoder is last-wins on duplicates, which would hash the bytes an
+    attacker kept and drop the ones they replaced, so a duplicated name is a
+    terminal parse failure raised before any hashing. Self-contained here (mirrors
+    ``asqav/strict_json.py``) because this file ships standalone.
     """
 
 
@@ -369,16 +373,10 @@ def _get_json(url: str, *, timeout: int = 30) -> dict:
 def fetch_jwks(url: str = JWKS_URL, *, timeout: int = 30) -> dict:
     """Fetch and return the Asqav public JWKS directory as a dict.
 
-    Snapshot this before going air-gapped; pass the result to
+    Snapshot this before going air-gapped and pass the result to
     ``verify_receipt_offline(receipt, jwks)`` or ``run(envelope, jwks, ...)``.
-    The endpoint is public and unauthenticated.
-
-    Args:
-        url: JWKS URL (default: https://api.asqav.com/.well-known/jwks.json).
-        timeout: HTTP timeout in seconds.
-
-    Returns:
-        Parsed JWKS dict with a ``"keys"`` list.
+    The endpoint is public and unauthenticated. Returns the parsed JWKS dict
+    with a ``"keys"`` list.
     """
     return _get_json(url, timeout=timeout)
 
@@ -395,33 +393,726 @@ def _b64decode(value: str) -> bytes:
 _ANCHOR_B64_RE = re.compile(r"[A-Za-z0-9+/]+={0,2}")
 
 
+    # Strict base64 -> decoded bytes, or None on any junk (None never raises).
+def _anchor_bytes(v: object):
+    if not isinstance(v, str) or not v:
+        return None
+    s = v.replace("-", "+").replace("_", "/")
+    s += "=" * ((-len(s)) % 4)
+    # The alphabet and padding decision lives here, not in b64decode, because
+    # b64decode(validate=True) accepts excess padding on 3.11 and raises on 3.12
+    if not _ANCHOR_B64_RE.fullmatch(s):
+        return None
+    # fullmatch leaves only alphabet characters and a length that is a multiple
+    # of 4 with at most two pads, so a strict decode cannot raise here
+    raw = base64.b64decode(s, validate=True)
+    return raw if raw else None
+
+
 def _safe_b64(v: object) -> bool:
     """True only when ``v`` is real base64 carrying at least one byte.
 
     Kept separate from ``_b64decode``, which stays lenient for keys and
     signatures. Anchors are unsigned, so this half refuses junk instead.
     """
-    if not isinstance(v, str) or not v:
+    return _anchor_bytes(v) is not None
+
+
+# --- Offline anchor cryptographic verification -------------------------------
+#
+# Presence is not proof: anchors sit outside the signed bytes, so the draft
+# requires a successful cryptographic check before an anchor counts. Per entry:
+#   "verified"     - the token commits this envelope's digest AND its own
+#                    signature/merkle path checks out against pinned trust material
+#   "invalid"      - the check ran and failed (wrong committed digest, TSA
+#                    rejection status, a signature that does not verify, a merkle
+#                    path that misses the stated block)
+#   "unverifiable" - the check could not complete offline (unparseable token,
+#                    missing optional dep, no pinned TSA key, no Bitcoin header
+#                    source, unknown anchor type, declared status pending/failed).
+#                    Never a PASS on presence alone.
+#
+# Trust material is caller-pinned, never derived from the unsigned envelope:
+# ``trusted_tsa_keys`` is TSA public keys (raw ML-DSA/Ed25519 bytes) or X.509
+# certificates (PEM or DER); ``bitcoin_headers`` maps a block height to
+# {"merkle_root": <display hex>, "time": <ISO-8601>}.
+
+
+class _AnchorParseError(ValueError):
+    """A token blob did not parse; the anchor reports unverifiable, never a crash."""
+
+
+    # Read one DER TLV at ``off``; return (tag, content bytes, next offset).
+def _der_read(buf: bytes, off: int) -> tuple[int, bytes, int]:
+    if off + 2 > len(buf):
+        raise _AnchorParseError("truncated DER header")
+    tag = buf[off]
+    if tag & 0x1F == 0x1F:
+        raise _AnchorParseError("multi-byte DER tags unsupported")
+    first = buf[off + 1]
+    off += 2
+    if first & 0x80:
+        n = first & 0x7F
+        if n == 0 or n > 4 or off + n > len(buf):
+            raise _AnchorParseError("bad DER length")
+        length = int.from_bytes(buf[off : off + n], "big")
+        off += n
+    else:
+        length = first
+    if length > len(buf) - off:
+        raise _AnchorParseError("DER content overruns buffer")
+    return tag, buf[off : off + length], off + length
+
+
+    # DER length bytes for a content of ``n`` bytes (definite form).
+def _der_len(n: int) -> bytes:
+    if n < 0x80:
+        return bytes([n])
+    body = n.to_bytes((n.bit_length() + 7) // 8, "big")
+    return bytes([0x80 | len(body)]) + body
+
+
+    # Iterate the TLVs concatenated inside a constructed element's content.
+def _der_children(content: bytes) -> list[tuple[int, bytes, int, int]]:
+    out = []
+    off = 0
+    while off < len(content):
+        tag, value, nxt = _der_read(content, off)
+        out.append((tag, value, off, nxt))
+        off = nxt
+    return out
+
+
+#: Real arcs are tiny. Unbounded, a relay-supplied arc builds an int whose
+#: str() raises the interpreter's digit-limit ValueError, crashing the verifier.
+_MAX_OID_ARC_BITS = 512
+
+
+def _der_oid_str(content: bytes) -> str:
+    if not content:
+        raise _AnchorParseError("empty OID")
+    first = content[0]
+    arcs = [str(min(first // 40, 2)), str(first - 40 * min(first // 40, 2))]
+    val = 0
+    for byte in content[1:]:
+        val = (val << 7) | (byte & 0x7F)
+        if val.bit_length() > _MAX_OID_ARC_BITS:
+            raise _AnchorParseError("OID arc exceeds the supported width")
+        if not byte & 0x80:
+            arcs.append(str(val))
+            val = 0
+    if content[-1] & 0x80 and len(content) > 1:
+        raise _AnchorParseError("truncated OID arc")
+    return ".".join(arcs)
+
+
+    # Decode an AlgorithmIdentifier's OID out of its SEQUENCE content.
+def _algid_oid(content: bytes) -> str:
+    children = _der_children(content)
+    if not children or children[0][0] != 0x06:
+        raise _AnchorParseError("AlgorithmIdentifier without OID")
+    return _der_oid_str(children[0][1])
+
+
+_OID_SIGNED_DATA = "1.2.840.113549.1.7.2"
+_OID_MESSAGE_DIGEST = "1.2.840.113549.1.9.4"
+#: RFC 5652 s11.1 contentType and the eContentType it must equal. Binding both
+#: blocks reuse of a TSA signature over content that parses as a TSTInfo.
+_OID_CONTENT_TYPE = "1.2.840.113549.1.9.3"
+_OID_CT_TST_INFO = "1.2.840.113549.1.9.16.1.4"
+#: digestAlgorithm OIDs this verifier hashes with, OID -> hashlib name.
+_DIGEST_OIDS = {
+    "2.16.840.1.101.3.4.2.1": "sha256",
+    "2.16.840.1.101.3.4.2.2": "sha384",
+    "2.16.840.1.101.3.4.2.3": "sha512",
+}
+#: TSA signature algorithms verified via dilithium-py (raw pinned keys).
+_ML_DSA_SIG_OIDS = {
+    "2.16.840.1.101.3.4.3.17": "ML_DSA_44",
+    "2.16.840.1.101.3.4.3.18": "ML_DSA_65",
+    "2.16.840.1.101.3.4.3.19": "ML_DSA_87",
+}
+_OID_ED25519 = "1.3.101.112"
+#: RSA/ECDSA signature OIDs verified via cryptography (pinned X.509 certs).
+_RSA_SIG_OIDS = {
+    "1.2.840.113549.1.1.11": "sha256",
+    "1.2.840.113549.1.1.12": "sha384",
+    "1.2.840.113549.1.1.13": "sha512",
+}
+_ECDSA_SIG_OIDS = {
+    "1.2.840.10045.4.3.2": "sha256",
+    "1.2.840.10045.4.3.3": "sha384",
+    "1.2.840.10045.4.3.4": "sha512",
+}
+
+
+def _parse_generalized_time(content: bytes):
+    """GeneralizedTime -> aware datetime; RFC 3161 pins the Z (UTC) form."""
+    m = re.fullmatch(rb"(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(?:\.\d+)?Z", content)
+    if m is None:
+        raise _AnchorParseError("unparseable genTime")
+    try:
+        return datetime(
+            *(int(g) for g in m.groups()), tzinfo=timezone.utc
+        )
+    except ValueError as exc:
+        raise _AnchorParseError(f"genTime out of range: {exc}") from exc
+
+
+    # Parse a retained TimeStampResp into the fields the checks below read.
+def _parse_time_stamp_resp(der: bytes) -> dict:
+    tag, content, nxt = _der_read(der, 0)
+    if tag != 0x30 or nxt != len(der):
+        raise _AnchorParseError("TimeStampResp is not one DER SEQUENCE")
+    resp = _der_children(content)
+    if not resp or resp[0][0] != 0x30:
+        raise _AnchorParseError("missing PKIStatusInfo")
+    status_fields = _der_children(resp[0][1])
+    if not status_fields or status_fields[0][0] != 0x02:
+        raise _AnchorParseError("PKIStatusInfo without status integer")
+    status = int.from_bytes(status_fields[0][1], "big")
+    if status not in (0, 1):  # granted / grantedWithMods; anything else is a refusal
+        return {"status": status}
+    if len(resp) < 2 or resp[1][0] != 0x30:
+        raise _AnchorParseError("granted status but no timeStampToken")
+    ci = _der_children(resp[1][1])
+    if len(ci) != 2 or ci[0][0] != 0x06 or _der_oid_str(ci[0][1]) != _OID_SIGNED_DATA:
+        raise _AnchorParseError("timeStampToken is not a CMS SignedData")
+    if ci[1][0] != 0xA0:
+        raise _AnchorParseError("SignedData content missing")
+    sd_children = _der_children(ci[1][1])
+    if not sd_children or sd_children[0][0] != 0x30:
+        raise _AnchorParseError("SignedData body missing")
+    sd = _der_children(sd_children[0][1])
+    if len(sd) < 4:
+        raise _AnchorParseError("SignedData too short")
+    encap = _der_children(sd[2][1])
+    if len(encap) != 2 or encap[1][0] != 0xA0:
+        raise _AnchorParseError("encapContentInfo without eContent")
+    if encap[0][0] != 0x06 or _der_oid_str(encap[0][1]) != _OID_CT_TST_INFO:
+        # Not a time-stamp token: the signature covers some other content type.
+        raise _AnchorParseError("eContentType is not id-ct-TSTInfo")
+    etag, tst_bytes, _ = _der_read(encap[1][1], 0)
+    if etag != 0x04:
+        raise _AnchorParseError("eContent is not an OCTET STRING")
+    certs = []
+    signer_infos = None
+    for stag, svalue, _sstart, _send in sd[3:]:
+        if stag == 0xA0:
+            certs = [svalue[cstart:send] for _t, _v, cstart, send in _der_children(svalue)]
+        elif stag == 0x31:
+            signer_infos = _der_children(svalue)
+    if not signer_infos:
+        raise _AnchorParseError("SignedData without signerInfos")
+    si = _der_children(signer_infos[0][1])
+    if len(si) < 5:
+        raise _AnchorParseError("SignerInfo too short")
+    # version, sid, digestAlgorithm, [signedAttrs], signatureAlgorithm, signature
+    rest = si[3:]
+    signed_attrs = None
+    if rest[0][0] == 0xA0:
+        signed_attrs = rest[0][1]
+        rest = rest[1:]
+    if len(rest) < 2 or rest[0][0] != 0x30 or rest[1][0] != 0x04:
+        raise _AnchorParseError("SignerInfo without signatureAlgorithm/signature")
+    return {
+        "status": status,
+        "tst": tst_bytes,
+        "certs": certs,
+        "digest_alg": _algid_oid(si[2][1]) if si[2][0] == 0x30 else None,
+        "signed_attrs": signed_attrs,
+        "sig_alg": _algid_oid(rest[0][1]),
+        "signature": rest[1][1],
+    }
+
+
+    # Parse TSTInfo; return (imprint digest bytes, imprint hash OID, genTime).
+def _parse_tst_info(tst: bytes):
+    tag, content, nxt = _der_read(tst, 0)
+    if tag != 0x30 or nxt != len(tst):
+        raise _AnchorParseError("TSTInfo is not one DER SEQUENCE")
+    fields = _der_children(content)
+    if len(fields) < 5 or fields[2][0] != 0x30:
+        raise _AnchorParseError("TSTInfo without messageImprint")
+    imprint = _der_children(fields[2][1])
+    if len(imprint) != 2 or imprint[0][0] != 0x30 or imprint[1][0] != 0x04:
+        raise _AnchorParseError("malformed messageImprint")
+    if fields[4][0] != 0x18:
+        raise _AnchorParseError("TSTInfo without genTime")
+    return imprint[1][1], _algid_oid(imprint[0][1]), _parse_generalized_time(fields[4][1])
+
+
+    # The bytes a CMS signature covers: signedAttrs re-tagged as SET OF, else eContent.
+def _cms_signed_bytes(info: dict) -> bytes:
+    attrs = info["signed_attrs"]
+    if attrs is None:
+        return info["tst"]
+    return b"\x31" + _der_len(len(attrs)) + attrs
+
+
+    # A signedAttrs messageDigest attribute must commit the eContent bytes.
+def _cms_message_digest_ok(info: dict) -> bool:
+    attrs = info["signed_attrs"]
+    if attrs is None:
+        return True
+    digest_name = _DIGEST_OIDS.get(info.get("digest_alg") or "")
+    if digest_name is None:
         return False
-    s = v.replace("-", "+").replace("_", "/")
-    s += "=" * ((-len(s)) % 4)
-    # The alphabet and padding decision lives here, not in b64decode, because
-    # b64decode(validate=True) accepts excess padding on 3.11 and raises on 3.12
-    if not _ANCHOR_B64_RE.fullmatch(s):
-        return False
-    # fullmatch leaves only alphabet characters and a length that is a multiple
-    # of 4 with at most two pads, so a strict decode cannot raise here
-    return len(base64.b64decode(s, validate=True)) > 0
+    want = hashlib.new(digest_name, info["tst"]).digest()
+    digest_ok = False
+    content_type_ok = False
+    for atag, avalue, _s, _e in _der_children(attrs):
+        if atag != 0x30:
+            continue
+        attr = _der_children(avalue)
+        if len(attr) != 2 or attr[0][0] != 0x06:
+            continue
+        attr_oid = _der_oid_str(attr[0][1])
+        if attr_oid == _OID_MESSAGE_DIGEST:
+            vals = _der_children(attr[1][1])
+            digest_ok = len(vals) == 1 and vals[0][0] == 0x04 and vals[0][1] == want
+        elif attr_oid == _OID_CONTENT_TYPE:
+            vals = _der_children(attr[1][1])
+            content_type_ok = (
+                len(vals) == 1
+                and vals[0][0] == 0x06
+                and _der_oid_str(vals[0][1]) == _OID_CT_TST_INFO
+            )
+    # contentType is mandatory alongside signedAttrs (RFC 5652 s11.1).
+    return digest_ok and content_type_ok
+
+
+def _tsa_key_candidates(trusted_tsa_keys):
+    """Split pinned TSA material into (raw key bytes, cryptography public keys).
+
+    A PEM/DER X.509 certificate or public key needs ``cryptography`` to decode;
+    without it those entries are unusable and the caller's axis reports
+    unverifiable rather than trusting anything. Raw bytes pass through for the
+    ML-DSA / Ed25519 paths.
+    """
+    raw, pkeys = [], []
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives.serialization import (
+            load_der_public_key,
+            load_pem_public_key,
+        )
+    except ImportError:
+        x509 = None
+    for entry in trusted_tsa_keys or []:
+        if not isinstance(entry, (bytes, bytearray)) or not entry:
+            continue
+        blob = bytes(entry)
+        if x509 is not None:
+            try:
+                if blob.startswith(b"-----BEGIN"):
+                    try:
+                        pkeys.append(x509.load_pem_x509_certificate(blob).public_key())
+                    except ValueError:
+                        pkeys.append(load_pem_public_key(blob))
+                    continue
+                pkeys.append(x509.load_der_x509_certificate(blob).public_key())
+                continue
+            except ValueError:
+                try:
+                    pkeys.append(load_der_public_key(blob))
+                    continue
+                except ValueError:
+                    pass
+        raw.append(blob)
+    return raw, pkeys
+
+
+def _verify_tsa_signature(sig_alg: str, signed: bytes, signature: bytes, trusted_tsa_keys) -> str:
+    """Verify the TSA signature against pinned key material only.
+
+    Returns "verified", "invalid" (a usable key was present and no signature
+    verified), or "unverifiable" (no usable key material or optional dep).
+    """
+    raw_keys, pkeys = _tsa_key_candidates(trusted_tsa_keys)
+    usable = False
+    if sig_alg in _ML_DSA_SIG_OIDS:
+        try:
+            import dilithium_py.ml_dsa as _ml
+        except ImportError:
+            return "unverifiable"
+        mod = getattr(_ml, _ML_DSA_SIG_OIDS[sig_alg])
+        for pk in raw_keys:
+            usable = True
+            try:
+                if mod.verify(pk, signed, signature):
+                    return "verified"
+            except Exception:  # wrong-size or malformed candidate key; try the next
+                continue
+    elif sig_alg == _OID_ED25519:
+        try:
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+        except ImportError:
+            # cryptography is optional (see the module docstring); without it
+            # this branch reports unverifiable, exactly as the RSA/ECDSA one
+            # does, rather than raising out of the anchors axis.
+            return "unverifiable"
+
+        for pk in raw_keys:
+            if len(pk) != 32:
+                continue
+            usable = True
+            try:
+                Ed25519PublicKey.from_public_bytes(pk).verify(signature, signed)
+                return "verified"
+            except Exception:
+                continue
+        for pk in pkeys:
+            usable = True
+            try:
+                pk.verify(signature, signed)
+                return "verified"
+            except Exception:
+                continue
+    elif sig_alg in _RSA_SIG_OIDS or sig_alg in _ECDSA_SIG_OIDS:
+        try:
+            from cryptography.hazmat.primitives import hashes
+            from cryptography.hazmat.primitives.asymmetric import ec, padding
+        except ImportError:
+            return "unverifiable"
+        table = _RSA_SIG_OIDS if sig_alg in _RSA_SIG_OIDS else _ECDSA_SIG_OIDS
+        hash_alg = getattr(hashes, table[sig_alg].upper())()
+        for pk in pkeys:
+            usable = True
+            try:
+                if sig_alg in _RSA_SIG_OIDS:
+                    pk.verify(signature, signed, padding.PKCS1v15(), hash_alg)
+                else:
+                    pk.verify(signature, signed, ec.ECDSA(hash_alg))
+                return "verified"
+            except Exception:
+                continue
+    else:
+        # An algorithm family this verifier cannot evaluate at all.
+        return "unverifiable"
+    return "invalid" if usable else "unverifiable"
+
+
+def _check_rfc3161_anchor(
+    blob: bytes, bound: bytes, trusted_tsa_keys, env_jcs: bytes | None = None
+) -> tuple[str, str, object]:
+    """One RFC 3161 anchor -> (outcome, detail, genTime when verified).
+
+    ``env_jcs`` is the JCS of the envelope minus anchors, needed only to re-derive
+    the committed digest under a non-sha256 messageImprint algorithm; ``bound`` is
+    its sha256 and stays the default. The imprint comparison is stdlib-only; the
+    TSA signature needs pinned key material (dilithium-py for ML-DSA, cryptography
+    for RSA/ECDSA/Ed25519). A full PKI chain walk is out of scope offline: trust
+    comes from the caller's allowlist, never from the unsigned envelope.
+    """
+    # Every DER walk stays inside this guard: an escaping exception exits 1
+    # (invalid), claiming a binding failure for input never evaluated.
+    try:
+        info = _parse_time_stamp_resp(blob)
+        if info["status"] not in (0, 1):
+            return "invalid", f"TimeStampResp carries TSA status {info['status']}, not granted", None
+        imprint, imprint_alg, gen_time = _parse_tst_info(info["tst"])
+        digest_name = _DIGEST_OIDS.get(imprint_alg)
+        if digest_name is None:
+            return (
+                "unverifiable",
+                f"offline RFC3161 check did not complete; unknown messageImprint OID {imprint_alg}",
+                None,
+            )
+        # A sha384/sha512 imprint we never computed is not a proven mismatch.
+        if digest_name != "sha256":
+            if env_jcs is None:
+                return (
+                    "unverifiable",
+                    f"offline RFC3161 check did not complete; {digest_name} imprint not recomputable",
+                    None,
+                )
+            bound = hashlib.new(digest_name, env_jcs).digest()
+        if imprint != bound:
+            return "invalid", "RFC3161 imprint commits a different digest than this envelope", None
+        if not _cms_message_digest_ok(info):
+            return "invalid", "signedAttrs messageDigest does not commit the TSTInfo bytes", None
+        sig_state = _verify_tsa_signature(
+            info["sig_alg"], _cms_signed_bytes(info), info["signature"], trusted_tsa_keys
+        )
+    except _AnchorParseError:
+        # Shared note with the TypeScript shim, which runs no DER parse; the
+        # parity corpora pin this exact wording for shape-valid junk values.
+        return "unverifiable", "offline RFC3161 check did not complete", None
+    except (ValueError, IndexError, TypeError, MemoryError, RecursionError):
+        # Anything else the DER walk raises: still unverifiable, never a pass.
+        return "unverifiable", "offline RFC3161 check did not complete", None
+    if sig_state == "verified":
+        return (
+            "verified",
+            f"RFC3161 imprint commits this envelope; TSA signature verifies at {gen_time.isoformat()}",
+            gen_time,
+        )
+    if sig_state == "invalid":
+        return "invalid", "TSA signature does not verify against any trusted TSA key", None
+    return (
+        "unverifiable",
+        "offline RFC3161 check did not complete; imprint matches but no trusted "
+        "TSA key material verified the token signature",
+        None,
+    )
+
+
+#: Detached .ots header (python-opentimestamps DetachedTimestampFile.HEADER_MAGIC).
+_OTS_MAGIC = b"\x00OpenTimestamps\x00\x00Proof\x00\xbf\x89\xe2\xe8\x84\xe8\x92\x94"
+#: BitcoinBlockHeaderAttestation.TAG (opentimestamps.core.notary).
+_OTS_BITCOIN_TAG = bytes.fromhex("0588960d73d71901")
+#: CryptOp tags this evaluator can hash with (RFC4880 numbering, per ots op.py).
+_OTS_HASH_OPS = {0x02: "sha1", 0x03: "ripemd160", 0x08: "sha256"}
+_OTS_MAX_BLOB = 1 << 20
+_OTS_MAX_MSG = 4096
+_OTS_MAX_DEPTH = 128
+
+
+class _OtsState:
+    def __init__(self) -> None:
+        self.attestations: list[tuple[int, bytes]] = []
+        self.unknown = False
+
+
+#: Block heights fit in five groups. Unbounded, ~1 MiB of continuation bytes
+#: builds a multi-megabit int one shift at a time: 326s of CPU per anchor.
+_OTS_MAX_VARUINT_GROUPS = 10
+
+
+def _ots_varuint(buf: bytes, off: int) -> tuple[int, int]:
+    val = 0
+    groups = 0
+    while True:
+        if off >= len(buf):
+            raise _AnchorParseError("truncated ots varuint")
+        groups += 1
+        if groups > _OTS_MAX_VARUINT_GROUPS:
+            raise _AnchorParseError("ots varuint exceeds the supported width")
+        byte = buf[off]
+        off += 1
+        val = (val << 7) | (byte & 0x7F)
+        if not byte & 0x80:
+            return val, off
+
+
+def _ots_varbytes(buf: bytes, off: int) -> tuple[bytes, int]:
+    n, off = _ots_varuint(buf, off)
+    if n > len(buf) - off:
+        raise _AnchorParseError("truncated ots varbytes")
+    return buf[off : off + n], off + n
+
+
+def _ots_item(tag: int, buf: bytes, off: int, msg: bytes, depth: int, state: _OtsState) -> int:
+    if tag == 0x00:
+        atag = buf[off : off + 8]
+        if len(atag) != 8:
+            raise _AnchorParseError("truncated ots attestation tag")
+        off += 8
+        if atag == _OTS_BITCOIN_TAG:
+            height, off = _ots_varuint(buf, off)
+            state.attestations.append((height, msg))
+        else:
+            _payload, off = _ots_varbytes(buf, off)
+            state.unknown = True
+        return off
+    if tag in (0xF0, 0xF1):
+        arg, off = _ots_varbytes(buf, off)
+        new_msg = msg + arg if tag == 0xF0 else arg + msg
+        if len(new_msg) > _OTS_MAX_MSG:
+            raise _AnchorParseError("ots message exceeds the 4096-byte op limit")
+        return _ots_node(buf, off, new_msg, depth + 1, state)
+    if tag in _OTS_HASH_OPS:
+        try:
+            new_msg = hashlib.new(_OTS_HASH_OPS[tag], msg).digest()
+        except (ValueError, TypeError) as exc:
+            raise _AnchorParseError(f"ots hash op unavailable here: {exc}") from exc
+        return _ots_node(buf, off, new_msg, depth + 1, state)
+    raise _AnchorParseError(f"unknown ots op tag 0x{tag:02x}")
+
+
+def _ots_node(buf: bytes, off: int, msg: bytes, depth: int, state: _OtsState) -> int:
+    if depth > _OTS_MAX_DEPTH:
+        raise _AnchorParseError("ots proof nesting exceeds the supported depth")
+    if off >= len(buf):
+        raise _AnchorParseError("truncated ots timestamp")
+    tag = buf[off]
+    off += 1
+    while tag == 0xFF:
+        if off >= len(buf):
+            raise _AnchorParseError("truncated ots fork")
+        off = _ots_item(buf[off], buf, off + 1, msg, depth, state)
+        if off >= len(buf):
+            raise _AnchorParseError("truncated ots fork")
+        tag = buf[off]
+        off += 1
+    return _ots_item(tag, buf, off, msg, depth, state)
+
+
+def _check_ots_anchor(blob: bytes, bound: bytes, bitcoin_headers) -> tuple[str, str, object]:
+    """One OpenTimestamps anchor -> (outcome, detail, block time when verified).
+
+    Offline-checkable portion: the proof's initial commitment must equal this
+    envelope's digest, and the op chain evaluates to a merkle root. Placing that
+    root in a real block needs a caller-supplied header source; without one the
+    block portion reports unverifiable, never a PASS.
+    """
+    try:
+        if len(blob) > _OTS_MAX_BLOB or not blob.startswith(_OTS_MAGIC):
+            raise _AnchorParseError("not a detached .ots proof")
+        off = len(_OTS_MAGIC)
+        if blob[off] != 1:
+            raise _AnchorParseError("unsupported .ots major version")
+        off += 1
+        hash_op = blob[off]
+        off += 1
+        if hash_op != 0x08:  # the envelope digest is sha256; other ops cannot commit it
+            raise _AnchorParseError("proof does not commit a sha256 digest")
+        committed, blob_rest = blob[off : off + 32], off + 32
+        if len(committed) != 32:
+            raise _AnchorParseError("truncated commitment digest")
+        if committed != bound:
+            return "invalid", "OpenTimestamps proof commits a different digest than this envelope", None
+        state = _OtsState()
+        if _ots_node(blob, blob_rest, committed, 0, state) != len(blob):
+            raise _AnchorParseError("trailing bytes after the ots timestamp")
+    except (_AnchorParseError, IndexError):
+        return "unverifiable", "offline OpenTimestamps check did not complete", None
+    if not state.attestations:
+        return "unverifiable", "offline OpenTimestamps check did not complete; no bitcoin attestation in proof", None
+    headers = {}
+    if isinstance(bitcoin_headers, dict):
+        for k, v in bitcoin_headers.items():
+            try:
+                headers[int(k)] = v
+            except (TypeError, ValueError):
+                continue
+    saw_mismatch = None
+    for height, root in state.attestations:
+        header = headers.get(height)
+        if not isinstance(header, dict) or not isinstance(header.get("merkle_root"), str):
+            continue
+        try:
+            # The attestation message is the block's merkle root in internal
+            # (little-endian) order; the header source carries the display hex.
+            want = bytes.fromhex(header["merkle_root"])[::-1]
+        except ValueError:
+            continue
+        if len(want) != 32:
+            continue
+        if root != want:
+            saw_mismatch = height
+            continue
+        when = _parse_stamp(header.get("time")) if header.get("time") else None
+        return "verified", f"OpenTimestamps proof lands in bitcoin block {height}", when
+    if saw_mismatch is not None:
+        return "invalid", f"merkle path does not land in bitcoin block {saw_mismatch}", None
+    return (
+        "unverifiable",
+        "offline OpenTimestamps check did not complete; commitment matches but no "
+        "supplied bitcoin header confirms the block",
+        None,
+    )
+
+
+#: (result, note, trusted_times) triple for the anchors axis. ``trusted_times``
+#: carries the provenance times of anchors that CRYPTOGRAPHICALLY verified, the
+#: only times a caller may weigh against a key's revoked_at.
+AnchorEvaluation = namedtuple("AnchorEvaluation", ("result", "note", "trusted_times"))
+
+
+def evaluate_anchors(envelope: dict, *, trusted_tsa_keys=None, bitcoin_headers=None) -> AnchorEvaluation:
+    """Cryptographically evaluate every anchor against the envelope digest.
+
+    Shape rules are unchanged (malformed entries FAIL, absent/empty SKIPs), but a
+    shape-valid entry no longer PASSes on presence: the axis PASSes only when every
+    entry cryptographically verifies, FAILs when any entry's check runs and fails,
+    and reports SKIPPED (unverifiable) when a check cannot complete offline. Anchors
+    declared ``status: pending``/``failed`` never count as trusted anchors.
+    """
+    anchors = envelope.get("anchors")
+    # Absent/null is a legitimate no-anchors receipt (SKIPPED); a present
+    # non-list value ({} / "" / 0) is malformed and FAILs, never laundered to [].
+    if anchors is None:
+        return AnchorEvaluation("SKIPPED", "no anchors on this receipt", [])
+    if not isinstance(anchors, list):
+        return AnchorEvaluation("FAIL", f"anchors field is not a list (got {type(anchors).__name__})", [])
+    if not anchors:
+        return AnchorEvaluation("SKIPPED", "no anchors on this receipt", [])
+    try:
+        _env_jcs = envelope_minus_anchors_jcs(envelope)
+        bound = hashlib.sha256(_env_jcs).digest()
+    except RecursionError:
+        # Defense in depth, same rationale as check_chain's guard above.
+        return AnchorEvaluation(
+            "FAIL", "envelope too deeply nested to canonicalise for anchor binding", []
+        )
+    lines = [f"anchors bind envelope digest sha256:{bound.hex()[:16]}.."]
+    saw_invalid = False
+    saw_unverifiable = False
+    trusted_times = []
+    for a in anchors:
+        if not isinstance(a, dict):
+            saw_invalid = True
+            lines.append(f"    - malformed anchor entry (got {type(a).__name__}, expected an object)")
+            continue
+        atype = a.get("type", "?")
+        blob = _anchor_bytes(a.get("value"))
+        if blob is None:
+            saw_invalid = True
+            lines.append(f"    - {atype}: value MISSING or malformed")
+            continue
+        status = a.get("status")
+        if status in ("pending", "failed"):
+            saw_unverifiable = True
+            lines.append(
+                f"    - {atype}: value present, base64-ok; status {status}, not an anchored proof"
+            )
+            continue
+        if atype == "rfc3161":
+            outcome, detail, when = _check_rfc3161_anchor(
+                blob, bound, trusted_tsa_keys, _env_jcs
+            )
+        elif atype == "opentimestamps":
+            outcome, detail, when = _check_ots_anchor(blob, bound, bitcoin_headers)
+        else:
+            outcome, detail, when = (
+                "unverifiable",
+                "no offline verifier for this anchor type",
+                None,
+            )
+        if outcome == "verified":
+            lines.append(f"    - {atype}: verified ({detail})")
+            if when is not None:
+                trusted_times.append(when)
+        elif outcome == "invalid":
+            saw_invalid = True
+            lines.append(f"    - {atype}: invalid ({detail})")
+        else:
+            saw_unverifiable = True
+            lines.append(f"    - {atype}: value present, base64-ok; unverifiable ({detail})")
+    if saw_invalid:
+        return AnchorEvaluation("FAIL", "; ".join(lines), trusted_times)
+    if saw_unverifiable:
+        return AnchorEvaluation("SKIPPED", "; ".join(lines), trusted_times)
+    return AnchorEvaluation("PASS", "; ".join(lines), trusted_times)
+
+
+def check_anchors(envelope: dict, *, trusted_tsa_keys=None, bitcoin_headers=None):
+    """(result, note) for the anchors axis; see evaluate_anchors."""
+    ev = evaluate_anchors(
+        envelope, trusted_tsa_keys=trusted_tsa_keys, bitcoin_headers=bitcoin_headers
+    )
+    return ev.result, ev.note
 
 
 def normalise_envelope(raw: dict) -> dict:
     """Remap a hosted /verify response into the canonical 3-key envelope.
 
-    An Audit Pack already ships the canonical ``{payload, signature, anchors}``
-    shape, so pass it through untouched. The hosted ``/verify/{id}`` JSON instead
-    nests the signed dict under ``payload`` and exposes the signature object as
-    ``signature_envelope`` (and a possibly flat-string ``signature``); rebuild
-    the canonical envelope from those parts so ``run()`` sees one shape.
+    An Audit Pack already ships ``{payload, signature, anchors}``, so pass it
+    through untouched. The hosted ``/verify/{id}`` JSON nests the signed dict under
+    ``payload`` and exposes the signature object as ``signature_envelope`` (plus a
+    possibly flat-string ``signature``); rebuild from those so ``run()`` sees one shape.
     """
     # Already canonical: a top-level signature object plus a payload dict.
     sig = raw.get("signature")
@@ -531,18 +1222,18 @@ def match_signing_key(jwks: dict, kid: str, agent_id=None, issuer_id=None, org_i
     """Return the one jwks entry a receipt's signature is checked against.
 
     Exact key id, then the agent bind, then the bare-kid issuer match. Every caller
-    resolves through here, so the key that verifies a signature and the key whose
-    status and issuer the axes weigh are one entry rather than two independent
-    lookups. Resolving them separately lets a receipt verify against a key found one
-    way while the revocation and issuer axes read a key found the other way.
+    resolves through here so the key that verifies a signature and the key whose
+    status and issuer the axes weigh are one entry; resolving them separately lets a
+    receipt verify against a key found one way while revocation and issuer read a
+    key found the other.
 
-    Order carries the security. A cloud receipt puts the org id in kid and signs with
-    the agent's own key, and the directory publishes issuer_id on every key that org
-    owns, so an org-shaped kid matches each sibling alike and list position picks one.
-    Position binds nothing: agent_id and issuer_id both sit inside the signed bytes,
-    so the pair names the signer, while the sibling it lands on holds other key bytes,
-    another revocation status and another agent. The agent bind carries the org_id a
-    hash-mode receipt signs, so the correct sibling resolves before the loose match.
+    Order carries the security. A cloud receipt puts the org id in kid and the
+    directory publishes issuer_id on every key that org owns, so an org-shaped kid
+    matches each sibling alike and list position picks one. Position binds nothing -
+    agent_id and issuer_id both sit inside the signed bytes - while the sibling it
+    lands on holds other key bytes, another revocation status and another agent. The
+    agent bind carries the org_id a hash-mode receipt signs, so the correct sibling
+    resolves before the loose match.
     """
     entry = _match_key_by_id(jwks, kid)
     if entry is not None:
@@ -595,11 +1286,10 @@ def resolve_key_by_agent_id(jwks: dict, agent_id: str, issuer_id: str, org_id: s
     """Return (public_key_bytes, status, alg, kid, key_issuer_id) for an agent key.
 
     Cloud receipts set signature.kid to the issuer (org) id but sign with the
-    agent's own key; the JWKS publishes agent_id per key, so the signing key is
-    resolvable by the receipt's agent_id. agent_id is attacker-controlled, so a
-    match also requires the key's published issuer_id (or org_id) to equal the
-    receipt's claimed issuer: without that bind a valid key from any org would
-    verify a receipt claiming a different issuer. Same defensive shape as resolve_key.
+    agent's own key, and the JWKS publishes agent_id per key, so the signing key
+    resolves by agent_id. agent_id is attacker-controlled, so a match also requires
+    the key's published issuer_id (or org_id) to equal the claimed issuer: without
+    that bind a valid key from any org would verify a receipt claiming another.
     """
     k = _match_key_by_agent(jwks, agent_id, issuer_id, org_id)
     if k is None:
@@ -679,10 +1369,9 @@ def check_org_binding(key_issuer_id, key_org_id, claimed_org_id):
     """Bind a hash-mode receipt's org_id to the org the directory names for its key.
 
     issuer_id is the org's legal entity or its id, so it equals org_id only while
-    no org sets a legal entity. Prefer a published per-key org_id, the field the
-    server can guarantee equal. With neither an org_id nor an org-id-shaped
-    issuer the claim is not comparable offline: SKIP rather than FAIL an honest
-    receipt.
+    no org sets a legal entity; prefer the published per-key org_id, the field the
+    server can guarantee equal. With neither, the claim is not comparable offline:
+    SKIP rather than FAIL an honest receipt.
     """
     if not isinstance(claimed_org_id, str) or not claimed_org_id:
         return "FAIL", f"receipt org_id is {claimed_org_id!r}, so there is no org to bind"
@@ -704,22 +1393,37 @@ def check_org_binding(key_issuer_id, key_org_id, claimed_org_id):
 REVOKED_KEY_STATUSES = {"revoked", "suspended", "compromised"}
 
 
+def _has_trusted_pre_revocation_anchor(trusted_times, revoked_at) -> bool:
+    """True when a cryptographically verified anchor proves the envelope existed
+    at or before the key's revoked_at.
+
+    Only then is the self-attested issued_at corroborated for the historical verify
+    path: an anchor proves the envelope (payload + signature) existed at the anchor's
+    own proven time, so a time at/before revocation rules out a signature made with
+    the revoked key. An anchor with no proven time (an unplaced OTS proof) is False.
+    """
+    if not trusted_times or not revoked_at:
+        return False
+    rev = _parse_stamp(revoked_at)
+    if rev is None:
+        return False
+    return any(t <= rev for t in trusted_times)
+
+
 def check_key_status(status, issued_at: str, revoked_at=None, has_trusted_anchor: bool = False):
     """Gate the verdict on the signing key's published status.
 
-    The public JWKS marks a key revoked once its agent is revoked. A receipt
-    signed by such a key must not PASS offline, mirroring the hosted /verify.
-
-    When the JWKS carries a precise revoked_at, prefer the at-or-before-issuance
-    check so a receipt signed BEFORE revocation still PASSes (historical verify).
-    Without a revoked_at the axis cannot place issuance, so any revoked key fails.
+    The public JWKS marks a key revoked once its agent is revoked; a receipt signed
+    by such a key must not PASS offline, mirroring the hosted /verify. With a
+    precise revoked_at, prefer the at-or-before-issuance check so a receipt signed
+    BEFORE revocation still PASSes; without one the axis cannot place issuance, so
+    any revoked key fails.
 
     has_trusted_anchor must be an anchor the caller CRYPTOGRAPHICALLY verified as
-    pre-revocation timing; mere presence is not enough (anchors are unsigned and
+    pre-revocation; mere presence is not enough (anchors are unsigned and
     attacker-addable). Without one the self-attested issued_at is backdateable, so
-    that case downgrades to SKIPPED (INCOMPLETE), never a hiding PASS. The offline
-    verifier cannot do that walk and passes False; default False so a caller that
-    ignores the parameter never hides behind a bare timestamp.
+    that case downgrades to SKIPPED (INCOMPLETE), never a hiding PASS. Defaults
+    False so a caller that ignores the parameter never hides behind a bare timestamp.
     """
     s = (status or "").lower()
     if s not in REVOKED_KEY_STATUSES:
@@ -874,37 +1578,6 @@ def check_chain(payload: dict, predecessor_payload: dict | None):
     return "FAIL", f"chain break: expected {str(prev)[:16]}.. got {actual[:16]}.."
 
 
-def check_anchors(envelope: dict):
-    anchors = envelope.get("anchors")
-    # Absent/null is a legitimate no-anchors receipt (SKIPPED); a present
-    # non-list value ({} / "" / 0) is malformed and FAILs, never laundered to [].
-    if anchors is None:
-        return "SKIPPED", "no anchors on this receipt"
-    if not isinstance(anchors, list):
-        return "FAIL", f"anchors field is not a list (got {type(anchors).__name__})"
-    if not anchors:
-        return "SKIPPED", "no anchors on this receipt"
-    try:
-        bound = hashlib.sha256(envelope_minus_anchors_jcs(envelope)).hexdigest()
-    except RecursionError:
-        # Defense in depth, same rationale as check_chain's guard above.
-        return "FAIL", "envelope too deeply nested to canonicalise for anchor binding"
-    lines = [f"anchors bind envelope digest sha256:{bound[:16]}.."]
-    all_ok = True
-    for a in anchors:
-        if not isinstance(a, dict):
-            all_ok = False
-            lines.append(f"    - malformed anchor entry (got {type(a).__name__}, expected an object)")
-            continue
-        atype = a.get("type", "?")
-        val = a.get("value")
-        ok = bool(val) and _safe_b64(val)
-        all_ok = all_ok and ok
-        state = "present, base64-ok" if ok else "MISSING or malformed"
-        lines.append(f"    - {atype}: value {state}")
-    return ("PASS" if all_ok else "FAIL"), "; ".join(lines)
-
-
     # Closed-key-set and false-attestation rules for controls_evaluated.
 def check_controls_evaluated(payload: dict):
     ce = payload.get("controls_evaluated")
@@ -999,6 +1672,9 @@ def run(
     jwks: dict,
     predecessor_payload: dict | None,
     seen_nonces: set | None = None,
+    *,
+    trusted_tsa_keys=None,
+    bitcoin_headers=None,
 ) -> int:
     if not isinstance(envelope, dict):
         print("Asqav receipt verification")
@@ -1056,6 +1732,11 @@ def run(
     results = []
     results.append(("structure", *check_structure(payload)))
     results.append(("nonce", *check_nonce(payload, seen_nonces)))
+    # Evaluated once, up front: the anchors axis reports it, and the key_status
+    # axis weighs its cryptographically-proven timing against any revoked_at.
+    anchor_eval = evaluate_anchors(
+        envelope, trusted_tsa_keys=trusted_tsa_keys, bitcoin_headers=bitcoin_headers
+    )
 
     pk, status, jwks_alg = resolve_key(jwks, kid)
     if pk is None:
@@ -1143,21 +1824,21 @@ def run_structured(
     envelope: dict,
     jwks: dict,
     predecessor_payload: dict | None = None,
+    *,
+    trusted_tsa_keys=None,
+    bitcoin_headers=None,
 ) -> dict:
     """Verify a receipt offline and return a structured result dict.
 
-    Same logic as ``run()`` but returns a dict instead of printing and exiting.
-    Callable directly from the verifier module; the public SDK uses the oracle
-    adapter path for multi-format support.
+    Same logic as ``run()`` but returns a dict instead of printing and exiting; the
+    public SDK uses the oracle adapter path for multi-format support.
 
-    Returns:
-        dict with keys:
-          - ``"verdict"``: "verified" | "unverified" (criteria 418/438)
-          - ``"failure_class"``: "invalid" | "unverifiable" when unverified,
-            else None; the two are never collapsed (criterion 418)
-          - ``"axes"``: list of ``{"name", "result", "note", "failure_class"}``
-          - ``"canonical_sha256"``: hex SHA-256 of the canonical payload bytes
-          - ``"kid"``: the signature key id resolved
+    Keys: ``verdict`` ("verified" | "unverified", criteria 418/438);
+    ``failure_class`` ("invalid" | "unverifiable" when unverified, else None - the
+    two are never collapsed, criterion 418); ``axes``, a list of
+    ``{"name", "result", "note", "failure_class"}``; ``canonical_sha256``, hex
+    SHA-256 of the canonical payload bytes; ``kid``; and ``alg``, verbatim from the
+    wire (ML-DSA-65 cloud-issued, Ed25519/ES256 local).
     """
     if not isinstance(envelope, dict):
         return {
@@ -1172,6 +1853,7 @@ def run_structured(
             ],
             "canonical_sha256": None,
             "kid": None,
+            "alg": None,
         }
     envelope = normalise_envelope(envelope)
     payload = envelope.get("payload", envelope)
@@ -1190,6 +1872,7 @@ def run_structured(
             ],
             "canonical_sha256": None,
             "kid": None,
+            "alg": None,
         }
     shape = _scan_shape(envelope, max_depth=MAX_NESTING_DEPTH)
     if shape is None:
@@ -1201,6 +1884,7 @@ def run_structured(
             "axes": [_struct_axis("input", "FAIL", _SHAPE_MESSAGES[shape])],
             "canonical_sha256": None,
             "kid": None,
+            "alg": None,
         }
 
     sig_obj = envelope.get("signature", {})
@@ -1224,10 +1908,16 @@ def run_structured(
             "axes": [_struct_axis("input", "FAIL", _SHAPE_MESSAGES["too_deep"])],
             "canonical_sha256": None,
             "kid": None,
+            "alg": None,
         }
 
     axes: list[dict] = []
     axes.append(_struct_axis("structure", *check_structure(payload)))
+    # Evaluated once, up front: the anchors axis reports it, and the key_status
+    # axis weighs its cryptographically-proven timing against any revoked_at.
+    anchor_eval = evaluate_anchors(
+        envelope, trusted_tsa_keys=trusted_tsa_keys, bitcoin_headers=bitcoin_headers
+    )
 
     pk, status, jwks_alg = resolve_key(jwks, kid)
     if pk is None:
@@ -1295,6 +1985,7 @@ def run_structured(
         "axes": axes,
         "canonical_sha256": hashlib.sha256(msg).hexdigest(),
         "kid": kid,
+        "alg": alg,
     }
 
 
@@ -1311,6 +2002,33 @@ def _load(path: str) -> dict:
     return _parse_object(text, path)
 
 
+def _load_tsa_keys(paths) -> list:
+    """Read pinned TSA key material: PEM/DER X.509 certs, or base64/raw keys.
+
+    Anchors sit outside the signed bytes, so trust material must come from the
+    caller, never from the envelope; each file is one TSA public key or
+    certificate the RFC 3161 check may trust.
+    """
+    keys = []
+    for path in paths or []:
+        try:
+            with open(path, "rb") as fh:
+                blob = fh.read()
+        except OSError as exc:
+            raise VerifierInputError(f"{path}: {exc.strerror or exc}") from exc
+        text = blob.strip()
+        if text.startswith(b"-----BEGIN"):
+            keys.append(text + b"\n")
+            continue
+        try:
+            keys.append(base64.b64decode(text, validate=True))
+            continue
+        except Exception:
+            pass
+        keys.append(bytes(text))
+    return keys
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description="Standalone Asqav receipt verifier.")
     p.add_argument("--id", help="signature id to fetch from api.asqav.com")
@@ -1318,6 +2036,22 @@ def main() -> int:
     p.add_argument("--jwks", help="path to a saved jwks.json, or - for stdin (offline)")
     p.add_argument(
         "--predecessor", help="path to predecessor receipt JSON for the chain check"
+    )
+    p.add_argument(
+        "--tsa-key",
+        action="append",
+        default=[],
+        metavar="FILE",
+        help="pinned TSA public key or X.509 certificate (PEM, DER, or base64); "
+        "repeatable. Without one, an RFC 3161 anchor's TSA signature cannot be "
+        "trusted offline and the anchors axis reports unverifiable",
+    )
+    p.add_argument(
+        "--bitcoin-headers",
+        metavar="FILE",
+        help="JSON map of bitcoin block height to {\"merkle_root\": <display hex>, "
+        "\"time\": <ISO-8601>} for the OpenTimestamps block check; without it the "
+        "block portion reports unverifiable",
     )
     p.add_argument("--offline", action="store_true", help="never reach the network")
     args = p.parse_args()

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -212,7 +212,26 @@ _SHAPE_MESSAGES = {
 #: Public verdict vocabulary (criteria 418/438). The per-axis PASS/FAIL/SKIPPED
 #: tokens stay internal; the surface a caller reads speaks these three only.
 VERDICT_VERIFIED = "verified"
+#: Passing, but keyed under a holder salt so not third-party re-derivable.
+#: Never collapsed into `verified` or `unverified`.
+VERDICT_VERIFIED_KEYED = "verified_keyed"
 VERDICT_UNVERIFIED = "unverified"
+
+#: Unkeyed hash_algo values (absent defaults to sha256). Anything else counts
+#: as keyed, so a near-miss spelling under-claims rather than over-claims.
+_UNKEYED_HASH_ALGOS = frozenset({"sha256"})
+
+
+def is_keyed_digest(payload: dict) -> bool:
+    """True when the receipt's context digest is keyed (not re-derivable)."""
+    if not isinstance(payload, dict):
+        return False
+    algo = payload.get("hash_algo")
+    if algo is None:
+        return False
+    if not isinstance(algo, str):
+        return True
+    return algo.strip().lower() not in _UNKEYED_HASH_ALGOS
 
 #: Failure classes carried by every unverified verdict (criterion 418); the two
 #: are never collapsed - a proven binding failure is not an incomplete check.
@@ -269,6 +288,8 @@ def _fold_verdict(results) -> tuple[str, str | None]:
         return VERDICT_UNVERIFIED, failure_class
     if blocking_skip:
         return VERDICT_UNVERIFIED, FAILURE_UNVERIFIABLE
+    if keyed:
+        return VERDICT_VERIFIED_KEYED, None
     return VERDICT_VERIFIED, None
 
 
@@ -1068,28 +1089,35 @@ def run(
         results.append(
             ("issuer_bind", *check_issuer_binding(eff_issuer, payload.get("issuer_id")))
         )
-        # Offline anchor presence is unverifiable (anchors are unsigned); pass
-        # False so a forged anchor never rides a revoked key to PASS.
+        # Only a cryptographically verified anchor whose proven time lands at or
+        # before the key's revoked_at proves pre-revocation timing; presence
+        # alone never upgrades a revoked key (anchors are unsigned).
+        trusted_anchor = _has_trusted_pre_revocation_anchor(
+            anchor_eval.trusted_times, eff_revoked_at
+        )
         results.append(
-            ("key_status", *check_key_status(eff_status, payload.get("issued_at", ""), eff_revoked_at, False))
+            ("key_status", *check_key_status(eff_status, payload.get("issued_at", ""), eff_revoked_at, trusted_anchor))
         )
         results.append(("signature", *sig_res))
 
     results.append(("chain", *check_chain(payload, predecessor_payload)))
-    results.append(("anchors", *check_anchors(envelope)))
+    results.append(("anchors", anchor_eval.result, anchor_eval.note))
     results.append(("skew", *check_skew(payload.get("issued_at", ""))))
     results.append(("expiry", *check_expiry(payload)))
 
     print("Asqav receipt verification")
     print(f"  canonical bytes: sha256:{hashlib.sha256(msg).hexdigest()}")
     print(f"  signature.kid:   {kid}")
+    # The algorithm is per-receipt, verbatim from the signed envelope: ML-DSA-65
+    # for cloud-issued receipts, Ed25519/ES256 for locally signed ones.
+    print(f"  signature.alg:   {alg}")
     for name, res, note in results:
         mark = {"PASS": "ok", "FAIL": "FAIL", "SKIPPED": "skip"}[res]
         print(f"  [{mark:>4}] {name:<11} {note}")
 
     # Expiry reports on its own axis and never folds the verdict (criterion 426).
-    verdict, failure_class = _fold_verdict(results)
-    if verdict == VERDICT_VERIFIED:
+    verdict, failure_class = _fold_verdict(results, keyed=is_keyed_digest(payload))
+    if verdict in (VERDICT_VERIFIED, VERDICT_VERIFIED_KEYED):
         code = 0
         print(f"\n  => {verdict}")
     elif failure_class == FAILURE_INVALID:
@@ -1236,23 +1264,30 @@ def run_structured(
         # kid picks the key and the attacker picks the kid, so bind the key that
         # actually verified back to the issuer the receipt claims.
         axes.append(_struct_axis("issuer_bind", *check_issuer_binding(eff_issuer, payload.get("issuer_id"))))
-        # Offline anchor presence is not trusted timing; pass False so a forged
-        # anchor never upgrades a revoked key to a verified verdict.
+        # Only a cryptographically verified anchor whose proven time lands at or
+        # before revoked_at counts as trusted timing; presence alone never
+        # upgrades a revoked key to a verified verdict.
+        trusted_anchor = _has_trusted_pre_revocation_anchor(
+            anchor_eval.trusted_times, eff_revoked_at
+        )
         axes.append(
             _struct_axis(
                 "key_status",
-                *check_key_status(eff_status, payload.get("issued_at", ""), eff_revoked_at, False),
+                *check_key_status(eff_status, payload.get("issued_at", ""), eff_revoked_at, trusted_anchor),
             )
         )
         axes.append(_struct_axis("signature", sig_res[0], sig_res[1]))
 
     axes.append(_struct_axis("chain", *check_chain(payload, predecessor_payload)))
-    axes.append(_struct_axis("anchors", *check_anchors(envelope)))
+    axes.append(_struct_axis("anchors", anchor_eval.result, anchor_eval.note))
     axes.append(_struct_axis("skew", *check_skew(payload.get("issued_at", ""))))
     axes.append(_struct_axis("expiry", *check_expiry(payload)))
 
     # Expiry reports on its own axis and never folds the verdict (criterion 426).
-    verdict, failure_class = _fold_verdict([(a["name"], a["result"], a["note"]) for a in axes])
+    verdict, failure_class = _fold_verdict(
+        [(a["name"], a["result"], a["note"]) for a in axes],
+        keyed=is_keyed_digest(payload),
+    )
 
     return {
         "verdict": verdict,

--- a/python/tests/test_anchor_crypto.py
+++ b/python/tests/test_anchor_crypto.py
@@ -1,0 +1,341 @@
+"""Cryptographic anchor verification (draft: presence without a successful
+check MUST NOT yield valid).
+
+Covers the three anchor outcomes:
+  - verified:     token commits this envelope and its own proof checks out
+                  against caller-pinned trust material (trusted anchor)
+  - invalid:      the check ran and failed (wrong digest, bad TSA signature,
+                  merkle path missing the stated block)
+  - unverifiable: the check could not run offline (junk token, no pinned TSA
+                  key, no bitcoin header source, pending/failed status)
+and the key_status wiring: only a verified anchor whose proven time lands at
+or before revoked_at activates the pre-revocation historical-verify path.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from asqav.verifier import verify_receipt as v
+from tests.tsa_testkit import make_timestamp_resp, make_tst_info, mint_ml_dsa_anchor
+
+FIXTURES = Path(__file__).resolve().parents[2] / "verifier" / "docs" / "fixtures"
+
+
+def _envelope() -> dict:
+    return {
+        "payload": {
+            "type": "protectmcp:decision",
+            "issued_at": "2026-06-01T00:00:00Z",
+            "issuer_id": "org-anchor",
+            "action_ref": "sha256:" + "a" * 64,
+            "payload_digest": {"hash": "b" * 64, "size": 128},
+            "policy_digest": "sha256:" + "c" * 64,
+            "previousReceiptHash": "0" * 64,
+            "decision": "allow",
+        },
+        "signature": {"alg": "ML-DSA-65", "kid": "org-anchor", "sig": "AAAA"},
+    }
+
+
+def _bound(env: dict) -> bytes:
+    return hashlib.sha256(v.envelope_minus_anchors_jcs(env)).digest()
+
+
+def _anchored(env: dict, anchor: dict) -> dict:
+    out = dict(env)
+    out["anchors"] = [anchor]
+    return out
+
+
+# --- RFC 3161 ---------------------------------------------------------------
+
+
+def test_rfc3161_verified_against_pinned_tsa_key() -> None:
+    pytest.importorskip("dilithium_py")
+    env = _envelope()
+    tok, pk = mint_ml_dsa_anchor(_bound(env))
+    ev = v.evaluate_anchors(
+        _anchored(env, {"type": "rfc3161", "value": tok}), trusted_tsa_keys=[pk]
+    )
+    assert ev.result == "PASS", ev.note
+    assert ev.trusted_times and ev.trusted_times[0].isoformat().startswith("2026-06-01")
+
+
+def test_rfc3161_without_pinned_key_is_unverifiable_never_pass() -> None:
+    pytest.importorskip("dilithium_py")
+    env = _envelope()
+    tok, _pk = mint_ml_dsa_anchor(_bound(env))
+    res, note = v.check_anchors(_anchored(env, {"type": "rfc3161", "value": tok}))
+    assert res == "SKIPPED", note
+    assert "imprint matches" in note
+    assert v.evaluate_anchors(_anchored(env, {"type": "rfc3161", "value": tok})).trusted_times == []
+
+
+def test_rfc3161_wrong_tsa_key_is_invalid() -> None:
+    pytest.importorskip("dilithium_py")
+    from dilithium_py.ml_dsa import ML_DSA_65
+
+    env = _envelope()
+    tok, _pk = mint_ml_dsa_anchor(_bound(env))
+    other_pk, _sk = ML_DSA_65.keygen()
+    res, note = v.check_anchors(
+        _anchored(env, {"type": "rfc3161", "value": tok}), trusted_tsa_keys=[other_pk]
+    )
+    assert res == "FAIL", note
+    assert "TSA signature" in note
+
+
+def test_rfc3161_imprint_mismatch_is_invalid() -> None:
+    pytest.importorskip("dilithium_py")
+    env = _envelope()
+    tok, pk = mint_ml_dsa_anchor(b"\x00" * 32)  # commits some other digest
+    res, note = v.check_anchors(
+        _anchored(env, {"type": "rfc3161", "value": tok}), trusted_tsa_keys=[pk]
+    )
+    assert res == "FAIL", note
+    assert "different digest" in note
+
+
+def test_rfc3161_rejection_status_is_invalid() -> None:
+    env = _envelope()
+    tst = make_tst_info(_bound(env))
+    token = base64.b64encode(make_timestamp_resp(tst, b"\x00" * 16, status=2)).decode()
+    res, note = v.check_anchors(_anchored(env, {"type": "rfc3161", "value": token}))
+    assert res == "FAIL", note
+    assert "status 2" in note
+
+
+def test_rfc3161_junk_token_is_unverifiable_not_invalid() -> None:
+    env = _envelope()
+    res, note = v.check_anchors(_anchored(env, {"type": "rfc3161", "value": "dGVzdA=="}))
+    assert res == "SKIPPED", note
+    assert "offline RFC3161 check did not complete" in note
+
+
+def test_rsa_tsa_cert_allowlist_verifies() -> None:
+    """The cryptography path: TSA cert pinned by the caller, sid issuerAndSerial."""
+    pytest.importorskip("cryptography")
+    import datetime as dt
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa
+    from cryptography.x509.oid import NameOID
+
+    from tests.tsa_testkit import _int, _seq
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-tsa")])
+    now = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(7)
+        .not_valid_before(now)
+        .not_valid_after(now + dt.timedelta(days=3650))
+        .sign(key, hashes.SHA256())
+    )
+    env = _envelope()
+    tst = make_tst_info(_bound(env))
+    signature = key.sign(tst, padding.PKCS1v15(), hashes.SHA256())
+    sid = _seq(name.public_bytes(), _int(7))  # issuerAndSerialNumber
+    token = base64.b64encode(
+        make_timestamp_resp(
+            tst,
+            signature,
+            sig_alg_oid="1.2.840.113549.1.1.11",
+            sid=sid,
+            certs=[cert.public_bytes(serialization.Encoding.DER)],
+        )
+    ).decode()
+    der = cert.public_bytes(serialization.Encoding.DER)
+    res, note = v.check_anchors(
+        _anchored(env, {"type": "rfc3161", "value": token}), trusted_tsa_keys=[der]
+    )
+    assert res == "PASS", note
+
+
+def test_published_fixture_imprint_matches_but_tsa_untrusted() -> None:
+    """Parser check against the real production token: imprint must match."""
+    env = json.loads((FIXTURES / "published-receipt.json").read_text())
+    res, note = v.check_anchors(env)
+    assert res == "SKIPPED", note
+    assert "imprint matches" in note, note
+    assert "status pending" in note, note
+
+
+# --- OpenTimestamps ----------------------------------------------------------
+
+
+def _varuint(n: int) -> bytes:
+    out = bytearray([n & 0x7F])
+    n >>= 7
+    while n:
+        out.insert(0, 0x80 | (n & 0x7F))
+        n >>= 7
+    return bytes(out)
+
+
+def _mint_ots(digest32: bytes, height: int) -> tuple[str, bytes]:
+    """A proof digest->append->sha256->bitcoin attestation; returns (b64, root)."""
+    suffix = b"merkle-sibling"
+    root = hashlib.sha256(digest32 + suffix).digest()
+    body = (
+        bytes([0xF0, len(suffix)])
+        + suffix
+        + b"\x08"  # OpSHA256
+        + b"\x00"  # attestation marker
+        + bytes.fromhex("0588960d73d71901")
+        + _varuint(height)
+    )
+    blob = v._OTS_MAGIC + b"\x01\x08" + digest32 + body
+    return base64.b64encode(blob).decode(), root
+
+
+def test_ots_commitment_mismatch_is_invalid() -> None:
+    env = _envelope()
+    proof, _root = _mint_ots(b"\x11" * 32, 900000)
+    res, note = v.check_anchors(_anchored(env, {"type": "opentimestamps", "value": proof}))
+    assert res == "FAIL", note
+    assert "different digest" in note
+
+
+def test_ots_without_header_source_is_unverifiable() -> None:
+    env = _envelope()
+    proof, _root = _mint_ots(_bound(env), 900000)
+    res, note = v.check_anchors(_anchored(env, {"type": "opentimestamps", "value": proof}))
+    assert res == "SKIPPED", note
+    assert "commitment matches" in note
+
+
+def test_ots_merkle_root_mismatch_is_invalid() -> None:
+    env = _envelope()
+    proof, _root = _mint_ots(_bound(env), 900000)
+    headers = {"900000": {"merkle_root": "00" * 32, "time": "2026-06-01T00:00:00Z"}}
+    res, note = v.check_anchors(
+        _anchored(env, {"type": "opentimestamps", "value": proof}), bitcoin_headers=headers
+    )
+    assert res == "FAIL", note
+    assert "does not land" in note
+
+
+def test_ots_verified_against_supplied_header() -> None:
+    env = _envelope()
+    proof, root = _mint_ots(_bound(env), 900000)
+    headers = {900000: {"merkle_root": root[::-1].hex(), "time": "2026-06-01T12:00:00Z"}}
+    ev = v.evaluate_anchors(
+        _anchored(env, {"type": "opentimestamps", "value": proof}), bitcoin_headers=headers
+    )
+    assert ev.result == "PASS", ev.note
+    assert ev.trusted_times and ev.trusted_times[0].isoformat().startswith("2026-06-01T12:00")
+
+
+# --- status / shape rules ----------------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["pending", "failed"])
+def test_declared_pending_or_failed_status_is_never_trusted(status: str) -> None:
+    pytest.importorskip("dilithium_py")
+    env = _envelope()
+    tok, pk = mint_ml_dsa_anchor(_bound(env))
+    anchor = {"type": "rfc3161", "value": tok, "status": status}
+    ev = v.evaluate_anchors(_anchored(env, anchor), trusted_tsa_keys=[pk])
+    assert ev.result == "SKIPPED", ev.note
+    assert ev.trusted_times == []
+    assert f"status {status}" in ev.note
+
+
+def test_unknown_anchor_type_is_unverifiable() -> None:
+    env = _envelope()
+    res, note = v.check_anchors(_anchored(env, {"type": "merkle", "value": "YWJjZA=="}))
+    assert res == "SKIPPED", note
+    assert "no offline verifier for this anchor type" in note
+
+
+def test_bad_base64_still_fails_invalid() -> None:
+    env = _envelope()
+    res, note = v.check_anchors(_anchored(env, {"type": "rfc3161", "value": "!!!!"}))
+    assert res == "FAIL", note
+    assert "MISSING or malformed" in note
+
+
+def test_one_invalid_anchor_dominates_a_verified_sibling() -> None:
+    pytest.importorskip("dilithium_py")
+    env = _envelope()
+    tok, pk = mint_ml_dsa_anchor(_bound(env))
+    out = dict(env)
+    out["anchors"] = [
+        {"type": "rfc3161", "value": tok},
+        {"type": "rfc3161", "value": "!!!!"},
+    ]
+    res, _note = v.check_anchors(out, trusted_tsa_keys=[pk])
+    assert res == "FAIL"
+
+
+# --- key_status wiring (item 3) ----------------------------------------------
+
+
+def _signed_revoked_env(gen_time: str):
+    from dilithium_py.ml_dsa import ML_DSA_65
+
+    pk, sk = ML_DSA_65.keygen()
+    env = _envelope()
+    # The anchor commits payload+signature, so sign first, then anchor the
+    # digest of the envelope as it will ship.
+    env["signature"] = {
+        "alg": "ML-DSA-65",
+        "kid": "org-anchor",
+        "sig": base64.b64encode(ML_DSA_65.sign(sk, v.canonical_json(env["payload"]))).decode(),
+    }
+    tok, tsa_pk = mint_ml_dsa_anchor(_bound(env), gen_time=gen_time)
+    env["anchors"] = [{"type": "rfc3161", "value": tok}]
+    jwks = {
+        "keys": [
+            {
+                "kid": "org-anchor",
+                "issuer_id": "org-anchor",
+                "alg": "ML-DSA-65",
+                "public_key": base64.b64encode(pk).decode(),
+                "status": "revoked",
+                "revoked_at": "2026-07-01T00:00:00Z",
+            }
+        ]
+    }
+    return env, jwks, tsa_pk
+
+
+def test_pre_revocation_receipt_passes_with_verified_anchor() -> None:
+    """Draft historical verify: signed before revocation, proven by the anchor."""
+    pytest.importorskip("dilithium_py")
+    env, jwks, tsa_pk = _signed_revoked_env("20260601000000Z")  # before revoked_at
+    result = v.run_structured(env, jwks, None, trusted_tsa_keys=[tsa_pk])
+    ks = next(a for a in result["axes"] if a["name"] == "key_status")
+    assert ks["result"] == "PASS", ks
+    assert result["verdict"] == "verified", result["axes"]
+
+
+def test_anchor_after_revocation_does_not_prove_pre_revocation_timing() -> None:
+    pytest.importorskip("dilithium_py")
+    env, jwks, tsa_pk = _signed_revoked_env("20260801000000Z")  # after revoked_at
+    result = v.run_structured(env, jwks, None, trusted_tsa_keys=[tsa_pk])
+    ks = next(a for a in result["axes"] if a["name"] == "key_status")
+    assert ks["result"] == "SKIPPED", ks
+    assert result["verdict"] != "verified"
+
+
+def test_unverified_anchor_never_upgrades_a_revoked_key() -> None:
+    pytest.importorskip("dilithium_py")
+    env, jwks, _tsa_pk = _signed_revoked_env("20260601000000Z")
+    # No pinned TSA key: the anchor cannot be trusted, so key_status stays SKIPPED.
+    result = v.run_structured(env, jwks, None)
+    ks = next(a for a in result["axes"] if a["name"] == "key_status")
+    assert ks["result"] == "SKIPPED", ks
+    assert result["verdict"] != "verified"

--- a/python/tests/test_anchor_crypto_hardening.py
+++ b/python/tests/test_anchor_crypto_hardening.py
@@ -1,0 +1,303 @@
+"""Anchor-verification hardening: malformed input never crashes or over-claims.
+
+`anchors` sits outside the signed bytes, so any relay can steer these values.
+Two invariants: no input escapes as an unhandled exception (the CLI maps one to
+exit 1, indistinguishable from a proven binding failure), and no input reaches
+PASS without a real cryptographic check.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+
+import pytest
+
+from asqav.verifier import verify_receipt as vr
+
+from .tsa_testkit import (  # type: ignore[import-not-found]
+    _len,
+    _oid,
+    _seq,
+    _tlv,
+    make_signed_attrs,
+    make_timestamp_resp,
+    make_tst_info,
+    signed_attrs_signing_input,
+)
+
+
+def _envelope(anchors: list[dict]) -> dict:
+    return {
+        "payload": {"type": "protectmcp:decision", "issuer_id": "x", "decision": "allow"},
+        "signature": {"alg": "ML-DSA-65", "kid": "x", "sig": "AA=="},
+        "anchors": anchors,
+    }
+
+
+def _bound_for(envelope: dict, algo: str = "sha256") -> bytes:
+    """The digest an anchor must commit: H(JCS(envelope minus anchors))."""
+    return hashlib.new(algo, vr.envelope_minus_anchors_jcs(envelope)).digest()
+
+
+def _anchor(atype: str, blob: bytes) -> dict:
+    return {"type": atype, "value": base64.b64encode(blob).decode()}
+
+
+# --- 1. Nothing escapes as a crash -----------------------------------------
+
+
+def test_giant_oid_arc_reports_unverifiable_not_crash():
+    """A multi-thousand-byte OID arc must not raise the interpreter's
+    int-to-str ValueError out of the anchors axis."""
+    giant = _tlv(0x06, b"\x2a" + b"\xff" * 2100 + b"\x01")
+    poison = _seq(_seq(_tlv(0x02, b"\x00")), _seq(giant))
+    ev = vr.evaluate_anchors(_envelope([_anchor("rfc3161", poison)]))
+    assert ev.result == "SKIPPED"
+    assert ev.trusted_times == []
+
+
+def test_giant_oid_arc_through_run_exits_unverifiable(capsys):
+    """Exit 2 (unverifiable), never 1 (invalid) - an uncaught exception in the
+    DER walk would also exit 1, collapsing the distinction."""
+    giant = _tlv(0x06, b"\x2a" + b"\xff" * 2100 + b"\x01")
+    poison = _seq(_seq(_tlv(0x02, b"\x00")), _seq(giant))
+    code = vr.run(_envelope([_anchor("rfc3161", poison)]), {"keys": []}, None)
+    assert code == 2, "a parse failure must not be reported as `invalid`"
+
+
+def test_giant_oid_arc_structured_is_unverifiable():
+    giant = _tlv(0x06, b"\x2a" + b"\xff" * 2100 + b"\x01")
+    poison = _seq(_seq(_tlv(0x02, b"\x00")), _seq(giant))
+    res = vr.run_structured(_envelope([_anchor("rfc3161", poison)]), {"keys": []})
+    assert res["verdict"] == vr.VERDICT_UNVERIFIED
+    assert res["failure_class"] == vr.FAILURE_UNVERIFIABLE
+
+
+def test_truncated_signed_attrs_with_matching_imprint_is_unverifiable():
+    """The imprint check passes, then the signedAttrs walk hits truncated DER.
+    That walk sits after the imprint comparison, so it must be inside the
+    same parse guard."""
+    env = _envelope([])
+    bound = _bound_for(env)
+    tst = make_tst_info(bound)
+    attrs = make_signed_attrs(tst)
+    token = make_timestamp_resp(tst, b"\x00" * 64, signed_attrs=attrs[:-4])
+    ev = vr.evaluate_anchors(_envelope([_anchor("rfc3161", token)]))
+    assert ev.result in ("SKIPPED", "FAIL")
+    assert ev.trusted_times == []
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        b"",
+        b"\x30",
+        b"\x30\x80" + b"\x00" * 8,  # indefinite length
+        b"\x30\x84\xff\xff\xff\xff",  # length overruns the buffer
+        b"\x30\x03" + b"\x00" * 32,  # trailing garbage
+        b"\x3f\x1f\x01\x02",  # high-tag-number form
+        b"\x30" + b"\x30" * 5000,  # deep-ish nesting attempt
+    ],
+)
+def test_malformed_der_never_raises(blob):
+    ev = vr.evaluate_anchors(_envelope([_anchor("rfc3161", blob)]))
+    assert ev.result in ("SKIPPED", "FAIL")
+    assert ev.trusted_times == []
+
+
+def test_deeply_nested_der_does_not_recurse():
+    """The DER walk is iterative; 10k nested SEQUENCEs must not blow the stack."""
+    blob = b""
+    for _ in range(10000):
+        blob = b"\x30" + _len(len(blob)) + blob
+    ev = vr.evaluate_anchors(_envelope([_anchor("rfc3161", blob)]))
+    assert ev.result in ("SKIPPED", "FAIL")
+
+
+# --- 2. No quadratic blow-up on caller-supplied bytes -----------------------
+
+
+def test_ots_varuint_is_width_bounded():
+    """An unbounded varuint builds a multi-megabit int one shift at a time;
+    900k continuation bytes measured at 326 seconds before the cap."""
+    blob = vr._OTS_MAGIC + bytes([1, 0x08]) + b"\x00" * 32 + b"\x00" + b"\xff" * 900_000
+    start = time.monotonic()
+    ev = vr.evaluate_anchors(_envelope([_anchor("opentimestamps", blob)]))
+    elapsed = time.monotonic() - start
+    assert ev.result in ("SKIPPED", "FAIL")
+    assert elapsed < 5.0, f"ots varuint took {elapsed:.1f}s; the width cap is gone"
+
+
+# --- 3. CMS content binding (RFC 5652 s11.1) -------------------------------
+
+
+def _ml_dsa_token(tst: bytes, *, signed_attrs: bytes | None = None, **kw):
+    """Sign whatever the CMS rules say is covered, with a real ML-DSA key."""
+    from dilithium_py.ml_dsa import ML_DSA_65
+
+    pk, sk = ML_DSA_65.keygen()
+    covered = tst if signed_attrs is None else signed_attrs_signing_input(signed_attrs)
+    token = make_timestamp_resp(
+        tst, ML_DSA_65.sign(sk, covered), signed_attrs=signed_attrs, **kw
+    )
+    return token, pk
+
+
+def test_signed_attrs_token_with_full_binding_verifies():
+    """Control case: a well-formed signedAttrs token DOES verify, so the
+    rejection tests below are not passing for the wrong reason."""
+    env = _envelope([])
+    tst = make_tst_info(_bound_for(env))
+    attrs = make_signed_attrs(tst)
+    token, pk = _ml_dsa_token(tst, signed_attrs=attrs)
+    ev = vr.evaluate_anchors(
+        _envelope([_anchor("rfc3161", token)]), trusted_tsa_keys=[pk]
+    )
+    assert ev.result == "PASS"
+    assert len(ev.trusted_times) == 1
+
+
+def test_signed_attrs_without_content_type_is_rejected():
+    """contentType is mandatory when signedAttrs is present; without it a TSA
+    signature over other content can be replayed as a timestamp."""
+    env = _envelope([])
+    tst = make_tst_info(_bound_for(env))
+    attrs = make_signed_attrs(tst, include_content_type=False)
+    token, pk = _ml_dsa_token(tst, signed_attrs=attrs)
+    ev = vr.evaluate_anchors(
+        _envelope([_anchor("rfc3161", token)]), trusted_tsa_keys=[pk]
+    )
+    assert ev.result != "PASS"
+    assert ev.trusted_times == []
+
+
+def test_signed_attrs_with_wrong_content_type_is_rejected():
+    env = _envelope([])
+    tst = make_tst_info(_bound_for(env))
+    attrs = make_signed_attrs(tst, content_type_oid="1.2.840.113549.1.7.1")  # id-data
+    token, pk = _ml_dsa_token(tst, signed_attrs=attrs)
+    ev = vr.evaluate_anchors(
+        _envelope([_anchor("rfc3161", token)]), trusted_tsa_keys=[pk]
+    )
+    assert ev.result != "PASS"
+    assert ev.trusted_times == []
+
+
+def test_wrong_econtent_type_is_rejected():
+    """The encapsulated content must be declared id-ct-TSTInfo."""
+    env = _envelope([])
+    tst = make_tst_info(_bound_for(env))
+    token, pk = _ml_dsa_token(tst, econtent_type_oid="1.2.840.113549.1.7.1")
+    ev = vr.evaluate_anchors(
+        _envelope([_anchor("rfc3161", token)]), trusted_tsa_keys=[pk]
+    )
+    assert ev.result != "PASS"
+    assert ev.trusted_times == []
+
+
+def test_message_digest_not_committing_tst_is_invalid():
+    env = _envelope([])
+    tst = make_tst_info(_bound_for(env))
+    attrs = make_signed_attrs(tst, message_digest=b"\x11" * 32)
+    token, pk = _ml_dsa_token(tst, signed_attrs=attrs)
+    ev = vr.evaluate_anchors(
+        _envelope([_anchor("rfc3161", token)]), trusted_tsa_keys=[pk]
+    )
+    assert ev.result == "FAIL"
+
+
+# --- 4. Imprint algorithm honesty ------------------------------------------
+
+
+def test_sha512_imprint_committing_this_envelope_verifies():
+    """A sha512 messageImprint the verifier never computed is not a proven
+    mismatch; recompute under the token's own algorithm instead of failing."""
+    env = _envelope([])
+    tst = _seq(
+        _tlv(0x02, b"\x01"),
+        _oid("1.2.3.4"),
+        _seq(
+            _seq(_oid("2.16.840.1.101.3.4.2.3"), _tlv(0x05, b"")),  # sha512
+            _tlv(0x04, _bound_for(env, "sha512")),
+        ),
+        _tlv(0x02, b"\x2a"),
+        _tlv(0x18, b"20260601000000Z"),
+    )
+    attrs = make_signed_attrs(tst)
+    token, pk = _ml_dsa_token(tst, signed_attrs=attrs)
+    ev = vr.evaluate_anchors(
+        _envelope([_anchor("rfc3161", token)]), trusted_tsa_keys=[pk]
+    )
+    assert ev.result == "PASS", ev.note
+
+
+def test_sha512_imprint_of_other_bytes_is_invalid():
+    tst = _seq(
+        _tlv(0x02, b"\x01"),
+        _oid("1.2.3.4"),
+        _seq(
+            _seq(_oid("2.16.840.1.101.3.4.2.3"), _tlv(0x05, b"")),
+            _tlv(0x04, hashlib.sha512(b"some other bytes").digest()),
+        ),
+        _tlv(0x02, b"\x2a"),
+        _tlv(0x18, b"20260601000000Z"),
+    )
+    attrs = make_signed_attrs(tst)
+    token, pk = _ml_dsa_token(tst, signed_attrs=attrs)
+    ev = vr.evaluate_anchors(
+        _envelope([_anchor("rfc3161", token)]), trusted_tsa_keys=[pk]
+    )
+    assert ev.result == "FAIL"
+
+
+def test_unknown_imprint_oid_is_unverifiable_not_invalid():
+    env = _envelope([])
+    tst = _seq(
+        _tlv(0x02, b"\x01"),
+        _oid("1.2.3.4"),
+        _seq(_seq(_oid("1.9.9.9.9"), _tlv(0x05, b"")), _tlv(0x04, _bound_for(env))),
+        _tlv(0x02, b"\x2a"),
+        _tlv(0x18, b"20260601000000Z"),
+    )
+    token, pk = _ml_dsa_token(tst)
+    ev = vr.evaluate_anchors(
+        _envelope([_anchor("rfc3161", token)]), trusted_tsa_keys=[pk]
+    )
+    assert ev.result == "SKIPPED", ev.note
+
+
+# --- 5. Keyed digests never report plain `verified` ------------------------
+
+
+@pytest.mark.parametrize(
+    "algo,expected",
+    [
+        ("sha256", False),
+        (None, False),
+        ("hmac-sha256", True),
+        ("HMAC-SHA256", True),  # near-miss spelling is still keyed
+        ("hmac_sha256", True),
+        ("hmac-sha512", True),
+        ("blake3", True),  # unknown label: assume not re-derivable
+        (12345, True),  # non-string: assume not re-derivable
+    ],
+)
+def test_keyed_digest_detection(algo, expected):
+    payload = {} if algo is None else {"hash_algo": algo}
+    assert vr.is_keyed_digest(payload) is expected
+
+
+def test_fold_verdict_keyed_never_collapses_to_verified():
+    passing = [("signature", "PASS", ""), ("chain", "PASS", "")]
+    assert vr._fold_verdict(passing, keyed=False)[0] == vr.VERDICT_VERIFIED
+    assert vr._fold_verdict(passing, keyed=True)[0] == vr.VERDICT_VERIFIED_KEYED
+
+
+def test_keyed_receipt_failing_a_check_stays_unverified():
+    """`verified_keyed` is a PASSING verdict; it must not mask a real failure."""
+    failing = [("signature", "FAIL", "bad signature")]
+    verdict, fc = vr._fold_verdict(failing, keyed=True)
+    assert verdict == vr.VERDICT_UNVERIFIED
+    assert fc == vr.FAILURE_INVALID

--- a/python/tests/test_anchor_forged_value.py
+++ b/python/tests/test_anchor_forged_value.py
@@ -117,10 +117,16 @@ def test_forged_value_never_reads_as_present(value: str) -> None:
 
 @pytest.mark.parametrize("value", LEGITIMATE, ids=repr)
 def test_legitimate_anchor_still_passes(value: str) -> None:
+    """Genuine base64 passes the shape gate, but shape is not proof.
+
+    Since the cryptographic anchor check landed, a value that is not a
+    verifiable token reports unverifiable (SKIPPED), never PASS on presence.
+    """
     assert _safe_b64(value) is True, repr(value)
     state, note = _axis(value)
-    assert state == "PASS", repr(value)
+    assert state == "SKIPPED", repr(value)
     assert "present, base64-ok" in note, repr(value)
+    assert "unverifiable" in note, repr(value)
 
 
 @pytest.mark.parametrize("value", NON_STRINGS, ids=repr)
@@ -162,7 +168,8 @@ def test_mime_line_wrapped_base64_is_refused(value: str) -> None:
     assert _axis(value)[0] == "FAIL", repr(value)
 
 
-    # Every encoding a real signer emits keeps passing, padded or not.
+    # Every encoding a real signer emits keeps passing the shape gate; the
+    # cryptographic check then reports unverifiable for a non-token, never PASS.
 def test_legitimate_anchor_values_still_pass() -> None:
     rng = random.Random(358)
     for n in range(1, 129):
@@ -171,7 +178,7 @@ def test_legitimate_anchor_values_still_pass() -> None:
         url = base64.urlsafe_b64encode(raw).decode()
         for value in (std, std.rstrip("="), url, url.rstrip("=")):
             assert _safe_b64(value) is True, repr(value)
-            assert _axis(value)[0] == "PASS", repr(value)
+            assert _axis(value)[0] == "SKIPPED", repr(value)
 
 
 def test_verdict_matches_the_grammar_rule_not_a_decoder() -> None:

--- a/python/tests/test_anchor_value_cases.py
+++ b/python/tests/test_anchor_value_cases.py
@@ -30,8 +30,13 @@ def test_corpus_is_populated() -> None:
     assert len(VALUES) >= 900, f"corpus has only {len(VALUES)} values"
     wide = [c for c in VALUES if any(ord(ch) > 127 for ch in c["value"])]
     assert len(wide) >= 350, f"only {len(wide)} values carry a non-ASCII codepoint"
-    passing = [c for c in VALUES if c["expect"]["axis"] == "PASS"]
-    assert len(passing) >= 100, f"only {len(passing)} values are expected to pass"
+    # Since the cryptographic anchor check landed, a shape-valid value reports
+    # SKIPPED (unverifiable) rather than PASS; both directions must be present
+    # or the corpus cannot tell a working shape gate from a stuck one.
+    failing = [c for c in VALUES if c["expect"]["axis"] == "FAIL"]
+    assert len(failing) >= 100, f"only {len(failing)} values are expected to fail"
+    skipped = [c for c in VALUES if c["expect"]["axis"] == "SKIPPED"]
+    assert len(skipped) >= 100, f"only {len(skipped)} values are expected to skip"
 
 
 def _surplus_padding(value: str) -> bool:

--- a/python/tests/test_axis_parity_cases.py
+++ b/python/tests/test_axis_parity_cases.py
@@ -7,6 +7,7 @@ typescript/tests/verifier-axis-parity.test.ts and reads the same file.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 from pathlib import Path
@@ -140,3 +141,29 @@ def test_normalise_case(case: dict) -> None:
     # halves normalise and canonicalise the same envelope.
     assert digest == case["expect"]["digest"], case["name"]
     assert check_anchors(env)[0] == case["expect"]["anchors_axis"], case["name"]
+
+
+# --- Cases where the two languages legitimately disagree (criterion 446) ---
+
+DIVERGENCE = TABLE["anchors_divergence"]
+
+
+def test_divergence_table_is_populated_and_two_sided() -> None:
+    """A one-sided table cannot tell a real divergence from a stuck axis."""
+    assert len(DIVERGENCE) >= 2, DIVERGENCE
+    assert {c["expect_python"]["result"] for c in DIVERGENCE} == {"FAIL", "PASS"}
+    assert {c["expect_ts"]["result"] for c in DIVERGENCE} == {"SKIPPED"}
+
+
+@pytest.mark.parametrize(
+    "case", DIVERGENCE, ids=[c["name"] for c in DIVERGENCE]
+)
+def test_anchor_divergence_python_side(case: dict) -> None:
+    """Python evaluates the token; the TS half of each case is asserted in
+    typescript/tests/verifier-axis-parity.test.ts against the same rows."""
+    keys = [base64.b64decode(case["trusted_tsa_key_b64"])]
+    result, note = check_anchors(case["envelope"], trusted_tsa_keys=keys)
+    assert result == case["expect_python"]["result"], f"{case['name']}: {note}"
+    assert case["expect_python"]["note_contains"] in note, case["name"]
+    # The divergence itself: TS cannot reach this verdict at all.
+    assert result != case["expect_ts"]["result"], case["name"]

--- a/python/tests/test_exit_artifact_cli.py
+++ b/python/tests/test_exit_artifact_cli.py
@@ -92,8 +92,10 @@ def _anchored_mldsa_pair() -> tuple[dict, dict, bytes]:
     envelope = {
         "payload": payload,
         "signature": {"alg": "ML-DSA-65", "kid": kid, "sig": base64.b64encode(sig).decode()},
-        "anchors": [{"type": "rfc3161", "value": "dGVzdC1hbmNob3I="}],
     }
+    bound = hashlib.sha256(vr.envelope_minus_anchors_jcs(envelope)).digest()
+    tok, tsa_pk = mint_ml_dsa_anchor(bound)
+    envelope["anchors"] = [{"type": "rfc3161", "value": tok}]
     jwks = {
         "keys": [
             {
@@ -105,14 +107,16 @@ def _anchored_mldsa_pair() -> tuple[dict, dict, bytes]:
             }
         ]
     }
-    return envelope, jwks
+    return envelope, jwks, tsa_pk
 
 
-    # Write the three files an exit artifact carries, and nothing else.
-def _lay_out_exit_artifact(root: Path, receipt: dict, jwks: dict) -> None:
+    # Write the files an exit artifact carries, and nothing else. The pinned TSA
+    # key ships beside them the way the walkthrough's <asqav-tsa-chain.pem> does.
+def _lay_out_exit_artifact(root: Path, receipt: dict, jwks: dict, tsa_pk: bytes) -> None:
     shutil.copy(VERIFIER_SOURCE, root / "verify_receipt.py")
     (root / "receipt.json").write_text(json.dumps(receipt))
     (root / "jwks.json").write_text(json.dumps(jwks))
+    (root / "tsa-key.b64").write_text(base64.b64encode(tsa_pk).decode())
     (root / "sitecustomize.py").write_text(SITECUSTOMIZE)
 
 
@@ -127,13 +131,13 @@ def _child_env(root: Path) -> dict[str, str]:
 
 
     # Run the exit-manifest command verbatim, with the network refused.
-def _run_documented_command(root: Path) -> subprocess.CompletedProcess:
+def _run_documented_command(root: Path, *extra: str) -> subprocess.CompletedProcess:
     argv = EXIT_MANIFEST_COMMAND.replace("<receipt.json>", "receipt.json").replace(
         "<jwks.json>", "jwks.json"
     ).split()
     assert argv[0] == "python" and argv[1] == "verify_receipt.py", argv
     return subprocess.run(
-        [sys.executable, *argv[1:]],
+        [sys.executable, *argv[1:], *extra],
         cwd=root,
         capture_output=True,
         text=True,
@@ -158,9 +162,9 @@ def test_the_network_block_actually_blocks(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_exit_artifact_command_passes_an_intact_pair(tmp_path: Path) -> None:
-    receipt, jwks = _anchored_mldsa_pair()
-    _lay_out_exit_artifact(tmp_path, receipt, jwks)
-    proc = _run_documented_command(tmp_path)
+    receipt, jwks, tsa_pk = _anchored_mldsa_pair()
+    _lay_out_exit_artifact(tmp_path, receipt, jwks, tsa_pk)
+    proc = _run_documented_command(tmp_path, "--tsa-key", "tsa-key.b64")
     assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
     assert "=> verified" in proc.stdout, proc.stdout
     # A verified verdict with a skipped signature axis is the failure this test exists for.
@@ -170,10 +174,28 @@ def test_exit_artifact_command_passes_an_intact_pair(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
+def test_exit_artifact_command_without_tsa_key_never_passes_on_presence(tmp_path: Path) -> None:
+    """The documented command alone: anchors report unverifiable, never verified.
+
+    The token's imprint matches (the offline proof the timestamp covers these
+    bytes), but without pinned TSA key material the TSA signature cannot be
+    trusted, so the draft's no-PASS-on-presence rule caps the verdict at
+    unverified/unverifiable. The verified path above adds --tsa-key.
+    """
+    receipt, jwks, tsa_pk = _anchored_mldsa_pair()
+    _lay_out_exit_artifact(tmp_path, receipt, jwks, tsa_pk)
+    proc = _run_documented_command(tmp_path)
+    assert proc.returncode == 2, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    assert "=> unverified (failure_class: unverifiable" in proc.stdout, proc.stdout
+    assert "[skip] anchors" in proc.stdout, proc.stdout
+    assert "imprint matches" in proc.stdout, proc.stdout
+
+
+@pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_exit_artifact_command_fails_a_tampered_receipt(tmp_path: Path) -> None:
-    receipt, jwks = _anchored_mldsa_pair()
+    receipt, jwks, tsa_pk = _anchored_mldsa_pair()
     receipt["payload"]["decision"] = "deny"
-    _lay_out_exit_artifact(tmp_path, receipt, jwks)
+    _lay_out_exit_artifact(tmp_path, receipt, jwks, tsa_pk)
     proc = _run_documented_command(tmp_path)
     assert proc.returncode == 1, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
     assert "=> unverified (failure_class: invalid)" in proc.stdout, proc.stdout
@@ -183,10 +205,10 @@ def test_exit_artifact_command_fails_a_tampered_receipt(tmp_path: Path) -> None:
     # A swapped verification key must not verify the receipt it did not sign.
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_exit_artifact_command_fails_a_tampered_jwks(tmp_path: Path) -> None:
-    receipt, jwks = _anchored_mldsa_pair()
-    _, other_jwks = _anchored_mldsa_pair()
+    receipt, jwks, tsa_pk = _anchored_mldsa_pair()
+    other_jwks = _anchored_mldsa_pair()[1]
     jwks["keys"][0]["public_key"] = other_jwks["keys"][0]["public_key"]
-    _lay_out_exit_artifact(tmp_path, receipt, jwks)
+    _lay_out_exit_artifact(tmp_path, receipt, jwks, tsa_pk)
     proc = _run_documented_command(tmp_path)
     assert proc.returncode == 1, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
     assert "=> unverified (failure_class: invalid)" in proc.stdout, proc.stdout

--- a/python/tests/test_exit_artifact_cli.py
+++ b/python/tests/test_exit_artifact_cli.py
@@ -65,8 +65,14 @@ except ImportError:  # pragma: no cover - optional dep
 
 
     # An anchored ML-DSA-65 receipt plus the JWKS an export would archive for it.
-def _anchored_mldsa_pair() -> tuple[dict, dict]:
+    # The anchor is a real RFC3161 token minted over the envelope digest; the
+    # caller pins the TSA key (--tsa-key), since presence alone never PASSes.
+def _anchored_mldsa_pair() -> tuple[dict, dict, bytes]:
+    import hashlib
+
     from dilithium_py.ml_dsa import ML_DSA_65
+
+    from tests.tsa_testkit import mint_ml_dsa_anchor
 
     pk, sk = ML_DSA_65.keygen()
     kid = "exit-artifact-key-01"

--- a/python/tests/test_standalone_verifier_surface.py
+++ b/python/tests/test_standalone_verifier_surface.py
@@ -64,19 +64,23 @@ def _module_names() -> list[tuple[str, bool]]:
     return found
 
 
-def test_import_surface_is_stdlib_plus_optional_dilithium_only() -> None:
-    allowed = set(sys.stdlib_module_names) | {"dilithium_py"}
+def test_import_surface_is_stdlib_plus_optional_crypto_only() -> None:
+    # cryptography joins dilithium_py as an optional lazy import: the RFC 3161
+    # anchor check decodes pinned X.509 TSA certificates with it when present
+    # (the verify extra already ships it), and degrades to unverifiable without.
+    allowed = set(sys.stdlib_module_names) | {"dilithium_py", "cryptography"}
     for root, _lazy in _module_names():
         assert root != "asqav", "the standalone verifier must never import producer code"
         assert root in allowed, f"non-stdlib import {root!r} in verify_receipt.py"
 
 
-def test_dilithium_is_the_only_non_stdlib_dep_and_imports_lazily() -> None:
+def test_optional_crypto_deps_import_lazily() -> None:
     roots = {root for root, _lazy in _module_names()}
     assert "dilithium_py" in roots, "the ML-DSA-65 axis must stay in the tool"
+    assert "cryptography" in roots, "the RFC 3161 TSA-cert path must stay in the tool"
     for root, lazy in _module_names():
-        if root == "dilithium_py":
-            assert lazy, "dilithium-py must import inside the check, not at top level"
+        if root in ("dilithium_py", "cryptography"):
+            assert lazy, f"{root} must import inside the check, not at top level"
 
 
 def test_the_file_level_apache_exception_stays_documented() -> None:
@@ -121,6 +125,15 @@ sys.meta_path.insert(0, _RefuseAsqav())
 
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_standalone_file_verifies_the_published_receipt_without_asqav(tmp_path) -> None:
+    """The published receipt offline: imprint proven, TSA untrusted, never verified.
+
+    Since the cryptographic anchor check landed, presence no longer yields a
+    verified verdict: the receipt's RFC3161 token commits this envelope (the
+    imprint matches), but the TSA trust anchor is not pinned by this fixture,
+    so the anchors axis reports unverifiable and the verdict caps at
+    unverified/unverifiable. A caller holding the TSA chain passes it via
+    --tsa-key for the full verified path (covered in test_exit_artifact_cli).
+    """
     shutil.copy(VERIFIER_SOURCE, tmp_path / "verify_receipt.py")
     shutil.copy(FIXTURES / "published-receipt.json", tmp_path / "receipt.json")
     shutil.copy(FIXTURES / "published-jwks.json", tmp_path / "jwks.json")
@@ -143,8 +156,12 @@ def test_standalone_file_verifies_the_published_receipt_without_asqav(tmp_path) 
         text=True,
         timeout=180,
     )
-    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
-    assert "=> verified" in proc.stdout, proc.stdout
+    assert proc.returncode == 2, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    assert "=> unverified (failure_class: unverifiable" in proc.stdout, proc.stdout
+    # The receipt signature itself verifies; only the anchor trust is missing.
+    assert "[  ok] signature" in proc.stdout, proc.stdout
+    assert "[skip] anchors" in proc.stdout, proc.stdout
+    assert "imprint matches" in proc.stdout, proc.stdout
     # The lapsed signed expiry reports on its own axis and never folds the verdict
     assert "[FAIL] expiry" in proc.stdout, proc.stdout
 

--- a/python/tests/test_time_edge_vectors.py
+++ b/python/tests/test_time_edge_vectors.py
@@ -133,17 +133,27 @@ def test_unreadable_expires_at_fails_closed_on_its_own_axis(monkeypatch) -> None
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")
 def test_time_edge_corpus_vector_expiry_never_folds_the_verdict() -> None:
     # asqav-12: extreme +14:00 issued_at (past, skew PASS) and a lapsed signed
-    # expires_at; the expiry axis FAILs alone and the verdict stays PASS (426)
+    # expires_at; the expiry axis FAILs alone and never folds the verdict (426).
+    # The vector's placeholder anchor is not a verifiable token, so since the
+    # cryptographic anchor check landed the anchors axis reports unverifiable
+    # (never PASS on presence); the 426 property is pinned by folding the same
+    # axes with and without the expiry row and requiring one verdict.
     receipt = json.loads((TIME_EDGE_VECTOR / "receipt.json").read_text())
     jwks = json.loads((TIME_EDGE_VECTOR / "jwks.json").read_text())
     result = vr.run_structured(receipt, jwks)
     axes = {a["name"]: a for a in result["axes"]}
-    assert result["verdict"] == "verified", result["axes"]
+    assert result["verdict"] == "unverified", result["axes"]
+    assert result["failure_class"] == "unverifiable", result["axes"]
     assert axes["skew"]["result"] == "PASS", axes["skew"]
+    assert axes["anchors"]["result"] == "SKIPPED", axes["anchors"]
     assert axes["expiry"]["result"] == "FAIL", axes["expiry"]
     assert "lapsed" in axes["expiry"]["note"], axes["expiry"]
-    non_expiry = [a for a in result["axes"] if a["name"] != "expiry"]
+    non_expiry = [a for a in result["axes"] if a["name"] not in ("expiry", "anchors")]
     assert all(a["result"] == "PASS" for a in non_expiry), non_expiry
+    rows = [(a["name"], a["result"], a["note"]) for a in result["axes"]]
+    assert vr._fold_verdict(rows) == vr._fold_verdict(
+        [r for r in rows if r[0] != "expiry"]
+    ), "the lapsed expiry moved the verdict (criterion 426)"
 
 
 @pytest.mark.skipif(not _DILITHIUM_AVAILABLE, reason="dilithium-py not installed")

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -287,8 +287,28 @@ def _envelope(payload: dict, sig: bytes, kid: str | None = None) -> dict:
             "kid": payload["issuer_id"] if kid is None else kid,
             "sig": base64.b64encode(sig).decode(),
         },
+        # A placeholder anchor: shape-valid but cryptographically unverifiable,
+        # so the anchors axis reports SKIPPED (unverifiable), never PASS.
         "anchors": [{"type": "test", "value": "AAAA"}],
     }
+
+
+def _trusted_envelope(payload: dict, sig: bytes, kid: str | None = None):
+    """_envelope plus a real RFC3161 anchor; returns (envelope, pinned TSA key).
+
+    A verified verdict needs a cryptographically verified anchor since the
+    anchor check landed, so the PASS-path tests mint one and pass the TSA key
+    through trusted_tsa_keys.
+    """
+    import hashlib
+
+    from tests.tsa_testkit import mint_ml_dsa_anchor
+
+    env = _envelope(payload, sig, kid)
+    bound = hashlib.sha256(v.envelope_minus_anchors_jcs(env)).digest()
+    tok, tsa_pk = mint_ml_dsa_anchor(bound)
+    env["anchors"] = [{"type": "rfc3161", "value": tok}]
+    return env, tsa_pk
 
 
 def test_run_agent_id_fallback_rejects_forged_issuer() -> None:

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -344,7 +344,8 @@ def test_run_agent_id_fallback_passes_legit_multi_agent() -> None:
             _jwks_key("agent-two", "agt_two", "org-legit", a2_pk),  # real signer via agent_id
         ]
     }
-    assert v.run(_envelope(payload, sig), jwks, None) == 0  # fallback resolves the bound signer
+    env, tsa_pk = _trusted_envelope(payload, sig)
+    assert v.run(env, jwks, None, trusted_tsa_keys=[tsa_pk]) == 0  # fallback resolves the bound signer
 
 
     # A flipped signature byte on the legit multi-agent receipt FAILs.
@@ -398,7 +399,8 @@ def test_run_structured_agent_id_fallback_passes_legit_multi_agent() -> None:
             _jwks_key("agent-two", "agt_two", "org-legit", a2_pk),  # real signer via agent_id
         ]
     }
-    out = v.run_structured(_envelope(payload, sig), jwks, None)
+    env, tsa_pk = _trusted_envelope(payload, sig)
+    out = v.run_structured(env, jwks, None, trusted_tsa_keys=[tsa_pk])
     axes = {a["name"]: a["result"] for a in out["axes"]}
     assert out["verdict"] == "verified"
     assert out["failure_class"] is None
@@ -490,7 +492,8 @@ def test_run_structured_passes_a_receipt_signed_by_the_claimed_issuer() -> None:
     payload = _valid_payload("org-legit", "agt_one")
     sig = ml.sign(sk, v.canonical_json(payload))
     jwks = {"keys": [_jwks_key("agent-one", "agt_one", "org-legit", pk)]}
-    result = v.run_structured(_envelope(payload, sig, kid="agent-one"), jwks, None)
+    env, tsa_pk = _trusted_envelope(payload, sig, kid="agent-one")
+    result = v.run_structured(env, jwks, None, trusted_tsa_keys=[tsa_pk])
     assert result["verdict"] == "verified", f"axes: {result['axes']}"
     assert result["failure_class"] is None, f"axes: {result['axes']}"
 
@@ -603,3 +606,20 @@ def test_run_prints_nonce_axis(capsys) -> None:
     v.run(envelope, {"keys": []}, predecessor_payload=None)
     out = capsys.readouterr().out
     assert "nonce" in out
+
+
+def test_alg_is_reported_verbatim_from_the_wire(capsys) -> None:
+    """The signature algorithm is per-receipt (ML-DSA-65 cloud, Ed25519/ES256
+    local); both surfaces report the signature.alg wire value, not a constant."""
+    envelope = {
+        "payload": _risk_payload(),
+        "signature": {"alg": "Ed25519", "kid": "c37probe-org-00001", "sig": "AAAA"},
+        "anchors": [],
+    }
+    v.run(envelope, {"keys": []}, predecessor_payload=None)
+    out = capsys.readouterr().out
+    assert "signature.alg:   Ed25519" in out
+    result = v.run_structured(envelope, {"keys": []}, None)
+    assert result["alg"] == "Ed25519"
+    # A non-object input carries no wire alg; the field is present and null.
+    assert v.run_structured("not-an-object", {"keys": []})["alg"] is None

--- a/python/tests/tsa_testkit.py
+++ b/python/tests/tsa_testkit.py
@@ -1,0 +1,154 @@
+"""Mint minimal RFC 3161 TimeStampResp tokens for the anchor-verification tests.
+
+A real TSA token is a CMS SignedData wrapping a TSTInfo; the verifier parses
+the DER directly, so the tests need tokens built byte by byte rather than by a
+TSA service. The shape mirrors the production anchor in
+verifier/docs/fixtures/published-receipt.json: no signedAttrs (the TSA signs
+the eContent bytes directly) and a [0] subjectKeyIdentifier sid.
+"""
+
+from __future__ import annotations
+
+import base64
+
+
+def _len(n: int) -> bytes:
+    if n < 0x80:
+        return bytes([n])
+    body = n.to_bytes((n.bit_length() + 7) // 8, "big")
+    return bytes([0x80 | len(body)]) + body
+
+
+def _tlv(tag: int, content: bytes) -> bytes:
+    return bytes([tag]) + _len(len(content)) + content
+
+
+def _seq(*items: bytes) -> bytes:
+    return _tlv(0x30, b"".join(items))
+
+
+def _set(*items: bytes) -> bytes:
+    return _tlv(0x31, b"".join(items))
+
+
+def _int(n: int) -> bytes:
+    body = n.to_bytes(max(1, (n.bit_length() + 7) // 8), "big")
+    if body[0] & 0x80:
+        body = b"\x00" + body
+    return _tlv(0x02, body)
+
+
+def _oid(dotted: str) -> bytes:
+    arcs = [int(x) for x in dotted.split(".")]
+    out = bytearray([arcs[0] * 40 + arcs[1]])
+    for arc in arcs[2:]:
+        stack = [arc & 0x7F]
+        arc >>= 7
+        while arc:
+            stack.append(0x80 | (arc & 0x7F))
+            arc >>= 7
+        out.extend(reversed(stack))
+    return _tlv(0x06, bytes(out))
+
+
+def _oct(content: bytes) -> bytes:
+    return _tlv(0x04, content)
+
+
+_OID_SHA256 = "2.16.840.1.101.3.4.2.1"
+_OID_SIGNED_DATA = "1.2.840.113549.1.7.2"
+_OID_TSTINFO = "1.2.840.113549.1.9.16.1.4"
+_OID_ML_DSA_65 = "2.16.840.1.101.3.4.3.18"
+
+
+def make_tst_info(digest32: bytes, gen_time: str = "20260601000000Z") -> bytes:
+    """A TSTInfo committing digest32, signed-content form the verifier parses."""
+    return _seq(
+        _int(1),
+        _oid("1.2.3.4"),  # policy OID, opaque to the check
+        _seq(_seq(_oid(_OID_SHA256), _tlv(0x05, b"")), _oct(digest32)),
+        _int(42),
+        _tlv(0x18, gen_time.encode("ascii")),
+    )
+
+
+_OID_CONTENT_TYPE = "1.2.840.113549.1.9.3"
+_OID_MESSAGE_DIGEST = "1.2.840.113549.1.9.4"
+
+
+def make_signed_attrs(
+    tst: bytes,
+    *,
+    include_content_type: bool = True,
+    content_type_oid: str = _OID_TSTINFO,
+    message_digest: bytes | None = None,
+) -> bytes:
+    """The signedAttrs CONTENT bytes (attributes concatenated, no outer tag).
+
+    Public TSAs all emit signedAttrs; the production fixture does not, so this
+    is what exercises the `_cms_message_digest_ok` / `_cms_signed_bytes` branch.
+    The knobs exist to build the RFC 5652 s11.1 violations the verifier must
+    reject: a missing contentType, and a contentType naming other content.
+    """
+    import hashlib
+
+    digest = hashlib.sha256(tst).digest() if message_digest is None else message_digest
+    attrs = b""
+    if include_content_type:
+        attrs += _seq(_oid(_OID_CONTENT_TYPE), _set(_oid(content_type_oid)))
+    attrs += _seq(_oid(_OID_MESSAGE_DIGEST), _set(_oct(digest)))
+    return attrs
+
+
+def signed_attrs_signing_input(attrs: bytes) -> bytes:
+    """Bytes a CMS signature covers when signedAttrs is present: SET OF re-tag."""
+    return _tlv(0x31, attrs)
+
+
+def make_timestamp_resp(
+    tst: bytes,
+    signature: bytes,
+    *,
+    status: int = 0,
+    sig_alg_oid: str = _OID_ML_DSA_65,
+    certs: list[bytes] | None = None,
+    sid: bytes | None = None,
+    signed_attrs: bytes | None = None,
+    econtent_type_oid: str = _OID_TSTINFO,
+) -> bytes:
+    """Wrap a TSTInfo and its CMS signature in a TimeStampResp.
+
+    ``signed_attrs`` carries the signedAttrs CONTENT bytes (see
+    make_signed_attrs); omit it for the no-signedAttrs production shape.
+    """
+    signer_fields = [
+        _int(3),
+        sid if sid is not None else _tlv(0xA0, b"\x00" * 20),  # [0] SKI, as in production
+        _seq(_oid(_OID_SHA256), _tlv(0x05, b"")),
+    ]
+    if signed_attrs is not None:
+        signer_fields.append(_tlv(0xA0, signed_attrs))  # [0] IMPLICIT SignedAttributes
+    signer_fields += [
+        _seq(_oid(sig_alg_oid)),
+        _oct(signature),
+    ]
+    sd_items = [
+        _int(3),
+        _set(_seq(_oid(_OID_SHA256), _tlv(0x05, b""))),
+        _seq(_oid(econtent_type_oid), _tlv(0xA0, _oct(tst))),
+    ]
+    if certs:
+        sd_items.append(_tlv(0xA0, b"".join(certs)))  # [0] IMPLICIT CertificateSet
+    sd_items.append(_set(_seq(*signer_fields)))
+    content_info = _seq(_oid(_OID_SIGNED_DATA), _tlv(0xA0, _seq(*sd_items)))
+    return _seq(_seq(_int(status)), content_info)
+
+
+def mint_ml_dsa_anchor(digest32: bytes, gen_time: str = "20260601000000Z"):
+    """(base64 token, raw public key) for a fresh ML-DSA-65 TSA keypair."""
+    from dilithium_py.ml_dsa import ML_DSA_65
+
+    pk, sk = ML_DSA_65.keygen()
+    tst = make_tst_info(digest32, gen_time)
+    token = make_timestamp_resp(tst, ML_DSA_65.sign(sk, tst))
+    return base64.b64encode(token).decode(), pk

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -121,7 +121,7 @@ The envelope extensions most callers reach for, camelCase on the SDK and snake_c
 
 ## Compliance receipts: the IETF profile
 
-Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 signature, JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `complianceMode: false` if you want the older shape.
+Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): cloud-issued receipts carry an ML-DSA-65 signature (locally signed receipts carry Ed25519/ES256 — the algorithm is per-receipt in `signature.alg`), JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `complianceMode: false` if you want the older shape.
 
 ### Shadow AI capture with passive_telemetry
 

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -1,11 +1,9 @@
 /**
- * A focused port of the standalone `verify_receipt.py` helpers the Asqav-native
- * and ACTA adapters reuse, so the TS oracle reproduces the same bytes and the
- * same structure verdict as the Python surface.
- *
- * Only the pieces the adapters touch are ported: base64 decoding, envelope
- * normalisation, the Asqav-native structure check, JWKS key resolution, and the
- * first-receipt seed constant.
+ * A focused port of the `verify_receipt.py` helpers the Asqav-native and ACTA
+ * adapters reuse, so the TS oracle reproduces the same bytes and the same
+ * structure verdict as the Python surface. Only what those adapters touch is
+ * ported: base64 decoding, envelope normalisation, the structure check, JWKS key
+ * resolution, and the first-receipt seed.
  */
 
 import { asqavJcs } from "./canonical.js";
@@ -227,8 +225,8 @@ function matchKey(
   return null;
 }
 
-// Exact key id (mirrors `_match_key_by_id`). A key id names one key, while the
-// issuer match above answers for every key an org publishes, which is a set.
+// Exact key id (mirrors `_match_key_by_id`): a key id names one key, while the
+// issuer match above answers for a whole set.
 function matchKeyById(
   jwks: Record<string, unknown> | null,
   kid: string,
@@ -247,8 +245,7 @@ function matchKeyById(
 
 // An agent key bound to the issuer the receipt claims (mirrors `_match_key_by_agent`).
 // agent_id is attacker-controlled, so the key's published issuer (or org) must equal
-// the one the receipt names inside its signed bytes; a hash-mode receipt signs the raw
-// org_id, so the org binding answers for that shape and names exactly one sibling.
+// the one the receipt names inside its signed bytes.
 function matchKeyByAgent(
   jwks: Record<string, unknown> | null,
   agentId: unknown,
@@ -273,13 +270,11 @@ function matchKeyByAgent(
 /**
  * The one JWKS entry a receipt's signature is checked against (mirrors `match_signing_key`).
  *
- * Exact key id, then the agent bind, then the bare-kid issuer match. A cloud receipt
- * puts the org id in kid and signs with the agent's own key, and the directory
- * publishes issuer_id on every key that org owns, so an org-shaped kid matches each
- * sibling alike and list position picks one. Position binds nothing: agent_id and
- * issuer_id both sit inside the signed bytes, so the pair names the signer, while the
- * sibling it lands on holds other key bytes and another revocation status. The agent
- * bind carries the org_id a hash-mode receipt signs, so the right sibling resolves.
+ * Order carries the security: exact key id, then the agent bind, then the bare-kid
+ * issuer match. An org-shaped kid matches every sibling that org publishes alike, so
+ * list position would pick one arbitrarily, and position binds nothing while the
+ * sibling holds other key bytes and another revocation status. The agent bind carries
+ * the org_id a hash-mode receipt signs, so the right sibling resolves first.
  */
 export function matchSigningKey(
   jwks: Record<string, unknown> | null,
@@ -444,8 +439,7 @@ const B64_STRICT = /^[A-Za-z0-9+/]*={0,2}$/;
  * True when Python's `_safe_b64` accepts `value`, false otherwise.
  *
  * Strict on purpose: an out-of-alphabet character is refused, not dropped, so a
- * forged all-punctuation anchor cannot read as present. A non-ASCII codepoint
- * falls outside the alphabet here, matching the ascii encode Python raises on.
+ * forged all-punctuation anchor cannot read as present.
  */
 function safeB64(value: unknown): boolean {
   if (typeof value !== "string") return false;
@@ -540,6 +534,11 @@ export function checkExpiry(payload: unknown): readonly [VerifyState, string] {
  * Absent or null anchors is a legitimate no-anchors receipt (SKIPPED). A present
  * non-list value is malformed and FAILs, never laundered to an empty list.
  * `anchors` sits outside the signed bytes, so a forged envelope can move it.
+ *
+ * This shim runs no ASN.1/CMS or ots evaluation, so it never returns PASS - safe -
+ * but it also never returns `invalid`, which is not: Python calls a provably forged
+ * imprint FAIL/invalid where this reports unverifiable. Use the Python verifier when
+ * "proven forged" must be distinguished from "not checked".
  */
 export function checkAnchors(envelope: Record<string, unknown>): readonly [VerifyState, string] {
   const anchors = envelope.anchors;
@@ -560,10 +559,11 @@ export function checkAnchors(envelope: Record<string, unknown>): readonly [Verif
     return ["FAIL", "envelope too deeply nested to canonicalise for anchor binding"];
   }
   const lines = [`anchors bind envelope digest sha256:${bound.slice(0, 16)}..`];
-  let allOk = true;
+  let sawInvalid = false;
+  let sawUnverifiable = false;
   for (const a of anchors as unknown[]) {
     if (a === null || typeof a !== "object" || Array.isArray(a)) {
-      allOk = false;
+      sawInvalid = true;
       lines.push(`    - malformed anchor entry (got ${pyTypeName(a)}, expected an object)`);
       continue;
     }
@@ -571,11 +571,32 @@ export function checkAnchors(envelope: Record<string, unknown>): readonly [Verif
     const atype = "type" in entry ? entry.type : "?";
     const val = entry.value;
     const ok = pyTruthy(val) && safeB64(val);
-    allOk = allOk && ok;
-    const state = ok ? "present, base64-ok" : "MISSING or malformed";
-    lines.push(`    - ${pyStr(atype)}: value ${state}`);
+    if (!ok) {
+      sawInvalid = true;
+      lines.push(`    - ${pyStr(atype)}: value MISSING or malformed`);
+      continue;
+    }
+    const status = entry.status;
+    if (status === "pending" || status === "failed") {
+      // A declared non-anchored status is never a trusted anchor (draft rule).
+      sawUnverifiable = true;
+      lines.push(`    - ${pyStr(atype)}: value present, base64-ok; status ${status}, not an anchored proof`);
+      continue;
+    }
+    sawUnverifiable = true;
+    const detail =
+      atype === "rfc3161"
+        ? "offline RFC3161 check did not complete"
+        : atype === "opentimestamps"
+          ? "offline OpenTimestamps check did not complete"
+          : "no offline verifier for this anchor type";
+    lines.push(`    - ${pyStr(atype)}: value present, base64-ok; unverifiable (${detail})`);
   }
-  return [allOk ? "PASS" : "FAIL", lines.join("; ")];
+  if (sawInvalid) {
+    return ["FAIL", lines.join("; ")];
+  }
+  // No PASS branch: every shape-valid entry above is unverifiable here.
+  return ["SKIPPED", lines.join("; ")];
 }
 
 // Mirrors Python REVOKED_KEY_STATUSES; receipts from these keys must not PASS offline.

--- a/typescript/tests/verifier-anchor-forged-value.test.ts
+++ b/typescript/tests/verifier-anchor-forged-value.test.ts
@@ -99,10 +99,13 @@ describe("forged anchor value", () => {
     expect(note).not.toContain("base64-ok");
   });
 
+  // Genuine base64 passes the shape gate, but shape is not proof: since the
+  // cryptographic anchor check landed, a non-token value reports unverifiable.
   it.each(LEGITIMATE)("still accepts %j", (value) => {
     const [state, note] = axisFor(value);
-    expect(state).toBe("PASS");
+    expect(state).toBe("SKIPPED");
     expect(note).toContain("present, base64-ok");
+    expect(note).toContain("unverifiable");
   });
 
   it.each(NON_STRINGS.map((v) => [v]))("never reads non-string %j as present", (value) => {
@@ -124,12 +127,14 @@ describe("forged anchor value", () => {
   });
 
   it("keeps every encoding a real signer emits", () => {
+    // Every encoding passes the shape gate; the crypto check then reports
+    // unverifiable for a non-token, never PASS.
     for (let n = 1; n <= 128; n++) {
       const raw = Buffer.from(Array.from({ length: n }, (_, i) => (n * 31 + i * 7) % 256));
       const std = raw.toString("base64");
       const url = raw.toString("base64url");
       for (const value of [std, std.replace(/=+$/, ""), url, url.replace(/=+$/, "")]) {
-        expect(axisFor(value)[0], value).toBe("PASS");
+        expect(axisFor(value)[0], value).toBe("SKIPPED");
       }
     }
   });

--- a/typescript/tests/verifier-anchor-value-parity.test.ts
+++ b/typescript/tests/verifier-anchor-value-parity.test.ts
@@ -25,7 +25,8 @@ const ENVELOPE = {
   signature: { alg: "ML-DSA-65", kid: "k1", sig: "AAAA" },
 };
 
-/** The axis result for one anchor value, which is PASS exactly when the value decodes. */
+/** The axis result for one anchor value: FAIL on junk, SKIPPED (unverifiable) on
+ * shape-valid non-tokens since the cryptographic anchor check landed. */
 function axisFor(value: string): string {
   return checkAnchors({ ...ENVELOPE, anchors: [{ type: "rfc3161", value }] })[0];
 }
@@ -35,7 +36,10 @@ describe("anchor value base64 parity", () => {
     expect(VALUES.length).toBeGreaterThanOrEqual(900);
     const wide = VALUES.filter((c) => [...c.value].some((ch) => ch.codePointAt(0)! > 127));
     expect(wide.length).toBeGreaterThanOrEqual(350);
-    expect(VALUES.filter((c) => c.expect.axis === "PASS").length).toBeGreaterThanOrEqual(100);
+    // Both directions present: junk FAILs (invalid), shape-valid non-tokens
+    // SKIP (unverifiable, never PASS on presence).
+    expect(VALUES.filter((c) => c.expect.axis === "FAIL").length).toBeGreaterThanOrEqual(100);
+    expect(VALUES.filter((c) => c.expect.axis === "SKIPPED").length).toBeGreaterThanOrEqual(100);
   });
 
   // Python's b64decode(validate=True) accepts this shape on 3.11 and raises on

--- a/typescript/tests/verifier-axis-parity.test.ts
+++ b/typescript/tests/verifier-axis-parity.test.ts
@@ -55,6 +55,13 @@ interface ChainPrevCase {
   expect: { verdict: string; chain: string; signature: string };
 }
 
+interface DivergenceCase {
+  name: string;
+  envelope: Record<string, unknown>;
+  expect_python: { result: string; note_contains: string };
+  expect_ts: { result: string; note_contains: string };
+}
+
 const CASES_FILE = resolve(__dirname, "..", "..", "verifier", "axis-parity-cases.json");
 const TABLE = JSON.parse(readFileSync(CASES_FILE, "utf-8")) as {
   anchors: AnchorCase[];
@@ -62,6 +69,7 @@ const TABLE = JSON.parse(readFileSync(CASES_FILE, "utf-8")) as {
   normalise: NormaliseCase[];
   expiry: ExpiryCase[];
   chain_prev_hash: ChainPrevCase[];
+  anchors_divergence: DivergenceCase[];
 };
 
 const PIPELOCK_VECTOR = resolve(
@@ -119,6 +127,27 @@ describe("anchor-binding axis parity", () => {
       // The digest in the note is the JCS of the envelope minus anchors, so an
       // exact match also proves the two canonicalisers agree byte for byte.
       expect(note, c.name).toBe(c.expect.note);
+    });
+  }
+});
+
+// Cases where the two halves legitimately disagree, because this shim carries no
+// anchor cryptography (criterion 446). The Python side of the same rows is
+// asserted in python/tests/test_axis_parity_cases.py.
+describe("anchor divergence from the Python verifier", () => {
+  it("the divergence table is populated and two-sided", () => {
+    expect(TABLE.anchors_divergence.length).toBeGreaterThanOrEqual(2);
+    const py = new Set(TABLE.anchors_divergence.map((c) => c.expect_python.result));
+    expect([...py].sort()).toEqual(["FAIL", "PASS"]);
+  });
+
+  for (const c of TABLE.anchors_divergence) {
+    it(c.name, () => {
+      const [result, note] = checkAnchors(c.envelope);
+      expect(result, c.name).toBe(c.expect_ts.result);
+      expect(note, c.name).toContain(c.expect_ts.note_contains);
+      // The divergence itself: Python reaches a verdict this shim cannot.
+      expect(result, c.name).not.toBe(c.expect_python.result);
     });
   }
 });

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -76,13 +76,21 @@ python -m asqav.verifier.verify_receipt --receipt receipt.json --jwks jwks.json 
 | canonical bytes | JCS reproduction | stdlib `json` (sorted keys, no whitespace, UTF-8) |
 | issuer_key | key resolution by `kid` | matched against `/.well-known/jwks.json` |
 | chain | SHA-256 link to predecessor | stdlib `hashlib` |
-| anchors | which envelope each anchor binds | stdlib `hashlib` + `base64` |
+| anchors | each anchor's token must commit `sha256(JCS(envelope minus anchors))`; RFC3161 TSA signature against pinned TSA key material, OpenTimestamps merkle path against supplied bitcoin headers | stdlib DER/ots parse + `dilithium-py`/`cryptography` for the TSA signature |
 | skew | `issued_at` within 300s of now | stdlib `datetime` |
 | structure | required fields and type namespace | stdlib |
 
-It does **not** perform the full RFC3161 certificate-chain walk or
-`policy_digest` artefact resolution; both need server state or ASN.1. For those,
-use the hosted `/verify` endpoint or the full Asqav SDK.
+An anchor never PASSes on presence alone: a token whose check runs and fails is
+`invalid`, and one the check cannot complete offline (no pinned TSA key via
+`--tsa-key`, no header source via `--bitcoin-headers`, a `pending`/`failed`
+status, an unknown type) reports `unverifiable`. A verified anchor whose proven
+time lands at or before a key's `revoked_at` lets a pre-revocation receipt pass
+the `key_status` axis; a forged or unverifiable one never does.
+
+It does **not** perform a PKI chain walk from the TSA certificate to a public
+root — offline trust comes from the TSA key material you pin — or
+`policy_digest` artefact resolution. For those, use the hosted `/verify`
+endpoint or the full Asqav SDK.
 
 ## The same axes from TypeScript
 

--- a/verifier/anchor-value-cases.json
+++ b/verifier/anchor-value-cases.json
@@ -1,5 +1,5 @@
 {
-  "note": "Anchor value corpus for the base64 tolerance inside the anchors axis. Expectations are the output of the Python _safe_b64 in python/src/asqav/verifier/verify_receipt.py, which accepts a value only when it is genuinely base64 and decodes to at least one byte. Both suites assert every value, and the TypeScript half additionally asserts that no disagreement is permissive: a value Python refuses must never read as base64-ok, since the anchors field is unsigned and attacker-steerable. A JSON string admits every codepoint, so the corpus sweeps Unicode rather than ASCII alone.",
+  "note": "Anchor value corpus for the base64 tolerance inside the anchors axis. Expectations are the output of the Python _safe_b64 and check_anchors in python/src/asqav/verifier/verify_receipt.py: _safe_b64 accepts a value only when it is genuinely base64 and decodes to at least one byte; the axis FAILs a value that is not (invalid) and, since the cryptographic anchor check landed, reports SKIPPED (unverifiable) for a shape-valid value that is not a verifiable token - never PASS on presence alone. Both suites assert every value, and the TypeScript half additionally asserts that no disagreement runs in the permissive direction: a value Python refuses must never read as base64-ok, since the anchors field is unsigned and attacker-steerable. A JSON string admits every codepoint, so the corpus sweeps Unicode rather than ASCII alone.",
   "values": [
     {
       "value": "",
@@ -19,21 +19,21 @@
       "value": "ab",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "abc",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "abcd",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -103,42 +103,42 @@
       "value": "MTIzNA==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "MTIzNA=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "MTIzNA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "YWJjZA==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "-_-_",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "+/+/",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -187,21 +187,21 @@
       "value": "AA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -222,95 +222,95 @@
       "value": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "\u00e9",
+      "value": "é",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u4e2d\u6587",
+      "value": "中文",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud83d\ude00",
+      "value": "😀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00a0",
+      "value": " ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00e1bc",
+      "value": "ábc",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "MTIzNA==\u00e9",
+      "value": "MTIzNA==é",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00e9MTIzNA==",
+      "value": "éMTIzNA==",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "MTI\u200bzNA==",
+      "value": "MTI​zNA==",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "e\u0301",
+      "value": "é",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "MTIzNA==\u2014",
+      "value": "MTIzNA==—",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0416",
+      "value": "Ж",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u65e5\u672c\u8a9e\u30c6\u30b9\u30c8",
+      "value": "日本語テスト",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -324,77 +324,77 @@
       }
     },
     {
-      "value": "\u00a0MTIzNA==",
+      "value": " MTIzNA==",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "MTIzNA\u00a0==",
+      "value": "MTIzNA ==",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "caf\u00e9",
+      "value": "café",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "na\u00efve",
+      "value": "naïve",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "MT\u0301IzNA==",
+      "value": "MT́IzNA==",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud83d\udd12\ud83d\udd12\ud83d\udd12\ud83d\udd12",
+      "value": "🔒🔒🔒🔒",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "MTIzNA==\ud83d\ude00",
+      "value": "MTIzNA==😀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "a\u00e9",
+      "value": "aé",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00e9a",
+      "value": "éa",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "aa\u00e9",
+      "value": "aaé",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "aaa\u00e9",
+      "value": "aaaé",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -572,7 +572,7 @@
       "value": "HlCh",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -586,7 +586,7 @@
       "value": "RuXf",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -691,7 +691,7 @@
       "value": "O02",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -817,7 +817,7 @@
       "value": "ur",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -978,25 +978,25 @@
       "value": "qTvm",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "]:\u0416\u00fc0\u0301",
+      "value": "]:Жü0́",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": ".\u0416jPj\u00f1\u672c",
+      "value": ".ЖjPjñ本",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "lG\u8a9ed\\\u04166",
+      "value": "lG語d\\Ж6",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1010,21 +1010,21 @@
       }
     },
     {
-      "value": "C$\ud83d\udd12a",
+      "value": "C$🔒a",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "_\ud83d\udd12\u00fc\ud83d\ude00S",
+      "value": "_🔒ü😀S",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud83d\udd12ZD0\u00fca\u672c",
+      "value": "🔒ZD0üa本",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1045,14 +1045,14 @@
       }
     },
     {
-      "value": "\ud83d\ude00vT\u8a9e",
+      "value": "😀vT語",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "Yk\u672c2",
+      "value": "Yk本2",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1062,18 +1062,18 @@
       "value": "fa",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "`j\u0416",
+      "value": "`jЖ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": ")\u0419\ud83d\ude00u5 p",
+      "value": ")Й😀u5 p",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1083,46 +1083,46 @@
       "value": "byp",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "Bv/J",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "\u0416\u4e2d",
+      "value": "Ж中",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0301\ud83d\udd12\u0419ll",
+      "value": "́🔒Йll",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "b(\u0416",
+      "value": "b(Ж",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "a\u0416\u65879^i[\u00fc",
+      "value": "aЖ文9^i[ü",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud83d\udd12\"w",
+      "value": "🔒\"w",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1136,35 +1136,35 @@
       }
     },
     {
-      "value": "\ud83d\udd129io",
+      "value": "🔒9io",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": ")\u4e2d",
+      "value": ")中",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u672c4x\u00e9O5Z",
+      "value": "本4xéO5Z",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "C\u672cx\u00e9\u2014n\u8a9e",
+      "value": "C本xé—n語",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "t\u00fcy\u00f15",
+      "value": "tüyñ5",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1178,7 +1178,7 @@
       }
     },
     {
-      "value": "\u6587\u00e0p",
+      "value": "文àp",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1192,42 +1192,42 @@
       }
     },
     {
-      "value": "`\u8a9eO",
+      "value": "`語O",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "glX\u65e5\u200b7\u0416",
+      "value": "glX日​7Ж",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "|L\u00f1h",
+      "value": "|Lñh",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "W5\u8a9e\u00e0\u672c\u00e0tz",
+      "value": "W5語à本àtz",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": ">\u00a0\ud83d\udd12{v6&P",
+      "value": "> 🔒{v6&P",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "[Xe?\u2014",
+      "value": "[Xe?—",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1244,11 +1244,11 @@
       "value": "5s",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "Y\u00e9",
+      "value": "Yé",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1262,42 +1262,42 @@
       }
     },
     {
-      "value": "D/\"[G\u0301",
+      "value": "D/\"[Ǵ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u4e2dM$ ",
+      "value": "中M$ ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "^\ud83d\udd12",
+      "value": "^🔒",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "U\u0301\u65e5\u0416",
+      "value": "Ú日Ж",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2014XT\u6587\u00f1",
+      "value": "—XT文ñ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "$T\u00f1d\u672cFx",
+      "value": "$Tñd本Fx",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1311,42 +1311,42 @@
       }
     },
     {
-      "value": "f\u0301G",
+      "value": "f́G",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "}\u00fc%\u2014<\u00e9_>",
+      "value": "}ü%—<é_>",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00f1M\ud83d\udd12&",
+      "value": "ñM🔒&",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "7HD\u672cK?e",
+      "value": "7HD本K?e",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u8a9e\u00e0tPf\u00fc ",
+      "value": "語àtPfü ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "8\u0301",
+      "value": "8́",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1360,28 +1360,28 @@
       }
     },
     {
-      "value": "\\D\u04167\u672c",
+      "value": "\\DЖ7本",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "D\u03018\ud83d\ude00\u00a0",
+      "value": "D́8😀 ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "bW\u4e2d\\\u0301tu6",
+      "value": "bW中\\́tu6",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "Ks?\ud83d\ude00lD@",
+      "value": "Ks?😀lD@",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -1776,28 +1776,28 @@
       "value": "--",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "---",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "----",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "--------",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -2189,28 +2189,28 @@
       "value": "__",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "___",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "____",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "________",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -2462,7 +2462,7 @@
       "value": "YQ==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -2662,28 +2662,28 @@
       }
     },
     {
-      "value": "YQ==\u007f",
+      "value": "YQ==",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u007fYQ==",
+      "value": "YQ==",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "YQ\u007f==",
+      "value": "YQ==",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u007fAAAA",
+      "value": "AAAAAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -2952,21 +2952,21 @@
       "value": "AY",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "Nyc",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "mjsg",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -2980,21 +2980,21 @@
       "value": "0rmj+3",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "xzVnw/+",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "LNDP5eha",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -3008,21 +3008,21 @@
       "value": "yz8/pobb7B",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "rh+DdfcSFwe",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "NKZ76EEz6vuL",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -3036,21 +3036,21 @@
       "value": "Ppjp4oaSPbK7VQ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "zA4IJuWwCm64f8Q",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "CuItZUMxcO493y+E",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -3064,21 +3064,21 @@
       "value": "YCUSTjb2bSX0uQdbNk",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "duS7Szpgo76Onkg94hi",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "ORUm2HGlbO+08cIaGAkE",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
@@ -3092,1901 +3092,1901 @@
       "value": "BRuvDP+lD1MzTmjMe8d87T",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "i8n9sh0qhNGUoJ/hjXvMiFq",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "CZdSWJJVSMBSx96KTNjYimKK",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAAAAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAAAAAAAAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAAAAAAAAAAAAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAAA_synthetic_tsr_base64_placeholder_AAAA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "XngedBv0",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "HvNhUPYrLCxrwcUN",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "i+tI",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "zHTuDpFY5zp1K5Jd",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "j/MUitruRQd9M9U5",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "udi2hiFS2eCnm561ovAdkL2uzOPmybfjsoWRbAStZ16ReP5nkpClDnWJcIFxYCoD",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "0b8z9fL4NGjnRfpX",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "oe+F0J91swRxj9NZ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "8Vl4EzmgEZuX4m7WwbYtSGZcyMeWu38T",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "/jpKDFYWGa1u2Gds",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "YQWDsMZGZjHKSXIQ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "JRc0EuyCB6VidOrR4ZdIol8Y",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "v8oRWNAufzHfTeMU7Ci15uXJROjtXBG4",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "3XgRhktdj3iaRh2CjE86iN1Ak2IsvLu8uwQN3b/NdHyuB7andcIwTbsg/WCv6z8O",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "J3aj5ioaMocjnyXBjdtZ2RMl",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "N6ED",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "YzzHatAzERKNY4fCvBxnfY/8",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "siCo2pMGypW0XwSkbfOz0g+fTzsXN7OoRWphe1px6uhD5H9yM7iHVWsdWeOMuNlQ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "J9e1",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "y1fNGRlFJUHD",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "JR+IK81ZC59KDMNKLNr9OPtCLPDx7+wtEH08PMoQyquq2/oJtWtL4znFe9jnaQv8",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "mTZ1afwRiG6GdCU33OkFW3kXydDKBVoraAjKyNAWjYiJtCYN1aZkcBnk8s/J5+SK",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "BZ5WNYTiLhYgW1f/0mj8y+vxnemAqLh4",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "JdEjKGwV0KTnuFY9hxhER8mhg7svd9+iuJT9ibN6O+bySX5HHsAEI9W6b3d8XRXo",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "0T/7gc7GITnmpkOJagmMTN9c",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "iTJLMPkLXXluacJG9mcz/HEx",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "c6HlMM0Pw1jN",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "Xplmmn6KYwgzQjgzDYf7vEfc80ITWxHf",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "CoomZCGZ8soaVUhtiEO4ZelAJzxE6N+0De1O2528cdK1ggZiLZ0PRQgZa3++xwUj",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "hv45OTHlwNXu",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "o_3D",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "ZnhgqwPkOROh33TAz0OM1GbW8doCVnFf",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "k5LMgPtR_OlpFft3",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "DLbD",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "ufVDRO8H",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "qvlg",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "CNTFyEkWrxEtCHrsoEn4XRh9pq71N1Ai",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "eEdOEgzh58sMkZds",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "3VrLAme_QKpNfRLFOKCTZlzJNDZ9uudG",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "RpIdp5D4Pph0iO-N",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "hhyn-bq1UiWYA2Gc",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "lZYsIxJw4yiYVcf-",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "Ot7P",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "gKcgWqHq_f4fnw4C",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "XcNk5wvOn4vQtLCazwp4uasCtCRkx087",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "Qt8xhyCrJ7gNK42C",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "hO4iNFhj7AcnligTaiZqIszbbjWwzQz7",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "q18i8sYliNf6Aq-gv_2fhnTZO7vggqNl",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "0eiG",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "5aSrs-kkT55xNbkbGIfjR34y37QrJtIv",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "\u00a0\u00a0\u00a0\u00a0",
+      "value": "    ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u00a0",
+      "value": "AAAA ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00a0AAAA",
+      "value": " AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u00a0AA",
+      "value": "AA AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0085",
+      "value": "",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0085\u0085\u0085\u0085",
+      "value": "",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u0085",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0085AAAA",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u0085AA",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u1680",
+      "value": " ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u1680\u1680\u1680\u1680",
+      "value": "    ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u1680",
+      "value": "AAAA ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u1680AAAA",
+      "value": " AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u1680AA",
+      "value": "AA AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2000",
+      "value": " ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2000\u2000\u2000\u2000",
+      "value": "    ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u2000",
+      "value": "AAAA ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2000AAAA",
+      "value": " AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u2000AA",
+      "value": "AA AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2007",
+      "value": " ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2007\u2007\u2007\u2007",
+      "value": "    ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u2007",
+      "value": "AAAA ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2007AAAA",
+      "value": " AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u2007AA",
+      "value": "AA AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2028",
+      "value": " ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2028\u2028\u2028\u2028",
+      "value": "    ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u2028",
+      "value": "AAAA ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2028AAAA",
+      "value": " AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u2028AA",
+      "value": "AA AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2029",
+      "value": " ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2029\u2029\u2029\u2029",
+      "value": "    ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u2029",
+      "value": "AAAA ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2029AAAA",
+      "value": " AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u2029AA",
+      "value": "AA AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u202f",
+      "value": " ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u202f\u202f\u202f\u202f",
+      "value": "    ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u202f",
+      "value": "AAAA ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u202fAAAA",
+      "value": " AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u202fAA",
+      "value": "AA AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u205f",
+      "value": " ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u205f\u205f\u205f\u205f",
+      "value": "    ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u205f",
+      "value": "AAAA ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u205fAAAA",
+      "value": " AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u205fAA",
+      "value": "AA AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u3000",
+      "value": "　",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u3000\u3000\u3000\u3000",
+      "value": "　　　　",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u3000",
+      "value": "AAAA　",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u3000AAAA",
+      "value": "　AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u3000AA",
+      "value": "AA　AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200b",
+      "value": "​",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200b\u200b\u200b\u200b",
+      "value": "​​​​",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u200b",
+      "value": "AAAA​",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200bAAAA",
+      "value": "​AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u200bAA",
+      "value": "AA​AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200c",
+      "value": "‌",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200c\u200c\u200c\u200c",
+      "value": "‌‌‌‌",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u200c",
+      "value": "AAAA‌",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200cAAAA",
+      "value": "‌AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u200cAA",
+      "value": "AA‌AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200d",
+      "value": "‍",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200d\u200d\u200d\u200d",
+      "value": "‍‍‍‍",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u200d",
+      "value": "AAAA‍",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200dAAAA",
+      "value": "‍AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u200dAA",
+      "value": "AA‍AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ufeff",
+      "value": "﻿",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ufeff\ufeff\ufeff\ufeff",
+      "value": "﻿﻿﻿﻿",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\ufeff",
+      "value": "AAAA﻿",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ufeffAAAA",
+      "value": "﻿AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\ufeffAA",
+      "value": "AA﻿AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200e",
+      "value": "‎",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200e\u200e\u200e\u200e",
+      "value": "‎‎‎‎",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u200e",
+      "value": "AAAA‎",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u200eAAAA",
+      "value": "‎AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u200eAA",
+      "value": "AA‎AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u202e",
+      "value": "‮",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u202e\u202e\u202e\u202e",
+      "value": "‮‮‮‮",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u202e",
+      "value": "AAAA‮",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u202eAAAA",
+      "value": "‮AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u202eAA",
+      "value": "AA‮AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00e9\u00e9\u00e9\u00e9",
+      "value": "éééé",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u00e9",
+      "value": "AAAAé",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00e9AAAA",
+      "value": "éAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u00e9AA",
+      "value": "AAéAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00c0",
+      "value": "À",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00c0\u00c0\u00c0\u00c0",
+      "value": "ÀÀÀÀ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u00c0",
+      "value": "AAAAÀ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00c0AAAA",
+      "value": "ÀAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u00c0AA",
+      "value": "AAÀAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0141",
+      "value": "Ł",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0141\u0141\u0141\u0141",
+      "value": "ŁŁŁŁ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u0141",
+      "value": "AAAAŁ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0141AAAA",
+      "value": "ŁAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u0141AA",
+      "value": "AAŁAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0301",
+      "value": "́",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0301\u0301\u0301\u0301",
+      "value": "́́́́",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u0301",
+      "value": "AAAÁ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0301AAAA",
+      "value": "́AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u0301AA",
+      "value": "AÁAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0416\u0416\u0416\u0416",
+      "value": "ЖЖЖЖ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u0416",
+      "value": "AAAAЖ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0416AAAA",
+      "value": "ЖAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u0416AA",
+      "value": "AAЖAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u05d0",
+      "value": "א",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u05d0\u05d0\u05d0\u05d0",
+      "value": "אאאא",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u05d0",
+      "value": "AAAAא",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u05d0AAAA",
+      "value": "אAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u05d0AA",
+      "value": "AAאAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0627",
+      "value": "ا",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0627\u0627\u0627\u0627",
+      "value": "اااا",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u0627",
+      "value": "AAAAا",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0627AAAA",
+      "value": "اAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u0627AA",
+      "value": "AAاAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u4e2d",
+      "value": "中",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u4e2d\u4e2d\u4e2d\u4e2d",
+      "value": "中中中中",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u4e2d",
+      "value": "AAAA中",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u4e2dAAAA",
+      "value": "中AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u4e2dAA",
+      "value": "AA中AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u3042",
+      "value": "あ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u3042\u3042\u3042\u3042",
+      "value": "ああああ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u3042",
+      "value": "AAAAあ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u3042AAAA",
+      "value": "あAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u3042AA",
+      "value": "AAあAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uac00",
+      "value": "가",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uac00\uac00\uac00\uac00",
+      "value": "가가가가",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\uac00",
+      "value": "AAAA가",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uac00AAAA",
+      "value": "가AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\uac00AA",
+      "value": "AA가AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff21",
+      "value": "Ａ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff21\uff21\uff21\uff21",
+      "value": "ＡＡＡＡ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\uff21",
+      "value": "AAAAＡ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff21AAAA",
+      "value": "ＡAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\uff21AA",
+      "value": "AAＡAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff10",
+      "value": "０",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff10\uff10\uff10\uff10",
+      "value": "００００",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\uff10",
+      "value": "AAAA０",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff10AAAA",
+      "value": "０AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\uff10AA",
+      "value": "AA０AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff0b",
+      "value": "＋",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff0b\uff0b\uff0b\uff0b",
+      "value": "＋＋＋＋",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\uff0b",
+      "value": "AAAA＋",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff0bAAAA",
+      "value": "＋AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\uff0bAA",
+      "value": "AA＋AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff0f",
+      "value": "／",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff0f\uff0f\uff0f\uff0f",
+      "value": "／／／／",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\uff0f",
+      "value": "AAAA／",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff0fAAAA",
+      "value": "／AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\uff0fAA",
+      "value": "AA／AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff1d",
+      "value": "＝",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff1d\uff1d\uff1d\uff1d",
+      "value": "＝＝＝＝",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\uff1d",
+      "value": "AAAA＝",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uff1dAAAA",
+      "value": "＝AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\uff1dAA",
+      "value": "AA＝AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2044",
+      "value": "⁄",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2044\u2044\u2044\u2044",
+      "value": "⁄⁄⁄⁄",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u2044",
+      "value": "AAAA⁄",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2044AAAA",
+      "value": "⁄AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u2044AA",
+      "value": "AA⁄AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2215",
+      "value": "∕",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2215\u2215\u2215\u2215",
+      "value": "∕∕∕∕",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u2215",
+      "value": "AAAA∕",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2215AAAA",
+      "value": "∕AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u2215AA",
+      "value": "AA∕AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u02d0",
+      "value": "ː",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u02d0\u02d0\u02d0\u02d0",
+      "value": "ːːːː",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u02d0",
+      "value": "AAAAː",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u02d0AAAA",
+      "value": "ːAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u02d0AA",
+      "value": "AAːAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0130",
+      "value": "İ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0130\u0130\u0130\u0130",
+      "value": "İİİİ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u0130",
+      "value": "AAAAİ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0130AAAA",
+      "value": "İAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u0130AA",
+      "value": "AAİAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u212a",
+      "value": "K",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u212a\u212a\u212a\u212a",
+      "value": "KKKK",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u212a",
+      "value": "AAAAK",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u212aAAAA",
+      "value": "KAAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u212aAA",
+      "value": "AAKAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud83d\ude00\ud83d\ude00\ud83d\ude00\ud83d\ude00",
+      "value": "😀😀😀😀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\ud83d\ude00",
+      "value": "AAAA😀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud83d\ude00AAAA",
+      "value": "😀AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\ud83d\ude00AA",
+      "value": "AA😀AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud835\udc00",
+      "value": "𝐀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud835\udc00\ud835\udc00\ud835\udc00\ud835\udc00",
+      "value": "𝐀𝐀𝐀𝐀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\ud835\udc00",
+      "value": "AAAA𝐀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud835\udc00AAAA",
+      "value": "𝐀AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\ud835\udc00AA",
+      "value": "AA𝐀AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud835\udfce",
+      "value": "𝟎",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud835\udfce\ud835\udfce\ud835\udfce\ud835\udfce",
+      "value": "𝟎𝟎𝟎𝟎",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\ud835\udfce",
+      "value": "AAAA𝟎",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud835\udfceAAAA",
+      "value": "𝟎AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\ud835\udfceAA",
+      "value": "AA𝟎AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud801\udc37",
+      "value": "𐐷",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud801\udc37\ud801\udc37\ud801\udc37\ud801\udc37",
+      "value": "𐐷𐐷𐐷𐐷",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\ud801\udc37",
+      "value": "AAAA𐐷",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud801\udc37AAAA",
+      "value": "𐐷AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\ud801\udc37AA",
+      "value": "AA𐐷AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud87e\udc00",
+      "value": "丽",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud87e\udc00\ud87e\udc00\ud87e\udc00\ud87e\udc00",
+      "value": "丽丽丽丽",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\ud87e\udc00",
+      "value": "AAAA丽",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud87e\udc00AAAA",
+      "value": "丽AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\ud87e\udc00AA",
+      "value": "AA丽AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udb40\udc01",
+      "value": "󠀁",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udb40\udc01\udb40\udc01\udb40\udc01\udb40\udc01",
+      "value": "󠀁󠀁󠀁󠀁",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\udb40\udc01",
+      "value": "AAAA󠀁",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udb40\udc01AAAA",
+      "value": "󠀁AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\udb40\udc01AA",
+      "value": "AA󠀁AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udbc0\udc00",
+      "value": "􀀀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udbc0\udc00\udbc0\udc00\udbc0\udc00\udbc0\udc00",
+      "value": "􀀀􀀀􀀀􀀀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\udbc0\udc00",
+      "value": "AAAA􀀀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udbc0\udc00AAAA",
+      "value": "􀀀AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\udbc0\udc00AA",
+      "value": "AA􀀀AA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5098,112 +5098,112 @@
       }
     },
     {
-      "value": "\u007f",
+      "value": "",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u007f\u007f\u007f\u007f",
+      "value": "",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u007f",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u007fAAAA",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u007fAA",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0080",
+      "value": "",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0080\u0080\u0080\u0080",
+      "value": "",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u0080",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0080AAAA",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u0080AA",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u009f",
+      "value": "",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u009f\u009f\u009f\u009f",
+      "value": "",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AAAA\u009f",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u009fAAAA",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "AA\u009fAA",
+      "value": "AAAA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "j,\u0c5e6+1",
+      "value": "j,౞6+1",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5217,161 +5217,161 @@
       }
     },
     {
-      "value": "s\u1703C\u085b\u08a3e",
+      "value": "sᜃC࡛ࢣe",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udbb7\udd7d\ub359K\ubcc1",
+      "value": "󽵽덙K볁",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "@\u045aP1\u1184\u6e83Fu\ud992\uddec`",
+      "value": "@њP1ᆄ溃Fu񴧬`",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uaa0f\u1d5e\u2117@8\ud95a\udf0dK\u9d22DA",
+      "value": "ꨏᵞ℗@8񦬍K鴢DA",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udb6d\udf16P",
+      "value": "󫜖P",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "sG\u4e90\u47f3>\u53ef\udaf5\ude86?",
+      "value": "sG亐䟳>可󍚆?",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2adb]\ud9b3\udf12WG",
+      "value": "⫛]񼼒WG",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u5ffa9L{\u1426",
+      "value": "忺9L{ᐦ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udaa4\udc435z\ud52b,3+RxM",
+      "value": "򹁃5z픫,3+RxM",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2f9e8`7\ud9f9\udd8eMd",
+      "value": "⾞8`7򎖎Md",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "_<P/xKf;s\u6239W",
+      "value": "_<P/xKf;s戹W",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "9\u15c5N",
+      "value": "9ᗅN",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "6nX\uf055\u2fecw\uf320\ud8b3\udc1e\udbae\udc0f;",
+      "value": "6nX⿬w𼰞󻠏;",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "9\u1c33;`Yr\u2495\u18cdb\ud94d\udfcb",
+      "value": "9ᰳ;`Yr⒕ᣍb񣟋",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "V\u2357U",
+      "value": "V⍗U",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "i/\u9750g\u6045\u15347\uc02c\ud949\udeba\uda84\udf74\u28e4",
+      "value": "i/靐g恅ᔴ7쀬񢚺򱍴⣤",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u407d\ua5bb\u4cecd8h\ued79",
+      "value": "䁽ꖻ䳬d8h",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "Y*O\udbb1\uddf6*F\u54fe0\u10cdp\u6d2bo",
+      "value": "Y*O󼗶*F哾0Ⴭp洫o",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u60c9",
+      "value": "惉",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u6c7bv\udb0b\udcdb\u1831\u6b5d.B",
+      "value": "汻v󒳛ᠱ歝.B",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "}cx\udbb7\uddec\uf4fb\ud8e8\uddd95:R\ud8f5\udf17*",
+      "value": "}cx󽷬񊇙5:R񍜗*",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uee6d)\u99b25MI\u394b",
+      "value": ")馲5MI㥋",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "akA\u1099\u2af6\uda7f\udee82`-\uda4d\udff9",
+      "value": "akA႙⫶򯻨2`-򣟹",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5381,81 +5381,81 @@
       "value": "F+y",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "q\ub808\ud971\udf54T\uba8b\u2c06\uda25\udde8V|n\u4655",
+      "value": "q레񬝔T몋Ⰶ򙗨V|n䙕",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud897\udf7a\u2a7cl1\ufb5aB\u60bb\u7b19/HD/",
+      "value": "𵽺⩼l1ﭚB悻笙/HD/",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "x\uda51\udfd4sJ",
+      "value": "x򤟔sJ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "CQ'\u08b5I",
+      "value": "CQ'ࢵI",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "a\u05ae!&\u017d\uacfd\ud404\u6665",
+      "value": "a֮!&Ž곽퐄晥",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uaff7AWB",
+      "value": "꿷AWB",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uad17\u410e#\udb32\ude095k",
+      "value": "괗䄎#󜨉5k",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0b17~$y\"-\ud971\udd97\u299a\u0244R\u29fb\ub1fb",
+      "value": "ଗ~$y\"-񬖗⦚ɄR⧻뇻",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "vq\u62dd",
+      "value": "vq拝",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud950\udf42\ud47f\u1983\ubdc4",
+      "value": "񤍂푿ᦃ뷄",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "e&Q\u3bd8\u0cf4}+~\u0952\u57dd",
+      "value": "e&Q㯘೴}+~॒埝",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5469,21 +5469,21 @@
       }
     },
     {
-      "value": "\u05eb\uf369RiR",
+      "value": "׫RiR",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "%\u0af7vj7\ud80f\ude72\uda0f\udf44@\u17d5\ud100\u1b84\u1fc8",
+      "value": "%૷vj7𓹲򓽄@៕턀ᮄῈ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "g'S\uda03\udc31;",
+      "value": "g'S򐰱;",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5497,7 +5497,7 @@
       }
     },
     {
-      "value": "\udae2\uddf7",
+      "value": "󈧷",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5507,109 +5507,109 @@
       "value": "o4",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "\u1c23\u0578.",
+      "value": "ᰣո.",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "jB\udbe5\udc4e",
+      "value": "jB􉑎",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "@\u2e21th\udb30\ude11\udafd\ude0b\u7980",
+      "value": "@⸡th󜈑󏘋禀",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udb66\ude4f5\u9ae7\u09bak}W\u1660m\u9f27\u2a1d",
+      "value": "󩩏5髧঺k}Wᙠm鼧⨝",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0d3c",
+      "value": "഼",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u9398.sIH8<eW",
+      "value": "鎘.sIH8<eW",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "%yj\uf414",
+      "value": "%yj",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "k<W:\u1f73",
+      "value": "k<W:έ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "PFf\udbfb\udd88HTt\uda7b\udf1e",
+      "value": "PFf􎶈HTt򮼞",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "u\u50d8E\"\ud880\udec3R",
+      "value": "u僘E\"𰋃R",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "]\ud91e\udf80\ud99d\udc1c?\u16b3\ucbfa<\u1582",
+      "value": "]񗮀񷐜?ᚳ쯺<ᖂ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u190eVKl",
+      "value": "ᤎVKl",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\udb36\udce9\u2919lG'b*A\u0e52c\uaed4a",
+      "value": "󝣩⤙lG'b*A๒c껔a",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ufc72j!\u2284\u01f9\u1b96\u25c9\u282d\ud8bb\udcd0g|5",
+      "value": "ﱲj!⊄ǹᮖ◉⠭𾳐g|5",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "D+\u4b15\u1f83\u0f05|W",
+      "value": "D+䬕ᾃ༅|W",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5619,67 +5619,67 @@
       "value": "Vag",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "\ud9c5\ude49\udbd8\udd83\uc053\u612a",
+      "value": "򁙉􆆃쁓愪",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "I(\ud93d\udc3a$nm\udb43\udd72\u7926z\u3d72",
+      "value": "I(񟐺$nm󠵲礦z㵲",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "@\ua1b69dH\u85dd\u186b\udbb1\uddb3",
+      "value": "@ꆶ9dH藝ᡫ󼖳",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "m\u1991\ua516\u0f1axo}}\uda7a\uddb8",
+      "value": "mᦑꔖ༚xo}}򮦸",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u00ce(\u2781Q\uce9a\u215a\ucdfdsqS",
+      "value": "Î(➁Q캚⅚췽sqS",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "J\u272b\u234b\u25c8",
+      "value": "J✫⍋◈",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u5b62\udafd\udce1",
+      "value": "孢󏓡",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "NO\u1fb4c\u2c5exj<7",
+      "value": "NOᾴcⱞxj<7",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "O\\\u3a02^+\u2481\ub9e0\ud9a4\udf94}",
+      "value": "O\\㨂^+⒁맠񹎔}",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5693,70 +5693,70 @@
       }
     },
     {
-      "value": "?5RQ\ud9d4\udcba\u1b7c:4\u2566\u5c01",
+      "value": "?5RQ򅂺᭼:4╦封",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "j2\udaf4\ude3dfo\u6d6f-?Q\u0aaa",
+      "value": "j2󍈽fo浯-?Qપ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "-:\u2fe6A\u1884\uda09\udd2b\u0db9T",
+      "value": "-:⿦Aᢄ򒔫ඹT",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\uda5b\udce2\ue3ffcUV4R\ud9b3\udf4dC",
+      "value": "򦳢cUV4R񼽍C",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "7\ud870\udff7OaW+Ac(T\ud978\udf2e\u20a5",
+      "value": "7𬏷OaW+Ac(T񮌮₥",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\\8\uc064G",
+      "value": "\\8쁤G",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2c1d\uaa94",
+      "value": "Ⱍꪔ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "'\u09a7E\udb46\udee8N\ud93d\uddedk\ud846\udf20h@y0",
+      "value": "'ধE󡫨N񟗭k𡬠h@y0",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "YZQW\u1293|",
+      "value": "YZQWና|",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "!\u06f6\ud8d9\udd98b\u7f78\u1684HLQc\u38aa",
+      "value": "!۶񆖘b罸ᚄHLQc㢪",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5766,25 +5766,25 @@
       "value": "LF2",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": ")\u05c1\ud83a\udcef\ud836\ude64R\u299cv~",
+      "value": ")ׁ𞣯𝩤R⦜v~",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2ea2Q\u1a84\u0e05\u3e58H",
+      "value": "⺢Q᪄ฅ㹘H",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "J\u2172\u27d3TP",
+      "value": "Jⅲ⟓TP",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5798,7 +5798,7 @@
       }
     },
     {
-      "value": "\u1088\u21d2",
+      "value": "ႈ⇒",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5812,7 +5812,7 @@
       }
     },
     {
-      "value": "05Z&3\udbf2\udfd4/\u951clE'U",
+      "value": "05Z&3􌯔/锜lE'U",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5826,7 +5826,7 @@
       }
     },
     {
-      "value": ";4\u95c3n:\u7596/c\ud7dbR\u0c54",
+      "value": ";4闃n:疖/cퟛR౔",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5840,63 +5840,63 @@
       }
     },
     {
-      "value": "I\ud9d4\udf23\"\u12e9g^R.\ud8b0\uddba\u0c6dB",
+      "value": "I򅌣\"ዩg^R.𼆺౭B",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "e\udbb8\udd82\u0128\u24e6S",
+      "value": "e󾆂ĨⓦS",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "3\u0a86\u25d7e\u08af\ua26c?96",
+      "value": "3આ◗eࢯꉬ?96",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u1b92\udaec\udca2\u270a\udb7e\udf38|1Zd!\u0d82\u284fS",
+      "value": "ᮒ󋂢✊󯬸|1Zd!ං⡏S",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "pcZ\u2a87#",
+      "value": "pcZ⪇#",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u2c7d8\u2eea\u23d1qx",
+      "value": "ⱽ8⻪⏑qx",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud8a9\uddcd\u5c208j",
+      "value": "𺗍尠8j",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "c\uadd0-(\ud890\udf71+\ud966\udc5b\u2142\uf08e",
+      "value": "c귐-(𴍱+񩡛⅂",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "n8v\u7720D\udacc\udfa7\u0b0f\udab3\udf35",
+      "value": "n8v眠D󃎧ଏ򼼵",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5906,18 +5906,18 @@
       "value": "FiA",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "\u2d81Ia\ub3eea;gIzSH",
+      "value": "ⶁIa돮a;gIzSH",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "Hob\udade\udf0a",
+      "value": "Hob󇬊",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5927,53 +5927,53 @@
       "value": "H3",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "\ud8cf\udd31p\ub865nGzwz\udb57\udc6c",
+      "value": "񃴱p롥nGzwz󥱬",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u08a3t\u42a1\u0d8aq",
+      "value": "ࢣt䊡ඊq",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "[I\uac22\u1666\u1203\u33eaL)*\u0306",
+      "value": "[I갢ᙦሃ㏪L)*̆",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u0a95\ud9b1\udd92",
+      "value": "ક񼖒",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "u\uef96<2iF\u7348\uda47\udd1e\u9c23+\\",
+      "value": "u<2iF獈򡴞鰣+\\",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\ud9ef\udd32\u3a0eVv\uee25+Xu",
+      "value": "򋴲㨎Vv+Xu",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "\u9665\ud8da\udcf4Bs\ud887\udfc9\uf587",
+      "value": "陥񆣴Bs𱿉",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -5983,32 +5983,32 @@
       "value": "Ff",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
-      "value": "T\u2d25\ud5badh\udac9\udcce9\ufef0",
+      "value": "Tⴥ햺dh󂓎9ﻰ",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "@\uda0c\udeb1\u2341",
+      "value": "@򓊱⍁",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "O}\u0c12umpZ\u1dcaye\u2e23",
+      "value": "O}ఒumpZ᷊ye⸣",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
       }
     },
     {
-      "value": "c\ue795YFs3h\u5ad7\udade\udd82\u9edf\u20d27",
+      "value": "cYFs3h嫗󇦂黟⃒7",
       "expect": {
         "safe_b64": false,
         "axis": "FAIL"
@@ -6445,357 +6445,357 @@
       "value": "Hw==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "Hw",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "PkU=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "PkU",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "XWRr",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "m6KpsLc=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "m6KpsLc",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "2eDn7vX8Aw==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "2eDn7vX8Aw",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "VVxjanF4f4aNlJs=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "VVxjanF4f4aNlJs",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "8Pf+BQwTGiEoLzY9REtSWQ==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "8Pf+BQwTGiEoLzY9REtSWQ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "8Pf-BQwTGiEoLzY9REtSWQ==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "8Pf-BQwTGiEoLzY9REtSWQ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "wcjP1t3k6/L5AAcOFRwjKjE4P0ZNVFtiaXB3foWMkw==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "wcjP1t3k6/L5AAcOFRwjKjE4P0ZNVFtiaXB3foWMkw",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "wcjP1t3k6_L5AAcOFRwjKjE4P0ZNVFtiaXB3foWMkw==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "wcjP1t3k6_L5AAcOFRwjKjE4P0ZNVFtiaXB3foWMkw",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "4Ofu9fwDChEYHyYtNDtCSVBXXmVsc3qBiI+WnaSrsrk=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "4Ofu9fwDChEYHyYtNDtCSVBXXmVsc3qBiI+WnaSrsrk",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "4Ofu9fwDChEYHyYtNDtCSVBXXmVsc3qBiI-WnaSrsrk=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "4Ofu9fwDChEYHyYtNDtCSVBXXmVsc3qBiI-WnaSrsrk",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "/wYNFBsiKTA3PkVMU1phaG92fYSLkpmgp661vMPK0djf",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "_wYNFBsiKTA3PkVMU1phaG92fYSLkpmgp661vMPK0djf",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "sbi/xs3U2+Lp8Pf+BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ+mrbS7wsnQ197l7PM=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "sbi/xs3U2+Lp8Pf+BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ+mrbS7wsnQ197l7PM",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "sbi_xs3U2-Lp8Pf-BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ-mrbS7wsnQ197l7PM=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "sbi_xs3U2-Lp8Pf-BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ-mrbS7wsnQ197l7PM",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "0Nfe5ezz+gEIDxYdJCsyOUBHTlVcY2pxeH+GjZSboqmwt77FzNPa4ejv9v0ECxIZ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "0Nfe5ezz-gEIDxYdJCsyOUBHTlVcY2pxeH-GjZSboqmwt77FzNPa4ejv9v0ECxIZ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "wMfO1dzj6vH4/wYNFBsiKTA3PkVMU1phaG92fYSLkpmgp661vMPK0djf5u30+wIJEBceJSwzOkFIT1ZdZGtyeQ==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "wMfO1dzj6vH4/wYNFBsiKTA3PkVMU1phaG92fYSLkpmgp661vMPK0djf5u30+wIJEBceJSwzOkFIT1ZdZGtyeQ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "wMfO1dzj6vH4_wYNFBsiKTA3PkVMU1phaG92fYSLkpmgp661vMPK0djf5u30-wIJEBceJSwzOkFIT1ZdZGtyeQ==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "wMfO1dzj6vH4_wYNFBsiKTA3PkVMU1phaG92fYSLkpmgp661vMPK0djf5u30-wIJEBceJSwzOkFIT1ZdZGtyeQ",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "oKeutbzDytHY3+bt9PsCCRAXHiUsMzpBSE9WXWRrcnmAh46VnKOqsbi/xs3U2+Lp8Pf+BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ+mrbS7wsnQ197l7PP6AQgPFh0kKzI5",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "oKeutbzDytHY3-bt9PsCCRAXHiUsMzpBSE9WXWRrcnmAh46VnKOqsbi_xs3U2-Lp8Pf-BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ-mrbS7wsnQ197l7PP6AQgPFh0kKzI5",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "gIeOlZyjqrG4v8bN1Nvi6fD3/gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz+gEIDxYdJCsyOUBHTlVcY2pxeH+GjZSboqmwt77FzNPa4ejv9v0ECxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM/W3eTr8vk=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "gIeOlZyjqrG4v8bN1Nvi6fD3/gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz+gEIDxYdJCsyOUBHTlVcY2pxeH+GjZSboqmwt77FzNPa4ejv9v0ECxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM/W3eTr8vk",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "gIeOlZyjqrG4v8bN1Nvi6fD3_gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz-gEIDxYdJCsyOUBHTlVcY2pxeH-GjZSboqmwt77FzNPa4ejv9v0ECxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM_W3eTr8vk=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "gIeOlZyjqrG4v8bN1Nvi6fD3_gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz-gEIDxYdJCsyOUBHTlVcY2pxeH-GjZSboqmwt77FzNPa4ejv9v0ECxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM_W3eTr8vk",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "OD9GTVRbYmlwd36FjJOaoaivtr3Ey9LZ4Ofu9fwDChEYHyYtNDtCSVBXXmVsc3qBiI+WnaSrsrnAx87V3OPq8fj/Bg0UGyIpMDc+RUxTWmFob3Z9hIuSmaCnrrW8w8rR2N/m7fT7AgkQFx4lLDM6QUhPVl1ka3J5gIeOlZyjqrG4v8bN1Nvi6fD3/gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz+gEIDxYdJCsyOUBHTlVcY2pxeH+GjZSboqk=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "OD9GTVRbYmlwd36FjJOaoaivtr3Ey9LZ4Ofu9fwDChEYHyYtNDtCSVBXXmVsc3qBiI+WnaSrsrnAx87V3OPq8fj/Bg0UGyIpMDc+RUxTWmFob3Z9hIuSmaCnrrW8w8rR2N/m7fT7AgkQFx4lLDM6QUhPVl1ka3J5gIeOlZyjqrG4v8bN1Nvi6fD3/gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz+gEIDxYdJCsyOUBHTlVcY2pxeH+GjZSboqk",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "OD9GTVRbYmlwd36FjJOaoaivtr3Ey9LZ4Ofu9fwDChEYHyYtNDtCSVBXXmVsc3qBiI-WnaSrsrnAx87V3OPq8fj_Bg0UGyIpMDc-RUxTWmFob3Z9hIuSmaCnrrW8w8rR2N_m7fT7AgkQFx4lLDM6QUhPVl1ka3J5gIeOlZyjqrG4v8bN1Nvi6fD3_gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz-gEIDxYdJCsyOUBHTlVcY2pxeH-GjZSboqk=",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "OD9GTVRbYmlwd36FjJOaoaivtr3Ey9LZ4Ofu9fwDChEYHyYtNDtCSVBXXmVsc3qBiI-WnaSrsrnAx87V3OPq8fj_Bg0UGyIpMDc-RUxTWmFob3Z9hIuSmaCnrrW8w8rR2N_m7fT7AgkQFx4lLDM6QUhPVl1ka3J5gIeOlZyjqrG4v8bN1Nvi6fD3_gUMExohKC82PURLUllgZ251fIOKkZifpq20u8LJ0Nfe5ezz-gEIDxYdJCsyOUBHTlVcY2pxeH-GjZSboqk",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "4ejv9v0ECxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM/W3eTr8vkABw4VHCMqMTg/Rk1UW2JpcHd+hYyTmqGor7a9xMvS2eDn7vX8AwoRGB8mLTQ7QklQV15lbHN6gYiPlp2kq7K5wMfO1dzj6vH4/wYNFBsiKTA3PkVMU1phaG92fYSLkpmgp661vMPK0djf5u30+wIJEBceJSwzOkFIT1ZdZGtyeYCHjpWco6qxuL/GzdTb4unw9/4FDBMaISgvNj1ES1JZYGdudXyDipGYn6attLvCydDX3uXs8/oBCA8WHSQrMjlAR05VXGNqcXh/ho2Um6KpsLe+xczT",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "4ejv9v0ECxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM_W3eTr8vkABw4VHCMqMTg_Rk1UW2JpcHd-hYyTmqGor7a9xMvS2eDn7vX8AwoRGB8mLTQ7QklQV15lbHN6gYiPlp2kq7K5wMfO1dzj6vH4_wYNFBsiKTA3PkVMU1phaG92fYSLkpmgp661vMPK0djf5u30-wIJEBceJSwzOkFIT1ZdZGtyeYCHjpWco6qxuL_GzdTb4unw9_4FDBMaISgvNj1ES1JZYGdudXyDipGYn6attLvCydDX3uXs8_oBCA8WHSQrMjlAR05VXGNqcXh_ho2Um6KpsLe-xczT",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAcOFRwjKjE4P0ZNVFtiaXB3foWMk5qhqK+2vcTL0tng5+71/AMKERgfJi00O0JJUFdeZWxzeoGIj5adpKuyucDHztXc4+rx+P8GDRQbIikwNz5FTFNaYWhvdn2Ei5KZoKeutbzDytHY3+bt9PsCCRAXHiUsMzpBSE9WXWRrcnmAh46VnKOqsbi/xs3U2+Lp8Pf+BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ+mrbS7wsnQ197l7PP6AQgPFh0kKzI5QEdOVVxjanF4f4aNlJuiqbC3vsXM09rh6O/2/QQLEhkgJy41PENKUVhfZm10e4KJkJeepayzusHIz9bd5Ovy+Q==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAcOFRwjKjE4P0ZNVFtiaXB3foWMk5qhqK+2vcTL0tng5+71/AMKERgfJi00O0JJUFdeZWxzeoGIj5adpKuyucDHztXc4+rx+P8GDRQbIikwNz5FTFNaYWhvdn2Ei5KZoKeutbzDytHY3+bt9PsCCRAXHiUsMzpBSE9WXWRrcnmAh46VnKOqsbi/xs3U2+Lp8Pf+BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ+mrbS7wsnQ197l7PP6AQgPFh0kKzI5QEdOVVxjanF4f4aNlJuiqbC3vsXM09rh6O/2/QQLEhkgJy41PENKUVhfZm10e4KJkJeepayzusHIz9bd5Ovy+Q",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAcOFRwjKjE4P0ZNVFtiaXB3foWMk5qhqK-2vcTL0tng5-71_AMKERgfJi00O0JJUFdeZWxzeoGIj5adpKuyucDHztXc4-rx-P8GDRQbIikwNz5FTFNaYWhvdn2Ei5KZoKeutbzDytHY3-bt9PsCCRAXHiUsMzpBSE9WXWRrcnmAh46VnKOqsbi_xs3U2-Lp8Pf-BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ-mrbS7wsnQ197l7PP6AQgPFh0kKzI5QEdOVVxjanF4f4aNlJuiqbC3vsXM09rh6O_2_QQLEhkgJy41PENKUVhfZm10e4KJkJeepayzusHIz9bd5Ovy-Q==",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     },
     {
       "value": "AAcOFRwjKjE4P0ZNVFtiaXB3foWMk5qhqK-2vcTL0tng5-71_AMKERgfJi00O0JJUFdeZWxzeoGIj5adpKuyucDHztXc4-rx-P8GDRQbIikwNz5FTFNaYWhvdn2Ei5KZoKeutbzDytHY3-bt9PsCCRAXHiUsMzpBSE9WXWRrcnmAh46VnKOqsbi_xs3U2-Lp8Pf-BQwTGiEoLzY9REtSWWBnbnV8g4qRmJ-mrbS7wsnQ197l7PP6AQgPFh0kKzI5QEdOVVxjanF4f4aNlJuiqbC3vsXM09rh6O_2_QQLEhkgJy41PENKUVhfZm10e4KJkJeepayzusHIz9bd5Ovy-Q",
       "expect": {
         "safe_b64": true,
-        "axis": "PASS"
+        "axis": "SKIPPED"
       }
     }
   ]

--- a/verifier/axis-parity-cases.json
+++ b/verifier/axis-parity-cases.json
@@ -662,7 +662,7 @@
         "anchors": [
           {
             "type": "rfc3161",
-            "value": "MTIzNА=="
+            "value": "MTIzN\u0410=="
           }
         ]
       },
@@ -1764,6 +1764,89 @@
         "signature": "FAIL",
         "failure_class": "invalid"
       }
+    }
+  ],
+  "anchors_divergence_note": "Cases where the two languages legitimately disagree because the TypeScript shim carries no anchor cryptography (criterion 446). Each case pins BOTH verdicts, so porting the DER/CMS + ots evaluation to TS turns these red and the corpus has to be updated deliberately rather than the divergence silently persisting.",
+  "anchors_divergence": [
+    {
+      "name": "rfc3161-imprint-commits-a-different-envelope",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00",
+          "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "agent_id": "agt_1",
+          "action_ref": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "payload_digest": {
+            "hash": "88",
+            "size": 512
+          },
+          "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MIINwjADAgEAMIINuQYJKoZIhvcNAQcCoIINqjCCDaYCAQMxDzANBglghkgBZQMEAgEFADBiBgsqhkiG9w0BCRABBKBTBFEwTwIBAQYDKgMEMDEwDQYJYIZIAWUDBAIBBQAEIP+GJMZgJbV/1Ricynrc/wp4l3cN14KQEg6Yqigk36pxAgEqGA8yMDI2MDYwMTAwMDAwMFoxgg0qMIINJgIBA6AUAAAAAAAAAAAAAAAAAAAAAAAAAAAwDQYJYIZIAWUDBAIBBQAwCwYJYIZIAWUDBAMSBIIM7WEhxUuoZsghnUPbrWzd/81v/NtMaRwXZQCocQOS8mNNzwTuGAgjIH67M9daBNx1GJ64n8WDSL5HUw6Xh0yuJ9kFPWXvz8APriWsL1mC0I3aPYUEn7XLpn4y5Rh/3DAEn/9A39OPpGHyt6pYAWrYph0HlFdcslQyg115MNxx/L555N5QJvnHdCj7jXmfSZpv/WGgwkK8DBcE15TFx34EBHoyS/Ta0rSV4xHt91359KoLx3XNTuqZE7i8cUBa8Hregx0adCjoHnbEDCRTtKLFbmsOxFLYnyY06dtHRiAYfGclJpKn9veq6wuKEAO0M1+BkMTPta7C/Km1ZQFzB4Us87n5jRACPkWqpcjyPABie674oCX0UP7O/cUbQqkd2i/+y2cdV9wagnNoR8u1wBWQUqkjMPNlXXM6fvD9yNUz1qCJbY3/he+RPstta/ugCRsfhm5t6s+nAKHTme1iPcptE5r4cSKPpPk58ZQylgvqN3K3wAKuPk3Svq5FWPVHooYmxWsERdImWp3bVHRMI8ol8TaaY8Ta/RnNCJkdwcWiCeWQU7apAYqZ9wTpFPRyB6b7nOnitRfg/pegfi2Q3KoyAqW6PZT+D/xuyRCv3MNKgJ4KQ5WmauS1FnVheMwLd+dwbybyT/ATO7GThgfq8eeQDhwbsz99Mufhan5bkUT6TtCCJvgtDQuyhJPDcMEtm5/8eki9z1wWVpjFIaSVOJmNC4KUbPELGPo7bghvSIXBEb1A3OrU5T/4inxisN76XHZiYHMDM3YAkHg0oGaFgElDFFwqofTuWHdEs5cg7xlczIup/Od907onDX/N86ixXhxk6YGkeE81M4AZ4Gpvlt0QrlnmaGXoC0tblzXIPPYo6jnUX3VpKPoJ0niJ7Lg1L95X6o0Gkz8QjwKvzqwAOWzsEljSRh+NzMTM9zPGXclBxVddTPGT9ewHVcE3ouGcmrZJ2xtN2xA5R21G4vs5rCUgM+lGEhTTQ7RwnNc3ZrnLbg2oaVhNkzc1AI/+cvJlbf+s32mPaGpKokfrcoHb3wzLIBf9mGSOiva4fRgzlLT1xj0SYmIN0oqUxQWrt2RA3h7QaPRrp5GUoNZMw1SuA+pjrpMbYV8/1miDxDAm50/KCicb4j/tzcoPQ9NtO0Un9Yw80Im+2tGusMCj5+6RBxt9jHXd/t+d01S1HDLzo4LPLx9ncYRkkMkJ/t2hdHNK606+P+SSgfwwz0IPW45uhUDjagab22kPdo3tfYUK9CyD/wc6kuW7CYt5d+hmcVGkceuOqhtzoE2RLlfJuzpccLpkCZsKbqgY2wGIoBvTz518vesVhsbSAaB2x3lLbTVpLcokGXIrXq1Wlos9VRPQH1Q+k6N3MHyEODITLslOb0x0yDKGEHxdhHJxbzPMY8A0iJJcXtM73r0k2CqH/KMqt/OMxVkSwmsJZVmppW0PYhT8hTiHeIc2+1mIoY6jENBhQ8ToYPSi7IwW5COMREELkHRes62c/RrJMJlORQR3s9vm191VGudvATwE/wsk9Z7nkWFCR/0WuDmTt6rMnRCcKhOgUuOSO9XJnARaUM7lx3H3li3f0Jb7qJpVyOyT8BdvVSLgmbfGVUiuNvtqvXd7QaAeRrmw7RuM9GEhHEGNo2K+CJTLFEYUsF4PpctQdLLNYaP71z2qC0WDAcD1h53wCBmEXYhu0PQ4swzLccDfexiXCo1J1K5VMumBDK5ROMWF9WQrJMYA2zHs7Qr0XB45pHMc6g1Qc2JSDxnWXKOI4nUAx82ak30htg8tAWGUV0gNRjMTONHapSsXNu6ovX9HV3v2TAivjd4WdYV58AYu7edVYEYZdHbDNmpbH5lo7Wzx/CctVvsUabbE6NDKISgusO6EMn9fC0osjMMlZhWBWkV/LQf2ACF72sxznjCEpE4RqGe5ANkhW9GzpvhmG2K0NxbHwESmXnH5eaPMarfv45hp5Gr4IkrN4LmsTmzUIDDv7wDHjA6nAMo4eS09cHh+fhxc1K0npwhtSV2P74mbyt1aEnGJiGx5jWbTC2rJ1AsA+qM/2izCgVMsRmHvv5litsP+OeTJYhP8UHoeHvxZ8jfyLnkNJbIRMdZ2sYsNjSbunopInxJfemm52VxS6Vkvs9qsLGufQVK4Mzo/f64jzYPi6bRciYDJXEEM1Mxn1bB3xWeeDKsJP0qlvBm933L44+MGZGQoK1lfPK2zmjmSBR4pJKlBJgex+NV8JERxnF4tZlM/Is0Lrg7JoULdEmep7fOGW1tOrPoGzbx2uZXQxDMTZRapPZlGWJUib1B6x1w48SSe1canEp6n+mZR6L0tOfQlVKN6RGqrsoYi9pYlltPRKW5HjD/tJ4YmbyZVtzYWHD8RxsncOYUNEceio3QffCl7AsJ2KKaGNZPHYEnGeBfOWVBP0qKBip73nq+gZhEqtdxYgtZnPr/2Bjcja1YIuMv0PcULMG6cL3eYC2HBMKhgUZrT7UYPCy/nE2zg2Huz2pvK53hKH59OaOMnJ8CbZCQ9pqfeWd7ZPKIHLlJ9Pk3dcIRhA2focmowPVK85v0DWCygCaWh8D05vsST2wxW8ETyyo4Kku+phz2vc7OhinzEB1dLLrhXYEi/itIRJpPobTeLp5BEhEZjCOlZT4U0IUGI3T8or1Zem6v8DK8sBMVZCtWbkxmzZ59YQ2njLX79LOLigWKSLYeNvrncIcWeFIUm32JcvU7EVmt0aHcccnSLWJNXZfSC/GT4BEaYRW/6VXT71uhybU9pKbz0LJAhiFVIM7N/v4CJzDXcKKBsEXFtLaMF91TjmWqISj136yT10fawpkwH2lIt+e47y+wBCWVjneUjmU3t/JGa++kdofK7x6hmQlNSf6oHzgvkJYqP+gKtqqTvxsmlKxFjjxFngsn11hnmRGn84vyd2vNBltKxDlltkj0NVIYWnhyoe/FGjl4S0VPN9kLS3sSVVHaH3oaUFDUL7FHCGC11ik82hS3PzMq/4fSwfEDHnpBTazki+dPuhq1pC2WRVXYC4ikOEy2nPxgj6V5EmHSOpgpA3F/OcH/fVH/bWq3+W++jMTVv1KffQE95qACbM8WTA8QuGqr13Zz1AYldcj4GQtYCE/7lA40COJiSgICRLXgKHAl2pNWTxrVwAYQxJ0q+++yfZgzGu3+ym17OWGxKJ9I4yTEjeoBM9HgvNbtWDDoJ/gorWp1dfVwxhorvIBh/zSbk1x27SL+FnLXW+l4mzcisAwJcwjOHmUhkEIWgOrCjCMQJVsSIhjVIkF4zD09d150/15JJotPey5JU0nFteGv0i7z4c56eUCxpCurKQtqyeFLnegkWEc7TON1vBDH7CR5AZi8UbvCQJ0ZE1ufBNB56ggKRTn+lllQskUbxYHl0Abl1tpjASD2IkwlDPZOTp8DLYxw43VOPSYirm5wuo/ZCu9neeqA1+jdqmFlY9WjcZQ3x2+TnkU9OVjlucZ0UsEt6bdxdSnI+CxG2Sbc26/V+vkJjXTIHZlMboMM1tN9bbdy+YwqUIHnGqq4hvC9k3/B0dLBPqHBLaD6D5zN0KN+lr32HQAqSXr6dtYM6TGeg/4MsTkKymAPbWwqcn8plp8Jdi6tnLtlB4cVs5fP2i4Xo0l4fADngrn4Z6FA2iAw8jCvP8eI1Ba7eeQAhCqB8cmtU6pY4Adou0EEozqaDH5RPbPb9ZREPn/K8e18rKn3uA7CHrhldO0mFHR3SaxIPPxJWnGc4zK5kDV1+UhKwWWDhbMcMzldgmFZS0aeMUEIRp+TYhQwFz5wb3Oqa2R/eIUK1UFggtEZMj7TMAOpQbmv15MlEbKu++A9bbltMta6VmY4OQTtHz/iKukPSM7J/IGAQkr3RNhFfz1hp5D61L3/BxGp182AegnK0h6h12in9fqzVsoQhA1AuzlJ5X0UGKafwYnKXdIrVyxg4r4O3Hqv3ZkeG+9TkRSL4othG4R+rYWOAJYLYmyKf2LYiVQKjsmuvYE9yJ82CcyGU3euiNI8GZaCBc/I8tClHonZVd+O54p9gFJnZ46o4uPZClu9A6AsnlrxQ0iFWWnrDBslT7M2c27RwvMb/7+rhHZ22pxN69WTJ0IxR8NuoWOWZYUDoWBnOLFFZxxDTgM+0Ha8nZSe6AeH2jJmoXYbKXXdDqOqtrMNp3oIAB3G7o3++MuGxVXQXJSlIONckgFSuXoFMP81YSMto3kKRePa2/44c86NZnnCTQRsHN4R1D14gnorKQbGZhBAj788YP0rw7dNJY7rseeHGPOM+p2M3ClHlhPJwKdhLlxRGryEo0i1l21qW8sYnLZQrU6e4tl5IvavBuF1r89hLSgNfXWFltML5ATJ9nMXJ6AYNFxgjc6fL9wY1SlNuk6LV3PgGEhUfb3yoy87S1fo8VFpjh53gAAAAAAYNFiAsMw=="
+          }
+        ]
+      },
+      "trusted_tsa_key_b64": "Ak6q/PTZpkODcNwCpmuV5U9J1xKM20AMmsogb8TBrKCA9HPVTIEhEdmp+LiSnqOlyMXk3v9tEnkrtpFhgRFIETw0KWRHNMdYkFVm1n96zytcjitszBvyka+0urO2jr9OS2KWj6+O0kyTRC8Pan7DqH8EmdSVZAEevC6cMiSNt73AKqkGqPBH9yghWsnaAwhlhy9Z+oJwBiW1uJvAYHCJaWbSMrrZbtCCHX5B/RruETDtv51DW8dW8joJW+d/tBbBoHXgB5Rt0z6MhvjgLYOLPY6b8N65jkKS/l1ahzDqQWs11eCyZfsLNEOxFLYX5LZ7KrDFSEa9c/Qx81H2PX/o5enZETKaXXBdoxrUl8pxcEW7HkP2vMuvOAr2Q8KViE03BcP2Y49dakk0dN/wdQ4k2sZuvf3rQKwGDlwI/FpfbhhdOas5h5gIVSOjThpF1Syfw7CvHX52tMV7TT9DSPiwAsAHMgpqb3w+kZwiTaSWGJB8TBtmSe4cTuKoMez0Ytl+qZc7HipSD35ot79X+whOsU5KdXcdodvUAy+ZTfCqKrgprHuFPaAAsUAErPnOpu/Lm6OjXuUUFKUiKrYqObHkWAlcnUDEKRcDluDit+f72a1AT7iB4OgfdP1PEteKy5P0PhV1WAwggi8vqaL9v1qzNftnjzdehhoAAqC/q8omEoHphPmOYaERJCo8K/mUgaeXTDPfnd1H2GIs6QxOHNFJ2SFijWQWBIYuEJ/P7EWOou4Q7jL7sLeIE082KwOTuHUpiPtpy7fhfjZYtMEeFZ5zsikruILDfsMrTOkPbfZVDlIAUmdPsgpNl/QRkcc+ShRuMf4BUun/8pG9Fmf5Zc1YFvQ4IyAq06p72MIqXt1aKdw4kMv595Or7p/3Xyt+CwcSguSAiHsroSa6J72Af18x+lmVtEB6LyGuewQngqyHHZbjQNl/PsO6AKkZZK0uZYka5nHbzx0Fq/a4IhEw2H9y4iFAhIMGF68G/g4rUCEB16CRCKJBnT/hhl52e8SpxmePq687R6abNnl4dkfliMhqjiVBbrTyvNvmiD73n4SDpnjik593cgtFGNu5Dk8SwcOdoAZJTln7wQrbaOuCeYxa3k/wTHPwUVro9gsDkFH6lLM9tn6vZPZRT5Rnpvkib2+MzS1Y3f+BDnfTkkCBY0kdgsQbOPxSrYy8YYvDg3G9cleQey/uckgXa8aK2O9te3bQi2t5WZ/s3Ma7X26pn1zdUVtrHYIw7NWWQBc60HavAD96yZQd0Nqt9y3rokjK3mwAkUr+6N8oxh41BLeQaDlD2JOC/uaruyFAzi7RaOKEHH1NxDRxpAUK87bl9dYXqlFyzNJj7ZPdCEZmfAUqHAPYyLFTxshk+G00bHS3GtBTXZVzhTflkXIJzXh+5un8yaDWnxEKqidIcuhEEzLKm+dDgjhgf02MARmDkUggcziG+p4NDQsHIr+VILMX8qbAEwSoD4WFNDyqIgg/vpFxOgHgn5YafbyUDEHyp1UzEDW58C1ur9f00snTec9vrFSkpU0PeJ3nHPcYUqpAmtozombXIK1sq7/qjNmXke5IyMZ8ARz5UPDiAvkVfjyjEhwgpJ1sompvzH8fEHryDk7LPCylVFhPRBo7RpkAvK2XXIdfcJ9Mu/Q/R3c3HcoKAy0wUeAs4Kp5h2zeK0JAXVnjCAM1CPVk/Ymzzv0CW9YebC7pR+hPKSKTRA0/vJK+jmc+lmPRrIqGLHD4h6O8ss8GDmyJwg2S5/+bYawuy6jOAh5ETRGiG7qVuhjG/j1RsxZZkzmGRUta3i6sq3XgnEbZxwJ8nnVP05wXSiHzmpA4qs4puOzNb0S0epnOxHo6WwFVESGqf2U+kirb0jI8XInmvXP4LrHVV1ma6Tjh43yTBQOOfMDDYYugPnx8uwFPwmX2zd6fxFp+b97+lFQ0yNNm8RUyybvbH1vA8YUscgg+KEvkRt3lmCAcl9DlC4rERE5M9WpdiunhZyIMbcIkW7O7tKgVkVBFfj3pevkp440RS6vxKR+/vdo7OPOPFRPUI6PxhJwtit7rFMT9XckjXjh2Y1C1ixMIYo+PBiB1M19D6JO49gJ7wICKlskECRIHy7iLXn/YThe2HfDFyEik5T2JOJazS1Rzgz7e8OQ8NOOZ3M6PKAti7gARdz2DSPUBgpLEUwlZvfer8d6Grih4V/DePJIbjKjgRLXC1VH/8/qKAjz02bTM6/kXceNmWf9q7D4LYcNTUHCaSFp2cThKRXyYSBSwG+Qoe69xm4r+hyzBIig2f9kR1ihFGEMMP25M+YZ4prUSuw4BnJQwMo838C+ac6CLqwKnsyklL5C8wRKOeP2pTIi9x2+zrbAK4MUJc8HTvv2zGhupXHYVPHC9tIjn0I0/9Rbbu9EZC32H2deYfYhyouHVFifI0c5p30zi6fkhY0/XUEM4akJ4UkxaKUQd4fQukrkKXdx7Beq8Y477qgW7c8LvmEhfWQU8ZHOOjQmAVXGMnpp7GP5VrUnFAzSkmvVnaqY8oyS3mjxp8AzxKqTWNrwRJeiUvVqwo3sxVlTfQI9CxjG6PqRPjyMftlwCoqSpeEvgYmGQHbRc27aLL5Dejq0=",
+      "expect_python": {
+        "result": "FAIL",
+        "note_contains": "commits a different digest"
+      },
+      "expect_ts": {
+        "result": "SKIPPED",
+        "note_contains": "unverifiable"
+      },
+      "why": "A real ML-DSA-65 TSA token whose messageImprint provably commits some other envelope. Python parses the token and calls it invalid; the TS shim runs no ASN.1 and can only say unverifiable. Under-claiming is the safe direction, but 'proven forged' and 'not checked' are different facts, so the divergence is pinned rather than left untested."
+    },
+    {
+      "name": "rfc3161-imprint-commits-this-envelope",
+      "envelope": {
+        "payload": {
+          "type": "protectmcp:decision",
+          "issued_at": "2026-06-19T00:00:00+00:00",
+          "issuer_id": "f94f66c0-c580-432d-a041-29374f7aee07",
+          "agent_id": "agt_1",
+          "action_ref": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+          "payload_digest": {
+            "hash": "88",
+            "size": 512
+          },
+          "policy_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "decision": "allow"
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "k1",
+          "sig": "AAAA"
+        },
+        "anchors": [
+          {
+            "type": "rfc3161",
+            "value": "MIINwjADAgEAMIINuQYJKoZIhvcNAQcCoIINqjCCDaYCAQMxDzANBglghkgBZQMEAgEFADBiBgsqhkiG9w0BCRABBKBTBFEwTwIBAQYDKgMEMDEwDQYJYIZIAWUDBAIBBQAEICziFOGrF4Ud4XxCNdW+aLETxYaVZYE5xqZ9/zk9IXHVAgEqGA8yMDI2MDYwMTAwMDAwMFoxgg0qMIINJgIBA6AUAAAAAAAAAAAAAAAAAAAAAAAAAAAwDQYJYIZIAWUDBAIBBQAwCwYJYIZIAWUDBAMSBIIM7evJuEpgixK4yC3zhdpCQO8qwha9hQboR7k+cpAjlHxmLfWxCaguMkYNbPJ9wcH6WH6GaNN+8HCilT8MuX9dxKIW4YrDcEMSK1TdB/PDsBHxCAKNuhqKzbXw9c5lzdt3ZPg+WYTE4BJaAu1kwnxovaFUnFxHgrMCZYY7HAEVgurAgJFrp5TR0+lzFtqK1YMew8twEmcOLAnBizIi0ughyAeFl1joKMthlEwhf1j6vbdt9zyRxeW489xKAKk/um+lAOgZLrMyzoW503Wyf3NWmbaXe7/UOGY9CT9VUXMD2+OtWaJ8NdHhNgcXMAHiL3h8+gsZlBki/Qm9O1ApqHwq2GYnV7zIWrYDi76+Z8G/xEJE9vNi5vhRNdMuNKLrTf6JejxR0wvU5gAYUULGVffSjyEPzQVvtsGYv5WlNoZ+AYwgKABIOwP0PXEYTaBmW8LHdy0XIgwrUAOpeqx40CwMtk/5U9PhhnWhk1KbS+np5OkL9a4ohUJmNV8P83CZjWp/B2plPIGvxux2DXKESajdYfHiOSeL/weoQFMYQY0esB1yRGhmn2Jg7UHNMoRuMso5pA2GQt3cuAvAUCD/oA3UOjNhcAEv4vcmmgU/iHpil5oIdYqiQsONZrUCFp9Hlu/3p2JtxyEbxUD111yf1X77ECsrSBjYoecBXCK7BzglthZNLBXcr5fhkwrT5NIIzvlO0gOKFtgmwxWm/PAqwgl7vDevn5HzR/kiwfhMkavxCUCRUJt0G5RlFnyRARtU/TY+pjR8Zqvm/chnm8l91TFTgKOFiHFepAy0FqBUoo8HXidkLnXdVyToMJtA5BdwRIyKsWMD5m8+QkJSH97L7+v3KnuYB0fznt+pqqNwYHirTMaj3xPnAaiBcvrDSqGS6JGY0M0RJG7r+X9IRT2dwOFWDTZKTYNisWHxm8RyHL8LGATw6zCVhvyLlVojbErKbo087eYsK9+NouHlWMPduEH3HxR+nI/Bh5Q7foQN3Re4ItOSf3QFmWBBFKSJLWBqMdTt4hIPSrL3BQ/nEUYZd66fv4jiNiIu1gI9GikT9eoixJ71TPuP7TdhfjU3Yv2y6w+YHgibLvu1ZZ/rJSrl+q3L28i0tXy8u29FQDeKqfMxnlqZUPmt/b3NFC8Tb1Ly2+0r7Baygm84CJbn7ld6vCrEvANOcSjV1WDFyqrNCECdwCI2oDm5qX5SFarPUXfUWXhDdmPcx2JFaOYtI4KryELwr2qXBLoGBT4ygOUVGzhxiDNun/WVtDqjsme6u1QA3b08zT+OK8Fe4IjyC/CD7nO+v9pXuiOjceZMdotZ6Qh5Q2TiO1rhT/cFz8BDH/xSM7ApZrv4Enb2NcobBUTVWSf3jydKp0eZYmiekEDE7LQRyXjdZxV68LRmeagGpVRovHUUTzYzs3/Vv72dGA9cSzS2idY55VWfXXulhFNVPwUlvD2IV26aCXT4+/ZVWVDxcA9tvj0tWUhuPsOAyq45GqO75ooo8ABPlFQN00HfGpoFqKdn3qINEJqZCxfrHIHllyMM+Fq5RiWgGXCBKJnldsd1QRaRKNSecmIFlEPjf3E+pphnRCdYx9437ie77kTZijvqglBBrjX4uPrPCkbI6ilPoYw8M74OOrm6gJcGDTalH9TV0qC7yFnKjYKKS1LdJ0F7Y7lITfUGngFGWbUqvfH3+g2Or55yxVbKBw4A9pcqB8NFV7Td685x9ngIn4giM6ujimN8hAAS6G8ej95a1t58YsMJItL+HGf5gAIvCr5M735LHdv9C5F2tfd+a6y4OU8e4ryeJZkuIcRmNnyfQM6x3OE7PjRKuVgNJqECG46beKVjp9gmG1zFngg2idwK181A8UbHYfOwvbOJ7Tl/GOU7JgNSMZJkwGKxrfRdG6Ktw7+UAfQIvocs7kdJy+UJ4liiEX0fb1gxShxTv0qJrel5J8sv3mjdPuQYIx0kEnYr2kyhzvfSjkdPeeBuwbxzA4AYMDI5kCE0OgFQbNOFnm3q/Lxe5HbTCKT6PVLbKf3psSoiLwZ1bAFcnrM5WaJrEU+ZOhgBRuC2zBFyHJ38Bv+2fQkmROClGvYT3gYrerAo2fHirBDgFC2OdWpiCOpb55vhxwvyiOz0PZKFjbJ+VvaxOa+7MtSDG5a2Be62OcaPCUdpXqSD/yJ+TLmIy5zlj5KRF2MR5pb4E6i8HMW89SWV+btmWXpDWRxOaAOBWdAtpJqxQBVpTJF/dBLbhhCTtRcl8yJh32XoDY2J1amglKsTMVMf4rh9XFSl9o8yYJtwKG0rrNPNi13WSoCGdodgArpuEshshnbTGA3Fgx6xG6SP1Pjxns86p6QUr1hmBKU0EYM1sQcyPrsIzkqka9Eqpi6FgXPyWZxpzLu5wdMRwz9svObce2Md0QkpCLyKGwegmFyKIH1t1KtIlQo2Dboh5QyGTifohw5FsqAvc/ChL1AW0WDRSOa9uSn7VHBJNuUCwlvJNf9GKgyv9sjnfIU5WI5MWZ4g+KuwpzJqIZotxhHA6o2lMqbAOmq9WY/bLgel3wceDLC779xCZXN9rD2oD866tSpdkhkCuuY6mdn7o2A+lfWuJY2WpM+9mIsfkb0JARJ2C55VdA05fLbhf3IiuaOlr9lnN2/6eboiBwO5JSRnPGo+QYabqJwHWC7PZXZoRUDFBTGWmOJfBdu0B58qiPJFktz3O/uoxR8x1acZ4qNSvT6mlsIW+YEiPQR4vzansXMCesEDVC+0wrJoN7kRoHU+ZaFh8T6mPiiKsaa+P0Y4j/mBvpZU5vxGg4m13jsdJUnI9u9Q5VeR067uG6x7LDLCxJSCpcRWQmfaWEzHgfa5gFaZjw63Ndg5+4ErPgf175rIRr2b4YDCDES/U9bMXFlGfNE4SCor9qncctWFwbQRK9t7U1gOcMZ2cP+Z6PgDI7vG/LXwv2lZRnoIc8NaNAQ62u03y8Gkl7VZrRElikbJUeQ5XT7G1IMel1mBO6RnJ7tSP1dJRSUjEK16U7FEgQvO3RTdMNS/Y1kUQqEZexEaqDU5xpK7YbRdh+kqgbHtj2aclcu2IJlm97gYna5p7gvsHxcOKe9lvdXjsS74vvU96h1TTYMsANtpHGjdDaL1vG4J5b9Vuyp7fCwqGjoV8YUwf7x3Z7j3gmqnzCz4BpWR1YXWrQFTIq72HG0qKEMg/Nz59hIwlZfvu9QF5+x4yPGolAtMZkkwsuWebYVEEVvXKvR9XCDhphJKnsrUqvgsqwKKclWY+axiMCcFhCdizDAQFnvJwbOCZjlZRke83PIGFJwOrghs+ti5QKmroHmvw5RWPMTP2dWT/L3TLaNuzUtZBQMYIYzY2Gy4zAjs1Wgk58uV453pilucSJ5SFXkdBeRMBs8pKcToOOgLVwiZ/WMIrvo7rWcWdxgLLkLIFILJqx/xk1vwxNTyXHjfkc72VHRj2elFmsJVkHFDWFOYjMdYWSzfDcbkxO+n44uYGRUZ2YIveNqVOwZhWsHTqehLFY2iH4vJmT0ZDxPYAXuLf0XXr5acJcaX/XmTUGPoaXOdq89OY8d9FDp90YFmFGMYyStTKX6+a4NPZIlQ9c80d5pz8u9kN4ZRK+srBDlR8RDY9Yr1Abw91N1tnYRVTUr2pnX95QUX+vV1Hbi8opRRwXyzLei4BqKDv7cOsz9Ohj9/43GHG9OC7Imjn6LoO1Kqk4ZOmXMETckbqs9okMLZuhvAARsOGk34ZFJBPxqQqdumGOaoMC0xV1HiKl8yhVggpTc49L7sbQcuNA5R+Lu7/EcMrGctNOvqB8rtfsb6ccnwyLhmXDZ/x8Rtk9/2ZcTYYCMg1wR0MnSvpnrUjl3DWcnyvH8uyQ4WSut870qpGd23miQrZGo/Z0f65wuev1TrTtP6AtTl9FO+tXneetDCi9727HECu4nkf9svvbC2lM5phIfcFqh9u5jbwejvmvgA6BhmwQVANWCKKLYq0fXwkkzaNxrUiWpX0rcycpR05/GtPdyUTUKnJcaI/+tG+Mte8jOBT3Uy9fQ2vE6ISgSsLZuDT9TJtqE63JTxMzYWMVJ47Idtxe2lXoIa2v5v3B4lHLa08msnhn5M9aEC8OKbE1AUSLBs+rdX5lfeSrZPjrBqAbHWo57WOfbho6lHOtZ9v0+l8RVpumX7U/LM0Vh2KWIao0Dg9QSUH6zn5dmXhzSdQwo0VMelW9UMOqdC88UB+MCcdkJto3CszyMY+JPDrTLUM9M2pxfK/dZgisJ1STBU/dCC6x46k3008MKl3Dq4eWK9g304At9Qs+hFjUClgvvP6RDWRfRQewp9nCvnpoFeBBO/K2tismD1R8D6v/Slo0FsGCej0BFzfaW5CxAmVltkgJYneI7x8xJBfNkDGj9EWrnQ1QAAAAAAAAAAAAAAAAAAAAAAAAAAAAQJERYaIg=="
+          }
+        ]
+      },
+      "trusted_tsa_key_b64": "D/JiWFj4DWSz8GbJ0qUniDzrO6V7jyUKp/K7OV7oeQ30GxKZ+c0zNSo3hkYvmS2dYnP3mK/GhCX2zs1oZa3a5wQPse7mjbPvj7u4DVltJNPDsu+P5Ih2F0WxJ8dWpAZiQEmThPkUEejzJ38WNAnZnGVPnOn3lB1OROoDMJQ4A8eKyZ7IsNsJeGO/qz0no/LYcZnXBQO7dQnyga2x0iONn+lu/zHABEjcmAkxCP4YUcjmdFm0DfFrtuM8TMaUD5h3Rr7mhUyFE/Wl+sYSIRtoxlTZBD4rGCiJL9mZpYohv9ksrXYtin0wDT27CwVjICgj4EKBmeobIIwp/kMEPdQkvqptN6NThXsPQTXuNeeHwT64b7fiH7Uzjgt9JVtTKZhYVdqcoKlki7voDWcpPhCkZ23/Pzz4+Vl1oryl1TzbG0cv/HxiQBPYlqsaBVWpaTCIXZ5dR5SqHBIn/Ccxl4PNbChRvcoNAeR2O/17t7xoxGmisrh3xfyEsfUyGbDa78FkTKcUikG+OfQ9dEbYRGrA9SZ8oSFsGgd+0WbrCsAHWH4SSvgMN9nERtUh19X3WLwxA+ml9doMrh+9S+aTcONk30T2XGUxM69zhnAJ4zyN3wKBMLA6XvxR1aJNHX/gUm9DKzfCP6XTLSnrpEMQU4Di96PtredHBXLcJtrtHT1QwoY7Lnh7h1vMt+Txh/E7AhFUb3Xm3yukgQiPBgy2ZR2HN/I6hhQXAQUEe4svMMkH4nBVR3K17LYPpofW7BVNEdSOBArlGPPKa398A/TIFOHF7FSAY8+F0QqCEtfuXMDRUYRtogZXrcldwOqYcfP+BpkgeYHG6I6iwpV1qe74VxQLSzMT2kKU71swErbXaBJQ87lyv1fOo0SbVXUosupQcVWwa9JOyXkICTxn/aGdHbF+WpJFcAdxxZJrRCupIlUIjHQLn2vwnhTtIxAlsynwm0/gdmeeUU+yvGwr2MyGJkshdYJfkHozHuRRNRL37jrWbOezFNo6fhd+slpTAjHrcI4pS77Y7FudvqIdHN+C3+3K63o7HVQeC0pxlFYsqcQDrMWFuH/yONF2eOvCOboFhzht9GIduiS6ArhhBuxEssqxhBT/LUrylCuLPdgkkxWRyTsoHBUK7S9u7MNyw1wwvpq7uuyPRR4RKBSz87J9+6rznjI1xisoGtuJlX2WVC5RMKdVeVlGqgGAbpvYf10SipB1SM0witQWvY/Dk3Dvk4UUEiQ988B7YfdwKDnG7AL/sja6Dn4EJXHx8MrEmXb7+qYLO7cJITFB2vX4VYtchWGSYrLU5jkGZ2gRhc1f1MQ0ugpYppE83mJUTVQ7idl197aYDdIJMPFEQRBQ8vsXfnR/3hlW1rEaX3BhWPnG8MWBfIipC7RUzT1vUYzkVHskIBvW05zLQ7ENTeGBAzo2iZ5YiR/KydPjdFZqhXxkaCW5DEZ13gCxpAXGtWRJxo/hYu79OZTTqxk/q4pFSDgJq7GG4LZNgeJv7M6wGZEojoUc7UrVOqURj8wdl8w29gaxrNklxjd7L6G8o7mAWXzO3HayKe9JcCoszjaJrs2h89gGCZEKHgv4IcHJM/6Tp5DhvV4SGk4c79R1TScrvDY6vC8MdZwwjXt+8ISDCNIogxotvaWogh8bLQ9urroCxzaWGfpikCoJKmtTBQ/fvMO3pqjQDn3z+9OPew9eW1RlOAB94CSqS4aoT3Aq+l2wk66//aHxfjfjNlk4L7bmTicNUQjLGXadS77bPcMD1820+jXLRrCL1Cy5370rx+vDOYy/b01up+Yf+YOx7MTsvO7SICyyLO6hCkhC3gEhqiSW18X4bwXTC0uIkhxI6T8SjBF3TKeFfeZk1XKyt7IcXtGd3ij7/x3sVOxjY+yu/tT+hasRzA/7GmTIScMeOx37P8tP90TKttPs/JUcraEiYSR3mw+55E5S0X9JgRw21H0/5pHUJQslA6OE2nF7rjn9snntCg+A5OtwK1Ix+ISSp9ZUH/6fC+qdLtXVebAM63QR173WXf/S3vJ0hmai9YF9S3MJSDXH1XnHOijL6OlfCOwEx5poCVn3OosAsRVC6v6LqLbwLvWRxKAHlPeVzyMBVLxQ2gScFk6pv+pcprk8zC2F8fCr087zWMxum3xTSga6qihY7ur0qVX8BY6MqnudLy6OeSWMjOh4Xd3t8ronhKC0pb/5huidn91DOW/LUnl/EWDkaENTWXXVaLttKWOUNVb595wEGkre5H9uq5lXMhkuXR56FxClmVEM/wiGk8tA2wOtCSIWdJ/P4hkc8K3ox6MVXBC34D07w6OWqRaeqkB6p9k77W+DCKrHx2RVWr+Lc+lpkpPAkOLgCpkNFjCP7euzuP/KNV3JbmsacIgmUJwFeID3lX/lTbGXbfVc5iBtlpJLuF6bs1zrZRvxse1NK33VDxn46OZocV6jB7n983FhIM9vLe/naDqQwVoQhWXPoHxdTreJJ7QJqzeeh8PPLigd0wF8nDnl2wUSUAZJuHvaF1rlJ3FjdO/pQYCgT+9cPrzGmH+kOMOHMp0fQZ2qKozfxnuYMGS3B9oFMcaoWL7E2EBT0A6LVawKAk/hsLcv7MjmhUs=",
+      "expect_python": {
+        "result": "PASS",
+        "note_contains": "commits this envelope"
+      },
+      "expect_ts": {
+        "result": "SKIPPED",
+        "note_contains": "unverifiable"
+      },
+      "why": "The control: an honest token over the right digest. Python verifies it to PASS, TS still reports unverifiable, so the divergence above is the absence of anchor cryptography in TS and not a quirk of a forged token."
     }
   ]
 }

--- a/verifier/axis-parity-cases.json
+++ b/verifier/axis-parity-cases.json
@@ -1,5 +1,5 @@
 {
-  "note": "Anchor-binding and clock-skew axis parity table. Expectations are the output of the Python check_anchors / check_skew in python/src/asqav/verifier/verify_receipt.py, and both suites feed every case through their own implementation. The anchors notes are deterministic so they are pinned whole; a skew note carries a live wall-clock reading, so only the stable fragment is pinned.",
+  "note": "Anchor-binding and clock-skew axis parity table. Expectations are the output of the Python check_anchors / check_skew in python/src/asqav/verifier/verify_receipt.py, and both suites feed every case through their own implementation. Since the cryptographic anchor check landed, a shape-valid anchor value that is not a verifiable token reports SKIPPED (unverifiable), never PASS on presence alone; the anchors notes are deterministic so they are pinned whole. A skew note carries a live wall-clock reading, so only the stable fragment is pinned.",
   "anchors": [
     {
       "name": "absent",
@@ -212,8 +212,8 @@
         ]
       },
       "expect": {
-        "result": "PASS",
-        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"
+        "result": "SKIPPED",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok; unverifiable (offline RFC3161 check did not complete)"
       }
     },
     {
@@ -475,8 +475,8 @@
         ]
       },
       "expect": {
-        "result": "PASS",
-        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"
+        "result": "SKIPPED",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok; unverifiable (offline RFC3161 check did not complete)"
       }
     },
     {
@@ -662,7 +662,7 @@
         "anchors": [
           {
             "type": "rfc3161",
-            "value": "MTIzN\u0410=="
+            "value": "MTIzNА=="
           }
         ]
       },
@@ -715,8 +715,8 @@
         ]
       },
       "expect": {
-        "result": "PASS",
-        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"
+        "result": "SKIPPED",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok; unverifiable (offline RFC3161 check did not complete)"
       }
     },
     {
@@ -739,8 +739,8 @@
         ]
       },
       "expect": {
-        "result": "PASS",
-        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok"
+        "result": "SKIPPED",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok; unverifiable (offline RFC3161 check did not complete)"
       }
     },
     {
@@ -918,8 +918,8 @@
         ]
       },
       "expect": {
-        "result": "PASS",
-        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - ?: value present, base64-ok"
+        "result": "SKIPPED",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - ?: value present, base64-ok; unverifiable (no offline verifier for this anchor type)"
       }
     },
     {
@@ -942,8 +942,8 @@
         ]
       },
       "expect": {
-        "result": "PASS",
-        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - None: value present, base64-ok"
+        "result": "SKIPPED",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - None: value present, base64-ok; unverifiable (no offline verifier for this anchor type)"
       }
     },
     {
@@ -966,8 +966,8 @@
         ]
       },
       "expect": {
-        "result": "PASS",
-        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - True: value present, base64-ok"
+        "result": "SKIPPED",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - True: value present, base64-ok; unverifiable (no offline verifier for this anchor type)"
       }
     },
     {
@@ -995,7 +995,7 @@
       },
       "expect": {
         "result": "FAIL",
-        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok;     - merkle: value MISSING or malformed"
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok; unverifiable (offline RFC3161 check did not complete);     - merkle: value MISSING or malformed"
       }
     },
     {
@@ -1022,8 +1022,8 @@
         ]
       },
       "expect": {
-        "result": "PASS",
-        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok;     - merkle: value present, base64-ok"
+        "result": "SKIPPED",
+        "note": "anchors bind envelope digest sha256:e0f1230ab2fbbe1a..;     - rfc3161: value present, base64-ok; unverifiable (offline RFC3161 check did not complete);     - merkle: value present, base64-ok; unverifiable (no offline verifier for this anchor type)"
       }
     }
   ],
@@ -1313,7 +1313,7 @@
       },
       "expect": {
         "digest": "39a39f4279c02b1e6e38e35f16238c6da0d14d42ad44377b60056d318f4727af",
-        "anchors_axis": "PASS"
+        "anchors_axis": "SKIPPED"
       }
     },
     {


### PR DESCRIPTION
Anchor cryptography is evaluated in the standalone verifier, and the shared
corpus pins the Python/TypeScript divergence it uncovered.

- `checkAnchors` verifies the anchor rather than answering "is a base64 value
  present", which passed on any well-formed but unverifiable anchor.
- The standalone verifier reports `verified_keyed` alongside the existing axes.
- A parse failure raised a plain `ValueError` that the anchor handler let escape;
  it is caught and reported as an anchor result.
- The parity corpus records the two implementations' differing answers so the gap
  cannot close silently.

Both language suites pass. The secret scanner is scoped around the corpus file:
its trusted timestamp keys are 1952-byte ML-DSA-65 public keys, which the
generic-api-key rule reads as credentials. The default ruleset is untouched
elsewhere.
