### PR TITLE
feat(verifier): add the seq continuity axis to both SDK halves

### DIFF
--- a/python/src/asqav/verifier/oracle/adapter.py
+++ b/python/src/asqav/verifier/oracle/adapter.py
@@ -108,6 +108,11 @@ class FormatAdapter(ABC):
         """
         return []
 
+    def seq_of(self, doc: dict) -> Any:
+        # Raw so the axis can report a malformed counter; extra_axes never sees the
+        # predecessor continuity needs, so the counter is read here instead.
+        return None
+
     def attestation(self, doc: dict) -> dict[str, Any]:
         """In-body attestation fields surfaced in the verdict (e.g. ``signer``).
 

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -49,8 +49,8 @@ _HASH_MODE_FIELDS = (
 
 
 #: Claims belonging to the signed payload; hash mode signs the flat fields only,
-#: so a thumbprint pasted onto one binds nothing.
-_UNSIGNED_CLAIM_FIELDS = ("issuer_id", "previousReceiptHash", "key_thumbprint")
+#: so a thumbprint or seq pasted onto one binds nothing.
+_UNSIGNED_CLAIM_FIELDS = ("issuer_id", "previousReceiptHash", "key_thumbprint", "seq")
 
 
 def _is_hash_mode(doc: dict) -> bool:
@@ -284,6 +284,12 @@ class AsqavNativeAdapter(FormatAdapter):
             entry.get("status"), issued_at, _vr.revoked_at_of(entry), False
         )
         return axes + [("key_status", res, note), ("issuer_bind", *bind)]
+
+    def seq_of(self, doc: dict) -> Any:
+        # Hash mode signs the flat field set only, so a seq sitting there binds nothing.
+        if _is_hash_mode(doc):
+            return None
+        return _payload(doc).get("seq")
 
     def attestation(self, doc: dict) -> dict[str, Any]:
         """Surface the v:2 in-body ``signer``. None for v:1 and hash-mode.

--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -82,6 +82,9 @@ _INVALID_FAIL_AXES = frozenset(
         "nonce",
         "parent_signature",
         "pdp_signature",
+        # A gap proves receipts were withheld and a malformed counter was signed as-is;
+        # both are proven defects, not a recompute that could not finish.
+        "seq",
     }
 )
 
@@ -190,6 +193,38 @@ def _chain_axis(
     return _axis("chain", crypto.FAIL, f"chain break: expected {exp}.. got {actual[:16]}..")
 
 
+def _seq_axis(
+    ad: FormatAdapter, doc: dict, adapters: list[FormatAdapter], predecessor: dict | None
+) -> AxisResult:
+    # A gap is omission evidence. Never SKIPPED: fold_verdict blocks on a non-chain
+    # SKIPPED, so a receipt with no counter would regress to unverified.
+    seq = ad.seq_of(doc)
+    if seq is None:
+        return _axis("seq", crypto.PASS, "no seq member; receipt is not part of a counted series")
+    if isinstance(seq, bool) or not isinstance(seq, int) or seq < 1:
+        return _axis("seq", crypto.FAIL, f"malformed seq: {seq!r}")
+    if predecessor is None:
+        return _axis("seq", crypto.PASS, f"seq {seq}; no predecessor supplied")
+    # A counter only means anything within one format's own series.
+    pred_ad = detect(predecessor, adapters)
+    if pred_ad is None or pred_ad.name != ad.name:
+        return _axis("seq", crypto.PASS, f"seq {seq}; predecessor is a different receipt format")
+    prev = ad.seq_of(predecessor)
+    if prev is None:
+        return _axis("seq", crypto.PASS, f"seq {seq}; predecessor carries no seq")
+    if isinstance(prev, bool) or not isinstance(prev, int) or prev < 1:
+        return _axis("seq", crypto.FAIL, f"malformed predecessor seq: {prev!r}")
+    if seq == prev + 1:
+        return _axis("seq", crypto.PASS, f"seq {seq} follows predecessor {prev}")
+    if seq <= prev:
+        return _axis("seq", crypto.FAIL, f"seq not monotonic: {seq} after predecessor {prev}")
+    return _axis(
+        "seq",
+        crypto.FAIL,
+        f"seq gap: {seq - prev - 1} receipt(s) withheld between {prev} and {seq}",
+    )
+
+
 #: Max nesting the recursive JCS encoder tolerates, mirrors the standalone verifier cap.
 MAX_NESTING_DEPTH = 200
 
@@ -241,6 +276,7 @@ def verify(
         _axis("structure", *ad.schema(doc)),
         _signature_axis(ad, doc, key_provider),
         _chain_axis(ad, doc, adapters, predecessor),
+        _seq_axis(ad, doc, adapters, predecessor),
     ]
     axes.extend(_axis(name, res, note) for name, res, note in ad.extra_axes(doc, key_provider))
 

--- a/python/tests/test_seq_continuity_axis.py
+++ b/python/tests/test_seq_continuity_axis.py
@@ -1,0 +1,162 @@
+"""Gates for the seq continuity axis - the SDK half of the omission class.
+
+A gap in the counter proves receipts were withheld without needing the withheld
+receipts. The no-SKIPPED gate matters most: fold_verdict blocks on a non-chain
+SKIPPED, so a counter-less receipt would go from verified to unverified.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from asqav.verifier.oracle import ADAPTERS, crypto, verify
+
+_CORPUS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+_ED25519_AVAILABLE = crypto.verify_ed25519(b"\x00" * 32, b"m", b"\x00" * 64)[0] != crypto.SKIPPED
+requires_ed25519 = pytest.mark.skipif(
+    not _ED25519_AVAILABLE, reason="cryptography not installed; Ed25519 verify SKIPs"
+)
+
+
+def _load(vec: str, name: str) -> dict:
+    return json.loads((_CORPUS / vec / name).read_text())
+
+
+def _provider(vec: str) -> dict:
+    return _load(vec, "jwks.json")
+
+
+def _with_seq(doc: dict, seq: object) -> dict:
+    # Injection breaks the signature, so assertions read the seq axis directly
+    # unless the verdict itself is under test on an untouched receipt.
+    out = json.loads(json.dumps(doc))
+    out["payload"]["seq"] = seq
+    return out
+
+
+@requires_ed25519
+def test_a_receipt_carrying_no_seq_still_verifies() -> None:
+    """A real receipt with no counter must stay verified, not blocked by a SKIPPED."""
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    res = verify(doc, ADAPTERS, key_provider=_provider("asqav-01-genesis-permit"))
+    assert res.verdict == "verified"
+    assert res.failure_class is None
+    seq = res.axis("seq")
+    assert seq is not None, "the seq axis must always be emitted, never dropped"
+    assert seq.result == crypto.PASS
+    assert "not part of a counted series" in seq.note
+
+
+def test_the_seq_axis_never_reports_skipped_across_the_whole_corpus() -> None:
+    """Corpus-wide, so a future branch that forgets the no-SKIPPED rule is caught."""
+    skipped = []
+    for vec_dir in sorted(p for p in _CORPUS.iterdir() if p.is_dir()):
+        receipt = vec_dir / "receipt.json"
+        if not receipt.exists():
+            continue
+        doc = json.loads(receipt.read_text())
+        pred_path = vec_dir / "predecessor.json"
+        pred = json.loads(pred_path.read_text()) if pred_path.exists() else None
+        res = verify(doc, ADAPTERS, predecessor=pred)
+        axis = res.axis("seq")
+        if axis is not None and axis.result == crypto.SKIPPED:
+            skipped.append((vec_dir.name, axis.note))
+    assert not skipped, f"seq axis reported a blocking SKIPPED: {skipped}"
+
+
+def test_a_contiguous_counter_passes() -> None:
+    pred = _with_seq(_load("asqav-03-chain-link", "predecessor.json"), 7)
+    doc = _with_seq(_load("asqav-03-chain-link", "receipt.json"), 8)
+    axis = verify(doc, ADAPTERS, predecessor=pred).axis("seq")
+    assert axis.result == crypto.PASS
+    assert "seq 8 follows predecessor 7" in axis.note
+
+
+def test_a_gap_fails_and_counts_the_withheld_receipts() -> None:
+    """The omission signal: 7 -> 11 means three receipts were withheld."""
+    pred = _with_seq(_load("asqav-03-chain-link", "predecessor.json"), 7)
+    doc = _with_seq(_load("asqav-03-chain-link", "receipt.json"), 11)
+    res = verify(doc, ADAPTERS, predecessor=pred)
+    axis = res.axis("seq")
+    assert axis.result == crypto.FAIL
+    assert "3 receipt(s) withheld between 7 and 11" in axis.note
+    # A proven omission is a binding failure, not an incomplete recompute.
+    assert axis.failure_class == "invalid"
+    assert res.verdict == "unverified"
+
+
+def test_a_repeated_or_rewound_counter_fails() -> None:
+    for seq in (7, 6, 1):
+        pred = _with_seq(_load("asqav-03-chain-link", "predecessor.json"), 7)
+        doc = _with_seq(_load("asqav-03-chain-link", "receipt.json"), seq)
+        axis = verify(doc, ADAPTERS, predecessor=pred).axis("seq")
+        assert axis.result == crypto.FAIL, f"seq {seq} after 7 must fail"
+        assert "not monotonic" in axis.note
+
+
+@pytest.mark.parametrize("bad", [True, False, "8", 0, -1, 1.5, [8], {"n": 8}, None])
+def test_a_malformed_counter_is_refused(bad: object) -> None:
+    """None is legal absence; True matters because bool is an int subclass."""
+    doc = _with_seq(_load("asqav-01-genesis-permit", "receipt.json"), bad)
+    axis = verify(doc, ADAPTERS).axis("seq")
+    if bad is None:
+        assert axis.result == crypto.PASS
+    else:
+        assert axis.result == crypto.FAIL, f"{bad!r} must not pass as a counter"
+        assert "malformed seq" in axis.note
+
+
+def test_a_counter_with_no_predecessor_supplied_passes_with_a_note() -> None:
+    doc = _with_seq(_load("asqav-01-genesis-permit", "receipt.json"), 4)
+    axis = verify(doc, ADAPTERS).axis("seq")
+    assert axis.result == crypto.PASS
+    assert "no predecessor supplied" in axis.note
+
+
+def test_a_predecessor_carrying_no_counter_passes_with_a_note() -> None:
+    """The migration case: the predecessor was minted before the counter shipped."""
+    pred = _load("asqav-03-chain-link", "predecessor.json")
+    assert "seq" not in pred["payload"], "fixture must genuinely lack a counter"
+    doc = _with_seq(_load("asqav-03-chain-link", "receipt.json"), 2)
+    axis = verify(doc, ADAPTERS, predecessor=pred).axis("seq")
+    assert axis.result == crypto.PASS
+    assert "predecessor carries no seq" in axis.note
+
+
+def test_a_malformed_predecessor_counter_fails() -> None:
+    pred = _with_seq(_load("asqav-03-chain-link", "predecessor.json"), "seven")
+    doc = _with_seq(_load("asqav-03-chain-link", "receipt.json"), 8)
+    axis = verify(doc, ADAPTERS, predecessor=pred).axis("seq")
+    assert axis.result == crypto.FAIL
+    assert "malformed predecessor seq" in axis.note
+
+
+def test_counters_are_never_compared_across_formats() -> None:
+    """A foreign receipt's counter is not this series; comparing would fake a gap."""
+    pred = _load("acta-01-genesis", "receipt.json")
+    pred["seq"] = 99
+    doc = _with_seq(_load("asqav-01-genesis-permit", "receipt.json"), 2)
+    axis = verify(doc, ADAPTERS, predecessor=pred).axis("seq")
+    assert axis.result == crypto.PASS
+    assert "different receipt format" in axis.note
+
+
+def test_a_hash_mode_receipt_cannot_claim_a_counter() -> None:
+    """Hash mode signs flat fields only, so a pasted seq is an unsigned claim."""
+    doc = _load("asqav-05-hash-mode-prod", "receipt.json")
+    clean = verify(doc, ADAPTERS, key_provider=_provider("asqav-05-hash-mode-prod"))
+    assert clean.axis("structure").result == crypto.PASS
+    assert clean.axis("seq").result == crypto.PASS
+
+    forged = json.loads(json.dumps(doc))
+    forged["seq"] = 5
+    res = verify(forged, ADAPTERS, key_provider=_provider("asqav-05-hash-mode-prod"))
+    assert res.axis("structure").result == crypto.FAIL
+    assert "signature does not cover" in res.axis("structure").note
+    # The counter itself is never read off an unsigned field set.
+    assert res.axis("seq").result == crypto.PASS
+    assert "not part of a counted series" in res.axis("seq").note
+    assert res.verdict == "unverified"

--- a/typescript/src/verifier/adapter.ts
+++ b/typescript/src/verifier/adapter.ts
@@ -74,6 +74,12 @@ export abstract class FormatAdapter {
     return [];
   }
 
+  // Raw so the axis can report a malformed counter; extraAxes never sees the
+  // predecessor continuity needs, so the counter is read here instead.
+  seqOf(_doc: Record<string, unknown>): unknown {
+    return null;
+  }
+
   // In-body attestation surfaced in the verdict (e.g. signer). Not a check.
   // Default none; a format with an in-signed-body attestation returns it.
   attestation(_doc: Record<string, unknown>): Record<string, unknown> {

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -55,8 +55,8 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 /** True for a flat hash-mode signature receipt (mode=hash, null payload, a sig). */
 // Claims belonging to the signed payload; hash mode signs the flat fields only,
-// so a thumbprint pasted onto one binds nothing.
-const UNSIGNED_CLAIM_FIELDS = ["issuer_id", "previousReceiptHash", "key_thumbprint"];
+// so a thumbprint or seq pasted onto one binds nothing.
+const UNSIGNED_CLAIM_FIELDS = ["issuer_id", "previousReceiptHash", "key_thumbprint", "seq"];
 
 /**
  * alg plus raw public-key bytes of the resolved directory entry. The directory publishes standard
@@ -273,6 +273,12 @@ export class AsqavNativeAdapter extends FormatAdapter {
       ["key_status", res, note],
       ["issuer_bind", bindRes, bindNote],
     ];
+  }
+
+  // Hash mode signs the flat field set only, so a seq sitting there binds nothing.
+  seqOf(doc: Record<string, unknown>): unknown {
+    if (isHashMode(doc)) return null;
+    return payloadOf(doc).seq ?? null;
   }
 
   // Surface the v:2 in-body signer. null for v:1 and hash-mode. Read only from

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -64,6 +64,9 @@ const INVALID_FAIL_AXES = new Set([
   "nonce",
   "parent_signature",
   "pdp_signature",
+  // A gap proves receipts were withheld and a malformed counter was signed as-is;
+  // both are proven defects, not a recompute that could not finish.
+  "seq",
 ]);
 
 /**
@@ -180,6 +183,44 @@ function chainAxis(
   return axis("chain", FAIL, `chain break: expected ${exp}.. got ${actual.slice(0, 16)}..`);
 }
 
+// A gap is omission evidence. Never SKIPPED: foldVerdict blocks on a non-chain
+// SKIPPED, so a receipt with no counter would regress to unverified.
+function seqAxis(
+  ad: FormatAdapter,
+  doc: Record<string, unknown>,
+  adapters: FormatAdapter[],
+  predecessor: Record<string, unknown> | null,
+): AxisResult {
+  const seq = ad.seqOf(doc);
+  if (seq === null || seq === undefined) {
+    return axis("seq", PASS, "no seq member; receipt is not part of a counted series");
+  }
+  if (!isCounter(seq)) return axis("seq", FAIL, `malformed seq: ${JSON.stringify(seq)}`);
+  if (predecessor === null) return axis("seq", PASS, `seq ${seq}; no predecessor supplied`);
+  // A counter only means anything within one format's own series.
+  const predAd = detect(predecessor, adapters);
+  if (predAd === null || predAd.name !== ad.name) {
+    return axis("seq", PASS, `seq ${seq}; predecessor is a different receipt format`);
+  }
+  const prev = ad.seqOf(predecessor);
+  if (prev === null || prev === undefined) {
+    return axis("seq", PASS, `seq ${seq}; predecessor carries no seq`);
+  }
+  if (!isCounter(prev)) {
+    return axis("seq", FAIL, `malformed predecessor seq: ${JSON.stringify(prev)}`);
+  }
+  if (seq === prev + 1) return axis("seq", PASS, `seq ${seq} follows predecessor ${prev}`);
+  if (seq <= prev) {
+    return axis("seq", FAIL, `seq not monotonic: ${seq} after predecessor ${prev}`);
+  }
+  return axis("seq", FAIL, `seq gap: ${seq - prev - 1} receipt(s) withheld between ${prev} and ${seq}`);
+}
+
+// A counter is a positive whole number; booleans and 1.5 are not counters.
+function isCounter(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v >= 1;
+}
+
 /** Max nesting the recursive JCS encoder tolerates, mirrors the Python core cap. */
 export const MAX_NESTING_DEPTH = 200;
 
@@ -232,6 +273,7 @@ export function verify(
     axis("structure", structResult, structNote),
     signatureAxis(ad, doc, keyProvider),
     chainAxis(ad, doc, adapters, predecessor),
+    seqAxis(ad, doc, adapters, predecessor),
   ];
   for (const [name, res, note] of ad.extraAxes(doc, keyProvider)) {
     axes.push(axis(name, res, note));

--- a/typescript/tests/verifier-seq-continuity.test.ts
+++ b/typescript/tests/verifier-seq-continuity.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Seq continuity axis, TypeScript half. Mirrors python/tests/test_seq_continuity_axis.py.
+ * The no-SKIPPED gate matters most: foldVerdict blocks on a non-chain SKIPPED, so a
+ * counter-less receipt would go from verified to unverified.
+ */
+
+import { readdirSync, existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { ADAPTERS, verify } from "../src/verifier/index.js";
+import { PASS, FAIL, SKIPPED } from "../src/verifier/crypto.js";
+
+const CORPUS = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
+
+function load(vec: string, name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(resolve(CORPUS, vec, name), "utf8"));
+}
+
+function withSeq(doc: Record<string, unknown>, seq: unknown): Record<string, unknown> {
+  // Injection breaks the signature, so assertions read the seq axis directly.
+  const out = JSON.parse(JSON.stringify(doc));
+  (out.payload as Record<string, unknown>).seq = seq;
+  return out;
+}
+
+function seqAxisOf(doc: Record<string, unknown>, pred: Record<string, unknown> | null = null) {
+  const axis = verify(doc, ADAPTERS, null, pred).axes.find((a) => a.axis === "seq");
+  expect(axis, "the seq axis must always be emitted").toBeDefined();
+  return axis!;
+}
+
+describe("seq continuity axis", () => {
+  it("leaves a receipt carrying no counter verified", () => {
+    const doc = load("asqav-01-genesis-permit", "receipt.json");
+    const res = verify(doc, ADAPTERS, load("asqav-01-genesis-permit", "jwks.json"), null);
+    expect(res.verdict).toBe("verified");
+    expect(res.failureClass).toBeNull();
+    const axis = res.axes.find((a) => a.axis === "seq")!;
+    expect(axis.result).toBe(PASS);
+    expect(axis.note).toContain("not part of a counted series");
+  });
+
+  it("never reports SKIPPED across the whole corpus", () => {
+    const offenders: string[] = [];
+    for (const vec of readdirSync(CORPUS, { withFileTypes: true })) {
+      if (!vec.isDirectory()) continue;
+      const receipt = resolve(CORPUS, vec.name, "receipt.json");
+      if (!existsSync(receipt)) continue;
+      const predPath = resolve(CORPUS, vec.name, "predecessor.json");
+      const pred = existsSync(predPath)
+        ? (JSON.parse(readFileSync(predPath, "utf8")) as Record<string, unknown>)
+        : null;
+      const axis = verify(JSON.parse(readFileSync(receipt, "utf8")), ADAPTERS, null, pred).axes.find(
+        (a) => a.axis === "seq",
+      );
+      if (axis && axis.result === SKIPPED) offenders.push(`${vec.name}: ${axis.note}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("passes a contiguous counter", () => {
+    const pred = withSeq(load("asqav-03-chain-link", "predecessor.json"), 7);
+    const axis = seqAxisOf(withSeq(load("asqav-03-chain-link", "receipt.json"), 8), pred);
+    expect(axis.result).toBe(PASS);
+    expect(axis.note).toContain("seq 8 follows predecessor 7");
+  });
+
+  it("fails a gap and counts the withheld receipts", () => {
+    const pred = withSeq(load("asqav-03-chain-link", "predecessor.json"), 7);
+    const doc = withSeq(load("asqav-03-chain-link", "receipt.json"), 11);
+    const res = verify(doc, ADAPTERS, null, pred);
+    const axis = res.axes.find((a) => a.axis === "seq")!;
+    expect(axis.result).toBe(FAIL);
+    expect(axis.note).toContain("3 receipt(s) withheld between 7 and 11");
+    // A proven omission is a binding failure, not an incomplete recompute.
+    expect(axis.failureClass).toBe("invalid");
+    expect(res.verdict).toBe("unverified");
+  });
+
+  it("fails a repeated or rewound counter", () => {
+    for (const seq of [7, 6, 1]) {
+      const pred = withSeq(load("asqav-03-chain-link", "predecessor.json"), 7);
+      const axis = seqAxisOf(withSeq(load("asqav-03-chain-link", "receipt.json"), seq), pred);
+      expect(axis.result, `seq ${seq} after 7 must fail`).toBe(FAIL);
+      expect(axis.note).toContain("not monotonic");
+    }
+  });
+
+  it("refuses a malformed counter but accepts legal absence", () => {
+    // true matters because a loose truthiness check would read it as the counter 1.
+    for (const bad of [true, false, "8", 0, -1, 1.5, [8], { n: 8 }]) {
+      const axis = seqAxisOf(withSeq(load("asqav-01-genesis-permit", "receipt.json"), bad));
+      expect(axis.result, `${JSON.stringify(bad)} must not pass as a counter`).toBe(FAIL);
+      expect(axis.note).toContain("malformed seq");
+    }
+    expect(seqAxisOf(withSeq(load("asqav-01-genesis-permit", "receipt.json"), null)).result).toBe(PASS);
+  });
+
+  it("passes with a note when no predecessor is supplied", () => {
+    const axis = seqAxisOf(withSeq(load("asqav-01-genesis-permit", "receipt.json"), 4));
+    expect(axis.result).toBe(PASS);
+    expect(axis.note).toContain("no predecessor supplied");
+  });
+
+  it("passes with a note when the predecessor carries no counter", () => {
+    const pred = load("asqav-03-chain-link", "predecessor.json");
+    expect((pred.payload as Record<string, unknown>).seq).toBeUndefined();
+    const axis = seqAxisOf(withSeq(load("asqav-03-chain-link", "receipt.json"), 2), pred);
+    expect(axis.result).toBe(PASS);
+    expect(axis.note).toContain("predecessor carries no seq");
+  });
+
+  it("fails a malformed predecessor counter", () => {
+    const pred = withSeq(load("asqav-03-chain-link", "predecessor.json"), "seven");
+    const axis = seqAxisOf(withSeq(load("asqav-03-chain-link", "receipt.json"), 8), pred);
+    expect(axis.result).toBe(FAIL);
+    expect(axis.note).toContain("malformed predecessor seq");
+  });
+
+  it("never compares counters across formats", () => {
+    // A foreign receipt's counter is not this series; comparing would fake a gap.
+    const pred = load("acta-01-genesis", "receipt.json");
+    pred.seq = 99;
+    const axis = seqAxisOf(withSeq(load("asqav-01-genesis-permit", "receipt.json"), 2), pred);
+    expect(axis.result).toBe(PASS);
+    expect(axis.note).toContain("different receipt format");
+  });
+
+  it("refuses a counter pasted onto a hash-mode receipt", () => {
+    // Hash mode signs flat fields only, so a pasted seq is an unsigned claim.
+    const doc = load("asqav-05-hash-mode-prod", "receipt.json");
+    const jwks = load("asqav-05-hash-mode-prod", "jwks.json");
+    const clean = verify(doc, ADAPTERS, jwks, null);
+    expect(clean.axes.find((a) => a.axis === "structure")!.result).toBe(PASS);
+    expect(clean.axes.find((a) => a.axis === "seq")!.result).toBe(PASS);
+
+    const forged = JSON.parse(JSON.stringify(doc));
+    forged.seq = 5;
+    const res = verify(forged, ADAPTERS, jwks, null);
+    const structure = res.axes.find((a) => a.axis === "structure")!;
+    expect(structure.result).toBe(FAIL);
+    expect(structure.note).toContain("signature does not cover");
+    const axis = res.axes.find((a) => a.axis === "seq")!;
+    expect(axis.result).toBe(PASS);
+    expect(axis.note).toContain("not part of a counted series");
+    expect(res.verdict).toBe("unverified");
+  });
+});


### PR DESCRIPTION
The SDK half of criterion 459, stacked on #432 so the diff shows only the feature.

**Draft on purpose.** This must not merge until production actually emits `seq`
(platform PR jagmarques/asqav#1393). Shipping a verifier axis ahead of the emission it
reads is the mistake criterion 457 recorded; the axis is written, tested and waiting.

A gap in the server-built per-agent counter is evidence that a receipt was withheld,
without needing the withheld receipt. The axis reports the gap and names how many are
missing.

### The trap this axis had to avoid

`fold_verdict` computes `blocking_skip = any(a.result == SKIPPED and a.axis != "chain")`.
An axis that returned a bare SKIPPED when it had no counter to compare would turn **every
receipt minted before the counter shipped — which is all of them today — from verified
into unverified.** So the axis never reports SKIPPED: every case it cannot evaluate PASSes
with a note saying why. A corpus-wide gate asserts no vector produces a blocking SKIPPED
here, so a future branch that forgets the rule is caught.

### Placement

Beside the chain axis rather than in `extra_axes`, because continuity needs the
predecessor and `extra_axes` only receives `(doc, key_provider)`.

Counters are compared only when the predecessor detects to the **same format**. A foreign
receipt that happens to carry a `seq` member is not this series, and comparing would
report a gap that never happened.

### The unsigned-claim guard

`seq` joins `key_thumbprint` in the hash-mode guard. Hash mode signs eleven flat fields
and nothing else, so a counter pasted onto a hash-mode receipt binds nothing; it is
refused as an unsigned claim rather than read as series membership.

### Mutation testing

Nine mutants per language, each killed by its own gate:

| Mutant | Killed by |
|---|---|
| no-counter branch reports SKIPPED | the corpus-wide and single-receipt gates |
| a bool is accepted as a counter | the malformed-counter gate (`bool` is an `int` subclass) |
| a gap is treated as contiguous | the gap gate |
| counters compared across formats | the cross-format gate |
| a gap classed unverifiable, not invalid | the failure-class assertion |
| the axis is never emitted | every gate |
| predecessor counter shape unchecked | the malformed-predecessor gate |
| hash mode exposes an unsigned counter | the hash-mode gate |
| the unsigned-claim guard is dropped | the hash-mode gate |

The harness rejects any anchor that matches more than once. That guard exists because the
first run reported a surviving mutant: the anchor string appeared **twice** in `core`, so
the edit landed in `_chain_axis` instead of `_seq_axis` and the gate was never exercised.
The gate was real; the harness was broken.

### Verification

2911 Python tests, 1078 TypeScript tests, conformance corpus 65/65.

Claude-Session: https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
