### PR TITLE
feat(verifier): check the two claims a receipt could assert unchecked

### DIFF
--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -251,7 +251,8 @@ class AsqavNativeAdapter(FormatAdapter):
         """
         # Expiry reads only the signed bytes, so no key is needed. Hash mode signs no
         # expires_at, and reading the flat doc would gate on an uncovered field.
-        signed = {} if _is_hash_mode(doc) else _payload(doc)
+        hash_mode = _is_hash_mode(doc)
+        signed = {} if hash_mode else _payload(doc)
         axes: list[tuple[str, str, str]] = [("expiry", *_vr.check_expiry(signed))]
         axes.append(("nonce", *_vr.check_nonce(signed, self._seen_nonces)))
         jwks = key_provider or {"keys": []}
@@ -260,6 +261,15 @@ class AsqavNativeAdapter(FormatAdapter):
         # still says so rather than dropping the axis when nothing resolved.
         bound_alg, bound_pk = _resolved_key_material(entry)
         axes.append(("key_binding", *_vr.check_key_binding(signed, bound_alg, bound_pk)))
+        # No database offline, so a claimed binding reports unresolved rather than
+        # riding along as corroboration nobody checked
+        axes.append(("counterparty", *_vr.check_counterparty_binding(signed)))
+        axes.append(("payload_digest", *_vr.check_payload_digest(signed)))
+        # Hash mode signs no issued_at, so skew reads the flat server_timestamp there.
+        # Without this the oracle accepted a receipt claiming a 2099 issue time that the
+        # standalone verifier has always refused
+        stamp = doc.get("server_timestamp", "") if hash_mode else signed.get("issued_at", "")
+        axes.append(("skew", *_vr.check_skew(stamp)))
         if entry is None:
             return axes
         key_issuer = _vr.key_issuer_of(entry)

--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -77,6 +77,8 @@ _INVALID_FAIL_AXES = frozenset(
         "issuer_bind",
         "key_status",
         "key_binding",
+        "counterparty",
+        "payload_digest",
         "nonce",
         "parent_signature",
         "pdp_signature",

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -245,7 +245,16 @@ FAILURE_UNVERIFIABLE = "unverifiable"
 
 #: Axes whose FAIL proves a cryptographic/policy binding failure (invalid).
 _INVALID_FAIL_AXES = frozenset(
-    {"signature", "anchors", "issuer_bind", "key_status", "nonce", "key_binding"}
+    {
+        "signature",
+        "anchors",
+        "issuer_bind",
+        "key_status",
+        "nonce",
+        "key_binding",
+        "counterparty",
+        "payload_digest",
+    }
 )
 
 
@@ -1617,6 +1626,132 @@ def check_skew(issued_at: str):
     return "PASS", f"skew {skew:.0f}s within bound"
 
 
+def check_payload_digest(payload: dict):
+    """Recompute payload_digest from the context carried in the same receipt.
+
+    A receipt that carries BOTH the context and a digest over it is checkable with
+    no external data at all, and the two disagreeing means one of them is a lie:
+    the digest is what downstream systems bind the action content to, so a receipt
+    whose own context does not hash to its own digest is internally inconsistent.
+    Nothing checked this before, so an issuer could sign a benign context beside a
+    digest committing to something else entirely and every verifier passed it.
+
+    Absence PASSes on both sides. Hash mode carries no context, and a payload-mode
+    receipt may legitimately omit it (redaction, or an org that does not store the
+    full payload), so a missing context is the ordinary case and never a failure.
+    """
+    if not isinstance(payload, dict):
+        return "PASS", "no signed payload; no digest to recompute"
+    digest = payload.get("payload_digest")
+    if digest is None:
+        return "PASS", "receipt binds no payload_digest; nothing to recompute"
+    if not isinstance(digest, dict):
+        return "FAIL", f"payload_digest is {type(digest).__name__}, not an object"
+    claimed = digest.get("hash")
+    if not isinstance(claimed, str) or not re.fullmatch(r"[0-9a-f]{64}", claimed):
+        return "FAIL", f"payload_digest.hash {claimed!r} is not 64 lowercase hex"
+    claimed_size = digest.get("size")
+    if claimed_size is not None and (
+        not isinstance(claimed_size, int) or isinstance(claimed_size, bool) or claimed_size < 0
+    ):
+        return "FAIL", f"payload_digest.size {claimed_size!r} is not a non-negative integer"
+    if payload.get("context") is None:
+        # An explicit null reads as absent: the hosted verifier returns payload: null
+        # for redacted and hash-only receipts, and null is not a context to hash
+        return "PASS", "no context carried; payload_digest not recomputable here"
+
+    try:
+        encoded = canonical_json(payload["context"])
+    except (TypeError, ValueError, RecursionError):
+        return "SKIPPED", "context is not canonicalisable, so payload_digest cannot be recomputed"
+    actual = hashlib.sha256(encoded).hexdigest()
+    if actual != claimed:
+        return "FAIL", (
+            f"payload_digest_mismatch: receipt binds {claimed[:16]}.., "
+            f"its own context hashes to {actual[:16]}.."
+        )
+    if claimed_size is not None and claimed_size != len(encoded):
+        return "FAIL", (
+            f"payload_digest_mismatch: size claims {claimed_size}, "
+            f"canonical context is {len(encoded)} bytes"
+        )
+    return "PASS", f"payload_digest rederives from the carried context ({len(encoded)} bytes)"
+
+
+def _envelope_hash(envelope: dict) -> str:
+    """Base64 SHA-256 over the originating envelope's full canonical bytes.
+
+    Scope includes the originator's signature bytes, which is the rule that stops a
+    re-signing intermediary from escaping detection. Mirrors the cloud's
+    core/envelope.py compute_envelope_hash.
+    """
+    return base64.b64encode(hashlib.sha256(canonical_json(envelope)).digest()).decode()
+
+
+def check_counterparty_binding(payload: dict, originator: dict | None = None):
+    """Weigh a claimed cross-agent binding instead of letting it ride unchecked.
+
+    counterparty_binding is caller-supplied: an issuer can attach one asserting
+    "the counterparty acknowledged this" over a receipt nobody else ever saw. The
+    hosted verifier resolves receipt_ref against its own database, but an offline
+    third party has no database, so before this axis existed a fabricated binding
+    reached a plain verified verdict with the corroboration claim unexamined.
+
+    Absence PASSes: a receipt that claims no corroboration is the ordinary case and
+    must not be penalised, and a skip would block every one of them. A claim the
+    verifier cannot resolve reports SKIPPED, which blocks, so an unchecked binding
+    can never read as corroborated - the same rule anchors follow, where presence
+    alone never passes the axis. A malformed or mismatched binding is a proven
+    break and FAILs, because the receipt asserts a binding it cannot satisfy.
+    """
+    if not isinstance(payload, dict):
+        return "PASS", "no signed payload; no counterparty binding to check"
+    cpb = payload.get("counterparty_binding")
+    if cpb is None:
+        return "PASS", "no counterparty binding; content is unilaterally asserted"
+    if not isinstance(cpb, dict):
+        return "FAIL", f"counterparty_binding is {type(cpb).__name__}, not an object"
+
+    receipt_ref = cpb.get("receipt_ref")
+    envelope_hash = cpb.get("envelope_hash")
+    if not isinstance(receipt_ref, str) or not receipt_ref:
+        return "FAIL", "counterparty_binding.receipt_ref missing or not a string"
+    if not isinstance(envelope_hash, str) or not envelope_hash:
+        return "FAIL", "counterparty_binding.envelope_hash missing or not a string"
+    try:
+        raw = base64.b64decode(envelope_hash, validate=True)
+    except Exception:
+        return "FAIL", f"counterparty_binding.envelope_hash {envelope_hash!r} is not base64"
+    if len(raw) != 32:
+        return "FAIL", (
+            f"counterparty_binding.envelope_hash decodes to {len(raw)} bytes, not a sha-256"
+        )
+
+    expect_ack_from = cpb.get("expect_ack_from")
+    if expect_ack_from is not None and not isinstance(expect_ack_from, str):
+        return "FAIL", "counterparty_binding.expect_ack_from is not a string"
+
+    if not isinstance(originator, dict):
+        # Structurally sound but nothing here corroborates it; blocking on purpose
+        return "SKIPPED", (
+            f"counterparty binding claims {receipt_ref}; no originating receipt supplied, "
+            "so the corroboration is unchecked"
+        )
+
+    actual = _envelope_hash(originator)
+    if actual != envelope_hash:
+        return "FAIL", (
+            f"counterparty_mismatch: binding commits {envelope_hash[:16]}.., "
+            f"supplied originator hashes to {actual[:16]}.."
+        )
+    if expect_ack_from is not None and payload.get("issuer_id") != expect_ack_from:
+        return "FAIL", (
+            f"counterparty_mismatch: binding expects an acknowledgment from "
+            f"{expect_ack_from}, this receipt is issued by {payload.get('issuer_id')!r}"
+        )
+    return "PASS", f"counterparty binding rederives from the supplied {receipt_ref}"
+
+
 def check_key_binding(payload: dict, alg, public_key):
     """Recompute the signed key_thumbprint from the resolved key and compare.
 
@@ -1784,6 +1919,7 @@ def run(
     *,
     trusted_tsa_keys=None,
     bitcoin_headers=None,
+    counterparty: dict | None = None,
 ) -> int:
     if not isinstance(envelope, dict):
         print("Asqav receipt verification")
@@ -1898,6 +2034,8 @@ def run(
     # Outside the else on purpose: a receipt binding no thumbprint still reports the
     # axis, so the report says the binding was not checked rather than staying silent.
     results.append(("key_binding", *check_key_binding(payload, eff_alg, eff_pk)))
+    results.append(("counterparty", *check_counterparty_binding(payload, counterparty)))
+    results.append(("payload_digest", *check_payload_digest(payload)))
     results.append(("chain", *check_chain(payload, predecessor_payload)))
     results.append(("anchors", anchor_eval.result, anchor_eval.note))
     results.append(("skew", *check_skew(payload.get("issued_at", ""))))
@@ -1944,6 +2082,7 @@ def run_structured(
     *,
     trusted_tsa_keys=None,
     bitcoin_headers=None,
+    counterparty: dict | None = None,
 ) -> dict:
     """Verify a receipt offline and return a structured result dict.
 
@@ -2093,6 +2232,10 @@ def run_structured(
     # Outside the else on purpose: a receipt binding no thumbprint still reports the
     # axis, so the report says the binding was not checked rather than staying silent.
     axes.append(_struct_axis("key_binding", *check_key_binding(payload, eff_alg, eff_pk)))
+    axes.append(
+        _struct_axis("counterparty", *check_counterparty_binding(payload, counterparty))
+    )
+    axes.append(_struct_axis("payload_digest", *check_payload_digest(payload)))
     axes.append(_struct_axis("chain", *check_chain(payload, predecessor_payload)))
     axes.append(_struct_axis("anchors", anchor_eval.result, anchor_eval.note))
     axes.append(_struct_axis("skew", *check_skew(payload.get("issued_at", ""))))

--- a/python/tests/test_receipt_integrity_axes.py
+++ b/python/tests/test_receipt_integrity_axes.py
@@ -1,0 +1,192 @@
+"""Receipt-internal integrity axes, Python half.
+
+Two classes of claim an issuer could previously assert unchecked:
+
+  - `payload_digest` over a `context` the receipt carries itself. Recomputable
+    with NO external data, so a receipt whose own context does not hash to its
+    own digest is provably inconsistent. Nothing checked it before.
+  - `counterparty_binding`, which asserts a counterparty acknowledged the action.
+    The hosted verifier resolves it against its database; an offline third party
+    has none, so a fabricated binding reached a plain verified verdict.
+
+The shared table in verifier/axis-parity-cases.json drives this file and
+typescript/tests/verifier-receipt-integrity-parity.test.ts.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+from asqav.verifier import verify_receipt as vr
+from asqav.verifier.oracle import ADAPTERS
+from asqav.verifier.oracle import verify as oracle_verify
+from asqav.verifier.oracle.core import _INVALID_FAIL_AXES as ORACLE_INVALID_FAIL_AXES
+
+CASES_FILE = Path(__file__).parent.parent.parent / "verifier" / "axis-parity-cases.json"
+TABLE = json.loads(CASES_FILE.read_text())
+
+ALG = "ML-DSA-65"
+KEY = bytes([0x00]) * 1952
+CTX = {"amount": 100, "currency": "EUR"}
+HONEST = hashlib.sha256(vr.canonical_json(CTX)).hexdigest()
+
+
+def _jwks() -> dict:
+    return {
+        "keys": [
+            {
+                "kid": "iss_1",
+                "issuer_id": "iss_1",
+                "agent_id": "ag_1",
+                "org_id": "org_1",
+                "alg": ALG,
+                "public_key": base64.b64encode(KEY).decode(),
+                "status": "active",
+            }
+        ]
+    }
+
+
+def _receipt(**extra) -> dict:
+    payload = {
+        "v": 1,
+        "type": "protectmcp:decision",
+        "issuer_id": "iss_1",
+        "agent_id": "ag_1",
+        "org_id": "org_1",
+        "previousReceiptHash": vr.FIRST_RECEIPT_SEED,
+        "issued_at": "2026-08-31T10:00:00Z",
+        "action_ref": "a" * 64,
+        "context": CTX,
+        "payload_digest": {"hash": HONEST, "size": len(vr.canonical_json(CTX))},
+        "policy_digest": "pd",
+        "decision": "allow",
+    }
+    payload.update(extra)
+    return {
+        "payload": payload,
+        "signature": {"alg": ALG, "kid": "iss_1", "sig": base64.b64encode(b"\x00" * 64).decode()},
+        "anchors": {},
+    }
+
+
+def test_table_is_populated() -> None:
+    assert len(TABLE["payload_digest"]) >= 10
+    assert len(TABLE["counterparty_binding"]) >= 8
+    assert {c["expect"]["result"] for c in TABLE["payload_digest"]} == {"PASS", "FAIL"}
+    assert {c["expect"]["result"] for c in TABLE["counterparty_binding"]} == {
+        "PASS",
+        "FAIL",
+        "SKIPPED",
+    }
+
+
+def test_payload_digest_table() -> None:
+    for case in TABLE["payload_digest"]:
+        result, note = vr.check_payload_digest(case["payload"])
+        assert result == case["expect"]["result"], f"{case['name']}: {note}"
+        assert case["expect"]["note_contains"] in note, f"{case['name']}: {note}"
+
+
+def test_counterparty_binding_table() -> None:
+    for case in TABLE["counterparty_binding"]:
+        result, note = vr.check_counterparty_binding(case["payload"])
+        assert result == case["expect"]["result"], f"{case['name']}: {note}"
+        assert case["expect"]["note_contains"] in note, f"{case['name']}: {note}"
+
+
+    # The originator path the table cannot carry: a real recompute, both directions.
+def test_counterparty_binding_resolves_against_a_supplied_originator() -> None:
+    originator = _receipt()
+    good = base64.b64encode(hashlib.sha256(vr.canonical_json(originator)).digest()).decode()
+
+    payload = _receipt(
+        counterparty_binding={"receipt_ref": "sig_orig", "envelope_hash": good}
+    )["payload"]
+    assert vr.check_counterparty_binding(payload, originator)[0] == "PASS"
+
+    wrong = base64.b64encode(b"\x00" * 32).decode()
+    payload = _receipt(
+        counterparty_binding={"receipt_ref": "sig_orig", "envelope_hash": wrong}
+    )["payload"]
+    result, note = vr.check_counterparty_binding(payload, originator)
+    assert result == "FAIL"
+    assert "counterparty_mismatch" in note
+
+    payload = _receipt(
+        counterparty_binding={
+            "receipt_ref": "sig_orig",
+            "envelope_hash": good,
+            "expect_ack_from": "somebody_else",
+        }
+    )["payload"]
+    result, note = vr.check_counterparty_binding(payload, originator)
+    assert result == "FAIL"
+    assert "expects an acknowledgment from somebody_else" in note
+
+
+# --------------------------------------------------------------------------
+# Wire tests - each fails if its own call site is deleted
+# --------------------------------------------------------------------------
+
+
+def test_oracle_emits_all_three_axes() -> None:
+    """The oracle lacked skew entirely, so a postdated receipt passed there."""
+    axes = {a.axis for a in oracle_verify(_receipt(), ADAPTERS, _jwks()).axes}
+    assert {"payload_digest", "counterparty", "skew"} <= axes, sorted(axes)
+
+
+def test_run_structured_emits_the_new_axes() -> None:
+    names = {a["name"] for a in vr.run_structured(_receipt(), _jwks())["axes"]}
+    assert {"payload_digest", "counterparty"} <= names, sorted(names)
+
+
+def test_a_lying_payload_digest_is_terminal_invalid() -> None:
+    assert "payload_digest" in ORACLE_INVALID_FAIL_AXES
+    assert "payload_digest" in vr._INVALID_FAIL_AXES
+    result = oracle_verify(
+        _receipt(payload_digest={"hash": "f" * 64, "size": 31}), ADAPTERS, _jwks()
+    )
+    axis = result.axis("payload_digest")
+    assert (axis.result, axis.failure_class) == ("FAIL", "invalid"), axis.note
+    assert "payload_digest_mismatch" in axis.note
+    assert result.verdict == "unverified"
+
+
+def test_a_fabricated_counterparty_binding_cannot_read_as_corroborated() -> None:
+    assert "counterparty" in ORACLE_INVALID_FAIL_AXES
+    assert "counterparty" in vr._INVALID_FAIL_AXES
+    forged = {
+        "receipt_ref": "sig_NEVER_EXISTED",
+        "envelope_hash": base64.b64encode(b"\x00" * 32).decode(),
+    }
+    axis = oracle_verify(_receipt(counterparty_binding=forged), ADAPTERS, _jwks()).axis(
+        "counterparty"
+    )
+    # SKIPPED blocks the verdict, so the claim never rides along as corroboration
+    assert axis.result == "SKIPPED", axis.note
+    assert axis.failure_class == "unverifiable"
+
+
+def test_the_oracle_refuses_a_postdated_receipt() -> None:
+    axis = oracle_verify(_receipt(issued_at="2099-01-01T00:00:00Z"), ADAPTERS, _jwks()).axis(
+        "skew"
+    )
+    assert axis.result == "FAIL", axis.note
+    assert axis.failure_class == "invalid"
+
+
+    # Absence must PASS: a skip blocks every axis but chain, so a receipt that
+    # claims neither would otherwise regress to unverified.
+def test_absence_of_both_claims_does_not_block() -> None:
+    doc = _receipt()
+    doc["payload"].pop("counterparty_binding", None)
+    doc["payload"].pop("payload_digest", None)
+    result = oracle_verify(doc, ADAPTERS, _jwks())
+    for name in ("payload_digest", "counterparty"):
+        axis = result.axis(name)
+        assert axis.result == "PASS", f"{name}: {axis.note}"
+        assert axis.failure_class is None

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -32,8 +32,11 @@ import {
   b64decode,
   checkExpiry,
   checkIssuerBinding,
+  checkCounterpartyBinding,
   checkKeyBinding,
   checkKeyStatus,
+  checkPayloadDigest,
+  checkSkew,
   checkNonce,
   checkOrgBinding,
   checkStructure,
@@ -265,7 +268,15 @@ export class AsqavNativeAdapter extends FormatAdapter {
     // Reported before the no-entry return, so a receipt binding no thumbprint
     // still says so rather than dropping the axis when nothing resolved.
     const [boundAlg, boundPk] = resolvedKeyMaterial(entry);
-    axes.push(["key_binding", ...checkKeyBinding(hashMode ? {} : payloadOf(doc), boundAlg, boundPk)]);
+    const signedUnit = hashMode ? {} : payloadOf(doc);
+    axes.push(["key_binding", ...checkKeyBinding(signedUnit, boundAlg, boundPk)]);
+    // No database offline, so a claimed binding reports unresolved rather than
+    // riding along as corroboration nobody checked
+    axes.push(["counterparty", ...checkCounterpartyBinding(signedUnit)]);
+    axes.push(["payload_digest", ...checkPayloadDigest(signedUnit)]);
+    // Hash mode signs no issued_at, so skew reads the flat server_timestamp there
+    const stamp = hashMode ? doc.server_timestamp : signedUnit.issued_at;
+    axes.push(["skew", ...checkSkew(stamp)]);
     if (entry === null) return axes;
     // Both wire shapes name their issuer inside the signed bytes: issuer_id in
     // compliance mode, org_id in hash mode.

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -68,6 +68,8 @@ const INVALID_FAIL_AXES = new Set([
   "issuer_bind",
   "key_status",
   "key_binding",
+  "counterparty",
+  "payload_digest",
   "nonce",
   "parent_signature",
   "pdp_signature",

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -750,3 +750,143 @@ export function checkKeyBinding(
   }
   return ["FAIL", `key_substituted: receipt binds ${claimed}, resolved key computes ${actual}`];
 }
+
+// ---------------------------------------------------------------------------
+// Receipt-internal integrity: payload_digest vs the carried context, and a
+// claimed counterparty binding. Ports of the Python check_payload_digest /
+// check_counterparty_binding; the shared vectors hold the two copies together.
+// ---------------------------------------------------------------------------
+
+const LOWER_HEX_64 = /^[0-9a-f]{64}$/;
+
+/**
+ * Recompute payload_digest from the context carried in the same receipt.
+ *
+ * A receipt carrying BOTH a context and a digest over it is checkable with no
+ * external data, and the two disagreeing means one of them is a lie. Absence
+ * PASSes on both sides: hash mode carries no context, and a payload-mode receipt
+ * may legitimately omit it under redaction.
+ */
+export function checkPayloadDigest(payload: unknown): readonly [VerifyState, string] {
+  if (!isRecord(payload)) return ["PASS", "no signed payload; no digest to recompute"];
+  const digest = payload.payload_digest;
+  if (digest === undefined || digest === null) {
+    return ["PASS", "receipt binds no payload_digest; nothing to recompute"];
+  }
+  if (!isRecord(digest)) {
+    return ["FAIL", `payload_digest is ${pyTypeName(digest)}, not an object`];
+  }
+  const claimed = digest.hash;
+  if (typeof claimed !== "string" || !LOWER_HEX_64.test(claimed)) {
+    return ["FAIL", `payload_digest.hash ${pyRepr(claimed)} is not 64 lowercase hex`];
+  }
+  const claimedSize = digest.size;
+  if (
+    claimedSize !== undefined &&
+    claimedSize !== null &&
+    (typeof claimedSize !== "number" || !Number.isInteger(claimedSize) || claimedSize < 0)
+  ) {
+    return ["FAIL", `payload_digest.size ${pyRepr(claimedSize)} is not a non-negative integer`];
+  }
+  if (payload.context === undefined || payload.context === null) {
+    return ["PASS", "no context carried; payload_digest not recomputable here"];
+  }
+  let encoded: Uint8Array;
+  try {
+    encoded = asqavJcs(payload.context);
+  } catch {
+    return ["SKIPPED", "context is not canonicalisable, so payload_digest cannot be recomputed"];
+  }
+  const actual = sha256Hex(encoded);
+  if (actual !== claimed) {
+    return [
+      "FAIL",
+      `payload_digest_mismatch: receipt binds ${claimed.slice(0, 16)}.., ` +
+        `its own context hashes to ${actual.slice(0, 16)}..`,
+    ];
+  }
+  if (claimedSize !== undefined && claimedSize !== null && claimedSize !== encoded.length) {
+    return [
+      "FAIL",
+      `payload_digest_mismatch: size claims ${claimedSize}, ` +
+        `canonical context is ${encoded.length} bytes`,
+    ];
+  }
+  return ["PASS", `payload_digest rederives from the carried context (${encoded.length} bytes)`];
+}
+
+/**
+ * Weigh a claimed cross-agent binding instead of letting it ride unchecked.
+ *
+ * counterparty_binding is caller-supplied, so an issuer can assert "the
+ * counterparty acknowledged this" over a receipt nobody else saw. Absence PASSes;
+ * a claim this verifier cannot resolve reports SKIPPED, which blocks, so an
+ * unchecked binding never reads as corroborated; malformed or mismatched FAILs.
+ */
+export function checkCounterpartyBinding(
+  payload: unknown,
+  originator?: Record<string, unknown> | null,
+): readonly [VerifyState, string] {
+  if (!isRecord(payload)) return ["PASS", "no signed payload; no counterparty binding to check"];
+  const cpb = payload.counterparty_binding;
+  if (cpb === undefined || cpb === null) {
+    return ["PASS", "no counterparty binding; content is unilaterally asserted"];
+  }
+  if (!isRecord(cpb)) {
+    return ["FAIL", `counterparty_binding is ${pyTypeName(cpb)}, not an object`];
+  }
+  const receiptRef = cpb.receipt_ref;
+  const envelopeHash = cpb.envelope_hash;
+  if (typeof receiptRef !== "string" || receiptRef.length === 0) {
+    return ["FAIL", "counterparty_binding.receipt_ref missing or not a string"];
+  }
+  if (typeof envelopeHash !== "string" || envelopeHash.length === 0) {
+    return ["FAIL", "counterparty_binding.envelope_hash missing or not a string"];
+  }
+  let raw: Buffer;
+  try {
+    raw = Buffer.from(envelopeHash, "base64");
+    if (raw.toString("base64").replace(/=+$/, "") !== envelopeHash.replace(/=+$/, "")) {
+      return ["FAIL", `counterparty_binding.envelope_hash ${pyRepr(envelopeHash)} is not base64`];
+    }
+  } catch {
+    return ["FAIL", `counterparty_binding.envelope_hash ${pyRepr(envelopeHash)} is not base64`];
+  }
+  if (raw.length !== 32) {
+    return [
+      "FAIL",
+      `counterparty_binding.envelope_hash decodes to ${raw.length} bytes, not a sha-256`,
+    ];
+  }
+  const expectAckFrom = cpb.expect_ack_from;
+  if (expectAckFrom !== undefined && expectAckFrom !== null && typeof expectAckFrom !== "string") {
+    return ["FAIL", "counterparty_binding.expect_ack_from is not a string"];
+  }
+  if (!isRecord(originator)) {
+    return [
+      "SKIPPED",
+      `counterparty binding claims ${receiptRef}; no originating receipt supplied, ` +
+        "so the corroboration is unchecked",
+    ];
+  }
+  const actual = Buffer.from(sha256Hex(asqavJcs(originator)), "hex").toString("base64");
+  if (actual !== envelopeHash) {
+    return [
+      "FAIL",
+      `counterparty_mismatch: binding commits ${envelopeHash.slice(0, 16)}.., ` +
+        `supplied originator hashes to ${actual.slice(0, 16)}..`,
+    ];
+  }
+  if (
+    expectAckFrom !== undefined &&
+    expectAckFrom !== null &&
+    payload.issuer_id !== expectAckFrom
+  ) {
+    return [
+      "FAIL",
+      `counterparty_mismatch: binding expects an acknowledgment from ${expectAckFrom}, ` +
+        `this receipt is issued by ${pyRepr(payload.issuer_id)}`,
+    ];
+  }
+  return ["PASS", `counterparty binding rederives from the supplied ${receiptRef}`];
+}

--- a/typescript/tests/verifier-receipt-integrity-parity.test.ts
+++ b/typescript/tests/verifier-receipt-integrity-parity.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Receipt-internal integrity axes, TypeScript half.
+ *
+ * Reads the same verifier/axis-parity-cases.json the Python suite reads, so a
+ * rule that drifts in one language fails a suite. Covers payload_digest (a
+ * digest recomputable from the context the receipt carries itself) and
+ * counterparty_binding (caller-supplied corroboration that used to ride
+ * unchecked through every offline verifier).
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { createHash } from "node:crypto";
+
+import {
+  checkCounterpartyBinding,
+  checkPayloadDigest,
+} from "../src/verifier/vrShim.js";
+import { asqavJcs } from "../src/verifier/canonical.js";
+import { verify } from "../src/verifier/core.js";
+import { ADAPTERS } from "../src/verifier/index.js";
+
+const CASES_FILE = resolve(__dirname, "..", "..", "verifier", "axis-parity-cases.json");
+const TABLE = JSON.parse(readFileSync(CASES_FILE, "utf-8"));
+
+const ALG = "ML-DSA-65";
+const KEY = new Uint8Array(1952).fill(0);
+const CTX = { amount: 100, currency: "EUR" };
+const HONEST = createHash("sha256").update(Buffer.from(asqavJcs(CTX))).digest("hex");
+
+function jwks(): Record<string, unknown> {
+  return {
+    keys: [
+      {
+        kid: "iss_1",
+        issuer_id: "iss_1",
+        agent_id: "ag_1",
+        org_id: "org_1",
+        alg: ALG,
+        public_key: Buffer.from(KEY).toString("base64"),
+        status: "active",
+      },
+    ],
+  };
+}
+
+function receipt(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    v: 1,
+    type: "protectmcp:decision",
+    issuer_id: "iss_1",
+    agent_id: "ag_1",
+    org_id: "org_1",
+    previousReceiptHash: "0".repeat(64),
+    issued_at: "2026-08-31T10:00:00Z",
+    action_ref: "a".repeat(64),
+    context: CTX,
+    payload_digest: { hash: HONEST, size: asqavJcs(CTX).length },
+    policy_digest: "pd",
+    decision: "allow",
+    ...extra,
+  };
+  return {
+    payload,
+    signature: { alg: ALG, kid: "iss_1", sig: Buffer.alloc(64).toString("base64") },
+    anchors: {},
+  };
+}
+
+describe("receipt-internal integrity parity", () => {
+  it("reads a populated shared table", () => {
+    expect(TABLE.payload_digest.length).toBeGreaterThanOrEqual(10);
+    expect(TABLE.counterparty_binding.length).toBeGreaterThanOrEqual(8);
+  });
+
+  for (const c of TABLE.payload_digest) {
+    it(`payload_digest: ${c.name}`, () => {
+      const [result, note] = checkPayloadDigest(c.payload);
+      expect(result, note).toBe(c.expect.result);
+      expect(note).toContain(c.expect.note_contains);
+    });
+  }
+
+  for (const c of TABLE.counterparty_binding) {
+    it(`counterparty: ${c.name}`, () => {
+      const [result, note] = checkCounterpartyBinding(c.payload);
+      expect(result, note).toBe(c.expect.result);
+      expect(note).toContain(c.expect.note_contains);
+    });
+  }
+
+  // Deleting any of the three adapter pushes fails here.
+  it("emits payload_digest, counterparty and skew from the oracle", () => {
+    const axes = new Set(verify(receipt(), ADAPTERS, jwks()).axes.map((a) => a.axis));
+    for (const name of ["payload_digest", "counterparty", "skew"]) {
+      expect(axes.has(name), `missing ${name}; got ${[...axes].sort().join(",")}`).toBe(true);
+    }
+  });
+
+  // Removing payload_digest from INVALID_FAIL_AXES fails here.
+  it("treats a lying payload_digest as terminal invalid", () => {
+    const r = verify(
+      receipt({ payload_digest: { hash: "f".repeat(64), size: 31 } }),
+      ADAPTERS,
+      jwks(),
+    );
+    const axis = r.axes.find((a) => a.axis === "payload_digest")!;
+    expect(axis.result).toBe("FAIL");
+    expect(axis.failureClass).toBe("invalid");
+    expect(axis.note).toContain("payload_digest_mismatch");
+    expect(r.verdict).toBe("unverified");
+  });
+
+  it("never lets a fabricated counterparty binding read as corroborated", () => {
+    const forged = { receipt_ref: "sig_NEVER_EXISTED", envelope_hash: Buffer.alloc(32).toString("base64") };
+    const axis = verify(receipt({ counterparty_binding: forged }), ADAPTERS, jwks()).axes.find(
+      (a) => a.axis === "counterparty",
+    )!;
+    expect(axis.result).toBe("SKIPPED");
+    expect(axis.failureClass).toBe("unverifiable");
+  });
+
+  it("refuses a postdated receipt", () => {
+    const axis = verify(receipt({ issued_at: "2099-01-01T00:00:00Z" }), ADAPTERS, jwks()).axes.find(
+      (a) => a.axis === "skew",
+    )!;
+    expect(axis.result).toBe("FAIL");
+    expect(axis.failureClass).toBe("invalid");
+  });
+
+  // Absence must PASS: a skip blocks every axis but chain.
+  it("does not block when neither claim is present", () => {
+    const doc = receipt();
+    const payload = doc.payload as Record<string, unknown>;
+    delete payload.counterparty_binding;
+    delete payload.payload_digest;
+    const r = verify(doc, ADAPTERS, jwks());
+    for (const name of ["payload_digest", "counterparty"]) {
+      const axis = r.axes.find((a) => a.axis === name)!;
+      expect(axis.result, `${name}: ${axis.note}`).toBe("PASS");
+      expect(axis.failureClass).toBeNull();
+    }
+  });
+});

--- a/verifier/axis-parity-cases.json
+++ b/verifier/axis-parity-cases.json
@@ -2103,5 +2103,258 @@
           "note_contains": "binding not checked"
         }
       }
+    ],
+    "receipt_integrity_note": "Receipt-internal integrity axes (payload_digest, counterparty). Expectations are the output of the Python check_payload_digest / check_counterparty_binding in python/src/asqav/verifier/verify_receipt.py; both suites feed every case through their own implementation. payload_digest is recomputable with NO external data whenever the receipt carries both a context and a digest over it, so the two disagreeing proves one of them is a lie. counterparty_binding is caller-supplied corroboration: absence PASSes, a claim the verifier cannot resolve reports SKIPPED (which blocks, so it never reads as corroborated), and malformed or mismatched FAILs.",
+    "payload_digest": [
+      {
+        "name": "no payload_digest bound",
+        "payload": {
+          "context": {
+            "amount": 100,
+            "currency": "EUR"
+          }
+        },
+        "expect": {
+          "result": "PASS",
+          "note_contains": "binds no payload_digest"
+        }
+      },
+      {
+        "name": "digest rederives from the carried context",
+        "payload": {
+          "context": {
+            "amount": 100,
+            "currency": "EUR"
+          },
+          "payload_digest": {
+            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+            "size": 31
+          }
+        },
+        "expect": {
+          "result": "PASS",
+          "note_contains": "rederives from the carried context"
+        }
+      },
+      {
+        "name": "digest commits to something the context does not hash to",
+        "payload": {
+          "context": {
+            "amount": 100,
+            "currency": "EUR"
+          },
+          "payload_digest": {
+            "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "size": 31
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "payload_digest_mismatch"
+        }
+      },
+      {
+        "name": "size disagrees with the canonical context",
+        "payload": {
+          "context": {
+            "amount": 100,
+            "currency": "EUR"
+          },
+          "payload_digest": {
+            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+            "size": 99999
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "payload_digest_mismatch"
+        }
+      },
+      {
+        "name": "no context carried, nothing to recompute against",
+        "payload": {
+          "payload_digest": {
+            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+            "size": 31
+          }
+        },
+        "expect": {
+          "result": "PASS",
+          "note_contains": "no context carried"
+        }
+      },
+      {
+        "name": "explicit null context reads as absent",
+        "payload": {
+          "context": null,
+          "payload_digest": {
+            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e"
+          }
+        },
+        "expect": {
+          "result": "PASS",
+          "note_contains": "no context carried"
+        }
+      },
+      {
+        "name": "payload_digest is not an object",
+        "payload": {
+          "context": {
+            "amount": 100,
+            "currency": "EUR"
+          },
+          "payload_digest": "nope"
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "not an object"
+        }
+      },
+      {
+        "name": "hash is not 64 lowercase hex",
+        "payload": {
+          "context": {
+            "amount": 100,
+            "currency": "EUR"
+          },
+          "payload_digest": {
+            "hash": "ABC"
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "not 64 lowercase hex"
+        }
+      },
+      {
+        "name": "hash is uppercase hex",
+        "payload": {
+          "context": {
+            "amount": 100,
+            "currency": "EUR"
+          },
+          "payload_digest": {
+            "hash": "F50D36C1739463E571DA8E929FDEB3BC35C5BF86051C653D6A61DEEDCB10944E"
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "not 64 lowercase hex"
+        }
+      },
+      {
+        "name": "size is negative",
+        "payload": {
+          "context": {
+            "amount": 100,
+            "currency": "EUR"
+          },
+          "payload_digest": {
+            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+            "size": -1
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "non-negative integer"
+        }
+      }
+    ],
+    "counterparty_binding": [
+      {
+        "name": "no counterparty binding claimed",
+        "payload": {},
+        "expect": {
+          "result": "PASS",
+          "note_contains": "unilaterally asserted"
+        }
+      },
+      {
+        "name": "claimed but no originating receipt supplied",
+        "payload": {
+          "counterparty_binding": {
+            "receipt_ref": "sig_X",
+            "envelope_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+          }
+        },
+        "expect": {
+          "result": "SKIPPED",
+          "note_contains": "corroboration is unchecked"
+        }
+      },
+      {
+        "name": "binding is not an object",
+        "payload": {
+          "counterparty_binding": "nope"
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "not an object"
+        }
+      },
+      {
+        "name": "receipt_ref missing",
+        "payload": {
+          "counterparty_binding": {
+            "envelope_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "receipt_ref missing"
+        }
+      },
+      {
+        "name": "envelope_hash missing",
+        "payload": {
+          "counterparty_binding": {
+            "receipt_ref": "sig_X"
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "envelope_hash missing"
+        }
+      },
+      {
+        "name": "envelope_hash is not base64",
+        "payload": {
+          "counterparty_binding": {
+            "receipt_ref": "sig_X",
+            "envelope_hash": "!!!not-b64!!!"
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "is not base64"
+        }
+      },
+      {
+        "name": "envelope_hash is not a sha-256 width",
+        "payload": {
+          "counterparty_binding": {
+            "receipt_ref": "sig_X",
+            "envelope_hash": "c2hvcnQ="
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "not a sha-256"
+        }
+      },
+      {
+        "name": "expect_ack_from is not a string",
+        "payload": {
+          "counterparty_binding": {
+            "receipt_ref": "sig_X",
+            "envelope_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            "expect_ack_from": 7
+          }
+        },
+        "expect": {
+          "result": "FAIL",
+          "note_contains": "expect_ack_from is not a string"
+        }
+      }
     ]
 }


### PR DESCRIPTION
Adversarial probing of the offline verifier surfaces turned up three gaps where an issuer
could put false content in a receipt and still reach a plain `verified` verdict. Everything
here is additive: every new axis PASSes on absence, so a receipt issued before this stays
conformant.

## 1. `payload_digest` was never recomputed

A receipt carrying **both** a `context` and a digest over it is checkable with no external data
at all, yet nothing compared them. An issuer could sign `{"amount":100,"currency":"EUR"}`
beside a digest committing to something else entirely, and every verifier passed it.

```
receipt.context        = {"amount":100,"currency":"EUR"}
receipt.payload_digest = ffff...ffff          <- commits to something else
verdict before         = structure PASS, no axis mentions it
verdict after          = payload_digest FAIL / invalid
```

The recomputation was cross-checked against a real production receipt: its carried context
hashes to exactly the `payload_digest.hash` the platform signed.

## 2. `counterparty_binding` was unknown to both language halves

It asserts that a counterparty acknowledged the action. The hosted `/verify/{id}` resolves it
against the database, but the SDK oracle, the standalone exit-artifact verifier, and
`/verify/universal` (which delegates to the oracle) have none - so a **fabricated** binding
pointing at a receipt that never existed rode through with the corroboration claim unexamined.

| case | before | after |
|---|---|---|
| absent | no axis | PASS, "unilaterally asserted" |
| points at a nonexistent receipt | no axis | **SKIPPED** (blocks) |
| not an object / bad base64 / wrong width | no axis | **FAIL invalid** |
| resolved and rederives | no axis | PASS |
| resolved and mismatches | no axis | **FAIL invalid** |

Unresolvable reports SKIPPED rather than PASS on purpose: a skip blocks the verdict, so an
unchecked binding can never read as corroborated. That mirrors the anchors rule, where
presence alone never passes the axis.

## 3. The oracle path had no `skew` axis at all

`check_skew` exists and `run_structured` uses it, but the oracle never emitted it, so the
oracle accepted a receipt claiming `issued_at: 2099-01-01` that the standalone verifier has
always refused. A parity gap between the two offline surfaces, not a new rule.

## Verified NOT broken

Probed and confirmed intact, so they are untouched here: chain and genesis forking (two
per-agent unique indexes, confirmed live and valid on the production database), the
platform-owned field guards that strip caller values before model construction, the forced
self-declared marker on threat-framework claims, agent deletion (soft, and the key stays
published so old receipts still resolve), nonce replay, and key substitution.

## Verification

- 18 shared cross-language vectors in `verifier/axis-parity-cases.json` drive both suites.
- Python 2888 passed, TypeScript 1067 passed, `tsc --noEmit` clean, `ruff check python/src` clean.
- 4 pre-existing failures in `test_exit_artifact_cli.py` / `test_standalone_verifier_surface.py`
  reproduce identically on a pristine worktree of the default branch and pass in CI; they are a
  local-env artifact of the standalone subprocess.

## Spec follow-up

Checked against the -08 XML. `key_thumbprint` recomputation and the 300-second forward-skew
bound are **already normative**, so gap 3 was an implementation gap only. Two rules are genuinely
missing and are tracked for -09: recomputing `payload_digest` when the context is carried, and
what a verifier must do with a `counterparty_binding` it cannot resolve.
