### PR TITLE
feat(vectors): publish the selective-omission conformance vectors

### DIFF
--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -25,7 +25,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # and in the corpus READMEs. A regenerated lock that forgets to update these is
 # drift, not a refresh
 FINGERPRINT_LOCK_DIGEST = "aa4e38f19dd227ffd4f674a9e25298199769d40ade9be63417eb9432ccb5ba6d"
-VERIFIER_LOCK_DIGEST = "8a8904f0b496b0ecb2580212f9cc59d3edd27e5292eaa0a15a5ba1f7bf4ee3b9"
+VERIFIER_LOCK_DIGEST = "525b0b407d6bf752e51d6bde74e384fd65020362aadf186ab73ed53013229653"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -237,7 +237,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 62
+    assert len(results) == 65
     # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -44,9 +44,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(62);
+    expect(results.length).toBe(65);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(62);
+    expect(passed).toBe(65);
   });
 
   it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {

--- a/verifier/conformance-vectors/asqav-14-omitted-action-chain/expected.json
+++ b/verifier/conformance-vectors/asqav-14-omitted-action-chain/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "An Action between the two receipts produced no receipt at all. The chain still verifies: links cover the receipts that exist and are silent about an Action that never reached the signer. Completeness is a deployment property, not a chain property."
+}

--- a/verifier/conformance-vectors/asqav-14-omitted-action-chain/jwks.json
+++ b/verifier/conformance-vectors/asqav-14-omitted-action-chain/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-omission-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "zzNtvKCoCHKRt2J8Ejr4hG+wkn36jIEzNh/dkW94AdA="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-14-omitted-action-chain/predecessor.json
+++ b/verifier/conformance-vectors/asqav-14-omitted-action-chain/predecessor.json
@@ -1,0 +1,23 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_omission_001",
+    "action_ref": "act_1",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-omission-vec-key",
+    "sig": "prmR3/QI8+v5rvoyEv3GwaGeuwOfVNjGklw6zp8EblacCBZK4GqgM+6a4uLT9J7cQHaud0dUO4F6WdG0wYl8CQ=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-14-omitted-action-chain/receipt.json
+++ b/verifier/conformance-vectors/asqav-14-omitted-action-chain/receipt.json
@@ -1,0 +1,23 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_omission_001",
+    "action_ref": "act_3",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "12da61a1f029b1d423500c8a2e26f30e4102b278da5f4a2d7861b317634f5ef5",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-omission-vec-key",
+    "sig": "ynIqJSN/kwVc6qhz9/YZi7vpURvQUZ3aKckJblQrdSSsMlf7jIhfnpNR8ml1I9OpcqSdzzJUG3L5uvYkjFWSAA=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-15-unsigned-gap/expected.json
+++ b/verifier/conformance-vectors/asqav-15-unsigned-gap/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "Server-built unsigned_gap evidences a signer outage that preceded this receipt. A verifier MUST NOT read it as an assertion that the unsigned Actions were policy-evaluated."
+}

--- a/verifier/conformance-vectors/asqav-15-unsigned-gap/jwks.json
+++ b/verifier/conformance-vectors/asqav-15-unsigned-gap/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-omission-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "zzNtvKCoCHKRt2J8Ejr4hG+wkn36jIEzNh/dkW94AdA="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-15-unsigned-gap/predecessor.json
+++ b/verifier/conformance-vectors/asqav-15-unsigned-gap/predecessor.json
@@ -1,0 +1,23 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_omission_001",
+    "action_ref": "act_10",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-omission-vec-key",
+    "sig": "BjvrFAX81FRblLgeitgqSPSx4ihGwO2qYFq/LIlBAHl+5ABfrpPZUT6E6/xEzvsNHmMg4l7ECcFTg47EJKP6Cw=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-15-unsigned-gap/receipt.json
+++ b/verifier/conformance-vectors/asqav-15-unsigned-gap/receipt.json
@@ -1,0 +1,28 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_omission_001",
+    "action_ref": "act_13",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "4635728a9f37ace512f56bda190afa733450f8f5bc450b497895e1f39923e0a8",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "unsigned_gap": {
+      "count": 2,
+      "from": "2026-08-30T11:58:00+00:00",
+      "to": "2026-08-30T11:59:30+00:00"
+    }
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-omission-vec-key",
+    "sig": "XEuaaiKLBkWU1s13pVaJfMXJOy8og0983F4KgJv1PI1GJ8lYmN3bOZOh3H1Vqxbbfo7kzCdlUTVQlXPx2rxSAg=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-16-chain-emission-blocked/expected.json
+++ b/verifier/conformance-vectors/asqav-16-chain-emission-blocked/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "A bounded predecessor-lookup timeout blocked emission. The lifecycle receipt naming it links into the chain once emission resumes, so the blocked interval is detectable rather than silent."
+}

--- a/verifier/conformance-vectors/asqav-16-chain-emission-blocked/jwks.json
+++ b/verifier/conformance-vectors/asqav-16-chain-emission-blocked/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-omission-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "zzNtvKCoCHKRt2J8Ejr4hG+wkn36jIEzNh/dkW94AdA="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-16-chain-emission-blocked/predecessor.json
+++ b/verifier/conformance-vectors/asqav-16-chain-emission-blocked/predecessor.json
@@ -1,0 +1,23 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_omission_001",
+    "action_ref": "act_20",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-omission-vec-key",
+    "sig": "MOZwlTl7aN9WBTXCEeIQQnr4Z9wcTAD2XMSb4LvqDUoWGutsy0/FuHZy5LeEoeT9MOZlS/Ox4x5nDcUEPTzcBQ=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-16-chain-emission-blocked/receipt.json
+++ b/verifier/conformance-vectors/asqav-16-chain-emission-blocked/receipt.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:lifecycle",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_omission_001",
+    "action_ref": "act_21",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "e0ba3346846c45e7a1f7b5a9e31ac7577265bf7f94297a6ca391b120003287d3",
+    "decision": "deny",
+    "tool_name": "demo.action",
+    "reason": "chain_emission_blocked"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-omission-vec-key",
+    "sig": "TTjqNGZ501bH5PL0mk5jOGj3bpJx1FNBIHkmn7yQqu6siJgmnmnkb8Gw7Hv+XkWmWDGcZpGsnzT4ntPtPRmBBw=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/gen_selective_omission_vectors.py
+++ b/verifier/conformance-vectors/gen_selective_omission_vectors.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the selective-omission conformance vectors.
+
+Three vectors covering what chain integrity does and does not show:
+
+  asqav-14-omitted-action-chain   an Action produced NO receipt; the successor
+                                  still verifies, because the chain links only
+                                  the receipts that exist
+  asqav-15-unsigned-gap           a signer outage carried as evidence in the
+                                  next receipt the issuer managed to sign
+  asqav-16-chain-emission-blocked a predecessor-lookup timeout carried as a
+                                  lifecycle receipt that links into the chain
+
+The signing key is derived from a published phrase so anyone can re-derive it;
+nothing here depends on a secret the corpus does not ship.
+
+Usage: python verifier/conformance-vectors/gen_selective_omission_vectors.py
+Re-freeze the corpus lock afterwards: python verifier/freeze_corpus_lock.py
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+_HERE = Path(__file__).resolve().parent
+
+#: Nothing-up-my-sleeve seed phrase; the key is SHA-256 of these ASCII bytes
+SEED_PHRASE = b"asqav conformance corpus v1 selective-omission signing seed"
+KID = "asqav-omission-vec-key"
+ISSUER = "Asqav Ltd"
+_ZERO_DIGEST = hashlib.sha256(b"").hexdigest()
+
+
+def _jcs(obj: object) -> bytes:
+    """Canonical JSON bytes, matching the oracle's asqav_jcs."""
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+
+
+def _signing_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(SEED_PHRASE).digest())
+
+
+def _sign(payload: dict, sk: Ed25519PrivateKey) -> dict:
+    """The three-key envelope: signature is over the canonical payload bytes."""
+    return {
+        "payload": payload,
+        "signature": {
+            "alg": "Ed25519",
+            "kid": KID,
+            "sig": base64.b64encode(sk.sign(_jcs(payload))).decode(),
+        },
+        "anchors": [],
+    }
+
+
+def _chain_hash(payload: dict) -> str:
+    """The successor's previousReceiptHash: SHA-256 of the predecessor payload."""
+    return hashlib.sha256(_jcs(payload)).hexdigest()
+
+
+def _payload(action_ref: str, previous: str, **extra) -> dict:
+    payload = {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-08-30T12:00:00+00:00",
+        "issuer_id": ISSUER,
+        "agent_id": "agt_omission_001",
+        "action_ref": action_ref,
+        "payload_digest": {"hash": _ZERO_DIGEST, "size": 0},
+        "policy_digest": f"sha256:{_ZERO_DIGEST}",
+        "previousReceiptHash": previous,
+        "decision": "allow",
+        "tool_name": "demo.action",
+    }
+    payload.update(extra)
+    return payload
+
+
+def _jwks() -> dict:
+    pub = _signing_key().public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return {
+        "keys": [
+            {
+                "kid": KID,
+                "issuer_id": ISSUER,
+                "alg": "Ed25519",
+                "status": "active",
+                "public_key": base64.b64encode(pub).decode(),
+            }
+        ]
+    }
+
+
+def _write(name: str, files: dict[str, object]) -> None:
+    out = _HERE / name
+    out.mkdir(parents=True, exist_ok=True)
+    for fname, obj in files.items():
+        (out / fname).write_text(json.dumps(obj, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {name}")
+
+
+def main() -> int:
+    sk = _signing_key()
+    genesis_prev = "0" * 64
+
+    # Action 1 is receipted, Action 2 happens with the signer never reached, and
+    # Action 3 is receipted linking straight back to Action 1's receipt
+    first = _payload("act_1", genesis_prev)
+    third = _payload("act_3", _chain_hash(first))
+    _write(
+        "asqav-14-omitted-action-chain",
+        {
+            "predecessor.json": _sign(first, sk),
+            "receipt.json": _sign(third, sk),
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "verified",
+                "reason_code": "",
+                "notes": (
+                    "An Action between the two receipts produced no receipt at all. "
+                    "The chain still verifies: links cover the receipts that exist "
+                    "and are silent about an Action that never reached the signer. "
+                    "Completeness is a deployment property, not a chain property."
+                ),
+            },
+        },
+    )
+
+    # The signer was unavailable for two Actions; the next receipt that signs
+    # carries the tally so the gap is evidenced rather than silent
+    gap_prev = _payload("act_10", genesis_prev)
+    gap = _payload(
+        "act_13",
+        _chain_hash(gap_prev),
+        unsigned_gap={
+            "count": 2,
+            "from": "2026-08-30T11:58:00+00:00",
+            "to": "2026-08-30T11:59:30+00:00",
+        },
+    )
+    _write(
+        "asqav-15-unsigned-gap",
+        {
+            "predecessor.json": _sign(gap_prev, sk),
+            "receipt.json": _sign(gap, sk),
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "verified",
+                "reason_code": "",
+                "notes": (
+                    "Server-built unsigned_gap evidences a signer outage that "
+                    "preceded this receipt. A verifier MUST NOT read it as an "
+                    "assertion that the unsigned Actions were policy-evaluated."
+                ),
+            },
+        },
+    )
+
+    # A predecessor-lookup timeout blocked emission; the lifecycle receipt
+    # naming it is itself a Compliance Receipt and links into the chain
+    blocked_prev = _payload("act_20", genesis_prev)
+    blocked = _payload(
+        "act_21",
+        _chain_hash(blocked_prev),
+        type="protectmcp:lifecycle",
+        decision="deny",
+        reason="chain_emission_blocked",
+    )
+    _write(
+        "asqav-16-chain-emission-blocked",
+        {
+            "predecessor.json": _sign(blocked_prev, sk),
+            "receipt.json": _sign(blocked, sk),
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "verified",
+                "reason_code": "",
+                "notes": (
+                    "A bounded predecessor-lookup timeout blocked emission. The "
+                    "lifecycle receipt naming it links into the chain once emission "
+                    "resumes, so the blocked interval is detectable rather than silent."
+                ),
+            },
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -466,5 +466,26 @@
     "outcome": "verified",
     "reason_code": "",
     "notes": "did:key issuer self-resolves inline from the base58btc multicodec frame; no injected map needed and Ed25519 over hashData verifies."
+  },
+  {
+    "dir": "asqav-14-omitted-action-chain",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "An Action between the two receipts produced no receipt at all; the chain still verifies because links cover only the receipts that exist. Completeness is a deployment property, not a chain property."
+  },
+  {
+    "dir": "asqav-15-unsigned-gap",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "Server-built unsigned_gap evidences a signer outage preceding this receipt; it is not an assertion that the unsigned Actions were policy-evaluated."
+  },
+  {
+    "dir": "asqav-16-chain-emission-blocked",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "A bounded predecessor-lookup timeout blocked emission; the lifecycle receipt naming it links into the chain once emission resumes."
   }
 ]

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -785,6 +785,66 @@
       "bytes": 915
     },
     {
+      "path": "asqav-14-omitted-action-chain/expected.json",
+      "sha256": "06357f2512c24e09451bee45b5c768c7209bdc478a6c6ed863ce98501cfeb33e",
+      "bytes": 339
+    },
+    {
+      "path": "asqav-14-omitted-action-chain/jwks.json",
+      "sha256": "66b48d812c9bd056eee1e1bcd53721d71158b2cf8ae16542a6ea925fd3d8be4a",
+      "bytes": 220
+    },
+    {
+      "path": "asqav-14-omitted-action-chain/predecessor.json",
+      "sha256": "813bdff36fb5b15876504f0b73c308e0035b64fb110c4f9d83a30343b5eb91d4",
+      "bytes": 773
+    },
+    {
+      "path": "asqav-14-omitted-action-chain/receipt.json",
+      "sha256": "4bf008228de990dded52c33ba719ca3b272bb2f247379f507a205fbbbd083696",
+      "bytes": 773
+    },
+    {
+      "path": "asqav-15-unsigned-gap/expected.json",
+      "sha256": "0a62093dbd9707846e0a44d528d693b92e0511572eb576cb35a113b4c01ba75f",
+      "bytes": 264
+    },
+    {
+      "path": "asqav-15-unsigned-gap/jwks.json",
+      "sha256": "66b48d812c9bd056eee1e1bcd53721d71158b2cf8ae16542a6ea925fd3d8be4a",
+      "bytes": 220
+    },
+    {
+      "path": "asqav-15-unsigned-gap/predecessor.json",
+      "sha256": "ed8344fa8ade76e7642a4e8ffa795d0d4198e12932fea97a8132615bf338cfde",
+      "bytes": 774
+    },
+    {
+      "path": "asqav-15-unsigned-gap/receipt.json",
+      "sha256": "235b7c2b6b7a9f568bfcfa49f3e9cd205b7b983ea7d511b1a3fe6ebf55fe4ad6",
+      "bytes": 904
+    },
+    {
+      "path": "asqav-16-chain-emission-blocked/expected.json",
+      "sha256": "6112858c2e1a334dd468928323bab52ee87e0d2337e53e74f50fd98bba4760e6",
+      "bytes": 280
+    },
+    {
+      "path": "asqav-16-chain-emission-blocked/jwks.json",
+      "sha256": "66b48d812c9bd056eee1e1bcd53721d71158b2cf8ae16542a6ea925fd3d8be4a",
+      "bytes": 220
+    },
+    {
+      "path": "asqav-16-chain-emission-blocked/predecessor.json",
+      "sha256": "61ccf21e6665e43bf5fa9a18967b53e0dc660e1896b30b9d0f323f1ba82d02a7",
+      "bytes": 774
+    },
+    {
+      "path": "asqav-16-chain-emission-blocked/receipt.json",
+      "sha256": "6cd73b2cab4375848a6df9c71dc39b4fbd756e005bb513c9d3d108c97c797f5a",
+      "bytes": 814
+    },
+    {
       "path": "authproof-01-genesis-real-sdk/expected.json",
       "sha256": "5599a2e6341d4194186cd5c43be8c271c2dd40d8a382f1be536d89488e6378a8",
       "bytes": 274
@@ -850,9 +910,14 @@
       "bytes": 4733
     },
     {
+      "path": "gen_selective_omission_vectors.py",
+      "sha256": "7e3cd796f549466afe4cbcb5e23dec205e537d42041de412ea16483805ac0cde",
+      "bytes": 6959
+    },
+    {
       "path": "manifest.json",
-      "sha256": "dcce074da806c01f83335172609efa7bda474d21d75ca7e378f92be4fe232e4b",
-      "bytes": 20564
+      "sha256": "c0134b830263efc9ff19820e809288cc655c52591742abf1a9786bfd8b903e2c",
+      "bytes": 21480
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
@@ -1020,5 +1085,5 @@
       ]
     }
   },
-  "digest": "8a8904f0b496b0ecb2580212f9cc59d3edd27e5292eaa0a15a5ba1f7bf4ee3b9"
+  "digest": "525b0b407d6bf752e51d6bde74e384fd65020362aadf186ab73ed53013229653"
 }


### PR DESCRIPTION
Three conformance vectors making the selective-omission boundary explicit, alongside `asqav-03-chain-link` and `acta-02-chain-link`.

| vector | what it shows |
|---|---|
| `asqav-14-omitted-action-chain` | An Action produced **no receipt at all**; the successor still verifies. The links cover only the receipts that exist, so the omission leaves no trace. This is the honest non-proof, not a bug. |
| `asqav-15-unsigned-gap` | A signer outage carried as evidence in the next receipt the issuer managed to sign. |
| `asqav-16-chain-emission-blocked` | A bounded predecessor-lookup timeout carried as a lifecycle receipt that links into the chain once emission resumes. |

The signing key derives from a published phrase (`gen_selective_omission_vectors.py`), so anyone can re-derive it; nothing depends on a secret the corpus does not ship.

## Both verifiers agree

- Python oracle: 2853 passed, 1 skipped
- TypeScript parity gate: 1017 passed across 62 files

All three vectors read as `verified` under each verifier independently, so cross-language parity holds.

## Existing corpus untouched

The only pins that move in `manifest.lock.json` are `manifest.json`'s own entry and the lock digest — every other file pin is byte-identical. The `manifest.json` diff is purely additive (21 insertions, 0 deletions). Three pinned counts move 62 to 65, and the lock digest constant is updated to match the re-freeze; `check_corpus_lock.sh` re-derives both corpora clean via the independent `sha256sum` path.

## MEM-001 review: false positive at both sites

- `typescript/src/index.ts:2383-2473` maps the Asqav server's own `/verify/{id}` response into a typed object. The source is the platform, not an LLM; required fields go through `requireField`; nothing is persisted, the value is returned to the caller.
- `typescript/src/verifier/adapters/authproof.ts:100-101` - the flagged lines *are* the validation (P-256 JWK coordinates must be exactly 32 bytes each), inside a read-only verifier that persists nothing. The key is embedded in the receipt by design, and the adapter header already documents that scope.

No code change made for MEM-001.

https://claude.ai/code/session_01Sso1TqNYL8gMYRLQPZBFrr