### PR TITLE
chore(release): 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-09-01
+
+### Added
+
+- **`seq` continuity verification axis, in both halves.** The platform binds a
+  server-built per-agent counter into every compliance receipt, so a gap in the
+  series proves receipts were withheld *without needing the withheld receipts*.
+  The chain axis alone cannot do this: hash linkage detects modification,
+  reordering and removal of interior records, but a gap and a duplicate position
+  are indistinguishable to it. A gap now FAILs as terminal `invalid` and names
+  the count, e.g. `seq gap: 4 receipt(s) withheld between 1 and 6`; a
+  non-monotonic counter and a malformed one FAIL too.
+- The axis is **never SKIPPED**. A counter-less receipt PASSes with a note, since
+  `fold_verdict` blocks on any non-chain SKIPPED and a bare skip would regress
+  every receipt minted before the counter shipped from verified to unverified. A
+  corpus-wide gate holds that property for future changes.
+- A counter is only compared within one format's own series, and a `seq` sitting
+  on a hash-mode receipt binds nothing (hash mode signs the flat field set only),
+  so it is treated as an unsigned claim rather than read as evidence.
+
+### Fixed
+
+- The TypeScript ACTA adapter named revision `-01` while its Python sibling named
+  `-02`. Both compute the signing input as the canonical JCS bytes of the payload
+  with no pre-hash, which is the `-02` rule, so the TypeScript label was stale.
+  Comment only; behaviour is unchanged.
+
 ## [0.10.2] - 2026-08-31
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.2"
+version = "0.10.3"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -186,7 +186,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -3,7 +3,7 @@
  * added under Node, since browsers forbid setting User-Agent on fetch.
  */
 
-export const SDK_VERSION = "0.10.2";
+export const SDK_VERSION = "0.10.3";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Patch bump per the pre-1.0 policy in CLAUDE.md: a small additive change climbs
the patch digit rather than the minor one, with the CHANGELOG carrying the new
public API so a strict-SemVer consumer still sees it. Registry checked first —
both npm and PyPI are on 0.10.2, so this number is free.

## What this releases

**The `seq` continuity verification axis, in both halves.** The platform binds a
server-built per-agent counter into every compliance receipt, so a gap in the
series proves receipts were withheld *without needing the withheld receipts*.
Hash linkage alone cannot show that: it detects modification, reordering and
removal of interior records, but a gap and a duplicate position are
indistinguishable to it.

A gap FAILs as terminal `invalid` and names the count
(`seq gap: 4 receipt(s) withheld between 1 and 6`); non-monotonic and malformed
counters FAIL too. The axis is **never SKIPPED** — `fold_verdict` blocks on any
non-chain SKIPPED, so a bare skip would regress every receipt minted before the
counter shipped from verified to unverified. A corpus-wide gate holds that.

Also carries the ACTA adapter revision label correction.

## Verified against real production receipts

The axis was run against genuine receipts minted by prod, not fixtures: two
consecutive compliance receipts gave `seq 2 follows predecessor 1` with the
chain axis also passing; doctoring one to seq 6 produced
`seq gap: 4 receipt(s) withheld between 1 and 6`.

Local: 2911 Python tests, 1078 TypeScript tests, all four version files plus
CHANGELOG as the version-consistency test requires.

## After merge

Publish is tag-gated — push the `py-` and `ts-` release tags for this number.
