### PR TITLE
docs(sdk): cut every comment block to at most two lines

### DIFF
--- a/python/src/asqav/attestation.py
+++ b/python/src/asqav/attestation.py
@@ -47,9 +47,8 @@ __all__ = [
 ATTESTATION_STATEMENT_SCHEMA = "asqav.attestation/1"
 DEFAULT_COMMITMENT_ALG = "HMAC-SHA256"
 
-#: Public verdict vocabulary (criteria 418/438). A good attestation receipt is
-#: verified_keyed, never plain verified: the commitment is an HMAC sealed with a
-#: holder-only key, so the commitment itself is never re-derivable here.
+#: Public verdict vocabulary (criteria 418/438). An attestation receipt is verified_keyed,
+#: never plain verified: the HMAC commitment is sealed with a holder-only key.
 VERDICT_VERIFIED_KEYED = "verified_keyed"
 VERDICT_UNVERIFIED = "unverified"
 

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -337,11 +337,8 @@ SANDBOX_STATE_NAMESPACE: frozenset[str] = frozenset({"enabled", "disabled", "una
 #: only this set (`rekor` rejected, not shipped). Mirrors the governance.json contract.
 WITNESS_NAMESPACE: frozenset[str] = frozenset({"rfc3161", "opentimestamps"})
 
-#: Producer-side `capture_topology` vocabulary mirrored from the cloud
-#: SignRequest Literal. See docs/capture-topology.md. A client-supplied
-#: capture_topology is ADVISORY: the server stamps the authoritative value
-#: from the ingress route (for code-authorship that is `github_sha_pull`,
-#: set only after the server re-fetches the commit and recomputes the diff).
+#: Producer-side `capture_topology` mirrored from the cloud SignRequest Literal.
+#: ADVISORY: the server stamps the authoritative value from the ingress route.
 CAPTURE_TOPOLOGY_NAMESPACE: frozenset[str] = frozenset(
     {
         "in_process_sdk",
@@ -421,10 +418,8 @@ def _resolve_previous_receipt_hash(data: dict[str, Any]) -> str | None:
     )
 
 
-#: REQUIRED fields on a Compliance Receipt envelope (wire form); the wire
-#: discriminator is ``type`` and the wire verdict field is ``decision``
-#: (matches the standalone verifier's REQUIRED_FIELDS). Used by
-#: `verify_compliance_receipt`.
+#: REQUIRED fields on a Compliance Receipt envelope (wire form); the discriminator is
+#: ``type`` and the verdict field is ``decision``. Used by `verify_compliance_receipt`.
 _COMPLIANCE_REQUIRED_FIELDS: tuple[str, ...] = (
     "type",
     "issuer_id",

--- a/python/src/asqav/code_authorship.py
+++ b/python/src/asqav/code_authorship.py
@@ -40,9 +40,8 @@ CODE_AUTHORSHIP_ASSET_CLASS: str = "code"
 #: The server stamps it after re-fetching the commit and recomputing the diff.
 AUTHORITATIVE_CAPTURE_LAYER: str = "github_sha_pull"
 
-#: Capture layers that are client self-reports. A code-authorship receipt
-#: carrying one of these is observation only and never an authoritative
-#: decision receipt.
+#: Capture layers that are client self-reports. A code-authorship receipt carrying one
+#: is observation only, never an authoritative decision receipt.
 OBSERVATION_ONLY_CAPTURE_LAYERS: frozenset[str] = frozenset(
     {"in_process_sdk", "passive_telemetry"}
 )

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -48,10 +48,8 @@ _HASH_MODE_FIELDS = (
 )
 
 
-#: Claim fields that live inside the signed compliance payload. A hash-mode
-#: receipt carrying one is presenting a claim its signature does not cover.
-#: key_thumbprint is here because hash mode signs the flat 11 fields above and
-#: nothing else, so a thumbprint pasted onto one binds no key at all.
+#: Claims belonging to the signed payload; hash mode signs the flat fields only,
+#: so a thumbprint pasted onto one binds nothing.
 _UNSIGNED_CLAIM_FIELDS = ("issuer_id", "previousReceiptHash", "key_thumbprint")
 
 
@@ -265,9 +263,8 @@ class AsqavNativeAdapter(FormatAdapter):
         # riding along as corroboration nobody checked
         axes.append(("counterparty", *_vr.check_counterparty_binding(signed)))
         axes.append(("payload_digest", *_vr.check_payload_digest(signed)))
-        # Hash mode signs no issued_at, so skew reads the flat server_timestamp there.
-        # Without this the oracle accepted a receipt claiming a 2099 issue time that the
-        # standalone verifier has always refused
+        # Hash mode signs no issued_at, so skew reads the flat server_timestamp; without
+        # this the oracle accepted a 2099 issue time the standalone verifier refuses.
         stamp = doc.get("server_timestamp", "") if hash_mode else signed.get("issued_at", "")
         axes.append(("skew", *_vr.check_skew(stamp)))
         if entry is None:
@@ -281,10 +278,8 @@ class AsqavNativeAdapter(FormatAdapter):
             payload = _payload(doc)
             issued_at = payload.get("issued_at", "")
             bind = _vr.check_issuer_binding(key_issuer, payload.get("issuer_id"))
-        # Only an anchor the caller cryptographically verified counts as trusted
-        # timing (verify_receipt.evaluate_anchors). This adapter pins no TSA key
-        # material, so it passes False: a forged anchor never rides a revoked key
-        # to PASS here.
+        # Only a caller-verified anchor counts as trusted timing. This adapter pins no
+        # TSA material, so it passes False: a forged anchor never rides a revoked key.
         res, note = _vr.check_key_status(
             entry.get("status"), issued_at, _vr.revoked_at_of(entry), False
         )

--- a/python/src/asqav/verifier/oracle/adapters/authproof.py
+++ b/python/src/asqav/verifier/oracle/adapters/authproof.py
@@ -28,10 +28,8 @@ from typing import Any
 
 from ..adapter import ChainStep, FormatAdapter, SignatureMaterial
 
-#: A shipping-SDK delegationId is ``auth-<epoch_ms>-<5 base36 chars>``.
-#: ``[0-9]`` (not ``\d``) and ``\A``/``\Z`` (not ``^``/``$``) keep this byte-for-byte
-#: with the ECMAScript regex: ``\d`` would admit non-ASCII digits and ``$`` would
-#: accept a trailing newline, both of which the TypeScript validator rejects.
+#: A shipping-SDK delegationId is ``auth-<epoch_ms>-<5 base36 chars>``. ``[0-9]`` and
+#: ``\A``/``\Z`` keep this byte-for-byte with the stricter ECMAScript regex.
 _DELEGATION_ID = re.compile(r"\Aauth-[0-9]+-[a-z0-9]{5}\Z")
 
 #: Fields the SDK always writes, used for the structural check.

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -399,13 +399,8 @@ def _b64decode(value: str) -> bytes:
     return base64.b64decode(s, validate=False)
 
 
-# ---------------------------------------------------------------------------
-# RFC 7638 JWK Thumbprint over an ML-DSA (AKP) public key.
-#
-# The mirror of the cloud's asqav_cloud.core.key_thumbprint. Inlined rather than
-# imported so this file stays the single-file offline verifier its header
-# promises; the cross-language vectors are what hold the two copies together.
-# ---------------------------------------------------------------------------
+# RFC 7638 JWK Thumbprint over an ML-DSA (AKP) public key, mirroring the cloud's
+# key_thumbprint. Inlined so this stays the single-file offline verifier.
 
 #: draft-ietf-cose-dilithium key type for ML-DSA key pairs
 AKP_KTY = "AKP"
@@ -414,8 +409,7 @@ AKP_KTY = "AKP"
 _THUMBPRINT_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 #: FIPS 204 public-key widths in bytes, fixed by the standard. A KMS-backed agent
-#: publishes a PEM in the same column as a locally generated raw key, and a PEM is
-#: not the key material an AKP `pub` carries, so width is what separates the two.
+#: publishes a PEM where a raw key would sit, so width is what separates the two.
 _ML_DSA_PUBLIC_KEY_BYTES = {"ML-DSA-44": 1312, "ML-DSA-65": 1952, "ML-DSA-87": 2592}
 
 
@@ -497,24 +491,8 @@ def _safe_b64(v: object) -> bool:
     return _anchor_bytes(v) is not None
 
 
-# --- Offline anchor cryptographic verification -------------------------------
-#
-# Presence is not proof: anchors sit outside the signed bytes, so the draft
-# requires a successful cryptographic check before an anchor counts. Per entry:
-#   "verified"     - the token commits this envelope's digest AND its own
-#                    signature/merkle path checks out against pinned trust material
-#   "invalid"      - the check ran and failed (wrong committed digest, TSA
-#                    rejection status, a signature that does not verify, a merkle
-#                    path that misses the stated block)
-#   "unverifiable" - the check could not complete offline (unparseable token,
-#                    missing optional dep, no pinned TSA key, no Bitcoin header
-#                    source, unknown anchor type, declared status pending/failed).
-#                    Never a PASS on presence alone.
-#
-# Trust material is caller-pinned, never derived from the unsigned envelope:
-# ``trusted_tsa_keys`` is TSA public keys (raw ML-DSA/Ed25519 bytes) or X.509
-# certificates (PEM or DER); ``bitcoin_headers`` maps a block height to
-# {"merkle_root": <display hex>, "time": <ISO-8601>}.
+# --- Offline anchor verification: presence is not proof, each entry reports
+# verified / invalid / unverifiable, and trust material is caller-pinned. ------
 
 
 class _AnchorParseError(ValueError):
@@ -827,9 +805,8 @@ def _verify_tsa_signature(sig_alg: str, signed: bytes, signature: bytes, trusted
         try:
             from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
         except ImportError:
-            # cryptography is optional (see the module docstring); without it
-            # this branch reports unverifiable, exactly as the RSA/ECDSA one
-            # does, rather than raising out of the anchors axis.
+            # cryptography is optional; without it this branch reports unverifiable,
+            # as the RSA/ECDSA one does, rather than raising out of the anchors axis.
             return "unverifiable"
 
         for pk in raw_keys:
@@ -1094,9 +1071,8 @@ def _check_ots_anchor(blob: bytes, bound: bytes, bitcoin_headers) -> tuple[str, 
     )
 
 
-#: (result, note, trusted_times) triple for the anchors axis. ``trusted_times``
-#: carries the provenance times of anchors that CRYPTOGRAPHICALLY verified, the
-#: only times a caller may weigh against a key's revoked_at.
+#: (result, note, trusted_times) for the anchors axis. ``trusted_times`` holds times of
+#: anchors that CRYPTOGRAPHICALLY verified, the only ones weighable against revoked_at.
 AnchorEvaluation = namedtuple("AnchorEvaluation", ("result", "note", "trusted_times"))
 
 
@@ -1546,9 +1522,8 @@ def verify_signature(pk: bytes, msg: bytes, sig: bytes, alg: object):
         return "FAIL", f"verify error: {exc}"
 
 
-#: Basic-format UTC offset (+0200, +02), which ISO 8601 allows and fromisoformat
-#: reads only from CPython 3.11 on. Matched on the part after the 10-char date so
-#: a bare "2020-01-01" is never mistaken for an offset.
+#: Basic-format UTC offset (+0200, +02); fromisoformat reads it only from CPython 3.11 on.
+#: Matched after the 10-char date so a bare "2020-01-01" is never mistaken for an offset.
 _BASIC_OFFSET_RE = re.compile(r"([+-])(\d{2}):?(\d{2})?$")
 
 #: Colon-separated clock time, the spelling every supported version reads alike.
@@ -2020,9 +1995,8 @@ def run(
         results.append(
             ("issuer_bind", *check_issuer_binding(eff_issuer, payload.get("issuer_id")))
         )
-        # Only a cryptographically verified anchor whose proven time lands at or
-        # before the key's revoked_at proves pre-revocation timing; presence
-        # alone never upgrades a revoked key (anchors are unsigned).
+        # Only a cryptographically verified anchor at or before revoked_at proves
+        # pre-revocation timing; presence alone never upgrades a revoked key.
         trusted_anchor = _has_trusted_pre_revocation_anchor(
             anchor_eval.trusted_times, eff_revoked_at
         )
@@ -2190,9 +2164,8 @@ def run_structured(
         eff_issuer = resolve_key_issuer(jwks, kid)
         eff_revoked_at = resolve_revoked_at(jwks, kid)
         eff_pk, eff_alg = pk, jwks_alg
-        # Cloud receipts sign with the agent key though kid is the issuer id; fall
-        # back, mirroring run(). agent_id is attacker-controlled, so trust only a
-        # key whose published issuer_id matches the claimed issuer.
+        # Cloud receipts sign with the agent key though kid is the issuer id; fall back,
+        # mirroring run(). agent_id is attacker-controlled, so match on issuer_id.
         if sig_res[0] != "PASS":
             agent_id = payload.get("agent_id") or envelope.get("agent_id")
             org_bind = payload.get("org_id") or envelope.get("org_id")
@@ -2215,9 +2188,8 @@ def run_structured(
         # kid picks the key and the attacker picks the kid, so bind the key that
         # actually verified back to the issuer the receipt claims.
         axes.append(_struct_axis("issuer_bind", *check_issuer_binding(eff_issuer, payload.get("issuer_id"))))
-        # Only a cryptographically verified anchor whose proven time lands at or
-        # before revoked_at counts as trusted timing; presence alone never
-        # upgrades a revoked key to a verified verdict.
+        # Only a cryptographically verified anchor at or before revoked_at counts as
+        # trusted timing; presence alone never upgrades a revoked key.
         trusted_anchor = _has_trusted_pre_revocation_anchor(
             anchor_eval.trusted_times, eff_revoked_at
         )

--- a/typescript/src/algorithms.ts
+++ b/typescript/src/algorithms.ts
@@ -1,8 +1,7 @@
 // Algorithm agility for receipt signing.
 
-// SUPPORTED_ALGORITHMS is the client-side validation set (all five). The cloud
-// signs only with ml-dsa-{44,65,87}; ed25519/es256 pass local validation but
-// the cloud returns HTTP 400. Those two are for local sign/verify only.
+// Client-side validation set (all five). The cloud signs only ml-dsa-{44,65,87};
+// ed25519/es256 pass locally but the cloud returns HTTP 400, so they are local-only.
 
 import {
   createPrivateKey,

--- a/typescript/src/budget.ts
+++ b/typescript/src/budget.ts
@@ -1,10 +1,6 @@
 /**
- * Client-side spend budget tracking for AI agent actions.
- *
- * Mirrors the Python BudgetTracker. Each recorded spend is signed via
- * the agent so the budget trail itself is tamper-evident. Enforcement
- * is the caller's responsibility: `check()` is a fail-closed arithmetic
- * check; the SDK does not block actions on its own.
+ * Client-side spend budget tracking mirroring the Python BudgetTracker; each spend is signed so the trail
+ * is tamper-evident. Enforcement is the caller's: `check()` is arithmetic, the SDK blocks nothing.
  */
 
 import type { Agent, SignatureResponse } from "./index.js";

--- a/typescript/src/canonicalize.ts
+++ b/typescript/src/canonicalize.ts
@@ -1,17 +1,6 @@
 /**
- * Canonical JSON + content hashing for the @asqav/sdk TypeScript client.
- *
- * Mirrors the Python ``asqav.canonicalize`` module byte-for-byte. The
- * conformance vectors at ``conformance/vectors.json`` are validated against
- * both implementations, so a hash computed in Node and a hash computed in
- * Python over the same dict are guaranteed to agree.
- *
- * JCS subset:
- *   - object keys sorted lexicographically
- *   - no whitespace anywhere
- *   - non-ASCII strings emitted as raw UTF-8
- *   - integers as integers (no trailing ``.0``)
- *   - finite floats only (NaN / Infinity rejected)
+ * Canonical JSON + content hashing, mirroring the Python ``asqav.canonicalize`` byte-for-byte: sorted
+ * keys, no whitespace, raw UTF-8, integers as integers, finite floats only.
  */
 
 import { createHash, createHmac } from "node:crypto";
@@ -25,11 +14,8 @@ type JsonValue =
   | { [key: string]: JsonValue };
 
 /**
- * Canonicalize a JSON-serializable value into UTF-8 bytes.
- *
- * Throws on values that aren't representable in JSON (functions, undefined,
- * BigInt, Symbol) and on non-finite numbers (NaN / Infinity), matching
- * the behavior of Python's ``json.dumps(allow_nan=False)``.
+ * Canonicalize a JSON-serializable value into UTF-8 bytes. Throws on values JSON cannot represent and
+ * on non-finite numbers, matching Python's ``json.dumps(allow_nan=False)``.
  */
 export function canonicalize(value: unknown): Uint8Array {
   return new TextEncoder().encode(canonicalString(value));
@@ -73,13 +59,8 @@ function numberToCanonical(n: number): string {
 }
 
 /**
- * Standard JSON string serialization.
- *
- * Escapes control chars below U+0020, plus the two characters that JSON
- * requires (`"` and `\`). Everything U+0020 and above (including all
- * non-ASCII letters) is emitted as raw UTF-8. This matches Python's
- * ``json.dumps(ensure_ascii=False)`` which is what the conformance
- * vectors are generated with.
+ * Standard JSON string serialization: escapes control chars below U+0020 plus `"` and `\`, everything
+ * else raw UTF-8. Matches the ``ensure_ascii=False`` form the conformance vectors are generated with.
  */
 function jsonString(s: string): string {
   let out = '"';
@@ -148,17 +129,8 @@ function findFloatPointer(value: unknown, pointer: string): string | null {
 }
 
 /**
- * Pre-validate ``tool_args`` and return JCS-canonical bytes.
- *
- * Floats are not byte-stable across runtimes, so the Compliance Receipts
- * profile keeps them out of the signed canonical scope. Serialize
- * numerics as strings (``"1.5"``) or integer-rational pairs before
- * calling this helper. Integers (including any value where
- * ``Number.isInteger`` is true) and booleans pass through.
- *
- * @throws Error When any leaf is a non-integer or non-finite number; the
- *   message includes the JSON pointer to the offending value so the
- *   caller can fix the input.
+ * Pre-validate ``tool_args`` and return JCS-canonical bytes. Floats are not byte-stable across runtimes,
+ * so a non-integer leaf throws with a JSON pointer to the offending value; serialize numerics as strings.
  */
 export function canonicalizeToolArgs(args: unknown): Uint8Array {
   const pointer = findFloatPointer(args, "");
@@ -174,10 +146,8 @@ export function canonicalizeToolArgs(args: unknown): Uint8Array {
 }
 
 /**
- * Self-describing hash for an action: `sha256:<hex>`.
- * With `salt` set, uses HMAC-SHA-256 keyed by that caller-held salt. The prefix
- * reads `sha256` either way, so a verifier recomputing per the fingerprint spec
- * cannot tell a salted digest from a plain one.
+ * Self-describing hash for an action: `sha256:<hex>`, or HMAC-SHA-256 when `salt` is set. The prefix
+ * reads `sha256` either way, so a verifier cannot tell a salted digest from a plain one.
  */
 export async function hashAction(
   actionType: string,

--- a/typescript/src/cli.ts
+++ b/typescript/src/cli.ts
@@ -1,22 +1,7 @@
 #!/usr/bin/env node
 /**
- * asqav CLI for TypeScript / Node.
- *
- * Mirrors the Python `asqav` CLI surface:
- *   asqav --version
- *   asqav verify <signature_id>
- *   asqav agents list / create <name>
- *   asqav sessions list / end <session_id>
- *   asqav replay <agent_id> <session_id>
- *   asqav preflight <agent_id> <action_type>
- *   asqav budget check / record
- *   asqav approve <session_id> <entity_id>
- *   asqav compliance frameworks / export
- *   asqav audit-pack verify <bundle>
- *   asqav org halt / resume <org_id>          (admin, ASQAV_SESSION_TOKEN)
- *
- * Every command here works on the free tier. The server is the source of
- * truth for what a given key may do.
+ * asqav CLI for TypeScript / Node, mirroring the Python `asqav` CLI surface. Every command works on the
+ * free tier; the server is the source of truth for what a given key may do.
  */
 
 import fs from "node:fs";
@@ -455,9 +440,10 @@ function validateSignFlags(flags: SignCliFlags): void {
   }
 }
 
-/** Assemble the call-time `context` map by reading the optional JSON
- * file, layering the optional policy artefact under a sentinel key, and
- * stamping the `_action_id` sentinel when supplied. */
+/**
+ * Assemble the call-time `context` map: the optional JSON file, the optional policy artefact under a
+ * sentinel key, and the `_action_id` sentinel when supplied.
+ */
 async function loadSignContext(
   flags: SignCliFlags,
 ): Promise<Record<string, unknown> | undefined> {
@@ -740,11 +726,8 @@ async function cmdOrgSetComplianceStrict(args: string[]): Promise<void> {
 }
 
 /**
- * Call an admin/owner route that authenticates with a dashboard JWT.
- *
- * The emergency-halt routes resolve the caller via the cloud's
- * get_current_user dependency (cookie or Authorization: Bearer), not the
- * X-API-Key an agent key carries. Reads the JWT from ASQAV_SESSION_TOKEN.
+ * Call an admin/owner route that authenticates with a dashboard JWT read from ASQAV_SESSION_TOKEN, not
+ * the X-API-Key an agent key carries.
  */
 async function sessionRequest(
   method: string,

--- a/typescript/src/codeAuthorship.ts
+++ b/typescript/src/codeAuthorship.ts
@@ -1,18 +1,6 @@
 /**
- * SDK half of the un-bypassable code-authorship path.
- *
- * POST /v1/code-authorship is the authoritative ingress. The client supplies an
- * ADVISORY change digest (sha256 of `git diff base..head`) and the server
- * re-fetches the commit, recomputes the canonical diff, and signs an in-toto
- * Statement whose `subject[0].digest.sha256` is the SERVER-recomputed hash. The
- * client digest is never trusted. `digest_match` only reports whether the
- * advisory value agreed with the server's.
- *
- * The authoritative capture layer for a code-authorship receipt is
- * `github_sha_pull`. A receipt whose capture layer is `in_process_sdk` or
- * `passive_telemetry` is a client self-report and can NEVER be an authoritative
- * decision receipt (observation only), mirroring the cloud's
- * `observation_decision_not_allowed` rule.
+ * SDK half of the un-bypassable code-authorship path: the client digest is ADVISORY and the server
+ * re-fetches the commit and signs its own. Only `github_sha_pull` is an authoritative capture layer.
  */
 
 import { createHash } from "node:crypto";
@@ -42,9 +30,8 @@ export const CODE_AUTHORSHIP_ASSET_CLASS = "code";
 export const AUTHORITATIVE_CAPTURE_LAYER = "github_sha_pull";
 
 /**
- * Capture layers that are client self-reports. A code-authorship receipt
- * carrying one of these is observation only and never an authoritative
- * decision receipt.
+ * Capture layers that are client self-reports. A code-authorship receipt carrying one is observation
+ * only, never an authoritative decision receipt.
  */
 export const OBSERVATION_ONLY_CAPTURE_LAYERS = [
   "in_process_sdk",
@@ -56,13 +43,8 @@ export const VERDICT_PASS = "PASS";
 export const VERDICT_REJECT = "REJECT";
 
 /**
- * Compute the ADVISORY change digest `sha256:<hex>`.
- *
- * The advisory digest is sha256 of `git diff base..head`. When `diffText` is
- * supplied it is hashed directly. With no diff the bare head sha is hashed so
- * the field is always a well-formed `sha256:<64 hex>` existence proof. The
- * server recomputes its own digest and signs that. This value only lets the
- * server report `digest_match`.
+ * Compute the ADVISORY change digest `sha256:<hex>` over `git diff base..head`, or over the bare head
+ * sha when no diff is supplied. The server recomputes and signs its own; this only feeds `digest_match`.
  */
 export function computeAdvisoryDigest(
   headSha: string,
@@ -160,12 +142,8 @@ export interface CodeAuthorshipOptions {
 }
 
 /**
- * POST an advisory code-authorship record to /v1/code-authorship.
- *
- * `changeDigest` is ADVISORY (sha256 of `git diff base..head`). The server
- * recomputes the authoritative digest and signs it. Requires `init({ apiKey })`
- * with a key holding the `code_authorship:write` scope. Returns the parsed
- * authoritative envelope.
+ * POST an advisory code-authorship record to /v1/code-authorship; the server recomputes the
+ * authoritative digest and signs it. Needs an apiKey holding the `code_authorship:write` scope.
  */
 export async function submitCodeAuthorship(
   options: CodeAuthorshipOptions,
@@ -201,14 +179,8 @@ export interface CodeAuthorshipVerification {
 }
 
 /**
- * Verify the code-authorship structural + capture-layer invariant.
- *
- * Checks the in-toto Statement shape (`_type`, `predicateType`), that
- * `subject[0].digest.sha256` is present, and the capture-layer rule:
- * `github_sha_pull` is authoritative, `in_process_sdk` / `passive_telemetry`
- * are observation only and never authoritative. The cryptographic DSSE
- * signature is verified by the standalone verifier or the hosted /verify. The
- * cloud is the authoritative verifier and this helper is a convenience.
+ * Verify the in-toto Statement shape and the capture-layer invariant. The DSSE signature is verified by
+ * the standalone verifier or the hosted /verify; this helper is a convenience, not the authority.
  */
 export function verifyCodeAuthorshipEnvelope(
   envelope: unknown,

--- a/typescript/src/counterparty.ts
+++ b/typescript/src/counterparty.ts
@@ -1,27 +1,15 @@
 /**
- * Counterparty acknowledgment binding helpers for the IETF Compliance Receipts profile.
- *
- * The acknowledging receipt's `receipt_type` is `protectmcp:acknowledgment`;
- * the binding object travels on the signed payload of B's receipt and
- * gates verification per the staged IETF -04 revision.
- *
- * See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
+ * Counterparty acknowledgment binding helpers for the IETF Compliance Receipts profile. The binding
+ * travels on the signed payload of B's `protectmcp:acknowledgment` receipt and gates verification.
  */
 
 import { createHash } from "node:crypto";
 
 import { canonicalJson } from "./jcs.js";
 
-/** Cross-agent byte-equality binding to an originating receipt.
- *
- * `envelope_hash` is the base64-encoded SHA-256 digest over the
- * originating receipt's full canonical signed envelope (signature bytes
- * included). `receipt_ref` is the opaque resolvable locator the
- * verifier uses to fetch A's envelope from the Audit Pack or a
- * Deployer-published index. `expect_ack_from` is an OPTIONAL
- * cross-check on the acknowledging receipt's signature `kid`;
- * `transport_label` is operational only and MUST NOT serve as a basis
- * for trust derivation.
+/**
+ * Cross-agent byte-equality binding to an originating receipt: `envelope_hash` over A's full canonical
+ * signed envelope, `receipt_ref` to fetch it. `transport_label` is operational, never a basis for trust.
  */
 export interface CounterpartyBinding {
   envelope_hash: string;
@@ -30,11 +18,9 @@ export interface CounterpartyBinding {
   transport_label?: string;
 }
 
-/** Per-axis outcome of the SDK-side counterparty-binding sanity check.
- *
- * `label` vocabulary: `matches` | `mismatch` | `unresolved` |
- * `kid_mismatch`. Mirrors the cloud's `counterparty_binding_verified`
- * axis in `api/routes/verify.py`.
+/**
+ * Per-axis outcome of the SDK-side counterparty-binding check; `label` is matches | mismatch |
+ * unresolved | kid_mismatch, mirroring the cloud's `counterparty_binding_verified` axis.
  */
 export interface CounterpartyBindingVerification {
   valid: boolean;
@@ -43,11 +29,9 @@ export interface CounterpartyBindingVerification {
   label: "matches" | "mismatch" | "unresolved" | "kid_mismatch";
 }
 
-/** Base64 SHA-256 of the originating envelope's full JCS bytes.
- *
- * Mirrors the cloud's `core.envelope.compute_envelope_hash` so the
- * acknowledger and the verifier produce byte-identical digests across
- * SDKs and the cloud emit path.
+/**
+ * Base64 SHA-256 of the originating envelope's full JCS bytes, mirroring the cloud's
+ * `compute_envelope_hash` so acknowledger, verifier and cloud produce byte-identical digests.
  */
 export function computeEnvelopeHash(
   envelope: Record<string, unknown>,
@@ -57,10 +41,10 @@ export function computeEnvelopeHash(
 
 /** Options for {@link computeCounterpartyBinding}. */
 export interface ComputeCounterpartyBindingOptions {
-  /** Resolvable locator for A's receipt. Defaults to
-   * `originatingEnvelope.payload.action_id` (then `signature_id`); pass
-   * an explicit value when the Audit Pack production layer uses a
-   * different identifier scheme. */
+  /**
+   * Resolvable locator for A's receipt, defaulting to `payload.action_id` then `signature_id`. Pass an
+   * explicit value when the Audit Pack uses a different identifier scheme.
+   */
   receiptRef?: string;
   /** Optional declared acknowledger identifier; the verifier cross-checks
    * the acknowledging receipt's `signature.kid` against this value. */
@@ -69,14 +53,9 @@ export interface ComputeCounterpartyBindingOptions {
   transportLabel?: string;
 }
 
-/** Build a {@link CounterpartyBinding} for the originating envelope.
- *
- * The digest is computed over the canonical bytes of the dict as-passed;
- * callers MUST pass the bytes B actually received, not a
- * re-canonicalization, so intermediary tampering is detectable.
- *
- * @throws Error if `receiptRef` was not supplied and the originating
- *   envelope's payload has no `action_id` to default to.
+/**
+ * Build a {@link CounterpartyBinding} over the canonical bytes of the dict as-passed; callers MUST pass
+ * the bytes B actually received, not a re-canonicalization, so intermediary tampering is detectable.
  */
 export function computeCounterpartyBinding(
   originatingEnvelope: Record<string, unknown>,
@@ -111,12 +90,9 @@ export function computeCounterpartyBinding(
   return binding;
 }
 
-/** Re-derive and compare the binding's `envelope_hash`.
- *
- * Returns `label` in {`matches`, `mismatch`, `unresolved`,
- * `kid_mismatch`} so callers can distinguish a tampered handoff from
- * a missing originator. `kidMatches` is `null` when `expect_ack_from`
- * was not declared on the binding.
+/**
+ * Re-derive and compare the binding's `envelope_hash`, returning a label that separates a tampered
+ * handoff from a missing originator. `kidMatches` is null when `expect_ack_from` was not declared.
  */
 export function verifyCounterpartyBinding(
   acknowledgmentEnvelope: Record<string, unknown>,

--- a/typescript/src/credentials.ts
+++ b/typescript/src/credentials.ts
@@ -1,9 +1,6 @@
 /**
- * File-backed credential layer for the Asqav SDK.
- *
- * Stores an API key (and optional API base) in ~/.asqav/credentials so the SDK
- * and CLI can resolve a key without an environment variable. Resolution mirrors
- * the Python half: explicit argument, then environment, then file.
+ * File-backed credential layer storing an API key in ~/.asqav/credentials. Resolution mirrors the Python
+ * half: explicit argument, then environment, then file.
  */
 
 import fs from "node:fs";
@@ -23,10 +20,8 @@ function expandHome(raw: string): string {
 }
 
 /**
- * Sanitize a caller-supplied path before any file I/O. Expands a leading "~"
- * and rejects the two classic path-injection vectors, null bytes and traversal
- * ("..") components, so an attacker-influenced value cannot redirect a read,
- * write, or chmod to an arbitrary location. Throws on a rejected path.
+ * Sanitize a caller-supplied path before any file I/O: expands a leading "~" and rejects null bytes and
+ * traversal components, so an attacker-influenced value cannot redirect I/O. Throws on a rejected path.
  */
 export function validatedPath(raw: string, source: string): string {
   if (raw.includes("\0")) {
@@ -40,9 +35,8 @@ export function validatedPath(raw: string, source: string): string {
 }
 
 /**
- * Resolve the credentials file location (env override, else ~/.asqav/credentials).
- * The ASQAV_CREDENTIALS_PATH override is validated before it is used for I/O, so
- * a traversal value such as ../../etc/passwd is rejected rather than read or written.
+ * Resolve the credentials file location (env override, else ~/.asqav/credentials). ASQAV_CREDENTIALS_PATH
+ * is validated before use, so a traversal value is rejected rather than read or written.
  */
 export function credentialsPath(): string {
   const override = process.env.ASQAV_CREDENTIALS_PATH;

--- a/typescript/src/doors.ts
+++ b/typescript/src/doors.ts
@@ -1,6 +1,5 @@
-// Standards-interop doors: one Asqav receipt, N native envelopes (W3C VC, CloudEvents,
-// OTel GenAI, C2PA, ERC-8004). Inner receipt is byte-identical across every door.
-// Pure and offline: no signing, no network, no mutation, no clock reads. See doors.py.
+// Standards-interop doors: one Asqav receipt, N native envelopes, inner receipt
+// byte-identical across every door. Pure and offline. See doors.py.
 import { createHash } from "node:crypto";
 
 import { canonicalJson } from "./jcs.js";

--- a/typescript/src/extras/_base.ts
+++ b/typescript/src/extras/_base.ts
@@ -1,33 +1,13 @@
 /**
- * Base adapter for Asqav framework integrations.
- *
- * Mirrors the Python ``asqav.extras._base.AsqavAdapter`` surface so the
- * documentation can cross-link the two SDKs. Framework-specific adapters
- * (LangChain.js, Mastra, OpenAI Agents JS, etc.) compose this class via
- * an internal field rather than multiple inheritance because TypeScript
- * does not support multi-class inheritance.
- *
- * Responsibilities:
- *   - Resolve an Asqav ``Agent`` from either a pre-built instance,
- *     ``agentId`` (calls ``Agent.get``), or ``agentName`` (calls
- *     ``Agent.create``).
- *   - Provide a shared ``signAction`` helper that is fail-open: signing
- *     errors are routed to the caller-supplied ``onError`` handler and
- *     never raise into the host pipeline.
- *   - Provide a stable place to attach future cross-cutting features
- *     (observe mode, session grouping) without touching every adapter.
+ * Base adapter for Asqav framework integrations, mirroring the Python ``asqav.extras._base`` surface.
+ * Resolves an Agent and provides a fail-open ``signAction``; adapters compose it rather than inherit.
  */
 
 import { Agent } from "../index.js";
 
 /**
- * Options accepted by every Asqav adapter constructor.
- *
- * Exactly one of ``agent``, ``agentId``, or ``agentName`` should be
- * provided. When ``agent`` is set the adapter signs against it directly.
- * When ``agentId`` is set the adapter calls ``Agent.get`` lazily on the
- * first event. When ``agentName`` is set the adapter calls
- * ``Agent.create`` lazily on the first event.
+ * Options accepted by every Asqav adapter constructor. Provide exactly one of ``agent`` (used directly),
+ * ``agentId`` (lazy ``Agent.get``), or ``agentName`` (lazy ``Agent.create``).
  */
 export interface AsqavAdapterOptions {
   /** Pre-built Asqav Agent. Takes precedence over agentId/agentName. */
@@ -54,11 +34,8 @@ interface SignActionInput {
 }
 
 /**
- * Shared base for the framework adapters in this folder.
- *
- * Subclasses call ``protected signAction`` on every framework callback.
- * They MUST NOT call the Asqav SDK directly so the fail-open contract is
- * preserved at one place.
+ * Shared base for the framework adapters here. Subclasses call ``signAction`` on every framework
+ * callback and MUST NOT call the SDK directly, so the fail-open contract lives in one place.
  */
 export class AsqavAdapter {
   protected readonly options: AsqavAdapterOptions;
@@ -140,10 +117,8 @@ function defaultOnError(err: unknown, ctx: { actionType: string }): void {
 }
 
 /**
- * Throw the canonical missing-peer error for an Asqav framework adapter.
- * Mirrors the Python ``ImportError`` contract. Optional ``cause`` keeps
- * the underlying module-resolution error (ERR_MODULE_NOT_FOUND, ESM/CJS
- * interop, version mismatch, native binding crash) visible to the user.
+ * Throw the canonical missing-peer error, mirroring the Python ``ImportError`` contract. ``cause`` keeps
+ * the underlying module-resolution error visible to the user.
  */
 export function raiseMissingPeer(
   framework: string,

--- a/typescript/src/extras/index.ts
+++ b/typescript/src/extras/index.ts
@@ -1,10 +1,6 @@
 /**
- * Barrel for Asqav framework adapters.
- *
- * Each adapter is also published as a discrete subpath export
- * (``@asqav/sdk/extras/<framework>``) so peers stay tree-shakable. This
- * barrel exists so callers who already depend on multiple peers can
- * import everything from a single specifier.
+ * Barrel for Asqav framework adapters. Each is also published as a discrete subpath export so peers stay
+ * tree-shakable; this exists for callers that already depend on several.
  */
 
 export { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";

--- a/typescript/src/extras/langchain.ts
+++ b/typescript/src/extras/langchain.ts
@@ -1,6 +1,5 @@
-// LangChain.js integration for Asqav. Install: npm install @langchain/core.
-// Default-on: await enableLangchainGovernance({ agentName: "my-chain" }) then chain.invoke.
-// Manual: const h = await AsqavCallbackHandler.create({...}); chain.invoke(i, {callbacks:[h]}).
+// LangChain.js integration. Install @langchain/core, then either
+// enableLangchainGovernance({ agentName }) or AsqavCallbackHandler.create({...}).
 
 import { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
 

--- a/typescript/src/extras/mastra.ts
+++ b/typescript/src/extras/mastra.ts
@@ -1,20 +1,6 @@
 /**
- * Mastra integration for Asqav.
- *
- * Install (peer dependency):
- *   npm install @mastra/core
- *
- * Usage:
- *   import { init } from "@asqav/sdk";
- *   import { AsqavMastraHook } from "@asqav/sdk/extras/mastra";
- *   init({ apiKey: process.env.ASQAV_API_KEY! });
- *   const hook = new AsqavMastraHook({ agentName: "my-mastra-agent" });
- *   await hook.attach(mastraAgent);
- *
- * Signs Mastra agent step ``before`` and ``after`` events so every tool
- * call, LLM call, and workflow step is captured as an Asqav receipt.
- * Falls back to a direct ``before``/``after`` API for tests when no
- * Mastra instance is present.
+ * Mastra integration. Signs agent step ``before`` / ``after`` events so every tool call, LLM call and
+ * workflow step becomes a receipt. Needs the `@mastra/core` peer dependency; see the README.
  */
 
 import { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
@@ -26,9 +12,8 @@ function truncate(s: string, max = MAX_PREVIEW): string {
 }
 
 /**
- * Shape of the minimum surface we touch on a Mastra agent. We avoid
- * importing ``@mastra/core`` at the top level so the SDK installs
- * cleanly without it.
+ * Minimum surface we touch on a Mastra agent. ``@mastra/core`` is never imported at the top level, so
+ * the SDK installs cleanly without it.
  */
 interface MastraAgentLike {
   readonly name?: string;
@@ -52,11 +37,8 @@ export interface AsqavMastraHookOptions extends AsqavAdapterOptions {
 }
 
 /**
- * Mastra hook that signs agent step lifecycle events through Asqav.
- *
- * The class composes with Asqav's shared adapter base. ``before`` and
- * ``after`` are public so callers can wire them into custom Mastra
- * middleware or invoke them directly from tests.
+ * Mastra hook signing agent step lifecycle events through Asqav. ``before`` and ``after`` are public so
+ * callers can wire them into custom middleware or invoke them from tests.
  */
 export class AsqavMastraHook extends AsqavAdapter {
   public readonly name: string;
@@ -86,9 +68,8 @@ export class AsqavMastraHook extends AsqavAdapter {
   }
 
   /**
-   * Attach to a Mastra agent. Subscribes to ``step:before`` and
-   * ``step:after`` if the agent exposes an event emitter; otherwise
-   * registers a middleware that wraps each step.
+   * Attach to a Mastra agent: subscribes to ``step:before`` / ``step:after`` when the agent exposes an
+   * event emitter, otherwise registers a middleware that wraps each step.
    */
   async attach(agent: MastraAgentLike): Promise<void> {
     // Validate the peer is available so attach() fails fast with a

--- a/typescript/src/extras/openai-agents.ts
+++ b/typescript/src/extras/openai-agents.ts
@@ -1,20 +1,6 @@
 /**
- * OpenAI Agents JS integration for Asqav.
- *
- * Install (peer dependency):
- *   npm install @openai/agents
- *
- * Usage:
- *   import { init } from "@asqav/sdk";
- *   import { AsqavOpenAIAgentsAdapter } from "@asqav/sdk/extras/openai-agents";
- *   init({ apiKey: process.env.ASQAV_API_KEY! });
- *   const adapter = new AsqavOpenAIAgentsAdapter({ agentName: "my-agent" });
- *   adapter.wrapTool(myTool);
- *
- * Mirrors the Python ``asqav.extras.openai_agents.AsqavGuardrail`` /
- * ``AsqavTracingProcessor`` adapter: signs ``agent:input`` /
- * ``agent:output`` / ``tool:start`` / ``tool:end`` events as the agent
- * runs. Operates fail-open so governance never breaks the agent loop.
+ * OpenAI Agents JS integration, mirroring the Python ``AsqavGuardrail`` / ``AsqavTracingProcessor``.
+ * Signs agent and tool lifecycle events, fail-open so governance never breaks the agent loop.
  */
 
 import { AsqavAdapter, raiseMissingPeer, type AsqavAdapterOptions } from "./_base.js";
@@ -26,9 +12,8 @@ function truncate(s: string, max = MAX_PREVIEW): string {
 }
 
 /**
- * Minimal surface of an OpenAI Agents JS ``tool``. We accept any object
- * with ``name`` and ``execute`` so we never bind to a specific SDK
- * version.
+ * Minimal surface of an OpenAI Agents JS ``tool``: any object with ``name`` and ``execute``, so the
+ * adapter never binds to a specific SDK version.
  */
 export interface OpenAIAgentsToolLike<I = unknown, O = unknown> {
   name?: string;
@@ -42,9 +27,8 @@ export interface AsqavOpenAIAgentsAdapterOptions extends AsqavAdapterOptions {
 }
 
 /**
- * Wraps OpenAI Agents JS tools and run-loop callbacks so every
- * tool-call lifecycle event flows through Asqav. Mirrors the Python
- * ``AsqavGuardrail`` and ``AsqavTracingProcessor``.
+ * Wraps OpenAI Agents JS tools and run-loop callbacks so every tool-call lifecycle event flows through
+ * Asqav. Mirrors the Python ``AsqavGuardrail`` and ``AsqavTracingProcessor``.
  */
 export class AsqavOpenAIAgentsAdapter extends AsqavAdapter {
   public readonly name: string;
@@ -71,10 +55,8 @@ export class AsqavOpenAIAgentsAdapter extends AsqavAdapter {
   }
 
   /**
-   * Wrap an OpenAI Agents tool so each invocation signs
-   * ``tool:start`` and ``tool:end`` (or ``tool:error``). Returns a new
-   * tool object with the same ``name``/``description`` and a wrapped
-   * ``execute``.
+   * Wrap a tool so each invocation signs ``tool:start`` and ``tool:end`` (or ``tool:error``). Returns a
+   * new tool with the same ``name`` / ``description`` and a wrapped ``execute``.
    */
   wrapTool<I, O>(tool: OpenAIAgentsToolLike<I, O>): OpenAIAgentsToolLike<I, O> {
     if (typeof tool.execute !== "function") {

--- a/typescript/src/extras/vercel-ai.ts
+++ b/typescript/src/extras/vercel-ai.ts
@@ -1,39 +1,6 @@
 /**
- * Vercel AI SDK adapter.
- *
- * Wires Asqav signing into Vercel's `experimental_telemetry: { tracer }`
- * hook. Every span the AI SDK opens (generateText, streamText, tool call,
- * embed, etc.) becomes an asqav signature on `span.end()`.
- *
- * Usage:
- *   import { generateText } from "ai";
- *   import { openai } from "@ai-sdk/openai";
- *   import { Agent, init } from "@asqav/sdk";
- *   import { createAsqavExporter } from "@asqav/sdk/extras/vercel-ai";
- *
- *   init({ apiKey: process.env.ASQAV_API_KEY! });
- *   const agent = await Agent.create({ name: "writer" });
- *
- *   const tracer = createAsqavExporter({ agent });
- *   await generateText({
- *     model: openai("gpt-4o"),
- *     prompt: "...",
- *     experimental_telemetry: { isEnabled: true, tracer },
- *   });
- *
- * Source URLs verified:
- *   - https://ai-sdk.dev/docs/ai-sdk-core/telemetry
- *     ("You may provide a `tracer` which must return an OpenTelemetry `Tracer`.")
- *   - https://github.com/vercel/ai/blob/main/packages/otel/src/get-tracer.ts
- *     (signature: `{ isEnabled?: boolean; tracer?: Tracer }` from `@opentelemetry/api`)
- *   - https://github.com/vercel/ai/blob/main/packages/otel/src/noop-tracer.ts
- *     (Tracer surface used: startSpan, startActiveSpan;
- *      Span surface: spanContext, setAttribute, setAttributes, addEvent,
- *      addLink, addLinks, setStatus, updateName, end, isRecording,
- *      recordException)
- *   - https://github.com/vercel/ai/blob/main/packages/otel/src/record-span.ts
- *     (calls tracer.startActiveSpan(name, { attributes }, span => fn(span));
- *      records errors via span.setStatus + span.recordException then span.end)
+ * Vercel AI SDK adapter. Wires Asqav signing into `experimental_telemetry: { tracer }`, so every
+ * span the AI SDK opens becomes an asqav signature on `span.end()`. See the README for usage.
  */
 
 import type { Agent } from "../index.js";
@@ -90,12 +57,8 @@ export interface Tracer {
 // === Action-type mapping ===
 
 /**
- * Map a Vercel AI SDK span name to an asqav action_type.
- *
- * Span names emitted by the AI SDK include `ai.generateText`,
- * `ai.streamText`, `ai.embed`, `ai.embedMany`, `ai.toolCall`,
- * `ai.generateObject`, `ai.streamObject`. The full list lives at
- * https://ai-sdk.dev/docs/ai-sdk-core/telemetry#collected-data.
+ * Map a Vercel AI SDK span name (`ai.generateText`, `ai.toolCall`, ...) to an asqav action_type.
+ * Full list: https://ai-sdk.dev/docs/ai-sdk-core/telemetry#collected-data.
  */
 export function mapSpanNameToActionType(name: string): string {
   if (!name) return "ai:span";
@@ -213,11 +176,8 @@ function makeSpan(
 }
 
 /**
- * Build a `Tracer` you can hand to `generateText({ experimental_telemetry: { tracer } })`.
- *
- * Each span the AI SDK opens is buffered locally; on `span.end()` the
- * adapter fires a fire-and-forget `agent.sign(actionType, attributes)`.
- * Network errors are swallowed so signing never breaks generation.
+ * Build a `Tracer` for `generateText({ experimental_telemetry: { tracer } })`. Each span fires a
+ * fire-and-forget `agent.sign` on end; network errors are swallowed so signing never breaks generation.
  */
 export function createAsqavExporter(opts: CreateAsqavExporterOptions): Tracer {
   if (!opts.agent && !opts.agentId) {

--- a/typescript/src/hooks.ts
+++ b/typescript/src/hooks.ts
@@ -1,15 +1,6 @@
 /**
- * Hooks / middleware system for the Asqav TypeScript SDK.
- *
- * Mirrors the Python sibling's public surface:
- *   registerBefore(actionType, fn)  - mutate context before sign
- *   registerAfter(actionType, fn)   - observe response after sign
- *   clearHooks()                    - empty the registry
- *
- * Pattern matching:
- *   - "*"            matches every action type
- *   - "strands:*"    glob-matches any action type with the prefix "strands:"
- *   - "exact:type"   matches only that exact action type
+ * Hooks / middleware system mirroring the Python sibling: registerBefore, registerAfter, clearHooks.
+ * Patterns are `*`, a `prefix:*` glob, or an exact action type.
  */
 
 import type { SignatureResponse } from "./index.js";

--- a/typescript/src/ietfProjection.ts
+++ b/typescript/src/ietfProjection.ts
@@ -1,11 +1,6 @@
 /**
- * Compliance Receipts wire-shape projection helpers.
- *
- * Pure helpers for offline analysis of a receipt: extract the
- * spec-shape signature envelope `{alg, kid, sig}` and the anchors[]
- * array. The cloud emits the three-key envelope directly under
- * compliance_mode; the helpers below return the cloud-supplied values
- * and undefined on non-compliance receipts.
+ * Compliance Receipts wire-shape projection helpers: pure offline extraction of the signature envelope
+ * and anchors[]. They return the cloud-supplied values, and undefined on non-compliance receipts.
  */
 
 /** Spec-shape signature envelope. */
@@ -37,9 +32,10 @@ export interface ProjectableResponse {
   [key: string]: unknown;
 }
 
-/** Return `{alg, kid, sig}` when the response carries the object form,
- *  else undefined. The cloud emits `signature` as the object form under
- *  compliance_mode and as a base64 string in flat mode. */
+/**
+ * Return `{alg, kid, sig}` when the response carries the object form, else undefined. The cloud emits the
+ * object form under compliance_mode and a base64 string in flat mode.
+ */
 export function signatureEnvelopeFromResponse(
   response: ProjectableResponse | null | undefined,
 ): SignatureEnvelope | undefined {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,14 +1,6 @@
 /**
- * asqav - AI agent governance.
- *
- * Thin TypeScript SDK for asqav.com. All ML-DSA cryptography happens server-side.
- *
- * Quick start:
- *   import { init, Agent } from "@asqav/sdk";
- *
- *   init({ apiKey: "sk_..." });
- *   const agent = await Agent.create({ name: "my-agent" });
- *   const sig = await agent.sign({ actionType: "api:call", context: { model: "gpt-4" } });
+ * asqav - AI agent governance. Thin TypeScript SDK for asqav.com; all ML-DSA
+ * cryptography happens server-side. See the README for the quick start.
  */
 
 import { createHash, createHmac } from "node:crypto";
@@ -73,15 +65,8 @@ export const CODE_AUTHORSHIP_CHANGE_CLASS_NAMESPACE = [
  * receipt; the binding object travels on B's signed payload. */
 export const ACKNOWLEDGMENT_RECEIPT_TYPE = "protectmcp:acknowledgment" as const;
 
-/** DORA RTS JC 2024-33 Annex II field 3.23 canonical incident classification.
- *
- * The Joint Committee of the European Supervisory Authorities published
- * the final RTS on classification of major ICT-related incidents on
- * 17 July 2024 (JC 2024-33). Annex II field 3.23 fixes the controlled
- * vocabulary of `incident_class` to exactly six values. The cloud
- * accepts only these canonical tokens; this SDK forwards the caller's
- * value verbatim and rejects anything outside the canonical set.
- */
+/** DORA RTS JC 2024-33 Annex II field 3.23 canonical incident classification: six
+ * values, the only tokens the cloud accepts. */
 export const DORA_INCIDENT_CLASS_NAMESPACE = [
   "cybersecurity_related",
   "process_failure",
@@ -92,40 +77,28 @@ export const DORA_INCIDENT_CLASS_NAMESPACE = [
 ] as const;
 export type DoraIncidentClass = (typeof DORA_INCIDENT_CLASS_NAMESPACE)[number];
 
-/** HIPAA Security Rule canonical incident classification.
- *
- * HIPAA 45 CFR 164.304 is one of the canonical source regimes for
- * `incident_class` alongside DORA, NYDFS, and CIRCIA. A Covered Entity
- * SHOULD be able to emit a HIPAA token without falling back to a DORA
- * category.
- */
+/** HIPAA Security Rule (45 CFR 164.304) canonical incident classification, so a
+ * Covered Entity can emit a HIPAA token without falling back to DORA. */
 export const HIPAA_INCIDENT_CLASS_NAMESPACE = [
   "hipaa_security_incident",
 ] as const;
 export type HipaaIncidentClass = (typeof HIPAA_INCIDENT_CLASS_NAMESPACE)[number];
 
-/** Union of every canonical incident_class token the SDK accepts. The
- * cloud's `core/incident_vocabulary.py` is authoritative; this mirror
- * spares callers a network round-trip on obvious mistakes.
- */
+/** Union of every canonical incident_class token the SDK accepts. The cloud's
+ * `core/incident_vocabulary.py` is authoritative; this mirror saves a round-trip. */
 export const INCIDENT_CLASS_NAMESPACE = [
   ...DORA_INCIDENT_CLASS_NAMESPACE,
   ...HIPAA_INCIDENT_CLASS_NAMESPACE,
 ] as const;
 export type IncidentClass = (typeof INCIDENT_CLASS_NAMESPACE)[number];
 
-/** Sandbox state vocabulary per the High-Risk gate. Closes GAP-E3 on the
- * TypeScript SDK: the cloud already enforces this enum, the SDK now
- * refuses out-of-vocabulary values before the HTTP roundtrip. */
+/** Sandbox state vocabulary per the High-Risk gate. The cloud enforces this enum;
+ * the SDK refuses out-of-vocabulary values before the HTTP roundtrip. */
 export const SANDBOX_STATE_NAMESPACE = ["enabled", "disabled", "unavailable"] as const;
 export type SandboxState = (typeof SANDBOX_STATE_NAMESPACE)[number];
 
-/** Producer-side `capture_topology` vocabulary; mirrors the cloud
- * SignRequest Literal and the IETF -04 capture-topologies appendix.
- * A client-supplied captureTopology is ADVISORY: the server stamps the
- * authoritative value from the ingress route (for code-authorship that is
- * `github_sha_pull`, set only after the server re-fetches the commit and
- * recomputes the diff). */
+/** Producer-side `capture_topology` vocabulary mirroring the cloud SignRequest Literal.
+ * ADVISORY: the server stamps the authoritative value from the ingress route. */
 export const CAPTURE_TOPOLOGY_NAMESPACE = [
   "in_process_sdk",
   "network_proxy",
@@ -136,15 +109,13 @@ export const CAPTURE_TOPOLOGY_NAMESPACE = [
 ] as const;
 export type CaptureTopology = (typeof CAPTURE_TOPOLOGY_NAMESPACE)[number];
 
-/** Durable-anchoring witnesses Asqav ships. The cloud `witness_policy`
- * extension accepts only this set; `rekor` is explicitly rejected because
- * it is not a shipped witness. Mirrors the live governance.json contract. */
+/** Durable-anchoring witnesses Asqav ships. The cloud `witness_policy` extension
+ * accepts only this set; `rekor` is rejected as it is not a shipped witness. */
 export const WITNESS_NAMESPACE = ["rfc3161", "opentimestamps"] as const;
 export type Witness = (typeof WITNESS_NAMESPACE)[number];
 
 /** Caller-declared N-of-M durable-anchoring quorum. `required` must be in
- * `[1, witnesses.length]`; `witnesses` must be a non-empty subset of the
- * two shipped witnesses. `rekor` is rejected. */
+ * `[1, witnesses.length]` and `witnesses` a non-empty subset of the shipped two. */
 export interface WitnessPolicy {
   required: number;
   witnesses: Witness[];
@@ -161,9 +132,8 @@ export type PolicyDecision = "permit" | "deny" | "rate_limit" | "none";
  * lifecycle receipts emitted under `policyDecision="none"` (IETF -04). */
 export type Decision = "allow" | "deny" | "rate_limit" | "observation";
 
-/** Map an original `policyDecision` token to the spec-shape `decision`.
- * The `none -> observation` row is gated to lifecycle receipts by the
- * no-false-attestation rule on the cloud side. */
+/** Map an original `policyDecision` token to the spec-shape `decision`. The
+ * `none -> observation` row is gated to lifecycle receipts on the cloud side. */
 export const DECISION_MAP: Readonly<Record<string, Decision>> = Object.freeze({
   permit: "allow",
   allow: "allow",
@@ -172,10 +142,8 @@ export const DECISION_MAP: Readonly<Record<string, Decision>> = Object.freeze({
   none: "observation",
 });
 
-/** Translate `policyDecision` to the spec-shape `decision`. Falls back
- * to `"deny"` so a misconfigured caller never publishes an
- * out-of-vocabulary token to a draft-strict verifier.
- */
+/** Translate `policyDecision` to the spec-shape `decision`. Falls back to `"deny"` so a
+ * misconfigured caller never publishes an out-of-vocabulary token. */
 export function mapPolicyDecisionToDecision(
   policyDecision: string | null | undefined,
 ): Decision {
@@ -362,9 +330,8 @@ export class APIError extends AsqavError {
   }
 }
 
-/** Thrown when a cloud response omits a field the SDK requires (rule 3.9).
- * Replaces a silent `undefined` read so a caller gets a typed, catchable
- * error naming the missing field instead of an unexplained runtime bug. */
+/** Thrown when a cloud response omits a field the SDK requires (rule 3.9), so a caller
+ * gets a typed error naming the field instead of a silent `undefined`. */
 export class AsqavResponseError extends AsqavError {
   constructor(message: string, docsUrl?: string) {
     super(message, docsUrl);
@@ -375,10 +342,8 @@ export class AsqavResponseError extends AsqavError {
 /** Docs page anchoring missing-required-field response errors (rule 3.9). */
 export const RESPONSE_ERROR_DOCS_URL = "https://asqav.com/docs/sdk-errors" as const;
 
-/** Return `obj[key]` or throw `AsqavResponseError` if the field is absent.
- * Centralizes required-field response parsing so a cloud response missing
- * e.g. `signature_id` throws one typed error instead of leaving a
- * TS-typed-as-required field silently `undefined` at runtime. */
+/** Return `obj[key]` or throw `AsqavResponseError` if the field is absent, so a missing
+ * response field throws one typed error instead of reading `undefined` at runtime. */
 function requireField<T = unknown>(obj: object, key: string): T {
   const rec = obj as Record<string, unknown>;
   if (!(key in rec) || rec[key] === undefined) {
@@ -396,30 +361,21 @@ export interface InitOptions {
   apiKey?: string;
   baseUrl?: string;
   /**
-   * Wire mode for ``Agent.sign``. Defaults to ``"auto"``: hash-only for
-   * ``*.asqav.com`` cloud URLs, full-payload otherwise. Set to
-   * ``"hash-only"`` or ``"full-payload"`` to override. Also reads the
-   * ``ASQAV_MODE`` env var when ``"auto"``.
+   * Wire mode for ``Agent.sign``. Defaults to ``"auto"``: hash-only for ``*.asqav.com``,
+   * full-payload otherwise. Reads ``ASQAV_MODE`` when ``"auto"``.
    */
   mode?: "auto" | "hash-only" | "full-payload";
   /**
-   * Optional 32-byte salt that you generate and hold. When set, hash-only
-   * mode uses HMAC-SHA-256 keyed by it instead of plain SHA-256. Asqav
-   * never receives it and cannot recover it for you. Unset means an
-   * unsalted SHA-256 digest, which can be guessed for a predictable
-   * context. Salted digests still travel labelled `sha256`, so a third
-   * party recomputing per `docs/fingerprint-spec.md` sees a mismatch even
-   * though the signature verifies.
+   * Optional 32-byte salt you generate and hold; hash-only mode then uses HMAC-SHA-256
+   * keyed by it. Asqav never receives it, and salted digests still travel labelled `sha256`.
    */
   orgSalt?: Uint8Array;
 }
 
 export interface AgentCreateOptions {
   name: string;
-  /** One of `ml-dsa-65` (default), `ml-dsa-44`, `ml-dsa-87`, `ed25519`,
-   * or `es256`. Validated client-side; the cloud is the source of
-   * truth on which algorithms are honored on the receipt-signing
-   * path. */
+  /** One of `ml-dsa-65` (default), `ml-dsa-44`, `ml-dsa-87`, `ed25519`, or `es256`.
+   * Validated client-side; the cloud is the source of truth. */
   algorithm?: SupportedAlgorithm | string;
   capabilities?: string[];
 }
@@ -445,14 +401,11 @@ export interface SignOptions {
   /** Optional parent action ID for linking child actions to their parent
    * in a workflow. Powers the agent graph view. */
   parentId?: string;
-  /** Optional list of agent_ids in the same org expected to countersign
-   * this record. Each peer fetches the record and calls
-   * ``agent.countersign(signatureId)``. */
+  /** Optional agent_ids in the same org expected to countersign this record; each peer
+   * calls ``agent.countersign(signatureId)``. */
   coSigners?: string[];
-  /** Optional resolvable man_<token> mandate this sign is authorised under.
-   * The cloud re-verifies the issuer signature, scope, server-clock window,
-   * and revocation, then builds the signed authorized_under_mandate
-   * attestation. The attestation is never a request input. */
+  /** Optional resolvable man_<token> mandate this sign is authorised under. The cloud
+   * re-verifies it and builds the signed attestation; it is never a request input. */
   mandateId?: string;
   /** Optional user-intent envelope. The end user signs a digest of the
    * action and the SDK passes it through to the backend verbatim. */
@@ -460,14 +413,8 @@ export interface SignOptions {
   /** Optional opaque per-call token. The cloud stores it and checks no re-use, so
    * it gates no replay. Bound replay with `validSeconds` or `expiresAt`. */
   nonce?: string;
-  /** Optional validity window in seconds. Sets `valid_until = signed_at + validSeconds`
-   * on the server; verifying the record after expiry returns
-   * `verified=false` with `validation_label="signature_expired"`.
-   * Mutually exclusive with `expiresAt` (rule 10). Pass exactly one of
-   * the two: `validSeconds` for "expire N seconds after signing", or
-   * `expiresAt` for an explicit horizon. Passing both throws
-   * `expiry_collision_guard`. Passing neither falls back to the
-   * server-side default (`valid_seconds=86400`). */
+  /** Optional validity window in seconds, setting `valid_until = signed_at + validSeconds`.
+   * Mutually exclusive with `expiresAt`; passing both throws `expiry_collision_guard`. */
   validSeconds?: number;
   /** Counterparty pin: base64 executor pubkey expected on attestation;
    * other keys -> 403 `executor_key_mismatch`. */
@@ -475,15 +422,12 @@ export interface SignOptions {
 
   // === IETF Compliance Receipts profile fields ===
 
-  /** Emit the receipt under the IETF profile. When true, the cloud uses
-   * fail-closed anchoring, raises the retention floor, and writes the
-   * v3-20 envelope fields. Defaults to false. */
+  /** Emit the receipt under the IETF profile: fail-closed anchoring, a raised retention
+   * floor, and the v3-20 envelope fields. Defaults to false. */
   complianceMode?: boolean;
 
-  /** `sha256:<hex>` of the canonical Action object. When omitted under
-   * `complianceMode=true`, the SDK computes it client-side as
-   * `"sha256:" + sha256(canonicalJson(action))` where `action` is
-   * `{action_type, context}`. */
+  /** `sha256:<hex>` of the canonical Action object. Computed client-side when omitted
+   * under `complianceMode=true`, over `{action_type, context}`. */
   actionRef?: string;
 
   /** High-Risk gate. Caller-supplied; defaults to `"unavailable"` when
@@ -505,35 +449,24 @@ export interface SignOptions {
    * `Organization.legal_entity` when omitted. */
   issuerId?: string;
 
-  /** Digest of the request payload. Accepts the
-   * `"sha256:<hex>"` string or the wire object form
+  /** Digest of the request payload. Accepts `"sha256:<hex>"` or the wire object form
    * `{ hash, size?, preview? }`. */
   payloadDigest?: string | { hash: string; size?: number; preview?: string };
 
-  /** Receipt namespace. One of `protectmcp:decision` |
-   * `protectmcp:restraint` | `protectmcp:lifecycle` |
-   * `protectmcp:acknowledgment` | `protectmcp:observation`. Defaults to
-   * `protectmcp:decision`. Validated client-side. */
+  /** Receipt namespace: `protectmcp:` decision | restraint | lifecycle | acknowledgment |
+   * observation. Defaults to `protectmcp:decision`. Validated client-side. */
   receiptType?: ReceiptType;
 
-  /** Machine-readable code for `policy_decision in {deny, rate_limit}`.
-   * Drawn from the IETF rejection-reason vocabulary; the cloud is the
-   * source of truth on which codes are accepted. */
+  /** Machine-readable code for `policy_decision in {deny, rate_limit}`, drawn from the
+   * IETF rejection-reason vocabulary. The cloud is the source of truth. */
   reason?: string;
 
-  /** Policy decision. `permit` (default), `deny`, `rate_limit`, or `none`.
-   * `none` is the lifecycle opt-out and requires `receiptType` in the
-   * `protectmcp:lifecycle` namespace. When `deny` or `rate_limit`,
-   * `reason` is required. */
+  /** Policy decision: `permit` (default), `deny`, `rate_limit`, or `none`. `none` needs a
+   * `protectmcp:lifecycle` receiptType; `deny` / `rate_limit` need `reason`. */
   policyDecision?: PolicyDecision;
 
-  /** Producer-side topology. One of `in_process_sdk`, `network_proxy`,
-   * `browser_extension`, `mcp_proxy`, `passive_telemetry`, `github_sha_pull`.
-   * Stamped on the audit-pack manifest entry; never on the signed payload.
-   * Client-supplied captureTopology is advisory: the server stamps the
-   * authoritative value from the ingress route.
-   * `passive_telemetry` requires `receiptType='protectmcp:observation'`
-   * (false-attestation guard). */
+  /** Producer-side topology, stamped on the audit-pack manifest and never on the signed
+   * payload. Advisory; `passive_telemetry` requires `protectmcp:observation`. */
   captureTopology?: CaptureTopology;
 
   // === NSA CSI U/OO/6030316-26 alignment (cloud 0.5.0) ===
@@ -542,39 +475,28 @@ export interface SignOptions {
    * verbatim to the cloud. */
   resultDigest?: string;
 
-  /** Receipt validity horizon. ISO-8601 string or POSIX number. The cloud
-   * owns absolute time-binding and accepts only a duration, so the SDK
-   * converts this absolute horizon to a client-computed `valid_seconds` and
-   * sends that instead. Mutually exclusive with `validSeconds` (rule 10);
-   * see `validSeconds` for precedence. */
+  /** Receipt validity horizon (ISO-8601 or POSIX), converted client-side to
+   * `valid_seconds`. Mutually exclusive with `validSeconds`. */
   expiresAt?: string | number;
 
-  /** Optional JSON schema describing the tool surface. When provided
-   * alongside `toolName` and `toolFingerprint` is omitted, the SDK
-   * computes the fingerprint client-side via JCS canonicalization. */
+  /** Optional JSON schema describing the tool surface. With `toolName` and no
+   * `toolFingerprint`, the SDK computes the fingerprint client-side via JCS. */
   toolSchema?: Record<string, unknown>;
 
-  /** Explicit fingerprint over the canonical `{tool_name, schema}` blob.
-   * When omitted but `toolName` + `toolSchema` are present, the SDK
-   * derives it client-side. MUST be 32 bare lowercase hex chars
-   * (SHA-256[:32], no `sha256:` prefix), matching the cloud wire form; use
-   * `computeToolFingerprint` to avoid drift. */
+  /** Explicit fingerprint over the canonical `{tool_name, schema}` blob, 32 bare lowercase
+   * hex chars (SHA-256[:32]). Use `computeToolFingerprint` to avoid drift. */
   toolFingerprint?: string;
 
-  /** `sha256:<hex>` of the agent's runtime configuration manifest.
-   * REQUIRED for `receiptType='protectmcp:lifecycle:configuration_change'`
-   * (false-attestation rule 9). MUST match `sha256:<64-hex>` (rule 11);
-   * use `computeConfigManifestDigest` to avoid drift. */
+  /** `sha256:<hex>` of the agent's runtime configuration manifest, REQUIRED for
+   * `protectmcp:lifecycle:configuration_change`. Use `computeConfigManifestDigest`. */
   configManifestDigest?: string;
 
-  /** `sha256:<hex>` of the agent's CVE inventory snapshot at signing time.
-   * MUST match `sha256:<64-hex>` (rule 11); use
+  /** `sha256:<hex>` of the agent's CVE inventory snapshot at signing time. Use
    * `computeCveInventoryDigest` to avoid drift. */
   cveInventoryDigest?: string;
 
-  /** Build-provenance 4-tuple. `sha256:<hex>` of the executable that
-   * invoked the action. Binds build-side provenance into the signed
-   * receipt. MUST match `sha256:<64-hex>` (rule 11). */
+  /** Build-provenance 4-tuple: `sha256:<hex>` of the executable that invoked the action,
+   * binding build-side provenance into the signed receipt. */
   executableHash?: string;
 
   /** Build-provenance 4-tuple. `sha256:<hex>` of the canonical CycloneDX
@@ -589,10 +511,8 @@ export interface SignOptions {
    * Rekor entry covering the executing build. */
   supplyChainPointer?: string;
 
-  /** Caller-supplied list of MITRE ATT&CK technique ids (e.g.
-   * `["T1059", "T1078"]`). Self-declared; never Asqav-verified. Cloud
-   * sets `framework_mappings_self_declared=true` whenever any of the six
-   * taxonomy lists is populated. */
+  /** Caller-supplied MITRE ATT&CK technique ids. Self-declared, never Asqav-verified; any
+   * populated taxonomy list sets `framework_mappings_self_declared=true`. */
   mitreTechniques?: string[];
 
   /** Caller-supplied list of MITRE ATLAS ids for AI-system threats
@@ -615,46 +535,36 @@ export interface SignOptions {
    * `["Article-12", "Article-15"]`). Self-declared. */
   euAiActArticles?: string[];
 
-  /** Caller-supplied base64-encoded RFC 3161 TimeStampResp (DER).
-   * Preserved on the receipt for offline TSA chain verification
-   * independent of cloud-issued anchors. */
+  /** Caller-supplied base64 RFC 3161 TimeStampResp (DER), preserved for offline TSA chain
+   * verification independent of cloud-issued anchors. */
   rfc3161Timestamp?: string;
 
-  /** Caller-declared N-of-M durable-anchoring quorum. Shape
-   * `{ required, witnesses: [<subset of "rfc3161", "opentimestamps">] }`.
-   * `required` must be in `[1, witnesses.length]`; `witnesses` must be a
-   * non-empty subset of the two shipped witnesses. `rekor` is rejected
-   * (not a shipped witness). The receipt reaches `witness_quorum_met`
-   * only when `required` witnesses hold a real inclusion proof. Projected
-   * to the wire as snake_case `witness_policy`. */
+  /** Caller-declared N-of-M durable-anchoring quorum `{ required, witnesses }`. Reaches
+   * `witness_quorum_met` only when `required` witnesses hold a real inclusion proof. */
   witnessPolicy?: WitnessPolicy;
 
-  /** Risk-acceptance receipt: identity that authored the acceptance.
-   * REQUIRED on `receiptType='protectmcp:lifecycle:risk_acceptance'`. Field
-   * only: bound into the signed bytes, never compared or authenticated. */
+  /** Risk-acceptance receipt: identity that authored the acceptance, REQUIRED on
+   * `protectmcp:lifecycle:risk_acceptance`. Bound into the signed bytes, never authenticated. */
   approverId?: string;
 
   /** Risk-acceptance receipt: identity that requested the acceptance.
    * Field only; never compared to `approverId`. */
   initiatorId?: string;
 
-  /** Risk-acceptance receipt: free-text human rationale. REQUIRED on
-   * `receiptType='protectmcp:lifecycle:risk_acceptance'`. Proves the reason
-   * existed at signing time; never parsed or scored. */
+  /** Risk-acceptance receipt: free-text human rationale, REQUIRED on
+   * `protectmcp:lifecycle:risk_acceptance`. Never parsed or scored. */
   acceptanceReason?: string;
 
   /** Risk-acceptance receipt: RFC 3339 wall-clock the approver authored the
    * acceptance. Producer-asserted; Asqav-attested time is the anchors. */
   acceptedAt?: string;
 
-  /** Risk-acceptance receipt: pointer to the prior risk-acceptance receipt
-   * this one replaces. The chain stays immutable; supersession is a forward
-   * pointer only. */
+  /** Risk-acceptance receipt: pointer to the prior acceptance this one replaces. The chain
+   * stays immutable; supersession is a forward pointer only. */
   supersedes?: string;
 
-  /** Risk-acceptance receipt: `sha256:<64 hex>` of the SARIF scan artifact
-   * the acceptance rested on. Proves THAT SARIF existed unaltered; Asqav does
-   * not re-run or validate the scan. */
+  /** Risk-acceptance receipt: `sha256:<64 hex>` of the SARIF artifact the acceptance rested
+   * on. Proves that SARIF existed unaltered; Asqav does not re-run the scan. */
   sarifDigest?: string;
 
   /** Risk-acceptance receipt: opaque pointer to a finding / rule id inside
@@ -665,19 +575,16 @@ export interface SignOptions {
    * approval id. Free-text correlation anchor. */
   approvalRef?: string;
 
-  /** Risk-acceptance receipt: producer-asserted point-in-time risk snapshot.
-   * Projected to the wire as snake_case `risk_snapshot`. A numeric without
-   * `snapshotSource` is rejected so it is never read as an Asqav score. */
+  /** Risk-acceptance receipt: producer-asserted risk snapshot, wired as `risk_snapshot`. A
+   * numeric without `snapshotSource` is rejected so it is never read as an Asqav score. */
   riskSnapshot?: RiskSnapshot;
 
-  /** Code-authorship receipt: opaque pointer to the repository the change
-   * lives in. REQUIRED on `receiptType='protectmcp:lifecycle:code_authorship'`.
-   * Free-text; recorded, never resolved by Asqav. */
+  /** Code-authorship receipt: opaque repository pointer, REQUIRED on
+   * `protectmcp:lifecycle:code_authorship`. Recorded, never resolved by Asqav. */
   repoRef?: string;
 
-  /** Code-authorship receipt: commit sha of the change. REQUIRED on
-   * `receiptType='protectmcp:lifecycle:code_authorship'`. Producer-asserted;
-   * Asqav records it, never fetches or verifies the commit. */
+  /** Code-authorship receipt: commit sha of the change, REQUIRED on
+   * `protectmcp:lifecycle:code_authorship`. Recorded, never fetched or verified. */
   commitSha?: string;
 
   /** Code-authorship receipt: base sha the change is measured against.
@@ -700,27 +607,17 @@ export interface SignOptions {
    * one of read|write|delete|execute|deploy. */
   changeClass?: string;
 
-  /** Code-authorship receipt: producer-asserted author of the change.
-   * Projected to the wire as snake_case `authored_by`. A populated
-   * `modelId` / `modelVersion` requires `attestationSource` so the
-   * machine-authorship claim is never read as Asqav-verified. */
+  /** Code-authorship receipt: producer-asserted author, wired as `authored_by`. A populated
+   * `modelId` / `modelVersion` requires `attestationSource`. */
   authoredBy?: AuthoredBy;
 
-  /** Optional schema for context (criterion 328). Built-in descriptor map or
-   * custom validator function. Validates + normalises context before signing;
-   * throws ValidationError on mismatch. Omit for today's exact behavior. */
+  /** Optional schema for context (criterion 328). Validates and normalises context before
+   * signing; throws ValidationError on mismatch. */
   contextSchema?: ContextSchema | ((ctx: Record<string, unknown>) => void);
 }
 
-/** Producer-asserted point-in-time snapshot of third-party risk signals.
- *
- * Mirrors the cloud RiskSnapshot model. Every value is a snapshot the
- * producer READ at `snapshot_at` from `snapshot_source`; Asqav never
- * fetches, computes, verifies, or vouches for any of them. The
- * `snapshot_at` + `snapshot_source` labels are normative: a numeric
- * (`epss` / `cvss` / `cvssVector` / `kevListed`) without `snapshotSource`
- * is rejected so a value can never appear unlabeled and be mistaken for an
- * Asqav-derived score. Numerics are strings on the wire. */
+/** Producer-asserted point-in-time snapshot of third-party risk signals, mirroring the cloud
+ * RiskSnapshot. A numeric without `snapshotSource` is rejected; numerics are strings on the wire. */
 export interface RiskSnapshot {
   /** RFC 3339 read-time of the signals (REQUIRED). Producer-asserted. */
   snapshotAt: string;
@@ -738,14 +635,8 @@ export interface RiskSnapshot {
   cveIds?: string[];
 }
 
-/** Producer-asserted author of a code change on a code-authorship receipt.
- *
- * Mirrors the cloud AuthoredBy model. Every value is producer-asserted;
- * Asqav never verifies the identity, the model, or the change. `modelId` /
- * `modelVersion` are a machine-authorship claim: if either is populated,
- * `attestationSource` is REQUIRED so the claim is recorded as
- * producer-asserted and is never read as an Asqav-verified attestation.
- * Projected to the wire as snake_case keys. */
+/** Producer-asserted author of a code change, mirroring the cloud AuthoredBy. A populated
+ * `modelId` / `modelVersion` requires `attestationSource`; wired as snake_case. */
 export interface AuthoredBy {
   /** Human author identity (free-text id / email). Producer-asserted. */
   humanId?: string;
@@ -765,9 +656,8 @@ export interface CoSignature {
 }
 
 export interface SignatureResponse {
-  /** Polymorphic. Base64 string in non-compliance mode, `{alg, kid, sig}` object
-   * form under compliance_mode. Use `signatureEnvelope()` for the dict
-   * form. */
+  /** Polymorphic: base64 string in non-compliance mode, `{alg, kid, sig}` under compliance
+   * mode. Use `signatureEnvelope()` for the dict form. */
   signature: string | SignatureEnvelope;
   signatureId: string;
   actionId: string;
@@ -796,8 +686,7 @@ export interface SignatureResponse {
   receiptType?: string;
   /** Resolved legal entity for this receipt. */
   issuerId?: string;
-  /** Original `policy_decision` value echoed from the request (one of
-   * `"permit" | "deny" | "rate_limit"`). Kept for backward compat with
+  /** Original `policy_decision` echoed from the request, kept for backward compat with
    * tooling built against the pre-spec implementation. */
   policyDecision?: PolicyDecision;
   /** Spec-shape `decision`: echoed from cloud or mapped from
@@ -806,9 +695,8 @@ export interface SignatureResponse {
   /** Compliance Receipts envelope: the canonical signed dict. None on
    * non-compliance receipts. */
   payload?: Record<string, unknown>;
-  /** Compliance Receipts envelope: the type-discriminated anchors
-   * array. None on non-compliance receipts; `[]` when compliance_mode is on
-   * before anchors land. */
+  /** Compliance Receipts envelope: the type-discriminated anchors array. None on
+   * non-compliance receipts; `[]` before anchors land. */
   anchors?: AnchorEntry[];
 }
 
@@ -820,16 +708,8 @@ export interface SessionResponse {
   endedAt?: string;
 }
 
-/** Granular sub-checks the cloud returns alongside `verified`. The
- * `validationLabel` string is the dominant failure reason when
- * `verified=false`, e.g. `signature_expired` or `signer_key_changed`.
- *
- * The IETF profile sub-axes (`chainValid`, `anchorValidOts`,
- * `anchorValidRfc3161`, `anchorStatusOts`, `anchorStatusRfc3161`,
- * `signedAtSkewSeconds`, `missingFields`, `policyDigestResolved`,
- * `duplicateEmissionCandidate`, `regimesSatisfied`) populate only
- * when the cloud emits them on a compliance-mode receipt;
- * non-compliance-mode receipts leave them undefined. */
+/** Granular sub-checks the cloud returns alongside `verified`; `validationLabel` is the
+ * dominant failure reason. The IETF sub-axes populate only on compliance-mode receipts. */
 export interface VerificationDetail {
   signerKeyMatch: boolean;
   signatureValid: boolean;
@@ -851,40 +731,34 @@ export interface VerificationDetail {
     | string;
   /** Skew vs verifier wall clock; beyond the cloud's bound -> reject. */
   signedAtSkewSeconds?: number;
-  /** True when the cloud could rederive the chain hash from the stored
-   * `signed_envelope` and the predecessor matches. Undefined on
-   * non-compliance-mode records. */
+  /** True when the cloud could rederive the chain hash from the stored `signed_envelope`
+   * and the predecessor matches. Undefined on non-compliance-mode records. */
   chainValid?: boolean;
   /** OTS proof bool form. True when the OpenTimestamps proof rederived. */
   anchorValidOts?: boolean;
   /** Timestamp anchor bool form. True when the timestamp rederived. */
   anchorValidRfc3161?: boolean;
-  /** Tri-state OTS status. `pending` means inside the upgrade window;
-   * `invalid` means corruption or stale; `valid` mirrors the Bitcoin
-   * block-confirmed case. */
+  /** Tri-state OTS status: `pending` inside the upgrade window, `invalid` on corruption or
+   * staleness, `valid` for the Bitcoin block-confirmed case. */
   anchorStatusOts?: "valid" | "pending" | "invalid";
   /** Timestamp anchor outcome. Deterministic at issuance; never
    * `pending`. */
   anchorStatusRfc3161?: "valid" | "pending" | "invalid";
-  /** REQUIRED-fields presence check. Surfaces column names NULLed
-   * post-issuance on a compliance-mode receipt; empty / undefined means
-   * every required field is present. */
+  /** REQUIRED-fields presence check, surfacing column names NULLed post-issuance. Empty or
+   * undefined means every required field is present. */
   missingFields?: string[];
   /** True when the policy digest at issuance resolved to a known artefact. */
   policyDigestResolved?: boolean;
-  /** True / non-empty when more than one receipt exists for the
-   * (action_ref, issuer_id) pair; reporting flag, not a verification
-   * downgrade. */
+  /** Set when more than one receipt exists for the (action_ref, issuer_id) pair. A reporting
+   * flag, not a verification downgrade. */
   duplicateEmissionCandidate?: boolean | string;
-  /** Regulator tokens the cloud derived for the receipt (e.g.
-   * `eu_ai_act`, `dora`). Empty / undefined on non-compliance-mode
-   * receipts. */
+  /** Regulator tokens the cloud derived for the receipt (e.g. `eu_ai_act`, `dora`). Empty or
+   * undefined on non-compliance-mode receipts. */
   regimesSatisfied?: string[];
 }
 
-/** Execution-evidence projection on a verification response. `label`
- * vocabulary: result_bound | digest_present | none_by_design | absent.
- * `present` is the top-line boolean; `resultDigest` echoes the bound hash. */
+/** Execution-evidence projection on a verification response. `label` is one of result_bound |
+ * digest_present | none_by_design | absent; `resultDigest` echoes the bound hash. */
 export interface ExecutionEvidence {
   present: boolean;
   label: "result_bound" | "digest_present" | "none_by_design" | "absent" | string;
@@ -893,11 +767,8 @@ export interface ExecutionEvidence {
   noneByDesign?: boolean;
 }
 
-/** Anchor attestation state on a verification response. `status`
- * vocabulary: none | pending | confirmed | failed. `anchorTxRef` and
- * `anchorBlockHeight` populate once the OpenTimestamps proof upgrades
- * to a confirmed attestation. Field names are provider-agnostic so the
- * response shape survives a future switch off OpenTimestamps + Bitcoin. */
+/** Anchor attestation state: `status` is none | pending | confirmed | failed. Field names are
+ * provider-agnostic so the shape survives a switch off OpenTimestamps + Bitcoin. */
 export interface BitcoinAnchorStatus {
   status: "none" | "pending" | "confirmed" | "failed" | string;
   anchorTxRef?: string | null;
@@ -927,9 +798,8 @@ export interface VerificationResponse {
   /** IETF projection of the signed envelope: `{alg, kid}`. Undefined on
    * non-compliance-mode receipts. */
   signatureEnvelope?: { alg: string; kid: string } & Record<string, string>;
-  /** IETF anchors projection: list of `{type, value, ...}` per anchor.
-   * `type` is `"opentimestamps"` or `"rfc3161"`. Undefined on
-   * non-compliance-mode receipts. */
+  /** IETF anchors projection: `{type, value, ...}` per anchor, `type` being
+   * `"opentimestamps"` or `"rfc3161"`. Undefined on non-compliance-mode receipts. */
   anchors?: Array<
     {
       type: "opentimestamps" | "rfc3161" | string;
@@ -1173,11 +1043,8 @@ export async function request<T = unknown>(
 // === Sign body builder (mode-aware) ===
 
 /**
- * Merge explicit kwargs (`toolName`, `modelName`, `parentId`) into the
- * caller-supplied context as underscored sentinel keys so the hash-only
- * metadata builder picks them up. Returns a fresh object only when one
- * of the kwargs was present; otherwise returns the original ref. Mirrors
- * the Python SDK's surface-into-context behaviour.
+ * Merge explicit kwargs into the caller's context as underscored sentinel keys so the
+ * hash-only metadata builder picks them up. Returns the original ref when none were present.
  */
 function surfaceKwargsIntoContext(options: SignOptions): Record<string, unknown> {
   const initial = options.context ?? {};
@@ -1196,10 +1063,8 @@ function surfaceKwargsIntoContext(options: SignOptions): Record<string, unknown>
 }
 
 /**
- * Fail-fast vocabulary checks on caller input before the HTTP roundtrip.
- * The cloud remains source of truth; these mirror the canonical sets so
- * obvious mistakes do not consume a network call. Throws AsqavError on
- * the first offending field.
+ * Fail-fast vocabulary checks before the HTTP roundtrip; the cloud stays source of truth.
+ * Throws AsqavError on the first offending field.
  */
 function validateSignOptions(options: SignOptions, complianceMode: boolean): void {
   if (
@@ -1366,12 +1231,8 @@ function validateSignOptions(options: SignOptions, complianceMode: boolean): voi
 }
 
 /**
- * Reject malformed `witnessPolicy` before the HTTP roundtrip. Lockstep
- * with the cloud witness_policy extension: `{ required, witnesses }` where
- * `witnesses` is a non-empty subset of the two shipped witnesses and
- * `required` is an integer in `[1, witnesses.length]`. `rekor` is rejected
- * because it is not a shipped witness. Verbatim guard tokens match the
- * Python SDK so SDK errors round-trip through the conformance vectors.
+ * Reject malformed `witnessPolicy` before the HTTP roundtrip, in lockstep with the cloud
+ * extension. Guard tokens match the Python SDK so errors round-trip through the vectors.
  */
 function validateWitnessPolicy(value: WitnessPolicy | undefined): void {
   if (value === undefined) return;
@@ -1411,9 +1272,8 @@ function validateWitnessPolicy(value: WitnessPolicy | undefined): void {
 }
 
 /**
- * Reject `incident_class` values outside the canonical union (HIPAA
- * token plus the six DORA tokens). Accepts a single value, an array,
- * or undefined / empty string (skip).
+ * Reject `incident_class` values outside the canonical union. Accepts a single value, an
+ * array, or undefined / empty string (skip).
  */
 function validateIncidentClass(value: string | string[] | undefined): void {
   if (value === undefined || value === "") return;
@@ -1431,11 +1291,8 @@ function validateIncidentClass(value: string | string[] | undefined): void {
 const RISK_ACCEPTANCE_RECEIPT_TYPE = "protectmcp:lifecycle:risk_acceptance";
 
 /**
- * Reject a malformed `riskSnapshot` before the HTTP roundtrip. Lockstep with
- * the cloud RiskSnapshot validator: `snapshotAt` is required, a numeric
- * (`epss` / `cvss` / `cvssVector` / `kevListed`) requires `snapshotSource`,
- * `epss` / `cvss` must be strings, and `cveIds` must be a non-empty array of
- * strings (<= 128 chars). Verbatim guard tokens match the Python SDK.
+ * Reject a malformed `riskSnapshot` before the HTTP roundtrip, in lockstep with the cloud
+ * validator. Verbatim guard tokens match the Python SDK.
  */
 function validateRiskSnapshot(rs: RiskSnapshot | undefined): void {
   if (rs === undefined) return;
@@ -1488,13 +1345,8 @@ function validateRiskSnapshot(rs: RiskSnapshot | undefined): void {
 }
 
 /**
- * Reject malformed risk-acceptance receipts before the HTTP roundtrip.
- * Lockstep with the cloud SignRequest `_validate_risk_acceptance_extensions`:
- * sarifDigest must be `sha256:<64 hex>`; the extension fields are fenced to
- * `receiptType='protectmcp:lifecycle:risk_acceptance'`; the receipt requires
- * `approverId` + `acceptanceReason`, signs with `policyDecision='none'`, and
- * (mirroring the cloud compliance-mode guard) requires `complianceMode` so the
- * fields are never silently dropped from the signed bytes.
+ * Reject malformed risk-acceptance receipts before the HTTP roundtrip, in lockstep with the
+ * cloud validator. `complianceMode` is required so the fields reach the signed bytes.
  */
 function validateRiskAcceptance(options: SignOptions, complianceMode: boolean): void {
   if (options.sarifDigest !== undefined && !SHA256_HEX_RE.test(options.sarifDigest)) {
@@ -1555,11 +1407,8 @@ function validateRiskAcceptance(options: SignOptions, complianceMode: boolean): 
 const CODE_AUTHORSHIP_RECEIPT_TYPE = "protectmcp:lifecycle:code_authorship";
 
 /**
- * Reject a malformed `authoredBy` before the HTTP roundtrip. Lockstep with the
- * cloud AuthoredBy validator: it must be an object, and a populated `modelId` /
- * `modelVersion` (a machine-authorship claim) requires `attestationSource` so
- * the claim is never read as Asqav-verified. Verbatim guard tokens match the
- * Python SDK.
+ * Reject a malformed `authoredBy` before the HTTP roundtrip: a populated `modelId` /
+ * `modelVersion` requires `attestationSource` so the claim is never read as Asqav-verified.
  */
 function validateAuthoredBy(ab: AuthoredBy | undefined): void {
   if (ab === undefined) return;
@@ -1579,15 +1428,8 @@ function validateAuthoredBy(ab: AuthoredBy | undefined): void {
 }
 
 /**
- * Reject malformed code-authorship receipts before the HTTP roundtrip.
- * Lockstep with the cloud SignRequest `_validate_code_authorship_extensions`:
- * changeDigest must be `sha256:<64 hex>`; changeClass is a closed
- * read|write|delete|execute|deploy set; the extension fields are fenced to
- * `receiptType='protectmcp:lifecycle:code_authorship'`; the receipt requires
- * `repoRef` + `commitSha`, signs with `policyDecision='none'`, and (mirroring
- * the cloud compliance-mode guard) requires `complianceMode` so the fields are
- * never silently dropped from the signed bytes. Honest-scope: every field is
- * producer-asserted / recorded-not-verified.
+ * Reject malformed code-authorship receipts before the HTTP roundtrip, in lockstep with the
+ * cloud validator. Every field is producer-asserted and recorded, never verified.
  */
 function validateCodeAuthorship(options: SignOptions, complianceMode: boolean): void {
   if (options.changeDigest !== undefined && !SHA256_HEX_RE.test(options.changeDigest)) {
@@ -1643,10 +1485,8 @@ function validateCodeAuthorship(options: SignOptions, complianceMode: boolean): 
 }
 
 /**
- * Derive `action_ref` locally when omitted under compliance mode; matches
- * the cloud's `hash_action` shape (`sha256:<hex>` over canonical JSON of
- * `{action_type, context}`). Returns the caller's value verbatim when
- * compliance mode is off or `actionRef` is already set.
+ * Derive `action_ref` locally when omitted under compliance mode, matching the cloud's
+ * `hash_action` shape. Returns the caller's value verbatim otherwise.
  */
 function deriveActionRef(
   complianceMode: boolean,
@@ -1660,24 +1500,16 @@ function deriveActionRef(
   return `sha256:${hex}`;
 }
 
-/** Wire format for every caller-supplied digest field
- * (`tool_fingerprint`, `config_manifest_digest`, `cve_inventory_digest`,
- * `result_digest`). The cloud accepts the same exact-match form so the
- * SDK surfaces bad inputs before the HTTP roundtrip; the regex matches
- * the helper outputs byte-for-byte. */
+/** Wire format for every caller-supplied digest field. The cloud accepts the same exact-match
+ * form, and the regex matches the helper outputs byte-for-byte. */
 const SHA256_HEX_RE = /^sha256:[a-f0-9]{64}$/;
 
-/** Wire format for `tool_fingerprint`: 32 bare lowercase hex chars
- * (SHA-256[:32]). The cloud validates this field with the bare form, not
- * the self-describing `sha256:<hex>` form used by the other digests. */
+/** Wire format for `tool_fingerprint`: 32 bare lowercase hex chars (SHA-256[:32]), not the
+ * self-describing `sha256:<hex>` form the other digests use. */
 const TOOL_FINGERPRINT_RE = /^[0-9a-f]{32}$/;
 
-/** Compute a deterministic 32-bare-hex fingerprint over `{tool_name,
- * schema}` per NSA CSI U/OO/6030316-26. The fingerprint is
- * byte-deterministic under JCS (RFC 8785) so the SDK and cloud agree when
- * the cloud rehashes for tamper detection. The cloud requires the first 32
- * hex chars of the SHA-256 digest, bare (no `sha256:` prefix), matching
- * `TOOL_FINGERPRINT_RE`. */
+/** Compute a deterministic 32-bare-hex fingerprint over `{tool_name, schema}` per NSA CSI
+ * U/OO/6030316-26. Byte-deterministic under JCS so the SDK and cloud agree. */
 export function computeToolFingerprint(
   toolName: string,
   toolSchema: Record<string, unknown> | undefined,
@@ -1687,13 +1519,8 @@ export function computeToolFingerprint(
   return hex.slice(0, 32);
 }
 
-/** Compute the canonical `sha256:<hex>` of a runtime configuration
- * manifest. NSA CSI U/OO/6030316-26 anchors the "silent capability creep"
- * audit on `protectmcp:lifecycle:configuration_change` receipts (rule 9).
- * This helper produces a digest byte-deterministic under JCS (RFC 8785)
- * so two auditors who receive the same manifest object produce identical
- * digests regardless of insertion order. Output matches `SHA256_HEX_RE`
- * byte-for-byte. */
+/** Compute the canonical `sha256:<hex>` of a runtime configuration manifest, byte-deterministic
+ * under JCS so two auditors with the same object produce identical digests. */
 export function computeConfigManifestDigest(
   manifest: Record<string, unknown>,
 ): string {
@@ -1701,20 +1528,15 @@ export function computeConfigManifestDigest(
   return `sha256:${hex}`;
 }
 
-/** Compute the canonical `sha256:<hex>` of a CVE inventory snapshot. NSA
- * CSI U/OO/6030316-26 anchors the "known-vulnerable invocation" audit on
- * receipts that carry `cve_inventory_digest`. The helper takes the list
- * of CVE records (any JSON-serialisable shape) and produces a digest
- * byte-deterministic under JCS (RFC 8785). Output matches
- * `SHA256_HEX_RE` byte-for-byte. */
+/** Compute the canonical `sha256:<hex>` of a CVE inventory snapshot, byte-deterministic under
+ * JCS. Output matches `SHA256_HEX_RE` byte-for-byte. */
 export function computeCveInventoryDigest(cveList: unknown[]): string {
   const hex = createHash("sha256").update(canonicalJson(cveList)).digest("hex");
   return `sha256:${hex}`;
 }
 
-/** Return a 24-hex-char (12 random bytes) value for the `nonce` wire field.
- * The cloud stores it verbatim and runs no uniqueness check, so re-sending one
- * produces a second accepted signature. Bound replay with `validSeconds`. */
+/** Return a 24-hex-char value for the `nonce` wire field. The cloud stores it verbatim and
+ * runs no uniqueness check, so bound replay with `validSeconds`. */
 export function generateNonce(): string {
   // Use Web Crypto (Node >=19 + browsers); avoids require("crypto") CJS shim in the .mjs bundle.
   const buf = new Uint8Array(12);
@@ -1723,11 +1545,8 @@ export function generateNonce(): string {
 }
 
 /**
- * Tack the optional non-IETF wire fields (`co_signers`, `nonce`,
- * `valid_seconds`, `expected_executor_pubkey_b64`) onto the body when
- * the caller supplied them. Mutates `body` in place for parity with the
- * inline original. Fills `nonce` (NSA CSI alignment) when the caller omits
- * one. The cloud stores that value and checks no re-use.
+ * Tack the optional non-IETF wire fields onto the body when supplied, filling `nonce` when
+ * the caller omits one. Mutates `body` in place for parity with the inline original.
  */
 function applyOptionalWireFields(
   body: Record<string, unknown>,
@@ -1755,9 +1574,8 @@ function applyOptionalWireFields(
   }
 }
 
-/** Convert a camelCase `RiskSnapshot` to its snake_case wire object so the
- * signed payload uses the same keys the cloud RiskSnapshot model emits.
- * Returns undefined when no snapshot is supplied (field omitted from wire). */
+/** Convert a camelCase `RiskSnapshot` to its snake_case wire object. Returns undefined when no
+ * snapshot is supplied, so the field is omitted from the wire. */
 function riskSnapshotToWire(rs: RiskSnapshot | undefined): Record<string, unknown> | undefined {
   if (rs === undefined) return undefined;
   const wire: Record<string, unknown> = {
@@ -1772,9 +1590,8 @@ function riskSnapshotToWire(rs: RiskSnapshot | undefined): Record<string, unknow
   return wire;
 }
 
-/** Convert a camelCase `AuthoredBy` to its snake_case wire object so the
- * signed payload uses the same keys the cloud AuthoredBy model emits.
- * Returns undefined when no author is supplied (field omitted from wire). */
+/** Convert a camelCase `AuthoredBy` to its snake_case wire object. Returns undefined when no
+ * author is supplied, so the field is omitted from the wire. */
 function authoredByToWire(ab: AuthoredBy | undefined): Record<string, unknown> | undefined {
   if (ab === undefined) return undefined;
   const wire: Record<string, unknown> = {};
@@ -1785,9 +1602,8 @@ function authoredByToWire(ab: AuthoredBy | undefined): Record<string, unknown> |
   return wire;
 }
 
-/** Snake_case wire-key projection of the optional IETF profile fields
- * that do not depend on `complianceMode`. Defined as a const table so
- * the `applyComplianceFields` loop stays single-pass. */
+/** Snake_case wire-key projection of the optional IETF fields that do not depend on
+ * `complianceMode`. A const table so the `applyComplianceFields` loop stays single-pass. */
 const IETF_OPTIONAL_FIELD_MAP: ReadonlyArray<{
   wire: string;
   read: (o: SignOptions) => unknown;
@@ -1848,12 +1664,8 @@ const IETF_OPTIONAL_FIELD_MAP: ReadonlyArray<{
 ];
 
 /**
- * Project IETF Compliance Receipts profile fields onto the request body
- * using snake_case wire keys. Adds `compliance_mode`, `action_ref`, the
- * non-conditional optional fields (`sandbox_state`, `iteration_id`,
- * `risk_class`, `incident_class`, `issuer_id`, `payload_digest`,
- * `receipt_type`, `reason`), then the decision / topology fields that
- * depend on `complianceMode`.
+ * Project IETF Compliance Receipts profile fields onto the request body using snake_case wire
+ * keys, then the decision / topology fields that depend on `complianceMode`.
  */
 function applyComplianceFields(
   body: Record<string, unknown>,
@@ -1870,9 +1682,8 @@ function applyComplianceFields(
   applyDecisionFields(body, options, complianceMode);
 }
 
-/** Attach `policy_decision`, the spec-shape `decision` mirror, and the
- * compliance-only `capture_topology` to the body. Split out so
- * `applyComplianceFields` stays a flat loop plus one helper call. */
+/** Attach `policy_decision`, the spec-shape `decision` mirror, and the compliance-only
+ * `capture_topology`. Split out so `applyComplianceFields` stays a flat loop. */
 function applyDecisionFields(
   body: Record<string, unknown>,
   options: SignOptions,
@@ -1918,10 +1729,8 @@ interface SignWireResponse {
 }
 
 /**
- * Shape the snake_case wire response into the camelCase
- * `SignatureResponse` returned to callers. Prefers cloud-supplied
- * `decision`; maps from `policy_decision` for older clouds under
- * compliance_mode. Accepts either casing on `previous_receipt_hash`.
+ * Shape the snake_case wire response into the camelCase `SignatureResponse`. Prefers
+ * cloud-supplied `decision`, mapping from `policy_decision` for older clouds.
  */
 function mapSignWireToResponse(data: SignWireResponse): SignatureResponse {
   // Some clouds nest these under `payload` instead of top level.
@@ -2028,10 +1837,8 @@ const _DELETE_SQL_PREFIX = "data:delete:sql:";
 const _DESTRUCTIVE_VERB_RE = /(?<![A-Za-z])(DELETE|DROP|TRUNCATE|ALTER|GRANT|REVOKE|REPLACE|COPY|UPSERT)(?![A-Za-z])/i;
 
 /**
- * Returns match candidates for a given action type.
- * Normalizes (trim + lowercase) so case variants and stray whitespace cannot
- * dodge the prefix check. For a destructive SQL write, also returns a
- * `data:delete:sql:` candidate so delete-namespace policies fire.
+ * Return match candidates for an action type, normalised (trim + lowercase) so case variants
+ * cannot dodge the prefix check. A destructive SQL write also yields a `data:delete:sql:` candidate.
  */
 function _actionCandidates(actionType: string): string[] {
   const normalized = actionType.trim().toLowerCase();
@@ -2245,9 +2052,8 @@ export class Agent {
   }
 
   /**
-   * Pre-flight check combining revocation/suspension status and policy.
-   * Fail-closed: if a sub-check cannot complete, checksComplete is false and
-   * cleared is false so a fetch error never clears. Mirrors Python preflight.
+   * Pre-flight check combining revocation/suspension status and policy. Fail-closed: an incomplete
+   * sub-check leaves checksComplete and cleared false, so a fetch error never clears.
    */
   async preflight(actionType: string): Promise<PreflightResult> {
     let agentActive = true;
@@ -2442,9 +2248,8 @@ export async function verifySignature(signatureId: string): Promise<Verification
 }
 
 /**
- * Publicly verify a receipt by id. No API key or `init()` required. Recomputes
- * `chainHash` locally (sha256 of the RFC 8785 canonical payload) so the chain
- * link stays reproducible offline.
+ * Publicly verify a receipt by id; no API key or `init()` required. Recomputes `chainHash`
+ * locally so the chain link stays reproducible offline.
  */
 export async function verify(signatureId: string): Promise<{
   verified: boolean;
@@ -2488,15 +2293,8 @@ export async function verify(signatureId: string): Promise<{
   };
 }
 
-/** Post the executor side of an action.
- *
- * The executor signs the canonical bytes
- * `{applied_at, error_code, outcome, signature_id}` (sorted-keys JSON,
- * no whitespace) with its identity key and posts the base64 of pubkey +
- * signature back. If the original signer pinned an expected executor
- * public key on `agent.sign({ expectedExecutorPubkeyB64 })`, any
- * attestation from a different key is rejected with 403.
- */
+/** Post the executor side of an action, signed over the canonical
+ * `{applied_at, error_code, outcome, signature_id}`. An unpinned executor key is rejected with 403. */
 export async function postAppliedAttestation(
   options: AppliedAttestationOptions,
 ): Promise<AppliedAttestationResponse> {
@@ -2534,9 +2332,8 @@ export async function postAppliedAttestation(
   };
 }
 
-/** List rejected sign / verify / replay attempts for the caller's
- * org. Public verify rejections (org NULL) are filtered out by design.
- * Admins query those separately via maintenance. */
+/** List rejected sign / verify / replay attempts for the caller's org. Public verify
+ * rejections (org NULL) are filtered out by design. */
 export async function listRejectedAttempts(
   options: ListRejectedAttemptsOptions = {},
 ): Promise<RejectedAttemptList> {
@@ -2642,13 +2439,8 @@ export async function exportAuditJson(
 const DEFAULT_JWKS_URL = "https://api.asqav.com/.well-known/jwks.json";
 
 /**
- * Fetch and return the Asqav public JWKS directory as a plain object.
- *
- * Snapshot this before going air-gapped; pass the result to
- * `verifyReceiptOffline(receipt, jwks)`. The endpoint is public and
- * unauthenticated.
- *
- * @param url - JWKS URL (default: https://api.asqav.com/.well-known/jwks.json).
+ * Fetch the Asqav public JWKS directory as a plain object; snapshot it before going
+ * air-gapped and pass it to `verifyReceiptOffline`. Defaults to the public api.asqav.com URL.
  */
 export async function fetchJwks(url: string = DEFAULT_JWKS_URL): Promise<Record<string, unknown>> {
   const res = await fetch(url, { headers: { Accept: "application/json" } });
@@ -2660,14 +2452,8 @@ import { ADAPTERS as _ADAPTERS, verify as _oracleVerify } from "./verifier/index
 import type { VerifyResult } from "./verifier/core.js";
 
 /**
- * Verify a receipt fully offline against an in-memory JWKS snapshot.
- *
- * Runs the full oracle: structure, signature (Ed25519/ES256/ML-DSA-65 via
- * `@noble/post-quantum`), hash-chain link. No network call is made.
- *
- * @param receipt - Parsed receipt envelope object ({payload, signature, anchors}).
- * @param jwks - JWKS object previously fetched via `fetchJwks()`.
- * @param predecessor - Parsed predecessor receipt for the chain check (optional).
+ * Verify a receipt fully offline against an in-memory JWKS snapshot, running the full oracle
+ * (structure, signature, hash-chain link). No network call is made.
  */
 export function verifyReceiptOffline(
   receipt: Record<string, unknown>,

--- a/typescript/src/jcs.ts
+++ b/typescript/src/jcs.ts
@@ -1,32 +1,6 @@
 /**
- * JCS canonicalization helper for the IETF Compliance Receipts profile.
- *
- * Public surface: `canonicalJson(obj): Uint8Array`.
- *
- * The output bytes are the exact bytes the cloud (`core/canonical.py`)
- * signs and the bytes the chain hashes over.
- *
- * See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
- *
- * Subset implemented:
- *   - Lexicographic (UTF-16 code unit) ordering of object keys.
- *   - No insignificant whitespace.
- *   - UTF-8 byte output, no BOM, non-ASCII passes through verbatim.
- *   - Standard JSON string escapes (backslash, quote, b, f, n, r, t,
- *     and `\u00xx` for U+0000..U+001F).
- *   - Numbers: integers within IEEE-754 safe range serialize without
- *     trailing ".0"; finite floats use the shortest round-trip form
- *     (V8's Number.toString already produces this, matching ECMAScript).
- *   - NaN / Infinity rejected (not representable in JSON).
- *
- * Out of scope: pre-2024 erratum normalization for non-finite numbers
- * and explicit handling of negative zero (we map -0 to "0", as
- * Python's json.dumps does, since the Compliance Receipts profile signs
- * no floats).
- *
- * The companion module `canonicalize.ts` exposes the same function under
- * the alias `canonicalize()`. They are kept byte-identical; this module
- * is the named landing for the IETF profile callers.
+ * JCS canonicalization for the IETF Compliance Receipts profile; `canonicalJson(obj)` returns the exact
+ * bytes the cloud signs and the chain hashes over. `canonicalize.ts` exposes the same bytes by alias.
  */
 
 type JsonValue =
@@ -38,11 +12,8 @@ type JsonValue =
   | { [key: string]: JsonValue };
 
 /**
- * Canonicalize a JSON-serializable value to JCS bytes.
- *
- * Throws TypeError for values not representable in JSON (functions,
- * undefined, BigInt, Symbol) and for non-finite numbers (NaN, Infinity,
- * -Infinity).
+ * Canonicalize a JSON-serializable value to JCS bytes. Throws TypeError for values JSON cannot
+ * represent (functions, undefined, BigInt, Symbol) and for non-finite numbers.
  */
 export function canonicalJson(value: unknown): Uint8Array {
   return new TextEncoder().encode(canonicalString(value));

--- a/typescript/src/mode.ts
+++ b/typescript/src/mode.ts
@@ -1,9 +1,6 @@
 /**
- * Mode resolver for hash-only vs full-payload signing.
- *
- * Mirrors ``asqav._mode`` in the Python SDK exactly: same precedence
- * (explicit > env > URL auto-detection) and same "is this an Asqav cloud
- * URL?" rule.
+ * Mode resolver for hash-only vs full-payload signing, mirroring ``asqav._mode``: same precedence
+ * (explicit > env > URL auto-detection) and the same Asqav-cloud-URL rule.
  */
 
 export type Mode = "hash-only" | "full-payload";
@@ -21,11 +18,8 @@ export function isAsqavCloudHost(hostname: string | null | undefined): boolean {
 }
 
 /**
- * Resolve the wire mode for a client.
- *
- * @param apiBaseUrl  The configured API URL.
- * @param env         Value of ASQAV_MODE env var (or null).
- * @param explicit    Caller-passed mode. ``"auto"`` defers to env then URL.
+ * Resolve the wire mode for a client from the API URL, the ASQAV_MODE env value, and the caller's
+ * explicit choice. ``"auto"`` defers to env, then URL.
  */
 export function resolveMode(
   apiBaseUrl: string | null | undefined,

--- a/typescript/src/replay.ts
+++ b/typescript/src/replay.ts
@@ -1,24 +1,6 @@
 /**
- * Offline replay / chain verification for the IETF Compliance Receipts profile.
- *
- * See https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/
- *
- * The verifier walks an ordered list of signed envelopes for one agent,
- * re-derives each predecessor's `previousReceiptHash`, and reports any
- * mismatch as a chain break. Equivalent to the Python SDK's
- * `replay.ReplayTimeline.verify_chain`.
- *
- * Chain link (cloud-canonical):
- *
- *   previousReceiptHash[i+1] = sha256(canonicalJson(payload[i]))   // 64 hex
- *   previousReceiptHash[0]   = "0".repeat(64)
- *
- * The cloud hashes the inner compliance payload only, not the
- * `{payload, signature, anchors}` wrapper. When a record's `signedEnvelope`
- * carries that wrapper, the verifier unwraps and hashes only `payload`.
- *
- * This module is import-free of any HTTP / network code so it can run
- * over a downloaded ComplianceBundle.
+ * Offline replay / chain verification for the IETF Compliance Receipts profile: walk ordered envelopes
+ * for one agent, re-derive each `previousReceiptHash`, report mismatches. Network-free by design.
  */
 
 import { createHash } from "node:crypto";
@@ -30,9 +12,10 @@ export const FIRST_RECEIPT_SEED = "0".repeat(64);
 
 /** A single record in the chain to verify. */
 export interface ChainRecord {
-  /** The full signed envelope (the bytes the cloud signed, as a JSON
-   * object). Must include `previousReceiptHash`. Other fields are
-   * passed through as-is into the JCS canonical bytes. */
+  /**
+   * The full signed envelope as a JSON object; must include `previousReceiptHash`. Other fields pass
+   * through as-is into the JCS canonical bytes.
+   */
   signedEnvelope: Record<string, unknown>;
   /** Optional pre-computed chain hash for this record. When omitted,
    * the verifier derives it from the envelope. */
@@ -51,9 +34,10 @@ export interface ChainStepResult {
   actualPreviousReceiptHash: string;
   /** This record's derived chain hash. */
   derivedChainHash: string;
-  /** When `chainHash` was supplied on the input, true if it matches the
-   * derived value (catches storage-side mutation). Undefined when not
-   * supplied. */
+  /**
+   * When `chainHash` was supplied on the input, true if it matches the derived value, catching
+   * storage-side mutation. Undefined when not supplied.
+   */
   storedChainHashMatches?: boolean;
 }
 
@@ -63,22 +47,15 @@ export interface ChainVerificationResult {
   steps: ChainStepResult[];
 }
 
-/** Reserved for future verifier knobs. No keys are accepted today;
- * passing any unrecognized key (including flag names removed in this release)
- * throws so silent-fallback bugs surface immediately. */
+/**
+ * Reserved for future verifier knobs. No keys are accepted today; any unrecognized key throws so
+ * silent-fallback bugs surface immediately.
+ */
 export type VerifyChainOptions = Record<string, never>;
 
 /**
- * Re-derive the chain over an ordered list of signed envelopes for one
- * agent and return per-step + aggregate validity.
- *
- * The list MUST be in chain order (oldest first). Mixing agents yields
- * `chainIntegrity=false` because the predecessor links won't match.
- *
- * @throws TypeError if `options` carries any unrecognized key. The
- *   `signedEnvelope` is now required on every step; callers that
- *   relied on a synthetic chain shape must migrate their bundles
- *   accordingly.
+ * Re-derive the chain over an ordered list of signed envelopes for one agent (oldest first) and return
+ * per-step plus aggregate validity. Throws TypeError on any unrecognized `options` key.
  */
 export function verifyChain(
   records: ChainRecord[],
@@ -141,12 +118,8 @@ export function deriveChainHash(envelope: Record<string, unknown>): string {
 }
 
 /**
- * Return the inner compliance payload the cloud hashes for the chain link.
- *
- * The cloud computes `sha256(canonicalJson(payload))` where `payload` is
- * the IETF compliance payload dict. When the input is the bundle-shaped
- * `{payload, signature, anchors, ...}` wrapper this returns
- * `envelope.payload`; otherwise the envelope is hashed as-is.
+ * Return the inner compliance payload the cloud hashes for the chain link, unwrapping the bundle-shaped
+ * `{payload, signature, anchors}` wrapper when present.
  */
 function payloadForChain(
   envelope: Record<string, unknown>,

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -1,10 +1,6 @@
 /**
- * Shared User-Agent for every outbound HTTP call the SDK makes from Node.
- *
- * The api.asqav.com edge runs a Cloudflare browser-integrity check that
- * 403s anonymous default agents, so SDK requests must identify themselves.
- * Browsers forbid setting User-Agent on fetch (it is a forbidden header
- * name), so the helper only adds it when running under Node.
+ * Shared User-Agent for outbound SDK calls: the api.asqav.com edge 403s anonymous default agents. Only
+ * added under Node, since browsers forbid setting User-Agent on fetch.
  */
 
 export const SDK_VERSION = "0.10.2";

--- a/typescript/src/verifier/adapter.ts
+++ b/typescript/src/verifier/adapter.ts
@@ -1,9 +1,6 @@
 /**
- * The format-adapter seam - a port of the Python oracle's `verifier/oracle/adapter.py`.
- *
- * Everything format-specific lives behind this seam; everything shared (the JCS
- * canonicaliser, the Ed25519 / ES256 verify, the SHA-256 chain walk, the vector
- * runner) is infrastructure the core drives.
+ * The format-adapter seam, a port of the Python oracle's `adapter.py`. Everything format-specific lives
+ * behind it; the canonicaliser, verify, chain walk and vector runner are shared infrastructure.
  */
 
 import type { VerifyState } from "./crypto.js";
@@ -21,10 +18,8 @@ export interface SignatureMaterial {
 /** The hash-chain linkage for one receipt. */
 export interface ChainStep {
   /**
-   * The value of the format's previous-hash field, or null when the format omits
-   * it on genesis (AERF) - distinct from an explicit-null genesis. Typed unknown
-   * because the wire value is producer-set: a non-string must reach the chain
-   * axis as-is rather than be narrowed into an absent link.
+   * The format's previous-hash field value, or null when the format omits it on genesis. Typed unknown
+   * because the wire value is producer-set: a non-string must reach the chain axis as-is.
    */
   prevField: unknown;
   /** True when this receipt declares itself first on its chain. */
@@ -43,9 +38,8 @@ export type ExtraAxis = readonly [string, VerifyState, string];
 export type KeyProvider = Record<string, unknown> | null;
 
 /**
- * One receipt format's binding to the shared verification core. Subclasses
- * implement the six methods; `name` labels the format in results and the manifest;
- * `detect` is a cheap structural fingerprint (no crypto).
+ * One receipt format's binding to the shared verification core. `name` labels the format in results and
+ * the manifest; `detect` is a cheap structural fingerprint with no crypto.
  */
 export abstract class FormatAdapter {
   /** Stable format label surfaced in results and the vector manifest. */
@@ -73,10 +67,8 @@ export abstract class FormatAdapter {
   abstract schema(doc: Record<string, unknown>): AxisCheck;
 
   /**
-   * Format-specific axes beyond structure / issuer-signature / chain. Returns a
-   * list of `[axisName, result, note]`. The default is none; a format whose
-   * verification procedure layers additional REQUIRED checks returns one tuple
-   * per check so a missing-but-required or invalid layer FAILs the verdict.
+   * Format-specific axes beyond structure / signature / chain, as `[axisName, result, note]`. Default is
+   * none; a format layering REQUIRED checks returns one tuple each so a missing layer FAILs the verdict.
    */
   extraAxes(_doc: Record<string, unknown>, _keyProvider: KeyProvider): ExtraAxis[] {
     return [];
@@ -89,10 +81,8 @@ export abstract class FormatAdapter {
   }
 
   /**
-   * True when the receipt's digest is keyed (criterion 438). A keyed digest
-   * (e.g. HMAC-SHA256) is internally consistent but not third-party
-   * re-derivable, so a fully-checked receipt reports `verified_keyed`, never
-   * plain `verified`. Default is false.
+   * True when the receipt's digest is keyed (criterion 438): internally consistent but not third-party
+   * re-derivable, so a fully-checked receipt reports `verified_keyed`. Default is false.
    */
   keyedDigest(_doc: Record<string, unknown>): boolean {
     return false;

--- a/typescript/src/verifier/adapters/acta.ts
+++ b/typescript/src/verifier/adapters/acta.ts
@@ -1,19 +1,6 @@
 /**
- * ACTA adapter - Ed25519 over the JCS of the payload, signed directly.
- * A port of the Python oracle's `verifier/oracle/adapters/acta.py`.
- *
- * Targets draft-farley-acta-signed-receipts-01. The envelope is
- * `{payload, signature:{alg, kid, sig}}`; the signature is Ed25519 over the JCS
- * canonical bytes of the `payload` object, signed DIRECTLY (no pre-hash), with the
- * sig as a lowercase hex string. The OPTIONAL Commitment Mode is NOT implemented:
- * a commitment-mode receipt fails the baseline signature check (the honest outcome).
- *
- * Asqav-native is a PROFILE of ACTA, so the payloads look identical; the formats
- * are kept disjoint by the signature encoding (ACTA hex, Asqav-native base64) plus
- * the Asqav-only `anchors` envelope key.
- *
- * The chain field `previousReceiptHash` is SHA-256 of the JCS of the FULL
- * predecessor receipt INCLUDING its signature.
+ * ACTA adapter (draft-farley-acta-signed-receipts-01): Ed25519 over the JCS of `payload`, hex sig. Kept
+ * disjoint from Asqav-native by sig encoding and the `anchors` key; Commitment Mode is not implemented.
  */
 
 import {

--- a/typescript/src/verifier/adapters/aerf.ts
+++ b/typescript/src/verifier/adapters/aerf.ts
@@ -1,20 +1,6 @@
 /**
- * AERF adapter - Ed25519 over RFC 8785 JCS, signed directly (no pre-hash).
- * A port of the Python oracle's `verifier/oracle/adapters/aerf.py`.
- *
- * AERF receipts are a flat object. The signature is Ed25519 over the JCS bytes of
- * the receipt with the non-payload fields stripped - `signature`, `timestamp`,
- * `parent_signature`, `parent_key_id`, `log_inclusion_proof` - signed DIRECTLY.
- *
- * Chain rule (AERF SPEC): `previous_receipt_hash` is the SHA-256 of the
- * predecessor's signable payload with the SAME field set stripped (signature
- * EXCLUDED). Genesis OMITS the field entirely; a present `previous_receipt_hash:
- * null` is a malformed genesis.
- *
- * AERF layers two conditionally-REQUIRED signature checks in `extraAxes`:
- *   - parent counter-signature: REQUIRED when `impact_tags` is non-empty.
- *   - PDP binding: REQUIRED when `impact_tags` is non-empty; the PDP key signs
- *     the canonical tuple `{context_hash_sha256, in_policy, policy_hash}`.
+ * AERF adapter: Ed25519 over RFC 8785 JCS of the receipt with the non-payload fields stripped, signed
+ * directly. Non-empty `impact_tags` makes the parent counter-signature and PDP binding REQUIRED.
  */
 
 import {

--- a/typescript/src/verifier/adapters/agentreceipts.ts
+++ b/typescript/src/verifier/adapters/agentreceipts.ts
@@ -1,19 +1,6 @@
 /**
- * agent-receipts adapter - W3C-VC AgentReceipt, Ed25519 over strict RFC 8785 JCS.
- * A port of the Python oracle's `verifier/oracle/adapters/agentreceipts.py`.
- *
- * An AgentReceipt is a W3C Verifiable Credential 2.0 envelope. The signature is
- * Ed25519 over the strict JCS bytes of the receipt with the `proof` member
- * removed, signed DIRECTLY. `proof.type` is `Ed25519Signature2020` and
- * `proof.proofValue` is multibase `u` (base64url, no padding).
- *
- * Uses `jcsRfc8785` (UTF-16 key sort, ECMAScript numbers), NOT the AERF/ACTA
- * `jcs` dialect. The signing key resolves from `proof.verificationMethod` through
- * the shared DID resolver.
- *
- * Chain rule: `credentialSubject.chain.previous_receipt_hash` is `"sha256:"` +
- * hex(SHA-256(JCS(predecessor without proof))). Genesis carries the field present
- * and explicitly `null`.
+ * agent-receipts adapter: a W3C VC 2.0 envelope, Ed25519 over strict RFC 8785 JCS with `proof` removed.
+ * The signing key resolves from `proof.verificationMethod` through the shared DID resolver.
  */
 
 import {

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -1,19 +1,6 @@
 /**
- * Asqav-native adapter - the existing verify_receipt logic behind the seam.
- * A port of the Python oracle's `verifier/oracle/adapters/asqav_native.py`.
- *
- * Two real Asqav wire shapes route here, kept mutually exclusive at detection:
- *
- *   - COMPLIANCE mode: the `{payload, signature, anchors}` envelope whose
- *     `payload` carries `previousReceiptHash` / `issuer_id`. The signature signs
- *     the canonical bytes of `payload` DIRECTLY; the chain hash is SHA-256 of the
- *     predecessor payload's canonical bytes.
- *   - HASH mode: the default `/sign` output - a FLAT receipt with `mode:"hash"`,
- *     `payload:null`, a `signature_b64` (or `signature`), and a `hash`. The
- *     signing input is the flat 11-field object the cloud rebuilds.
- *
- * Canonicalisation goes through `asqavJcs`, byte-identical to the cloud's
- * `verify_receipt.canonical_json`.
+ * Asqav-native adapter, a port of the Python oracle's `asqav_native.py`. Two wire shapes route here,
+ * mutually exclusive at detection: the compliance envelope and the flat hash-mode receipt.
  */
 
 import {
@@ -67,18 +54,13 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 /** True for a flat hash-mode signature receipt (mode=hash, null payload, a sig). */
-// Claim fields that live inside the signed compliance payload. A hash-mode
-// receipt carrying one is presenting a claim its signature does not cover.
-// key_thumbprint is here because hash mode signs the flat 11 fields and nothing
-// else, so a thumbprint pasted onto one binds no key at all.
+// Claims belonging to the signed payload; hash mode signs the flat fields only,
+// so a thumbprint pasted onto one binds nothing.
 const UNSIGNED_CLAIM_FIELDS = ["issuer_id", "previousReceiptHash", "key_thumbprint"];
 
 /**
- * alg plus raw public-key bytes of the resolved directory entry.
- *
- * The directory publishes the key as standard base64 under `public_key`; an AKP
- * thumbprint is taken over the same bytes in unpadded base64url, so the decode
- * has to happen before the digest, never after.
+ * alg plus raw public-key bytes of the resolved directory entry. The directory publishes standard
+ * base64 while an AKP thumbprint is over unpadded base64url, so the decode precedes the digest.
  */
 function resolvedKeyMaterial(
   entry: Record<string, unknown> | null,
@@ -154,14 +136,8 @@ export class AsqavNativeAdapter extends FormatAdapter {
   }
 
   /**
-   * The one JWKS entry this receipt's signature is checked against.
-   *
-   * Mirrors the Python adapter's `_signing_key_entry`. Every axis resolves through
-   * here, so the entry that verifies the signature is the entry each published field
-   * is read from. kid lives OUTSIDE the signed bytes, so a second independent lookup
-   * on it is attacker-steerable: a receipt could verify against a key found one way
-   * while the revocation and issuer axes read a key found another way, or emit no
-   * axis at all. An axis that never exists cannot be blocked on.
+   * The one JWKS entry this receipt's signature is checked against. Every axis resolves through here: kid
+   * sits outside the signed bytes, so a second independent lookup would be attacker-steerable.
    */
   private signingKeyEntry(
     doc: Record<string, unknown>,
@@ -308,10 +284,8 @@ export class AsqavNativeAdapter extends FormatAdapter {
   }
 
   /**
-   * A hash-mode digest sealed with the org salt is keyed (criterion 438).
-   * hash_algo hmac-sha256 is internally consistent but not third-party
-   * re-derivable, so a fully-checked receipt reports verified_keyed, never
-   * plain verified. Read from the signed field set only.
+   * A hash-mode digest sealed with the org salt is keyed (criterion 438): internally consistent but not
+   * third-party re-derivable, so a fully-checked receipt reports verified_keyed, never plain verified.
    */
   keyedDigest(doc: Record<string, unknown>): boolean {
     return isHashMode(doc) && doc.hash_algo === "hmac-sha256";

--- a/typescript/src/verifier/adapters/authproof.ts
+++ b/typescript/src/verifier/adapters/authproof.ts
@@ -1,16 +1,6 @@
 /**
- * Authproof adapter - ES256 over insertion-order JSON, key embedded as a JWK.
- * A port of the Python oracle's `verifier/oracle/adapters/authproof.py`.
- *
- * Authproof delegation receipts are signed by the reference JS SDK
- * (`Commonguy25/authproof-sdk`, `src/authproof.js`), authoritative for the wire
- * shape. A receipt is a flat object whose signature is ECDSA P-256 / SHA-256 over
- * `JSON.stringify(receipt-without-signature)` in INSERTION order (not JCS, no
- * pre-hash). The signature is hex-encoded raw r||s (64 bytes); the signer's public
- * key is embedded as a P-256 JWK at `signerPublicKey`.
- *
- * In TypeScript the signing input is produced with native `JSON.stringify`, which
- * is exactly what the JS SDK signs - byte-for-byte, no re-derivation.
+ * Authproof adapter: ES256 over `JSON.stringify(receipt-without-signature)` in INSERTION order, not JCS,
+ * with the signer key embedded as a P-256 JWK. Native stringify reproduces the JS SDK's bytes exactly.
  */
 
 import {
@@ -22,10 +12,8 @@ import {
 } from "../adapter.js";
 
 /**
- * A shipping-SDK delegationId is `auth-<epoch_ms>-<5 base36 chars>`.
- * `[0-9]` (not `\d`) spells out the ASCII digit class so the pattern reads
- * identical to the Python validator's; ECMAScript `^`/`$` are already strict
- * (no trailing newline) and `\d` is already ASCII here, so this is the anchor.
+ * A shipping-SDK delegationId is `auth-<epoch_ms>-<5 base36 chars>`. `[0-9]` spells out the ASCII digit
+ * class so the pattern reads identical to the Python validator's.
  */
 const DELEGATION_ID = /^auth-[0-9]+-[a-z0-9]{5}$/;
 

--- a/typescript/src/verifier/adapters/pipelock.ts
+++ b/typescript/src/verifier/adapters/pipelock.ts
@@ -1,25 +1,6 @@
 /**
- * Pipelock EvidenceReceipt v2 adapter - Ed25519 over JCS with zeroed signature.
- * A port of the Python oracle's `verifier/oracle/adapters/pipelock.py`.
- *
- * Signing rule: clone the receipt dict, zero out the `signature` object (all
- * four fields set to empty strings), then JCS-canonicalize (RFC 8785 dialect)
- * the result. The signature is Ed25519 PureEdDSA over those bytes; the 64-byte
- * signature is hex-encoded with an `ed25519:` prefix (`ed25519:<128 hex chars>`).
- *
- * Key resolution: EvidenceReceipt v2 does NOT embed its signer public key in
- * the envelope. The caller must supply the raw 32-byte Ed25519 key hex via the
- * key provider, keyed by `signature.signer_key_id`. When the key is absent the
- * signature axis SKIPs and the verdict is INCOMPLETE, never a hiding PASS.
- *
- * Chain rule: `chain_prev_hash` is `"sha256:" + hex(SHA-256(JCS(full predecessor
- * receipt)))` for non-genesis receipts. Genesis receipts set `chain_prev_hash`
- * to `"genesis"` or `"sha256:0"` (both are accepted). Unlike AERF, the chain
- * hash covers the full predecessor receipt INCLUDING its signature.
- *
- * Canonicalization: Pipelock v2 uses strict RFC 8785 JCS (NFC strings,
- * lexicographic UTF-16 code-unit key sort). We reuse `jcsRfc8785` which
- * byte-matches Pipelock's Go canonicaliser for all-ASCII field sets and NFC input.
+ * Pipelock EvidenceReceipt v2 adapter: Ed25519 over strict RFC 8785 JCS with the `signature` object
+ * zeroed. The caller supplies the signer key; absent, the signature axis SKIPs rather than hiding a PASS.
  */
 
 import {
@@ -88,9 +69,8 @@ function safeHex(value: unknown): Uint8Array {
 }
 
 /**
- * Build the signable preimage: full receipt with the `signature` sub-object
- * zeroed out (all four fields set to empty strings), then JCS RFC 8785.
- * Mirrors `pipelock_verify._evidence._signable_preimage`.
+ * Build the signable preimage: the full receipt with the `signature` sub-object zeroed, then JCS
+ * RFC 8785. Mirrors `pipelock_verify._evidence._signable_preimage`.
  */
 function signablePreimage(doc: Record<string, unknown>): Uint8Array {
   const clone: Record<string, unknown> = { ...doc };

--- a/typescript/src/verifier/adapters/w3cVc.ts
+++ b/typescript/src/verifier/adapters/w3cVc.ts
@@ -1,22 +1,6 @@
 /**
- * W3C VC 2.0 adapter - DataIntegrityProof with the eddsa-jcs-2022 cryptosuite.
- * A port of the Python oracle's `verifier/oracle/adapters/w3c_vc.py`.
- *
- * A Verifiable Credential 2.0 envelope secured by a `DataIntegrityProof` whose
- * `cryptosuite` is `eddsa-jcs-2022` (W3C TR vc-di-eddsa): Ed25519 (RFC 8032)
- * signs `SHA-256(JCS(proofOptions)) || SHA-256(JCS(unsecuredDocument))` where
- * JCS is strict RFC 8785, proofOptions is `proof` with `proofValue` removed,
- * and unsecuredDocument is the credential with `proof` removed. `proofValue` is
- * the raw 64-byte signature multibase base58btc ('z') encoded.
- *
- * When the proof options carry their own `@context` the spec's transform
- * requires the document `@context` to start with it in order and canonicalises
- * the document with the proof's `@context` substituted; both rules are enforced.
- *
- * Structure is intentionally stricter than the suite spec: proofPurpose must be
- * `assertionMethod` and the verificationMethod DID must equal the issuer DID,
- * fail-closed, mirroring the agentreceipts adapter. A W3C VC carries no in-band
- * chain link, so the chain axis reports genesis.
+ * W3C VC 2.0 adapter for DataIntegrityProof with the eddsa-jcs-2022 cryptosuite, a port of the Python
+ * `w3c_vc.py`. Stricter than the suite: assertionMethod only, and the signing-key DID must equal issuer.
  */
 
 import { createHash } from "node:crypto";

--- a/typescript/src/verifier/canonical.ts
+++ b/typescript/src/verifier/canonical.ts
@@ -1,34 +1,6 @@
 /**
- * Canonicalization shared across format adapters - a byte-for-byte port of the
- * Python oracle's `verifier/oracle/canonical.py`.
- *
- * Three callable shapes, because three signers disagree on what "JCS" means:
- *
- *   - `jcs(obj)`          : NFC-normalised, code-POINT key ordering (Python
- *                           `sort_keys`), numbers preserved as Python emits them.
- *                           Matches the AERF / ACTA reference producers.
- *   - `jcsRfc8785(obj)`   : strict RFC 8785 - UTF-16 code-UNIT key ordering and
- *                           ECMAScript Number.prototype.toString number output,
- *                           plus NFC. Byte-matches the agent-receipts upstream
- *                           canonicalization vectors.
- *   - `asqavJcs(obj)`     : the Asqav cloud's historical JCS WITHOUT NFC, kept
- *                           byte-identical to `verify_receipt.canonical_json`.
- *
- * Implementation parity notes vs the Python source:
- *   - Python `sort_keys` sorts by Unicode CODE POINT; JavaScript's default
- *     `Array.prototype.sort` on strings sorts by UTF-16 CODE UNIT. These differ
- *     only on supplementary-plane keys. `jcs`/`asqavJcs` therefore sort by code
- *     point (mirroring Python); `jcsRfc8785` sorts by code unit (RFC 8785).
- *   - V8's `Number.prototype.toString` already produces the ECMAScript shortest
- *     round-trip form RFC 8785 mandates; verified byte-equal against the upstream
- *     number vectors (1e-7, 1e+21, 0.30000000000000004, ...).
- *   - Python `json.dumps(ensure_ascii=False)` short-escapes \b \t \n \f \r,
- *     emits other control chars < 0x20 as \u00xx, and passes everything >= 0x20
- *     (including 0x7f and all non-ASCII) verbatim. `jsonString` reproduces this.
- *   - Python `json.dumps(allow_nan=False)` rejects NaN/Infinity; we throw too.
- *   - `jcs`/`asqavJcs` keep numbers as Python emits them. For the integer field
- *     sets these receipts carry, Python `repr` and V8 `toString` agree; floats
- *     are out of the Asqav/AERF/ACTA signed scope, so this is exact for the corpus.
+ * Canonicalization shared across format adapters, a byte-for-byte port of the Python oracle's
+ * `canonical.py`: `jcs`, `jcsRfc8785` and `asqavJcs` differ on key order, NFC and numbers.
  */
 
 type JsonValue =
@@ -40,22 +12,8 @@ type JsonValue =
   | { [key: string]: JsonValue };
 
 /**
- * A JSON number that was written as a FLOAT literal (had a `.`, `e`, or `E`).
- *
- * JavaScript's `JSON.parse` collapses `500.0` to the integer `500` because
- * IEEE-754 has no int/float distinction, so the trailing `.0` is lost. Python's
- * `json.load` keeps it as a `float` and `json.dumps` re-emits `500.0`. The
- * AERF / ACTA / Asqav `jcs` dialects sign numbers "as the producer emitted them",
- * so a receipt carrying `500.0` is signed over the bytes `500.0`, not `500`.
- *
- * To reproduce those exact bytes, parse receipts with `parseJsonPreservingFloats`
- * (below), which wraps float literals in this class; the canonicalisers then
- * re-emit the float form. Integer literals are left as plain `number`.
- *
- * Parity scope: the corpus floats are whole-magnitude (`500.0`, `1250.0`), where
- * Python repr, the AERF Go producer, and this emitter all agree on `<int>.0`.
- * Exotic floats (e.g. `1e-7` vs Python's `1e-07`) do not occur in any signed
- * receipt; were they to, the AERF Go producer - not Python repr - is the target.
+ * A JSON number written as a FLOAT literal, kept so `500.0` re-emits as `500.0` rather than the
+ * `500` JSON.parse collapses it to; the jcs dialects sign numbers as the producer emitted them.
  */
 export class RawFloat {
   constructor(public readonly value: number) {}
@@ -71,11 +29,8 @@ function isRawFloat(v: unknown): v is RawFloat {
 }
 
 /**
- * An integer literal beyond IEEE-754 safe range (|n| > 2^53). JS `JSON.parse`
- * collapses it to the nearest double, so two distinct integers can read as one
- * and a tampered receipt could verify. Keeping the exact source digits lets the
- * Python-dialect canonicalisers emit them verbatim (matching Python's
- * arbitrary-precision int), closing that false-PASS path.
+ * An integer beyond IEEE-754 safe range, kept as exact source digits. Collapsing it to the nearest
+ * double would let two distinct integers share one signature and a tampered receipt verify.
  */
 export class RawBigInt {
   constructor(public readonly source: string) {}
@@ -91,10 +46,8 @@ function isRawBigInt(v: unknown): v is RawBigInt {
 }
 
 /**
- * A JSON object repeated a member name (criterion 419). ECMAScript object
- * semantics are last-wins on duplicate keys, which would hash the bytes an
- * attacker kept and drop the ones they replaced; the strict parser therefore
- * throws this before any hashing, canonicalisation, or signature check.
+ * A JSON object repeated a member name (criterion 419). Last-wins would hash the bytes an attacker
+ * kept, so the strict parser throws before any hashing, canonicalisation or signature check.
  */
 export class DuplicateMemberError extends SyntaxError {
   constructor(message: string) {
@@ -115,18 +68,8 @@ function floatToString(n: number): string {
 }
 
 /**
- * Parse JSON while preserving float literals as `RawFloat` and out-of-safe-range
- * integers as `RawBigInt`, so the canonicalisers re-emit `500.0` rather than the
- * collapsed `500` and never let two distinct big integers share one signature.
- * Mirrors what Python's `json.load` preserves implicitly.
- *
- * Strict ingest (criterion 419): a duplicated object member name at ANY depth
- * throws `DuplicateMemberError` before the value returns, so last-wins bytes
- * never reach a hash, canonicaliser, or signature check.
- *
- * Hand-rolled recursive descent rather than a `JSON.parse` reviver: the reviver's
- * raw-literal `context.source` is only available on Node 21.1+, and this package
- * supports Node 18+. The grammar is RFC 8259 JSON; it is not a lenient parser.
+ * Parse JSON preserving float literals as `RawFloat` and out-of-safe-range integers as `RawBigInt`,
+ * mirroring Python's `json.load`. Strict: a duplicated member at any depth throws (criterion 419).
  */
 export function parseJsonPreservingFloats(text: string): unknown {
   let i = 0;
@@ -247,11 +190,8 @@ export function parseJsonPreservingFloats(text: string): unknown {
 }
 
 /**
- * Strip the `RawFloat` / `RawBigInt` wrappers back to plain JS values, the
- * exact shapes `JSON.parse` produces (whole floats collapse to `500`, big
- * integers to the nearest double). Callers that canonicalise with the
- * float-preserving dialects keep the wrappers; callers that need the plain
- * wire shape (doors parity, sign inputs, bundle re-post) unwrap them.
+ * Strip the `RawFloat` / `RawBigInt` wrappers back to the exact shapes `JSON.parse` produces.
+ * Canonicalising callers keep the wrappers; callers needing the plain wire shape unwrap them.
  */
 export function unwrapPreservedFloats(value: unknown): unknown {
   if (isRawFloat(value)) return value.value;
@@ -268,10 +208,8 @@ export function unwrapPreservedFloats(value: unknown): unknown {
 }
 
 /**
- * Strict ingest with `JSON.parse`-compatible values (criterion 419): rejects a
- * duplicated member name at ANY depth as a terminal `DuplicateMemberError` and
- * returns plain values, so it replaces `JSON.parse` at every receipt/record
- * parse site that does not canonicalise with the float-preserving dialects.
+ * Strict ingest with `JSON.parse`-compatible values (criterion 419): a duplicated member name at any
+ * depth throws. Replaces `JSON.parse` wherever the float-preserving dialects are not needed.
  */
 export function parseJsonStrict(text: string): unknown {
   return unwrapPreservedFloats(parseJsonPreservingFloats(text));
@@ -293,11 +231,8 @@ function nfc(obj: unknown): unknown {
 }
 
 /**
- * Compare two strings by Unicode CODE POINT (Python `sort_keys` ordering).
- *
- * JavaScript string `<` compares by UTF-16 code unit, which differs from code
- * point on supplementary-plane characters. Iterating with `for...of` yields code
- * points, so we compare those directly.
+ * Compare two strings by Unicode CODE POINT (Python `sort_keys` ordering). JS string `<` compares by
+ * UTF-16 code unit, which differs from code point on supplementary-plane characters.
  */
 function compareCodePoints(a: string, b: string): number {
   const ai = a[Symbol.iterator]();
@@ -315,11 +250,8 @@ function compareCodePoints(a: string, b: string): number {
 }
 
 /**
- * Standard JSON string serialization matching Python `json.dumps(ensure_ascii=False)`.
- *
- * Short-escapes \b \t \n \f \r, emits other control chars < 0x20 as \u00xx, and
- * passes everything else (including 0x7f and all non-ASCII) verbatim. Note `/` is
- * NOT escaped, matching Python.
+ * JSON string serialization matching Python `json.dumps(ensure_ascii=False)`: short-escapes the five
+ * C0 shorthands, other control chars as \u00xx, everything else verbatim. `/` is not escaped.
  */
 function jsonString(s: string): string {
   let out = '"';
@@ -363,13 +295,8 @@ function numberToString(n: number): string {
 }
 
 /**
- * Serialise with a chosen key-comparison function.
- *
- * `honorFloat` selects the number dialect for `RawFloat` tokens:
- *   - true  (jcs / asqavJcs, the Python-`json.dumps` dialect): emit the float
- *     form, e.g. `500.0` (Python `repr(500.0)`).
- *   - false (jcsRfc8785, strict ECMAScript): collapse a whole-valued float to its
- *     integer form `500`, matching Python `_number_8785`'s `str(int(value))`.
+ * Serialise with a chosen key-comparison function. `honorFloat` picks the number dialect: true emits
+ * the float form `500.0`, false collapses a whole-valued float to `500` (strict RFC 8785).
  */
 function serialize(
   value: unknown,

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -1,12 +1,6 @@
 /**
- * The shared verification core - format detection, dispatch, and the verdict.
- * A port of the Python oracle's `verifier/oracle/core.py`.
- *
- * `verify(doc, ...)` detects the format, then drives the adapter through the
- * shared axes: structure, signature, chain. It proves only what the bytes prove -
- * a valid signature over the canonical bytes, a reproducible chain link, and
- * structural presence at time T. It never attests the behaviour or correctness of
- * the recorded action.
+ * The shared verification core - format detection, dispatch and the verdict, a port of the Python
+ * oracle's `core.py`. It proves only what the bytes prove, never the behaviour of the recorded action.
  */
 
 import type { FormatAdapter, KeyProvider } from "./adapter.js";
@@ -47,11 +41,8 @@ export interface VerifyResult {
   fmt: string;
   axes: AxisResult[];
   /**
-   * `verified` only when every non-skipped axis passed AND the signature was
-   * actually checked; `verified_keyed` when the digest is keyed (internally
-   * consistent but not third-party re-derivable). A skipped signature
-   * downgrades to `unverified` with failureClass `unverifiable`, never a
-   * verified. Defaults fail closed: an unfolded result reads unverified.
+   * `verified` only when every non-skipped axis passed AND the signature was checked; `verified_keyed`
+   * when the digest is keyed. Defaults fail closed: an unfolded result reads unverified.
    */
   verdict: Verdict;
   /** invalid / unverifiable when unverified, else null. */
@@ -76,12 +67,8 @@ const INVALID_FAIL_AXES = new Set([
 ]);
 
 /**
- * Map one axis outcome to its failure class (criterion 418). A port of the
- * Python `axis_failure_class`: PASS carries none; SKIPPED means recomputation
- * could not complete (unverifiable); a FAIL is invalid when a binding was
- * proven broken and unverifiable when the receipt's own bytes stopped the
- * recompute. A FAIL this table does not name reads unverifiable, never a
- * proven binding failure.
+ * Map one axis outcome to its failure class (criterion 418). A FAIL is invalid when a binding was proven
+ * broken, unverifiable when the recompute could not finish; an unlisted FAIL reads unverifiable.
  */
 export function axisFailureClass(axis: string, result: VerifyState, note: string): FailureClass | null {
   if (result === PASS) return null;
@@ -199,11 +186,8 @@ export const MAX_NESTING_DEPTH = 200;
 const TOO_DEEP_NOTE = `receipt nesting exceeds the supported depth (> ${MAX_NESTING_DEPTH} levels)`;
 
 /**
- * True when `obj` nests deeper than `maxDepth`, walked with an explicit stack.
- *
- * No recursion here, so the check never overflows before it can cap a receipt the
- * JCS canonicaliser would crash on. `JSON.parse` applies no depth limit, so this
- * gate is the only cap an already-parsed object meets.
+ * True when `obj` nests deeper than `maxDepth`, walked with an explicit stack so the check itself never
+ * overflows. `JSON.parse` applies no depth limit, so this is the only cap a parsed object meets.
  */
 function exceedsDepth(obj: unknown, maxDepth: number): boolean {
   const stack: Array<[unknown, number]> = [[obj, 0]];

--- a/typescript/src/verifier/crypto.ts
+++ b/typescript/src/verifier/crypto.ts
@@ -1,22 +1,6 @@
 /**
- * Signature-verify dispatch shared across format adapters - a port of the Python
- * oracle's `verifier/oracle/crypto.py`.
- *
- * One entry point, `verifySignature(alg, pk, msg, sig)`, returns a 3-state
- * `{result, note}` where result is `PASS` / `FAIL` / `SKIPPED`, so the oracle
- * never prints a PASS for a signature it could not actually check.
- *
- * Algorithm wiring:
- *   - `Ed25519` / `EdDSA` : `node:crypto.verify` over a raw 32-byte public key.
- *   - `ES256`             : ECDSA P-256 / SHA-256 over a 65-byte uncompressed
- *                           point; signature is the 64-byte raw r||s form
- *                           (ieee-p1363), which `node:crypto` verifies directly.
- *   - `ML-DSA-65`         : `@noble/post-quantum` (MIT, pure JS). API:
- *                           `verify(sig, msg, publicKey)` -> boolean.
- *                           Public key is 1952 raw bytes; signature is 3309 bytes.
- *                           Byte-compatible with FIPS 204 / dilithium-py.
- *
- * Malformed key or signature bytes -> FAIL, never throw.
+ * Signature-verify dispatch shared across format adapters, a port of the Python oracle's `crypto.py`.
+ * `verifySignature` returns PASS / FAIL / SKIPPED, so a signature it could not check never reads PASS.
  */
 
 import { createPublicKey, verify } from "node:crypto";
@@ -40,10 +24,7 @@ function base64url(buf: Buffer): string {
 }
 
 /**
- * ML-DSA-65 verify via @noble/post-quantum (MIT, pure JS/WASM-free).
- *
- * Noble's API: verify(sig, msg, publicKey) -> boolean.
- * Key is 1952 raw bytes; signature is 3309 bytes (FIPS 204 ML-DSA-65).
+ * ML-DSA-65 verify via @noble/post-quantum: key 1952 raw bytes, signature 3309 (FIPS 204).
  * Byte-compatible with Python dilithium-py.
  */
 function verifyMlDsa65(pk: Uint8Array, msg: Uint8Array, sig: Uint8Array): VerifyOutcome {
@@ -83,11 +64,8 @@ function verifyEd25519(pk: Uint8Array, msg: Uint8Array, sig: Uint8Array): Verify
 }
 
 /**
- * ES256 (ECDSA P-256 over SHA-256) verify.
- *
- * The public key is the 65-byte uncompressed point (0x04 || X || Y). The
- * signature is the 64-byte raw r||s (ieee-p1363) form WebCrypto / JOSE emit,
- * which `node:crypto.verify` accepts with `dsaEncoding: "ieee-p1363"`.
+ * ES256 (ECDSA P-256 over SHA-256). Key is the 65-byte uncompressed point; signature is the 64-byte
+ * raw r||s form, which `node:crypto.verify` accepts with `dsaEncoding: "ieee-p1363"`.
  */
 function verifyEs256(pk: Uint8Array, msg: Uint8Array, sig: Uint8Array): VerifyOutcome {
   let key;

--- a/typescript/src/verifier/did.ts
+++ b/typescript/src/verifier/did.ts
@@ -1,21 +1,6 @@
 /**
- * Shared DID resolver - map a verificationMethod DID URL to a raw Ed25519 key.
- * A port of the Python oracle's `verifier/oracle/did.py`.
- *
- * `resolveEd25519Key(didUrl, injected)` returns the raw 32-byte Ed25519 public
- * key for a signer, or null when it cannot resolve without a network the oracle
- * is forbidden from touching.
- *
- *   - `did:key`  : self-contained. The multibase `z` (base58btc) identifier
- *                  decodes to a multicodec frame: the two-byte 0xed 0x01 Ed25519
- *                  prefix followed by the 32 raw key bytes. No network.
- *   - other      : resolved from an injected map. A value is either a raw key
- *                  (hex string or bytes, 32 bytes) or the DID DOCUMENT the
- *                  method's network fetch would have returned; the resolver then
- *                  walks `verificationMethod` / `assertionMethod` and extracts an
- *                  Ed25519 key (publicKeyMultibase Multikey, publicKeyJwk OKP, or
- *                  legacy publicKeyBase58). The oracle NEVER fetches a DID
- *                  document over the network; an unmapped DID returns null.
+ * Shared DID resolver mapping a verificationMethod DID URL to a raw Ed25519 key, a port of the Python
+ * oracle's `did.py`. did:key resolves inline; everything else comes from an injected map, never a fetch.
  */
 
 /** Bitcoin base58 alphabet - the base58btc encoding multibase 'z' uses. */
@@ -176,12 +161,8 @@ function keyFromDidDocument(
 }
 
 /**
- * Resolve a verificationMethod DID URL to `[rawKeyOrNull, note]`.
- *
- * did:key resolves inline; every other method resolves from `injected` keyed by
- * the full DID URL first, then by the bare DID (fragment stripped). An injected
- * value is a raw 32-byte key (bytes or hex) or the DID document the method's
- * fetch would have returned. No network.
+ * Resolve a verificationMethod DID URL to `[rawKeyOrNull, note]`. did:key resolves inline; others come
+ * from `injected`, keyed by full DID URL then bare DID. No network.
  */
 export function resolveEd25519Key(
   didUrl: string,

--- a/typescript/src/verifier/dsse.ts
+++ b/typescript/src/verifier/dsse.ts
@@ -1,24 +1,6 @@
 /**
- * Offline DSSE attestation verifier - verify a POST /v1/attest envelope locally,
- * with no round-trip to any Asqav server. Signing stays remote; verification is
- * air-gapped.
- *
- * The envelope is a DSSE (Dead Simple Signing Envelope) wrapping an in-toto
- * Statement v1, signed with ML-DSA-65. The signed bytes are the DSSE
- * Pre-Authentication Encoding (PAE), not the raw JSON:
- *
- *   PAE(type, body) = "DSSEv1" SP LEN(type) SP type SP LEN(body) SP body
- *
- * SP is a single 0x20 space and LEN is the ASCII-decimal byte length. This is a
- * byte-for-byte port of the backend `core/dsse.py` `pae()`, so an envelope the
- * cloud signs re-derives to the identical bytes here.
- *
- * Verify recomputes PAE over the DECODED payload bytes, exactly as the backend
- * `verify_dsse_envelope` does: canonicalization never sits on the trust path, so
- * a verifier never re-encodes the statement and cannot diverge from the signer.
- *
- * Verdict is fail-closed: a missing key, a revoked key, an unsupported algorithm,
- * or a signature that does not check is a FAIL, never a PASS or a skip.
+ * Offline DSSE attestation verifier: signing stays remote, verification is air-gapped. Signed bytes are
+ * the PAE, a byte-for-byte port of `core/dsse.py`. Fail-closed: anything unresolved is a FAIL.
  */
 
 import { verifySignature } from "./crypto.js";
@@ -40,11 +22,8 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 /**
- * DSSE Pre-Authentication Encoding of (payloadType, body).
- *
- * Returns `"DSSEv1" SP LEN(type) SP type SP LEN(body) SP body` with single 0x20
- * separators and ASCII-decimal byte lengths - the exact bytes a signer signs and
- * a verifier re-derives. Byte-compatible with `core/dsse.py` `pae()`.
+ * DSSE Pre-Authentication Encoding of (payloadType, body): `"DSSEv1" SP LEN(type) SP type SP LEN(body)
+ * SP body`, with 0x20 separators and ASCII-decimal lengths. Byte-compatible with `core/dsse.py`.
  */
 export function buildPae(payloadType: string | Uint8Array, body: Uint8Array): Uint8Array {
   const enc = new TextEncoder();
@@ -69,11 +48,8 @@ export function buildPae(payloadType: string | Uint8Array, body: Uint8Array): Ui
 }
 
 /**
- * Pull the sha256 hex digest an in-toto Statement binds its subject to.
- *
- * Returns `subject[0].digest.sha256` lowercased, or null when absent. A push
- * guard asserts this equals the pushed commit sha to bind the attestation to the
- * exact bytes that landed.
+ * Pull `subject[0].digest.sha256` from an in-toto Statement, lowercased, or null when absent. A push
+ * guard asserts it equals the pushed commit sha, binding the attestation to the bytes that landed.
  */
 export function extractSubjectDigest(statement: unknown): string | null {
   if (!isRecord(statement)) return null;
@@ -195,17 +171,8 @@ function checkAttestationStructure(envelope: unknown, expectedType: string): Str
 }
 
 /**
- * Verify a DSSE attestation envelope fully offline against an in-memory JWKS.
- *
- * Steps: decode the payload to the in-toto Statement; for each signature resolve
- * the JWKS key (fail-closed on missing/revoked); recompute PAE over the decoded
- * payload bytes and check the ML-DSA-65 signature. PASS requires a well-formed
- * Statement plus at least one signature that both verifies and resolves to an
- * active key. No network call is made.
- *
- * @param envelope - Parsed DSSE envelope ({payloadType, payload, signatures}).
- * @param jwks - JWKS object previously fetched via `fetchJwks()`.
- * @param opts - Optional overrides (expected payloadType).
+ * Verify a DSSE attestation envelope fully offline against an in-memory JWKS. PASS needs a well-formed
+ * Statement plus one signature that verifies against an active key. No network call is made.
  */
 export function verifyAttestation(
   envelope: unknown,

--- a/typescript/src/verifier/index.ts
+++ b/typescript/src/verifier/index.ts
@@ -1,19 +1,6 @@
 /**
- * Universal neutral verifier (TypeScript) - verify agent receipts across formats.
- * A port of the Python oracle at `verifier/oracle/`, to parity with the proven
- * Python verifier.
- *
- * It proves only what a verifier can prove from the bytes: a valid signature over
- * the canonical bytes, a reproducible hash-chain link, and structural presence at
- * time T. It never attests behaviour or correctness of the recorded action.
- *
- * Public surface:
- *   - `FormatAdapter` : the 6-method per-format seam.
- *   - `ADAPTERS`      : ordered registry the dispatcher walks for detection.
- *   - `verify`        : verify one parsed receipt; returns a `VerifyResult`.
- *   - `checkAnchors` / `checkSkew` : the two axes the oracle leaves out.
- *   - `checkExpiry`   : the signed expires_at window, mirroring the hosted verdict.
- *   - canonicalisers, crypto, and the conformance runner.
+ * Universal neutral verifier (TypeScript), a port of the Python oracle at `verifier/oracle/`. It proves
+ * only what the bytes prove: signature, chain link and structural presence, never behaviour.
  */
 
 import { FormatAdapter } from "./adapter.js";

--- a/typescript/src/verifier/parity-check.ts
+++ b/typescript/src/verifier/parity-check.ts
@@ -1,12 +1,6 @@
 /**
- * Reproducible equivalence gate - run ALL corpus vectors through the TS verifier
- * and compare each verdict to the EXPECTED manifest outcome, exactly as the Python
- * `runner.main()` does. ML-DSA vectors are tolerated as INCOMPLETE->PASS only for
- * reason_code `signature_skipped_no_dilithium` (Node has no ML-DSA, matching the
- * Python verifier without dilithium-py).
- *
- * Run directly:  node --import tsx typescript/src/verifier/parity-check.ts
- * or via the test `tests/verifier-parity.test.ts`, which asserts 62/62.
+ * Reproducible equivalence gate: run every corpus vector through the TS verifier and compare each verdict
+ * to the manifest, as Python's `runner.main()` does. ML-DSA vectors tolerate the no-dilithium skip.
  */
 
 import { resolve } from "node:path";

--- a/typescript/src/verifier/runner.ts
+++ b/typescript/src/verifier/runner.ts
@@ -1,20 +1,6 @@
 /**
- * Conformance-vector runner - drive the oracle over the vector corpus.
- * A port of the Python oracle's `verifier/oracle/runner.py`.
- *
- * The corpus uses the AERF dir-per-vector layout: a top-level `manifest.json`
- * lists `{dir, format, outcome, failure_class, reason_code, notes}` and each
- * `<NN-name>/` directory carries `receipt.json`, an `expected.json`, optional
- * `predecessor.json`, and optional key material (`jwks.json` for Asqav-native,
- * `keys.json` for AERF, `acta-keys.json` for ACTA, `did_map.json` for
- * agentreceipts and w3c-vc).
- *
- * `outcome` speaks the public verdict vocabulary (criteria 418/438):
- * verified / verified_keyed / unverified, and an `unverified` entry pins its
- * `failure_class` (invalid / unverifiable) so the two classes are never
- * collapsed. Every receipt/record file is parsed with duplicate-member
- * rejection (criterion 419); a receipt that fails to parse is a terminal
- * unverified/unverifiable outcome, never verified.
+ * Conformance-vector runner driving the oracle over the corpus, a port of the Python `runner.py`.
+ * `outcome` speaks the public verdict vocabulary, and an `unverified` entry pins its failure_class.
  */
 
 import { readFileSync, existsSync } from "node:fs";
@@ -47,9 +33,8 @@ interface ManifestEntry {
 }
 
 function loadJson(path: string): Record<string, unknown> | null {
-  // Receipts and predecessors are parsed float-preserving so a `500.0` literal
-  // survives to the canonicaliser (JSON.parse otherwise collapses it to `500`).
-  // The same parser rejects a duplicated member name at any depth (419).
+  // Float-preserving parse so a `500.0` literal reaches the canonicaliser intact;
+  // the same parser rejects a duplicated member name at any depth (419).
   return existsSync(path)
     ? (parseJsonPreservingFloats(readFileSync(path, "utf-8")) as Record<string, unknown>)
     : null;

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -1,9 +1,6 @@
 /**
- * A focused port of the `verify_receipt.py` helpers the Asqav-native and ACTA
- * adapters reuse, so the TS oracle reproduces the same bytes and the same
- * structure verdict as the Python surface. Only what those adapters touch is
- * ported: base64 decoding, envelope normalisation, the structure check, JWKS key
- * resolution, and the first-receipt seed.
+ * A focused port of the `verify_receipt.py` helpers the Asqav-native and ACTA adapters reuse, so
+ * the TS oracle reproduces the same bytes and the same structure verdict as the Python surface.
  */
 
 import { asqavJcs } from "./canonical.js";
@@ -64,9 +61,8 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 /**
- * Remap a hosted /verify response into the canonical 3-key envelope. Already
- * canonical or non-hosted shapes pass through unchanged (mirrors
- * `normalise_envelope`).
+ * Remap a hosted /verify response into the canonical 3-key envelope; already canonical or
+ * non-hosted shapes pass through unchanged (mirrors `normalise_envelope`).
  */
 export function normaliseEnvelope(raw: Record<string, unknown>): Record<string, unknown> {
   const sig = raw.signature;
@@ -244,8 +240,7 @@ function matchKeyById(
 }
 
 // An agent key bound to the issuer the receipt claims (mirrors `_match_key_by_agent`).
-// agent_id is attacker-controlled, so the key's published issuer (or org) must equal
-// the one the receipt names inside its signed bytes.
+// agent_id is attacker-controlled, so the key's issuer must match the signed bytes.
 function matchKeyByAgent(
   jwks: Record<string, unknown> | null,
   agentId: unknown,
@@ -269,12 +264,7 @@ function matchKeyByAgent(
 
 /**
  * The one JWKS entry a receipt's signature is checked against (mirrors `match_signing_key`).
- *
- * Order carries the security: exact key id, then the agent bind, then the bare-kid
- * issuer match. An org-shaped kid matches every sibling that org publishes alike, so
- * list position would pick one arbitrarily, and position binds nothing while the
- * sibling holds other key bytes and another revocation status. The agent bind carries
- * the org_id a hash-mode receipt signs, so the right sibling resolves first.
+ * Order carries the security: exact key id, then the agent bind, then the bare-kid issuer match.
  */
 export function matchSigningKey(
   jwks: Record<string, unknown> | null,
@@ -436,10 +426,8 @@ function pyTruthy(v: unknown): boolean {
 const B64_STRICT = /^[A-Za-z0-9+/]*={0,2}$/;
 
 /**
- * True when Python's `_safe_b64` accepts `value`, false otherwise.
- *
- * Strict on purpose: an out-of-alphabet character is refused, not dropped, so a
- * forged all-punctuation anchor cannot read as present.
+ * True when Python's `_safe_b64` accepts `value`. Strict on purpose: an out-of-alphabet character
+ * is refused, not dropped, so a forged all-punctuation anchor cannot read as present.
  */
 function safeB64(value: unknown): boolean {
   if (typeof value !== "string") return false;
@@ -504,9 +492,8 @@ export function checkSkew(issuedAt: unknown): readonly [VerifyState, string] {
   return ["PASS", `skew ${skew.toFixed(0)}s within bound`];
 }
 
-// True once the signed expiry sits in the past (mirrors the hosted signature_expired
-// verdict). The window is a negative delta from the wall clock, so the verdict does
-// not depend on which verifier the reader runs
+// True once the signed expiry sits in the past (mirrors signature_expired). A negative
+// delta from the wall clock, so the verdict never depends on which verifier runs.
 function expiryLapsed(deltaSeconds: number): boolean {
   return deltaSeconds < 0;
 }
@@ -529,16 +516,8 @@ export function checkExpiry(payload: unknown): readonly [VerifyState, string] {
 }
 
 /**
- * Report which envelope each anchor binds (mirrors `check_anchors`).
- *
- * Absent or null anchors is a legitimate no-anchors receipt (SKIPPED). A present
- * non-list value is malformed and FAILs, never laundered to an empty list.
- * `anchors` sits outside the signed bytes, so a forged envelope can move it.
- *
- * This shim runs no ASN.1/CMS or ots evaluation, so it never returns PASS - safe -
- * but it also never returns `invalid`, which is not: Python calls a provably forged
- * imprint FAIL/invalid where this reports unverifiable. Use the Python verifier when
- * "proven forged" must be distinguished from "not checked".
+ * Report which envelope each anchor binds (mirrors `check_anchors`). This shim runs no ASN.1/CMS or
+ * ots evaluation, so it never returns PASS and never returns `invalid` - use Python for that.
  */
 export function checkAnchors(envelope: Record<string, unknown>): readonly [VerifyState, string] {
   const anchors = envelope.anchors;
@@ -602,9 +581,8 @@ export function checkAnchors(envelope: Record<string, unknown>): readonly [Verif
 // Mirrors Python REVOKED_KEY_STATUSES; receipts from these keys must not PASS offline.
 const REVOKED_KEY_STATUSES = new Set(["revoked", "suspended", "compromised"]);
 
-// Gate on the key's JWKS status (mirrors `check_key_status`). With revoked_at and a trusted
-// anchor, pre-revocation receipts PASS, and without revoked_at any revoked-status key FAILs.
-// Without an anchor, issued_at is self-attested (backdateable), so downgrade to SKIPPED.
+// Gate on the key's JWKS status (mirrors `check_key_status`). Without a trusted anchor
+// issued_at is self-attested and backdateable, so downgrade to SKIPPED.
 export function checkKeyStatus(
   status: string | null,
   issuedAt: string,
@@ -636,11 +614,8 @@ export function checkKeyStatus(
   return ["FAIL", `signing key status ${JSON.stringify(status)}; receipt cannot be trusted`];
 }
 
-// ---------------------------------------------------------------------------
-// RFC 7638 JWK Thumbprint over an ML-DSA (AKP) public key (criterion 458).
-// A port of the Python `thumbprint_for_key` / `check_key_binding`; the shared
-// vectors in verifier/axis-parity-cases.json hold the two copies together.
-// ---------------------------------------------------------------------------
+// RFC 7638 JWK Thumbprint over an ML-DSA (AKP) public key (criterion 458). A port of
+// `thumbprint_for_key`; the shared axis-parity vectors hold the two copies together.
 
 /** draft-ietf-cose-dilithium key type for ML-DSA key pairs. */
 export const AKP_KTY = "AKP";
@@ -649,8 +624,7 @@ export const AKP_KTY = "AKP";
 const THUMBPRINT_RE = /^sha256:[0-9a-f]{64}$/;
 
 // FIPS 204 public-key widths in bytes, fixed by the standard. A KMS-backed agent
-// publishes a PEM in the same column as a locally generated raw key, and a PEM is
-// not the key material an AKP `pub` carries, so width is what separates the two.
+// publishes a PEM where a raw key would sit, so width is what separates the two.
 const ML_DSA_PUBLIC_KEY_BYTES: Record<string, number> = {
   "ML-DSA-44": 1312,
   "ML-DSA-65": 1952,
@@ -675,12 +649,8 @@ export function isWellFormedThumbprint(value: unknown): boolean {
 }
 
 /**
- * Build the required-members-only AKP JWK the thumbprint is taken over.
- *
- * `pub` is base64url WITHOUT padding, which is the one encoding trap here: the
- * published directory carries the same bytes as standard base64 under
- * `public_key`, and thumbprinting that alphabet yields a digest no third-party
- * verifier reproduces.
+ * Build the required-members-only AKP JWK the thumbprint is taken over. `pub` is base64url WITHOUT
+ * padding; thumbprinting the directory's standard-base64 alphabet yields an irreproducible digest.
  */
 export function akpJwk(alg: string, publicKey: Uint8Array): Record<string, string> {
   if (!alg) throw new Error("alg is required to build an AKP JWK");
@@ -689,9 +659,8 @@ export function akpJwk(alg: string, publicKey: Uint8Array): Record<string, strin
 }
 
 /**
- * Return `sha256:<hex>` for a JWK already reduced to its required members.
- * Sorting is what RFC 7638 section 3 calls for, so the caller cannot change the
- * digest by handing the members in a different order.
+ * Return `sha256:<hex>` for a JWK already reduced to its required members. Sorting is what RFC 7638
+ * section 3 calls for, so member order cannot change the digest.
  */
 export function jwkThumbprint(jwk: Record<string, string>): string {
   const canonical = `{${Object.keys(jwk)
@@ -707,18 +676,8 @@ export function thumbprintForKey(alg: string, publicKey: Uint8Array): string {
 }
 
 /**
- * Recompute the signed key_thumbprint from the resolved key and compare.
- *
- * The receipt names its own signing key INSIDE the signed bytes, so a key swapped
- * under the same kid stops rederiving the digest the issuer committed to. A
- * mismatch is a proven binding break, never a warning: `key_binding` sits in
- * INVALID_FAIL_AXES, so the verdict reads unverified with failureClass invalid.
- *
- * Absence is the profile's legacy case and stays conformant, so it PASSes with a
- * note rather than skipping; a skip would block every pre-binding receipt ever
- * issued. The two cases that cannot be recomputed - no key resolved, and a
- * resolved key that is not raw ML-DSA of the width its own alg fixes - report
- * SKIPPED, which blocks, so an unrecomputable binding never reads as verified.
+ * Recompute the signed key_thumbprint from the resolved key and compare; a mismatch is a proven
+ * binding break. Absence PASSes as the legacy case, but an unrecomputable binding SKIPs and blocks.
  */
 export function checkKeyBinding(
   payload: unknown,
@@ -751,21 +710,14 @@ export function checkKeyBinding(
   return ["FAIL", `key_substituted: receipt binds ${claimed}, resolved key computes ${actual}`];
 }
 
-// ---------------------------------------------------------------------------
-// Receipt-internal integrity: payload_digest vs the carried context, and a
-// claimed counterparty binding. Ports of the Python check_payload_digest /
-// check_counterparty_binding; the shared vectors hold the two copies together.
-// ---------------------------------------------------------------------------
+// Receipt-internal integrity: payload_digest vs the carried context, and a claimed
+// counterparty binding. Ports of check_payload_digest / check_counterparty_binding.
 
 const LOWER_HEX_64 = /^[0-9a-f]{64}$/;
 
 /**
- * Recompute payload_digest from the context carried in the same receipt.
- *
- * A receipt carrying BOTH a context and a digest over it is checkable with no
- * external data, and the two disagreeing means one of them is a lie. Absence
- * PASSes on both sides: hash mode carries no context, and a payload-mode receipt
- * may legitimately omit it under redaction.
+ * Recompute payload_digest from the context carried in the same receipt; the two disagreeing means
+ * one is a lie. Absence PASSes: hash mode carries no context and redaction may drop it.
  */
 export function checkPayloadDigest(payload: unknown): readonly [VerifyState, string] {
   if (!isRecord(payload)) return ["PASS", "no signed payload; no digest to recompute"];
@@ -816,12 +768,8 @@ export function checkPayloadDigest(payload: unknown): readonly [VerifyState, str
 }
 
 /**
- * Weigh a claimed cross-agent binding instead of letting it ride unchecked.
- *
- * counterparty_binding is caller-supplied, so an issuer can assert "the
- * counterparty acknowledged this" over a receipt nobody else saw. Absence PASSes;
- * a claim this verifier cannot resolve reports SKIPPED, which blocks, so an
- * unchecked binding never reads as corroborated; malformed or mismatched FAILs.
+ * Weigh a claimed cross-agent binding instead of letting it ride unchecked. Absence PASSes, an
+ * unresolvable claim SKIPs and blocks, and malformed or mismatched FAILs.
  */
 export function checkCounterpartyBinding(
   payload: unknown,


### PR DESCRIPTION
Comments say WHY in one or two lines. The rationale behind a design belongs in the
criterion evidence, not in the source; the long blocks had reached the point where the
comment cost more to read than the code it explained.

Mechanical and comment-only: **44 files, no executable line touched.** The sweep covers
the `//` and `#` runs plus the JSDoc blocks across both the TypeScript and Python
sources, taking every block to at most two content lines.

### What was deliberately left whole

- The Apache-2.0 licence header on the standalone verifier. It is a legal notice, not a
  comment, and shortening it would be wrong.
- One four-line block in the platform repo, held back because a queued pull request
  there would conflict with it.

### A stale claim corrected in passing

`parity-check.ts` described the corpus gate as asserting 62 vectors. The suite asserts
65. The prose now matches the assertion.

### Scope note

Python **docstrings** are not in this sweep. They are a larger and more delicate
surface: several are FastAPI route docstrings that FastAPI publishes as the OpenAPI
endpoint descriptions, so trimming them changes public API documentation rather than
just source readability. That pass is worth doing on its own terms, separately.

### Verification

| Gate | Result |
|---|---|
| `ruff check src tests` | clean |
| `tsc --noEmit` | clean |
| Python suite | 2892 passed, 1 skipped |
| TypeScript suite | 1067 passed |
| Conformance corpus | 65/65 vectors match their expected outcome |

The corpus gate is the one that matters most here: it drives every vector through both
verifiers and compares each verdict to the manifest, so a comment edit that had somehow
disturbed canonicalisation or dispatch would surface as a changed verdict rather than
passing quietly.

Claude-Session: https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
