### PR TITLE
feat(verifier): check the signed key_thumbprint against the resolved key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-08-31
+
+### Added
+
+- **`key_binding` verification axis: the signed `key_thumbprint` is recomputed
+  from the resolved signing key and compared.** Both language halves gain the
+  check for the JWK Thumbprint (RFC7638) over the draft-ietf-cose-dilithium AKP
+  form `{alg, kty, pub}`, with `pub` in unpadded base64url. A receipt whose
+  bound digest names a key other than the one that verified reports
+  `key_substituted`; `key_binding` is an invalid-fail axis in both cores, so the
+  verdict folds to `unverified` / `invalid` and is never softened to a warning
+  or reported as verified.
+- Absence of `key_thumbprint` PASSes the axis with a "binding not checked" note
+  rather than skipping, so every receipt issued before the member existed stays
+  conformant; a skip outside `chain` blocks a verdict. The two cases that cannot
+  be recomputed - no key resolved, and a resolved key that is not raw ML-DSA of
+  the width its own `alg` fixes, which is how a KMS-backed row storing a PEM
+  presents - report SKIPPED, which also blocks, so an unverifiable binding is
+  never read as verified.
+- `key_thumbprint` joins the hash-mode unsigned-claim guard. Hash mode signs a
+  flat 11-field object with no room for the member, so a thumbprint pasted onto
+  a hash-mode receipt FAILs the structure axis instead of appearing bound.
+- 15 axis cases and 4 thumbprint digest vectors in the shared
+  `verifier/axis-parity-cases.json`, read by both suites, including a vector
+  that pins the base64url alphabet: an implementation reusing the directory's
+  standard-base64 `public_key` alphabet computes a digest no other verifier
+  reproduces, and a case binding exactly that digest must FAIL.
+
+
 ## [0.10.0] - 2026-08-27
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.0"
+version = "0.10.1"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -186,7 +186,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -50,7 +50,9 @@ _HASH_MODE_FIELDS = (
 
 #: Claim fields that live inside the signed compliance payload. A hash-mode
 #: receipt carrying one is presenting a claim its signature does not cover.
-_UNSIGNED_CLAIM_FIELDS = ("issuer_id", "previousReceiptHash")
+#: key_thumbprint is here because hash mode signs the flat 11 fields above and
+#: nothing else, so a thumbprint pasted onto one binds no key at all.
+_UNSIGNED_CLAIM_FIELDS = ("issuer_id", "previousReceiptHash", "key_thumbprint")
 
 
 def _is_hash_mode(doc: dict) -> bool:
@@ -65,6 +67,21 @@ def _is_hash_mode(doc: dict) -> bool:
     if doc.get("mode") != "hash" or isinstance(doc.get("payload"), dict):
         return False
     return bool(doc.get("signature_b64") or doc.get("signature"))
+
+
+def _resolved_key_material(entry: dict | None) -> tuple[Any, bytes | None]:
+    """alg plus raw public-key bytes of the resolved directory entry.
+
+    The directory publishes the key as standard base64 under ``public_key``; an
+    AKP thumbprint is taken over the same bytes in unpadded base64url, so the
+    decode has to happen before the digest, never after.
+    """
+    if not isinstance(entry, dict):
+        return None, None
+    try:
+        return entry.get("alg"), _vr._b64decode(entry.get("public_key", ""))
+    except Exception:
+        return entry.get("alg"), None
 
 
 def _payload(doc: dict) -> dict:
@@ -239,6 +256,10 @@ class AsqavNativeAdapter(FormatAdapter):
         axes.append(("nonce", *_vr.check_nonce(signed, self._seen_nonces)))
         jwks = key_provider or {"keys": []}
         entry = self._signing_key_entry(doc, jwks)
+        # Reported before the no-entry return, so a receipt binding no thumbprint
+        # still says so rather than dropping the axis when nothing resolved.
+        bound_alg, bound_pk = _resolved_key_material(entry)
+        axes.append(("key_binding", *_vr.check_key_binding(signed, bound_alg, bound_pk)))
         if entry is None:
             return axes
         key_issuer = _vr.key_issuer_of(entry)

--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -76,6 +76,7 @@ _INVALID_FAIL_AXES = frozenset(
         "anchors",
         "issuer_bind",
         "key_status",
+        "key_binding",
         "nonce",
         "parent_signature",
         "pdp_signature",

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -244,7 +244,9 @@ FAILURE_INVALID = "invalid"
 FAILURE_UNVERIFIABLE = "unverifiable"
 
 #: Axes whose FAIL proves a cryptographic/policy binding failure (invalid).
-_INVALID_FAIL_AXES = frozenset({"signature", "anchors", "issuer_bind", "key_status", "nonce"})
+_INVALID_FAIL_AXES = frozenset(
+    {"signature", "anchors", "issuer_bind", "key_status", "nonce", "key_binding"}
+)
 
 
 def _axis_failure_class(axis: str, result: str, note: str) -> str | None:
@@ -386,6 +388,74 @@ def _b64decode(value: str) -> bytes:
     s = value.replace("-", "+").replace("_", "/")
     s += "=" * ((-len(s)) % 4)
     return base64.b64decode(s, validate=False)
+
+
+# ---------------------------------------------------------------------------
+# RFC 7638 JWK Thumbprint over an ML-DSA (AKP) public key.
+#
+# The mirror of the cloud's asqav_cloud.core.key_thumbprint. Inlined rather than
+# imported so this file stays the single-file offline verifier its header
+# promises; the cross-language vectors are what hold the two copies together.
+# ---------------------------------------------------------------------------
+
+#: draft-ietf-cose-dilithium key type for ML-DSA key pairs
+AKP_KTY = "AKP"
+
+#: The only well-formed key_thumbprint shape; anything else is refused, not compared
+_THUMBPRINT_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+#: FIPS 204 public-key widths in bytes, fixed by the standard. A KMS-backed agent
+#: publishes a PEM in the same column as a locally generated raw key, and a PEM is
+#: not the key material an AKP `pub` carries, so width is what separates the two.
+_ML_DSA_PUBLIC_KEY_BYTES = {"ML-DSA-44": 1312, "ML-DSA-65": 1952, "ML-DSA-87": 2592}
+
+
+    # base64url with padding stripped - the encoding RFC 7638 `pub` requires.
+def _b64url_nopad(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+    # True when these bytes are a raw ML-DSA public key of the width `alg` fixes.
+def is_akp_public_key(*, alg: str, public_key: bytes | None) -> bool:
+    if not public_key:
+        return False
+    expected = _ML_DSA_PUBLIC_KEY_BYTES.get(alg)
+    return expected is not None and len(public_key) == expected
+
+
+    # True for a `sha256:<64 lowercase hex>` string, the only comparable form.
+def is_well_formed(value) -> bool:
+    return isinstance(value, str) and bool(_THUMBPRINT_RE.match(value))
+
+
+def akp_jwk(*, alg: str, public_key: bytes) -> dict:
+    """Build the required-members-only AKP JWK the thumbprint is taken over.
+
+    `pub` is base64url WITHOUT padding, which is the one encoding trap here: the
+    published directory carries the same bytes as standard base64 under
+    `public_key`, and thumbprinting that alphabet yields a digest no third-party
+    verifier reproduces.
+    """
+    if not alg:
+        raise ValueError("alg is required to build an AKP JWK")
+    if not public_key:
+        raise ValueError("public_key is required to build an AKP JWK")
+    return {"alg": alg, "kty": AKP_KTY, "pub": _b64url_nopad(public_key)}
+
+
+def jwk_thumbprint(jwk: dict) -> str:
+    """Return `sha256:<hex>` for a JWK already reduced to its required members.
+
+    Sorting here is what RFC 7638 section 3 calls for, so the caller cannot change
+    the digest by handing the members in a different order.
+    """
+    canonical = json.dumps(jwk, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+
+
+    # The profile's key_thumbprint value for one ML-DSA public key.
+def thumbprint_for_key(*, alg: str, public_key: bytes) -> str:
+    return jwk_thumbprint(akp_jwk(alg=alg, public_key=public_key))
 
 
 # Anchor values only, and strict on purpose: anchors sit outside the signed
@@ -1547,6 +1617,45 @@ def check_skew(issued_at: str):
     return "PASS", f"skew {skew:.0f}s within bound"
 
 
+def check_key_binding(payload: dict, alg, public_key):
+    """Recompute the signed key_thumbprint from the resolved key and compare.
+
+    The receipt names its own signing key INSIDE the signed bytes, so a key swapped
+    under the same kid stops rederiving the digest the issuer committed to. A
+    mismatch is a proven binding break, never a warning: `key_binding` sits in
+    `_INVALID_FAIL_AXES`, so the verdict reads unverified with failure_class invalid.
+
+    Absence is the profile's legacy case and stays conformant, so it PASSes with a
+    note rather than skipping; a skip would block every pre-binding receipt ever
+    issued. The two cases that cannot be recomputed - no key resolved, and a
+    resolved key that is not raw ML-DSA of the width its own alg fixes - report
+    SKIPPED, which blocks, so an unrecomputable binding never reads as verified.
+
+    ``public_key`` is the key the signature axis actually verified against, not
+    whatever the unsigned kid names, matching how issuer_bind and key_status resolve.
+    """
+    if not isinstance(payload, dict):
+        return "PASS", "no signed payload; binding not checked"
+    claimed = payload.get("key_thumbprint")
+    if claimed is None:
+        return "PASS", "receipt binds no key_thumbprint; binding not checked"
+    if not is_well_formed(claimed):
+        return "FAIL", f"key_thumbprint {claimed!r} is not sha256:<64 lowercase hex>"
+    if not public_key:
+        return "SKIPPED", "no signing key resolved, so the bound key_thumbprint cannot be recomputed"
+    if not isinstance(alg, str) or not is_akp_public_key(alg=alg, public_key=public_key):
+        # A KMS-backed row publishes a PEM in this column, and a PEM is not the key
+        # material an AKP `pub` carries, so the digest is not reconstructible here
+        return "SKIPPED", (
+            "resolved key is not raw ML-DSA material, so the bound key_thumbprint "
+            "cannot be recomputed"
+        )
+    actual = thumbprint_for_key(alg=alg, public_key=public_key)
+    if actual == claimed:
+        return "PASS", f"key_thumbprint rederives from the resolved {alg} key"
+    return "FAIL", f"key_substituted: receipt binds {claimed}, resolved key computes {actual}"
+
+
     # Axis-only expiry flag, mirrors the hosted signature_expired label; never folds the verdict (426).
 def check_expiry(payload: dict):
     if not isinstance(payload, dict) or "expires_at" not in payload:
@@ -1739,6 +1848,9 @@ def run(
     )
 
     pk, status, jwks_alg = resolve_key(jwks, kid)
+    # The key the signature axis actually verified against, which is what the
+    # key_binding axis has to rederive the bound thumbprint from.
+    eff_pk, eff_alg = None, None
     if pk is None:
         results.append(("issuer_key", "FAIL", f"kid {kid!r} not in jwks directory"))
         results.append(("signature", "SKIPPED", "no issuer key to verify against"))
@@ -1749,6 +1861,7 @@ def run(
         eff_status, eff_kid = status, kid
         eff_issuer = resolve_key_issuer(jwks, kid)
         eff_revoked_at = resolve_revoked_at(jwks, kid)
+        eff_pk, eff_alg = pk, jwks_alg
         # Cloud receipts sign with the agent key though kid is the issuer id; fall back.
         # agent_id is attacker-controlled, so trust only a key whose issuer_id matches.
         if sig_res[0] != "PASS":
@@ -1764,6 +1877,7 @@ def run(
                     eff_status, eff_kid = status_a, kid_a
                     eff_issuer = issuer_a
                     eff_revoked_at = resolve_revoked_at(jwks, kid_a)
+                    eff_pk, eff_alg = pk_a, alg_a
         results.append(("issuer_key", "PASS", f"resolved signing key {eff_kid} (status={eff_status})"))
         # kid picks the key and the attacker picks the kid, so bind the key that
         # actually verified back to the issuer the receipt claims.
@@ -1781,6 +1895,9 @@ def run(
         )
         results.append(("signature", *sig_res))
 
+    # Outside the else on purpose: a receipt binding no thumbprint still reports the
+    # axis, so the report says the binding was not checked rather than staying silent.
+    results.append(("key_binding", *check_key_binding(payload, eff_alg, eff_pk)))
     results.append(("chain", *check_chain(payload, predecessor_payload)))
     results.append(("anchors", anchor_eval.result, anchor_eval.note))
     results.append(("skew", *check_skew(payload.get("issued_at", ""))))
@@ -1920,6 +2037,9 @@ def run_structured(
     )
 
     pk, status, jwks_alg = resolve_key(jwks, kid)
+    # The key the signature axis actually verified against, which is what the
+    # key_binding axis has to rederive the bound thumbprint from.
+    eff_pk, eff_alg = None, None
     if pk is None:
         axes.append(_struct_axis("issuer_key", "FAIL", f"kid {kid!r} not in jwks directory"))
         axes.append(_struct_axis("signature", "SKIPPED", "no issuer key to verify against"))
@@ -1930,6 +2050,7 @@ def run_structured(
         eff_status, eff_kid = status, kid
         eff_issuer = resolve_key_issuer(jwks, kid)
         eff_revoked_at = resolve_revoked_at(jwks, kid)
+        eff_pk, eff_alg = pk, jwks_alg
         # Cloud receipts sign with the agent key though kid is the issuer id; fall
         # back, mirroring run(). agent_id is attacker-controlled, so trust only a
         # key whose published issuer_id matches the claimed issuer.
@@ -1946,6 +2067,7 @@ def run_structured(
                     eff_status, eff_kid = status_a, kid_a
                     eff_issuer = issuer_a
                     eff_revoked_at = resolve_revoked_at(jwks, kid_a)
+                    eff_pk, eff_alg = pk_a, alg_a
         axes.append(
             _struct_axis(
                 "issuer_key", "PASS", f"resolved signing key {eff_kid} (status={eff_status})"
@@ -1968,6 +2090,9 @@ def run_structured(
         )
         axes.append(_struct_axis("signature", sig_res[0], sig_res[1]))
 
+    # Outside the else on purpose: a receipt binding no thumbprint still reports the
+    # axis, so the report says the binding was not checked rather than staying silent.
+    axes.append(_struct_axis("key_binding", *check_key_binding(payload, eff_alg, eff_pk)))
     axes.append(_struct_axis("chain", *check_chain(payload, predecessor_payload)))
     axes.append(_struct_axis("anchors", anchor_eval.result, anchor_eval.note))
     axes.append(_struct_axis("skew", *check_skew(payload.get("issued_at", ""))))

--- a/python/tests/test_key_binding_axis.py
+++ b/python/tests/test_key_binding_axis.py
@@ -1,0 +1,233 @@
+"""key_thumbprint binding axis, Python half (criterion 458).
+
+The shared table in verifier/axis-parity-cases.json drives this file and
+typescript/tests/verifier-key-binding-parity.test.ts, so a rule that drifts in one
+language fails a suite.
+
+Beyond the table, the wire tests here are mutation-shaped on purpose: each one
+fails if its own wire is deleted. Criterion 457's lesson was that driving only the
+helper chain leaves the call sites untested, so every place the axis is appended
+and every table entry that makes its FAIL terminal has a test that notices its
+removal.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from asqav.verifier import verify_receipt as vr
+from asqav.verifier.oracle import ADAPTERS
+from asqav.verifier.oracle import verify as oracle_verify
+from asqav.verifier.oracle.adapters.asqav_native import _UNSIGNED_CLAIM_FIELDS
+from asqav.verifier.oracle.core import _INVALID_FAIL_AXES as ORACLE_INVALID_FAIL_AXES
+
+CASES_FILE = Path(__file__).parent.parent.parent / "verifier" / "axis-parity-cases.json"
+TABLE = json.loads(CASES_FILE.read_text())
+
+ALG = "ML-DSA-65"
+KEY_GOOD = bytes([0x00]) * 1952
+KEY_EVIL = bytes([0x01]) * 1952
+TP_GOOD = vr.thumbprint_for_key(alg=ALG, public_key=KEY_GOOD)
+TP_EVIL = vr.thumbprint_for_key(alg=ALG, public_key=KEY_EVIL)
+
+
+    # Expand a table `key` spec into the bytes both languages build it from.
+def _expand(spec):
+    if spec is None:
+        return None, None
+    return spec["alg"], bytes([spec["fill"]]) * spec["len"]
+
+
+def _jwks(public_key: bytes, alg: str = ALG) -> dict:
+    return {
+        "keys": [
+            {
+                "kid": "iss_1",
+                "issuer_id": "iss_1",
+                "agent_id": "ag_1",
+                "org_id": "org_1",
+                "alg": alg,
+                "public_key": base64.b64encode(public_key).decode(),
+                "status": "active",
+            }
+        ]
+    }
+
+
+def _receipt(thumbprint=None) -> dict:
+    payload = {
+        "v": 1,
+        "issuer_id": "iss_1",
+        "agent_id": "ag_1",
+        "org_id": "org_1",
+        "previousReceiptHash": vr.FIRST_RECEIPT_SEED,
+        "issued_at": "2026-08-31T10:00:00Z",
+        "action": {"type": "x"},
+        "hash": "a" * 64,
+    }
+    if thumbprint is not None:
+        payload["key_thumbprint"] = thumbprint
+    return {
+        "payload": payload,
+        "signature": {"alg": ALG, "kid": "iss_1", "sig": base64.b64encode(b"\x00" * 64).decode()},
+        "anchors": {},
+    }
+
+
+# --------------------------------------------------------------------------
+# The shared cross-language table
+# --------------------------------------------------------------------------
+
+
+    # A table that silently empties would make every case below vacuous.
+def test_table_is_populated() -> None:
+    assert len(TABLE["key_binding"]) >= 15, f"only {len(TABLE['key_binding'])} cases"
+    assert len(TABLE["key_thumbprint_vectors"]) >= 4
+    # A table of one outcome cannot tell a working axis from a stuck one.
+    assert {c["expect"]["result"] for c in TABLE["key_binding"]} == {"PASS", "FAIL", "SKIPPED"}
+
+
+@pytest.mark.parametrize("case", TABLE["key_thumbprint_vectors"], ids=lambda c: c["name"])
+def test_rfc7638_thumbprint_vectors(case) -> None:
+    alg, public_key = _expand(case["key"])
+    assert vr.thumbprint_for_key(alg=alg, public_key=public_key) == case["thumbprint"]
+
+
+@pytest.mark.parametrize("case", TABLE["key_binding"], ids=lambda c: c["name"])
+def test_key_binding_axis_table(case) -> None:
+    alg, public_key = _expand(case["key"])
+    result, note = vr.check_key_binding(case["payload"], alg, public_key)
+    assert result == case["expect"]["result"], note
+    assert case["expect"]["note_contains"] in note, note
+
+
+    # pub is unpadded base64url; the directory's own alphabet yields another digest.
+def test_pub_member_uses_unpadded_base64url() -> None:
+    jwk = vr.akp_jwk(alg="ML-DSA-87", public_key=bytes([0xFF]) * 2592)
+    assert set(jwk) == {"alg", "kty", "pub"}
+    assert jwk["kty"] == "AKP"
+    assert "/" not in jwk["pub"] and "+" not in jwk["pub"] and "=" not in jwk["pub"]
+    assert jwk["pub"].startswith("____")
+
+
+    # RFC 7638 requires lexicographic members and no whitespace, whatever the caller passes.
+def test_thumbprint_ignores_member_insertion_order() -> None:
+    pk = bytes([0x07]) * 1952
+    ordered = {"alg": ALG, "kty": "AKP", "pub": vr._b64url_nopad(pk)}
+    shuffled = {"pub": vr._b64url_nopad(pk), "kty": "AKP", "alg": ALG}
+    assert vr.jwk_thumbprint(ordered) == vr.jwk_thumbprint(shuffled)
+    assert vr.jwk_thumbprint(ordered) == vr.thumbprint_for_key(alg=ALG, public_key=pk)
+
+
+# --------------------------------------------------------------------------
+# Wire tests - each fails if its own call site is deleted
+# --------------------------------------------------------------------------
+
+
+    # Deleting the axis from the oracle adapter's extra_axes fails here.
+def test_oracle_adapter_emits_the_axis() -> None:
+    result = oracle_verify(_receipt(TP_GOOD), ADAPTERS, _jwks(KEY_GOOD))
+    axis = result.axis("key_binding")
+    assert axis is not None, "adapter did not emit a key_binding axis"
+    assert axis.result == "PASS", axis.note
+
+
+    # Deleting the axis from run_structured fails here.
+def test_run_structured_emits_the_axis() -> None:
+    out = vr.run_structured(_receipt(TP_GOOD), _jwks(KEY_GOOD))
+    axes = {a["name"]: a for a in out["axes"]}
+    assert "key_binding" in axes, f"axes were {sorted(axes)}"
+    assert axes["key_binding"]["result"] == "PASS", axes["key_binding"]["note"]
+
+
+    # Deleting the axis from the printed CLI path (run) fails here.
+def test_cli_run_prints_the_axis(capsys) -> None:
+    vr.run(_receipt(TP_GOOD), _jwks(KEY_GOOD), None)
+    report = capsys.readouterr().out
+    assert "key_binding" in report, report
+    assert "rederives from the resolved" in report, report
+
+    code = vr.run(_receipt(TP_GOOD), _jwks(KEY_EVIL), None)
+    substituted = capsys.readouterr().out
+    assert "key_substituted" in substituted, substituted
+    assert code != 0
+
+
+    # Removing key_binding from either _INVALID_FAIL_AXES table fails here.
+def test_a_substituted_key_is_terminal_invalid_not_a_warning() -> None:
+    assert "key_binding" in ORACLE_INVALID_FAIL_AXES
+    assert "key_binding" in vr._INVALID_FAIL_AXES
+    result = oracle_verify(_receipt(TP_GOOD), ADAPTERS, _jwks(KEY_EVIL))
+    axis = result.axis("key_binding")
+    assert (axis.result, axis.failure_class) == ("FAIL", "invalid"), axis.note
+    assert "key_substituted" in axis.note
+    # The whole point: it is never reported as verified.
+    assert result.verdict == "unverified"
+    assert result.failure_class == "invalid"
+
+    out = vr.run_structured(_receipt(TP_GOOD), _jwks(KEY_EVIL))
+    binding = next(a for a in out["axes"] if a["name"] == "key_binding")
+    assert binding["result"] == "FAIL"
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "invalid"
+
+
+    # A skip blocks every axis but chain, so absence must PASS or all legacy receipts break.
+def test_absence_does_not_block_a_verdict() -> None:
+    binding = oracle_verify(_receipt(None), ADAPTERS, _jwks(KEY_GOOD)).axis("key_binding")
+    assert binding.result == "PASS", binding.note
+    assert binding.failure_class is None
+    out = vr.run_structured(_receipt(None), _jwks(KEY_GOOD))
+    binding = next(a for a in out["axes"] if a["name"] == "key_binding")
+    assert binding["result"] == "PASS"
+    assert binding["failure_class"] is None
+
+
+    # Removing key_thumbprint from _UNSIGNED_CLAIM_FIELDS fails here.
+def test_hash_mode_cannot_display_an_unsigned_thumbprint() -> None:
+    assert "key_thumbprint" in _UNSIGNED_CLAIM_FIELDS
+    doc = {
+        "v": 1,
+        "mode": "hash",
+        "hash": "a" * 64,
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-08-31T10:00:00Z",
+        "action_id": "a1",
+        "agent_id": "ag_1",
+        "org_id": "org_1",
+        "policy_decision": "allow",
+        "signature_b64": base64.b64encode(b"\x00" * 64).decode(),
+        "key_id": "iss_1",
+        "key_thumbprint": TP_GOOD,
+    }
+    result = oracle_verify(doc, ADAPTERS, _jwks(KEY_GOOD))
+    structure = result.axis("structure")
+    assert structure.result == "FAIL", structure.note
+    assert "key_thumbprint" in structure.note
+    assert result.verdict == "unverified"
+
+
+    # Hash mode signs no thumbprint, so a clean hash-mode receipt still reads not-checked.
+def test_hash_mode_without_a_thumbprint_reports_not_checked() -> None:
+    doc = {
+        "v": 1,
+        "mode": "hash",
+        "hash": "a" * 64,
+        "hash_algo": "sha256",
+        "metadata": {},
+        "server_timestamp": "2026-08-31T10:00:00Z",
+        "action_id": "a1",
+        "agent_id": "ag_1",
+        "org_id": "org_1",
+        "policy_decision": "allow",
+        "signature_b64": base64.b64encode(b"\x00" * 64).decode(),
+        "key_id": "iss_1",
+    }
+    axis = oracle_verify(doc, ADAPTERS, _jwks(KEY_GOOD)).axis("key_binding")
+    assert axis.result == "PASS"
+    assert "binding not checked" in axis.note

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.10.0";
+export const SDK_VERSION = "0.10.1";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -32,6 +32,7 @@ import {
   b64decode,
   checkExpiry,
   checkIssuerBinding,
+  checkKeyBinding,
   checkKeyStatus,
   checkNonce,
   checkOrgBinding,
@@ -65,7 +66,27 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 /** True for a flat hash-mode signature receipt (mode=hash, null payload, a sig). */
 // Claim fields that live inside the signed compliance payload. A hash-mode
 // receipt carrying one is presenting a claim its signature does not cover.
-const UNSIGNED_CLAIM_FIELDS = ["issuer_id", "previousReceiptHash"];
+// key_thumbprint is here because hash mode signs the flat 11 fields and nothing
+// else, so a thumbprint pasted onto one binds no key at all.
+const UNSIGNED_CLAIM_FIELDS = ["issuer_id", "previousReceiptHash", "key_thumbprint"];
+
+/**
+ * alg plus raw public-key bytes of the resolved directory entry.
+ *
+ * The directory publishes the key as standard base64 under `public_key`; an AKP
+ * thumbprint is taken over the same bytes in unpadded base64url, so the decode
+ * has to happen before the digest, never after.
+ */
+function resolvedKeyMaterial(
+  entry: Record<string, unknown> | null,
+): readonly [unknown, Uint8Array | null] {
+  if (entry === null) return [null, null];
+  try {
+    return [entry.alg, b64decode(entry.public_key as string)];
+  } catch {
+    return [entry.alg, null];
+  }
+}
 
 function isHashMode(doc: Record<string, unknown>): boolean {
   // Routing reads the shape of the signed unit only: a record payload is the
@@ -241,6 +262,10 @@ export class AsqavNativeAdapter extends FormatAdapter {
     axes.push(["nonce", ...checkNonce(hashMode ? {} : payloadOf(doc), this.seenNonces)]);
     const jwks = (keyProvider ?? { keys: [] }) as Record<string, unknown>;
     const entry = this.signingKeyEntry(doc, jwks);
+    // Reported before the no-entry return, so a receipt binding no thumbprint
+    // still says so rather than dropping the axis when nothing resolved.
+    const [boundAlg, boundPk] = resolvedKeyMaterial(entry);
+    axes.push(["key_binding", ...checkKeyBinding(hashMode ? {} : payloadOf(doc), boundAlg, boundPk)]);
     if (entry === null) return axes;
     // Both wire shapes name their issuer inside the signed bytes: issuer_id in
     // compliance mode, org_id in hash mode.

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -67,6 +67,7 @@ const INVALID_FAIL_AXES = new Set([
   "anchors",
   "issuer_bind",
   "key_status",
+  "key_binding",
   "nonce",
   "parent_signature",
   "pdp_signature",

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -635,3 +635,118 @@ export function checkKeyStatus(
   }
   return ["FAIL", `signing key status ${JSON.stringify(status)}; receipt cannot be trusted`];
 }
+
+// ---------------------------------------------------------------------------
+// RFC 7638 JWK Thumbprint over an ML-DSA (AKP) public key (criterion 458).
+// A port of the Python `thumbprint_for_key` / `check_key_binding`; the shared
+// vectors in verifier/axis-parity-cases.json hold the two copies together.
+// ---------------------------------------------------------------------------
+
+/** draft-ietf-cose-dilithium key type for ML-DSA key pairs. */
+export const AKP_KTY = "AKP";
+
+/** The only well-formed key_thumbprint shape; anything else is refused, not compared. */
+const THUMBPRINT_RE = /^sha256:[0-9a-f]{64}$/;
+
+// FIPS 204 public-key widths in bytes, fixed by the standard. A KMS-backed agent
+// publishes a PEM in the same column as a locally generated raw key, and a PEM is
+// not the key material an AKP `pub` carries, so width is what separates the two.
+const ML_DSA_PUBLIC_KEY_BYTES: Record<string, number> = {
+  "ML-DSA-44": 1312,
+  "ML-DSA-65": 1952,
+  "ML-DSA-87": 2592,
+};
+
+/** base64url with padding stripped - the encoding RFC 7638 `pub` requires. */
+export function b64urlNoPad(data: Uint8Array): string {
+  return Buffer.from(data).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** True when these bytes are a raw ML-DSA public key of the width `alg` fixes. */
+export function isAkpPublicKey(alg: unknown, publicKey: Uint8Array | null): boolean {
+  if (!publicKey || publicKey.length === 0 || typeof alg !== "string") return false;
+  const expected = ML_DSA_PUBLIC_KEY_BYTES[alg];
+  return expected !== undefined && publicKey.length === expected;
+}
+
+/** True for a `sha256:<64 lowercase hex>` string, the only comparable form. */
+export function isWellFormedThumbprint(value: unknown): boolean {
+  return typeof value === "string" && THUMBPRINT_RE.test(value);
+}
+
+/**
+ * Build the required-members-only AKP JWK the thumbprint is taken over.
+ *
+ * `pub` is base64url WITHOUT padding, which is the one encoding trap here: the
+ * published directory carries the same bytes as standard base64 under
+ * `public_key`, and thumbprinting that alphabet yields a digest no third-party
+ * verifier reproduces.
+ */
+export function akpJwk(alg: string, publicKey: Uint8Array): Record<string, string> {
+  if (!alg) throw new Error("alg is required to build an AKP JWK");
+  if (!publicKey || publicKey.length === 0) throw new Error("public_key is required to build an AKP JWK");
+  return { alg, kty: AKP_KTY, pub: b64urlNoPad(publicKey) };
+}
+
+/**
+ * Return `sha256:<hex>` for a JWK already reduced to its required members.
+ * Sorting is what RFC 7638 section 3 calls for, so the caller cannot change the
+ * digest by handing the members in a different order.
+ */
+export function jwkThumbprint(jwk: Record<string, string>): string {
+  const canonical = `{${Object.keys(jwk)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${JSON.stringify(jwk[k])}`)
+    .join(",")}}`;
+  return `sha256:${sha256Hex(new TextEncoder().encode(canonical))}`;
+}
+
+/** The profile's key_thumbprint value for one ML-DSA public key. */
+export function thumbprintForKey(alg: string, publicKey: Uint8Array): string {
+  return jwkThumbprint(akpJwk(alg, publicKey));
+}
+
+/**
+ * Recompute the signed key_thumbprint from the resolved key and compare.
+ *
+ * The receipt names its own signing key INSIDE the signed bytes, so a key swapped
+ * under the same kid stops rederiving the digest the issuer committed to. A
+ * mismatch is a proven binding break, never a warning: `key_binding` sits in
+ * INVALID_FAIL_AXES, so the verdict reads unverified with failureClass invalid.
+ *
+ * Absence is the profile's legacy case and stays conformant, so it PASSes with a
+ * note rather than skipping; a skip would block every pre-binding receipt ever
+ * issued. The two cases that cannot be recomputed - no key resolved, and a
+ * resolved key that is not raw ML-DSA of the width its own alg fixes - report
+ * SKIPPED, which blocks, so an unrecomputable binding never reads as verified.
+ */
+export function checkKeyBinding(
+  payload: unknown,
+  alg: unknown,
+  publicKey: Uint8Array | null,
+): readonly [VerifyState, string] {
+  if (!isRecord(payload)) return ["PASS", "no signed payload; binding not checked"];
+  const claimed = payload.key_thumbprint;
+  if (claimed === undefined || claimed === null) {
+    return ["PASS", "receipt binds no key_thumbprint; binding not checked"];
+  }
+  if (!isWellFormedThumbprint(claimed)) {
+    return ["FAIL", `key_thumbprint ${pyRepr(claimed)} is not sha256:<64 lowercase hex>`];
+  }
+  if (!publicKey || publicKey.length === 0) {
+    return ["SKIPPED", "no signing key resolved, so the bound key_thumbprint cannot be recomputed"];
+  }
+  if (!isAkpPublicKey(alg, publicKey)) {
+    // A KMS-backed row publishes a PEM in this column, and a PEM is not the key
+    // material an AKP `pub` carries, so the digest is not reconstructible here
+    return [
+      "SKIPPED",
+      "resolved key is not raw ML-DSA material, so the bound key_thumbprint cannot be recomputed",
+    ];
+  }
+  const actual = thumbprintForKey(alg as string, publicKey);
+  if (actual === claimed) {
+    return ["PASS", `key_thumbprint rederives from the resolved ${alg as string} key`];
+  }
+  return ["FAIL", `key_substituted: receipt binds ${claimed}, resolved key computes ${actual}`];
+}

--- a/typescript/tests/verifier-key-binding-parity.test.ts
+++ b/typescript/tests/verifier-key-binding-parity.test.ts
@@ -1,0 +1,167 @@
+/**
+ * key_thumbprint binding axis, TypeScript half (criterion 458).
+ *
+ * Reads the same verifier/axis-parity-cases.json the Python suite reads, so a
+ * rule that drifts in one language fails a suite. The wire tests below are
+ * mutation-shaped: each fails if its own call site is deleted.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  akpJwk,
+  b64urlNoPad,
+  checkKeyBinding,
+  jwkThumbprint,
+  thumbprintForKey,
+} from "../src/verifier/vrShim.js";
+import { verify } from "../src/verifier/core.js";
+import { ADAPTERS } from "../src/verifier/index.js";
+
+const CASES_FILE = resolve(__dirname, "..", "..", "verifier", "axis-parity-cases.json");
+const TABLE = JSON.parse(readFileSync(CASES_FILE, "utf8"));
+
+type KeySpec = { alg: string; fill: number; len: number } | null;
+
+// Expand a table `key` spec into the bytes both languages build it from.
+function expand(spec: KeySpec): readonly [string | null, Uint8Array | null] {
+  if (spec === null) return [null, null];
+  return [spec.alg, new Uint8Array(spec.len).fill(spec.fill)];
+}
+
+const ALG = "ML-DSA-65";
+const KEY_GOOD = new Uint8Array(1952).fill(0x00);
+const KEY_EVIL = new Uint8Array(1952).fill(0x01);
+const TP_GOOD = thumbprintForKey(ALG, KEY_GOOD);
+
+function jwks(publicKey: Uint8Array, alg = ALG): Record<string, unknown> {
+  return {
+    keys: [
+      {
+        kid: "iss_1",
+        issuer_id: "iss_1",
+        agent_id: "ag_1",
+        org_id: "org_1",
+        alg,
+        public_key: Buffer.from(publicKey).toString("base64"),
+        status: "active",
+      },
+    ],
+  };
+}
+
+function receipt(thumbprint?: string): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    v: 1,
+    issuer_id: "iss_1",
+    agent_id: "ag_1",
+    org_id: "org_1",
+    previousReceiptHash: "0".repeat(64),
+    issued_at: "2026-08-31T10:00:00Z",
+    action: { type: "x" },
+    hash: "a".repeat(64),
+  };
+  if (thumbprint !== undefined) payload.key_thumbprint = thumbprint;
+  return {
+    payload,
+    signature: { alg: ALG, kid: "iss_1", sig: Buffer.alloc(64).toString("base64") },
+    anchors: {},
+  };
+}
+
+describe("key_thumbprint binding parity", () => {
+  // A table that silently empties would make every case below vacuous.
+  it("reads a populated shared table", () => {
+    expect(TABLE.key_binding.length).toBeGreaterThanOrEqual(15);
+    expect(TABLE.key_thumbprint_vectors.length).toBeGreaterThanOrEqual(4);
+    const outcomes = new Set(TABLE.key_binding.map((c: any) => c.expect.result));
+    expect([...outcomes].sort()).toEqual(["FAIL", "PASS", "SKIPPED"]);
+  });
+
+  for (const testCase of TABLE.key_thumbprint_vectors) {
+    it(`RFC 7638 vector: ${testCase.name}`, () => {
+      const [alg, pk] = expand(testCase.key);
+      expect(thumbprintForKey(alg as string, pk as Uint8Array)).toBe(testCase.thumbprint);
+    });
+  }
+
+  for (const testCase of TABLE.key_binding) {
+    it(`axis case: ${testCase.name}`, () => {
+      const [alg, pk] = expand(testCase.key);
+      const [result, note] = checkKeyBinding(testCase.payload, alg, pk);
+      expect(result, note).toBe(testCase.expect.result);
+      expect(note).toContain(testCase.expect.note_contains);
+    });
+  }
+
+  // pub is unpadded base64url; the directory's own alphabet yields another digest.
+  it("builds pub as unpadded base64url", () => {
+    const jwk = akpJwk("ML-DSA-87", new Uint8Array(2592).fill(0xff));
+    expect(Object.keys(jwk).sort()).toEqual(["alg", "kty", "pub"]);
+    expect(jwk.kty).toBe("AKP");
+    expect(jwk.pub).not.toMatch(/[/+=]/);
+    expect(jwk.pub.startsWith("____")).toBe(true);
+  });
+
+  // RFC 7638 requires lexicographic members whatever order the caller passes.
+  it("ignores member insertion order", () => {
+    const pk = new Uint8Array(1952).fill(0x07);
+    const ordered = { alg: ALG, kty: "AKP", pub: b64urlNoPad(pk) };
+    const shuffled = { pub: b64urlNoPad(pk), kty: "AKP", alg: ALG };
+    expect(jwkThumbprint(ordered)).toBe(jwkThumbprint(shuffled));
+    expect(jwkThumbprint(ordered)).toBe(thumbprintForKey(ALG, pk));
+  });
+
+  // Deleting the axis from the adapter's extraAxes fails here.
+  it("emits the axis from the oracle adapter", () => {
+    const result = verify(receipt(TP_GOOD), ADAPTERS, jwks(KEY_GOOD));
+    const axis = result.axes.find((a) => a.axis === "key_binding");
+    expect(axis, "adapter did not emit a key_binding axis").toBeDefined();
+    expect(axis!.result, axis!.note).toBe("PASS");
+  });
+
+  // Removing key_binding from INVALID_FAIL_AXES fails here.
+  it("treats a substituted key as terminal invalid, never a warning", () => {
+    const result = verify(receipt(TP_GOOD), ADAPTERS, jwks(KEY_EVIL));
+    const axis = result.axes.find((a) => a.axis === "key_binding")!;
+    expect(axis.result).toBe("FAIL");
+    expect(axis.failureClass).toBe("invalid");
+    expect(axis.note).toContain("key_substituted");
+    expect(result.verdict).toBe("unverified");
+    expect(result.failureClass).toBe("invalid");
+  });
+
+  // A skip blocks every axis but chain, so absence must PASS or legacy receipts break.
+  it("does not block a verdict when no thumbprint is bound", () => {
+    const axis = verify(receipt(), ADAPTERS, jwks(KEY_GOOD)).axes.find(
+      (a) => a.axis === "key_binding",
+    )!;
+    expect(axis.result).toBe("PASS");
+    expect(axis.failureClass).toBeNull();
+  });
+
+  // Removing key_thumbprint from UNSIGNED_CLAIM_FIELDS fails here.
+  it("refuses a hash-mode receipt displaying an unsigned thumbprint", () => {
+    const doc = {
+      v: 1,
+      mode: "hash",
+      hash: "a".repeat(64),
+      hash_algo: "sha256",
+      metadata: {},
+      server_timestamp: "2026-08-31T10:00:00Z",
+      action_id: "a1",
+      agent_id: "ag_1",
+      org_id: "org_1",
+      policy_decision: "allow",
+      signature_b64: Buffer.alloc(64).toString("base64"),
+      key_id: "iss_1",
+      key_thumbprint: TP_GOOD,
+    };
+    const result = verify(doc, ADAPTERS, jwks(KEY_GOOD));
+    const structure = result.axes.find((a) => a.axis === "structure")!;
+    expect(structure.result, structure.note).toBe("FAIL");
+    expect(structure.note).toContain("key_thumbprint");
+    expect(result.verdict).toBe("unverified");
+  });
+});

--- a/verifier/axis-parity-cases.json
+++ b/verifier/axis-parity-cases.json
@@ -1848,5 +1848,260 @@
       },
       "why": "The control: an honest token over the right digest. Python verifies it to PASS, TS still reports unverifiable, so the divergence above is the absence of anchor cryptography in TS and not a quirk of a forged token."
     }
-  ]
+  ],
+    "key_thumbprint_vectors_note": "RFC 7638 JWK Thumbprint vectors over the draft-ietf-cose-dilithium AKP form: the digest is taken over {alg, kty, pub} sorted, separator-tight, with pub in UNPADDED BASE64URL. The all-0xff ML-DSA-87 vector is the alphabet trap: its pub is all '_' in base64url where standard base64 gives '/', so an implementation that reuses the directory's public_key alphabet produces a digest no other verifier reproduces.",
+    "key_thumbprint_vectors": [
+      {
+        "name": "ML-DSA-44 all-zero key",
+        "key": {
+          "alg": "ML-DSA-44",
+          "fill": 0,
+          "len": 1312
+        },
+        "thumbprint": "sha256:d822401dad5b6a8832b186e94c3be90b0918823b9f24dae4720432d208bfd9f5"
+      },
+      {
+        "name": "ML-DSA-65 all-zero key",
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 0,
+          "len": 1952
+        },
+        "thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+      },
+      {
+        "name": "ML-DSA-65 all-0x01 key",
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 1,
+          "len": 1952
+        },
+        "thumbprint": "sha256:f1c75378c00886a8c6b2df96564b21e5c189e2b4366fa78c8e42fb207c34c2ac"
+      },
+      {
+        "name": "ML-DSA-87 all-0xff key (base64url alphabet: pub is all '_', standard base64 would be '/')",
+        "key": {
+          "alg": "ML-DSA-87",
+          "fill": 255,
+          "len": 2592
+        },
+        "thumbprint": "sha256:95078132ec612bea77887e77a1652ee0df411afd32596dd647a15e378ea8dd92"
+      }
+    ],
+    "key_binding_note": "key_thumbprint binding axis parity table (criterion 458). Expectations are the output of the Python check_key_binding in python/src/asqav/verifier/verify_receipt.py; both suites feed every case through their own implementation. `key` describes the key the signature axis resolved, expanded by each suite as a byte of value `fill` repeated `len` times, so the table stays small and identical in both languages; `key: null` means nothing resolved. ABSENCE is PASS, not SKIPPED: a skip blocks the verdict, and every receipt issued before the field existed omits it. A mismatch is FAIL and key_binding is in _INVALID_FAIL_AXES, so the verdict is unverified with failure_class invalid, never a warning. The two unrecomputable cases report SKIPPED, which also blocks, so an unverifiable binding cannot read as verified.",
+    "key_binding": [
+      {
+        "name": "no key_thumbprint bound",
+        "payload": {},
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 0,
+          "len": 1952
+        },
+        "expect": {
+          "result": "PASS",
+          "note_contains": "receipt binds no key_thumbprint; binding not checked"
+        }
+      },
+      {
+        "name": "bound thumbprint rederives from the resolved key",
+        "payload": {
+          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+        },
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 0,
+          "len": 1952
+        },
+        "expect": {
+          "result": "PASS",
+          "note_contains": "rederives from the resolved ML-DSA-65 key"
+        }
+      },
+      {
+        "name": "ML-DSA-44 binding rederives",
+        "payload": {
+          "key_thumbprint": "sha256:d822401dad5b6a8832b186e94c3be90b0918823b9f24dae4720432d208bfd9f5"
+        },
+        "key": {
+          "alg": "ML-DSA-44",
+          "fill": 0,
+          "len": 1312
+        },
+        "expect": {
+          "result": "PASS",
+          "note_contains": "rederives from the resolved ML-DSA-44 key"
+        }
+      },
+      {
+        "name": "ML-DSA-87 binding rederives over the base64url alphabet",
+        "payload": {
+          "key_thumbprint": "sha256:95078132ec612bea77887e77a1652ee0df411afd32596dd647a15e378ea8dd92"
+        },
+        "key": {
+          "alg": "ML-DSA-87",
+          "fill": 255,
+          "len": 2592
+        },
+        "expect": {
+          "result": "PASS",
+          "note_contains": "rederives from the resolved ML-DSA-87 key"
+        }
+      },
+      {
+        "name": "key substituted under the same identifier",
+        "payload": {
+          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+        },
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 1,
+          "len": 1952
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "key_substituted"
+        }
+      },
+      {
+        "name": "alg participates in the digest: a 44 key cannot satisfy a 65 binding",
+        "payload": {
+          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+        },
+        "key": {
+          "alg": "ML-DSA-44",
+          "fill": 0,
+          "len": 1312
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "key_substituted"
+        }
+      },
+      {
+        "name": "standard-base64 pub yields a digest the AKP form never produces",
+        "payload": {
+          "key_thumbprint": "sha256:e187b36fdf876583a6a6429591900efd1b636ce6a6d00f48c85451a4278d2650"
+        },
+        "key": {
+          "alg": "ML-DSA-87",
+          "fill": 255,
+          "len": 2592
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "key_substituted"
+        }
+      },
+      {
+        "name": "malformed: digest too short",
+        "payload": {
+          "key_thumbprint": "sha256:abc"
+        },
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 0,
+          "len": 1952
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "is not sha256:<64 lowercase hex>"
+        }
+      },
+      {
+        "name": "malformed: uppercase hex",
+        "payload": {
+          "key_thumbprint": "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        },
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 0,
+          "len": 1952
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "is not sha256:<64 lowercase hex>"
+        }
+      },
+      {
+        "name": "malformed: wrong digest prefix",
+        "payload": {
+          "key_thumbprint": "sha1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 0,
+          "len": 1952
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "is not sha256:<64 lowercase hex>"
+        }
+      },
+      {
+        "name": "malformed: bare hex with no prefix",
+        "payload": {
+          "key_thumbprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 0,
+          "len": 1952
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "is not sha256:<64 lowercase hex>"
+        }
+      },
+      {
+        "name": "malformed: not a string",
+        "payload": {
+          "key_thumbprint": 42
+        },
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 0,
+          "len": 1952
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "is not sha256:<64 lowercase hex>"
+        }
+      },
+      {
+        "name": "no key resolved, so nothing to rederive from",
+        "payload": {
+          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+        },
+        "key": null,
+        "expect": {
+          "result": "SKIPPED",
+          "note_contains": "no signing key resolved"
+        }
+      },
+      {
+        "name": "resolved key is not raw ML-DSA material (the KMS PEM row)",
+        "payload": {
+          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+        },
+        "key": {
+          "alg": "ML-DSA-65",
+          "fill": 0,
+          "len": 800
+        },
+        "expect": {
+          "result": "SKIPPED",
+          "note_contains": "not raw ML-DSA material"
+        }
+      },
+      {
+        "name": "absence stays conformant even when no key resolved",
+        "payload": {},
+        "key": null,
+        "expect": {
+          "result": "PASS",
+          "note_contains": "binding not checked"
+        }
+      }
+    ]
 }


### PR DESCRIPTION
Adds the recomputed-thumbprint equality check on verification, the half of criterion 458 the emission work in jagmarques/asqav#1389 does not cover. That PR binds a server-built JWK Thumbprint (RFC7638) as `key_thumbprint` into the signed compliance payload; nothing yet checks it, so this adds the check to both language halves and pins the digest with cross-language vectors.

## The axis

A new `key_binding` axis resolves the signing key, rebuilds the AKP JWK thumbprint from it, and compares:

| case | result | why |
|---|---|---|
| no `key_thumbprint` bound | PASS, "binding not checked" | the profile's pre-binding case stays conformant |
| rederives from the resolved key | PASS | |
| digest names a different key | **FAIL `key_substituted`** | proven binding break |
| value is not `sha256:<64 lowercase hex>` | FAIL | a signed member that can never match |
| no key resolved | SKIPPED | recompute could not run |
| resolved key is not raw ML-DSA | SKIPPED | a KMS row publishes a PEM in that column |

`key_binding` joins `_INVALID_FAIL_AXES` in both cores, so a mismatch folds to `unverified` / `invalid` and can never be reported as verified or softened to a warning.

**Absence PASSes rather than SKIPs, deliberately.** `fold_verdict` treats any skip outside `chain` as blocking, so emitting SKIPPED for absence would turn every receipt issued before the field existed into `unverified`. It matches how `check_expiry` and `check_nonce` already report an absent optional member.

Hash mode signs a flat 11-field object that has no room for the member, so `key_thumbprint` joins `_UNSIGNED_CLAIM_FIELDS`: a hash-mode receipt displaying one FAILs the structure axis instead of appearing bound.

## Where the code lives

`thumbprint_for_key` is inlined into `verify_receipt.py` rather than imported, because that file's header promises a single-file offline verifier that ships in the exit artifact. It was checked byte-for-byte against `asqav_cloud.core.key_thumbprint` over 180 random keys and the width-gate cases before landing.

The KMS gate is kept on this side too: binding a digest over PEM text would commit a receipt to an unresolvable key inside the signature, so a resolved key that is not raw ML-DSA of the width its own alg fixes reports SKIPPED, which still blocks, rather than a guess.

## Vectors

15 axis cases and 4 JWK Thumbprint digest vectors go into the shared `verifier/axis-parity-cases.json`, read by both suites. The all-0xff ML-DSA-87 vector is the alphabet trap: its `pub` is all `_` in base64url where standard base64 gives `/`, so an implementation that reuses the directory's `public_key` alphabet produces a digest nobody else reproduces. One case binds exactly that wrong-alphabet digest and must FAIL.

## Verification

- Python 2853 tests, TypeScript 1043 tests, `tsc --noEmit` clean, `ruff check python/src` clean.
- Both CI ruff gates pass.
- **Mutation-tested, 18 mutations, all caught**: 10 on the Python wires, 8 on the TypeScript ones. Deleting either axis append, removing `key_binding` from either `_INVALID_FAIL_AXES`, dropping `key_thumbprint` from `_UNSIGNED_CLAIM_FIELDS`, downgrading a mismatch to PASS, skipping the compare, swapping base64url for standard base64, and dropping the required member sorting each fail a test. The harness asserts a green baseline first, after a first run reported every mutation "caught" for the wrong reason.
- 4 pre-existing failures in `test_exit_artifact_cli.py` / `test_standalone_verifier_surface.py` reproduce identically on a pristine worktree of the default branch; they are a local-env artifact of the standalone subprocess and untouched by this change.
