### PR TITLE
chore(release): 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-08-31
+
+### Added
+
+- **`payload_digest` verification axis: the digest is recomputed from the
+  `context` the receipt carries itself.** A receipt carrying both is checkable
+  with no external data, and the two disagreeing proves one of them is a lie.
+  Nothing compared them before, so an issuer could sign a benign context beside
+  a digest committing to something else entirely and every verifier passed it.
+  A mismatch is terminal invalid. Absence PASSes on both sides: hash mode carries
+  no context, and a payload-mode receipt may legitimately omit it under redaction.
+- **`counterparty` verification axis.** `counterparty_binding` asserts that a
+  counterparty acknowledged the Action. The hosted verifier resolves it against
+  its own database, but an offline third party has none, so a fabricated binding
+  pointing at a receipt that never existed previously reached a plain `verified`
+  verdict with the corroboration claim unexamined. Absence PASSes; a malformed
+  binding FAILs as invalid; a binding the verifier cannot resolve reports SKIPPED,
+  which blocks, so an unchecked claim can never read as corroborated. Supplying
+  the originating receipt recomputes the envelope digest and cross-checks
+  `expect_ack_from`.
+- **The oracle path now emits the `skew` axis.** `check_skew` existed and the
+  standalone verifier used it, but the oracle never emitted it, so the oracle
+  accepted a receipt claiming an `issued_at` in 2099 that the standalone verifier
+  had always refused. Closes a parity gap between the two offline surfaces.
+- 18 shared cross-language vectors in `verifier/axis-parity-cases.json` drive both
+  language halves.
+
+
 ## [0.10.1] - 2026-08-31
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.1"
+version = "0.10.2"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -186,7 +186,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -7,7 +7,7 @@
  * name), so the helper only adds it when running under Node.
  */
 
-export const SDK_VERSION = "0.10.1";
+export const SDK_VERSION = "0.10.2";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Patch bump publishing the three verifier integrity axes from #430: `payload_digest` recomputation from a carried context, the `counterparty` axis so a fabricated binding cannot read as corroborated, and the `skew` axis on the oracle path.

All additive - every new axis PASSes on absence, so a receipt issued before them stays conformant.

Moves the five version sites together plus the changelog entry. Both registries sit at 0.10.1, so 0.10.2 is free.