### PR TITLE
docs(verifier): name the ACTA revision the adapter actually implements

### DIFF
--- a/typescript/src/verifier/adapters/acta.ts
+++ b/typescript/src/verifier/adapters/acta.ts
@@ -1,5 +1,5 @@
 /**
- * ACTA adapter (draft-farley-acta-signed-receipts-01): Ed25519 over the JCS of `payload`, hex sig. Kept
+ * ACTA adapter (draft-farley-acta-signed-receipts-02): Ed25519 over the JCS of `payload`, hex sig. Kept
  * disjoint from Asqav-native by sig encoding and the `anchors` key; Commitment Mode is not implemented.
  */
 


### PR DESCRIPTION
The two SDK halves disagreed with each other about which ACTA revision the
adapter targets: the TypeScript header said `-01` while the Python sibling
already said `-02`. One of them had to be wrong.

Reading the `-02` changelog settles it. Its signing-preimage correction is that
the signature covers the canonical JCS bytes of the payload DIRECTLY, where
`-01` ambiguously described a digest of those bytes. `-02` also adds
`action_ref`, `verifier_sigil` and `iteration_id` and permits ES256 beside the
mandatory EdDSA, with no change to the `{payload, signature}` envelope.

Both halves compute `signing_input` as `jcs(payload)` with no pre-hash:

- `typescript/src/verifier/adapters/acta.ts` — `return jcs(asRecord(doc.payload))`
- `python/src/asqav/verifier/oracle/adapters/acta.py` — `return jcs(doc.get("payload", {}))`

So both implement the `-02` rule and the TypeScript label was stale. Naming
`-02` there makes the comment true, rather than turning a stale note into a
false claim about what the code does — which is the concern that left this open.
Behaviour is untouched; this is a comment.

Closes the incidental finding recorded under criterion 479.