### PR TITLE
test(conformance): four seq continuity vectors in the shared corpus

### DIFF
--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -25,7 +25,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # and in the corpus READMEs. A regenerated lock that forgets to update these is
 # drift, not a refresh
 FINGERPRINT_LOCK_DIGEST = "aa4e38f19dd227ffd4f674a9e25298199769d40ade9be63417eb9432ccb5ba6d"
-VERIFIER_LOCK_DIGEST = "525b0b407d6bf752e51d6bde74e384fd65020362aadf186ab73ed53013229653"
+VERIFIER_LOCK_DIGEST = "aec29cc3f2eefb5818214427bae1b575173a0c0119bab7c34710b9a63cf91262"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -237,7 +237,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 65
+    assert len(results) == 69
     # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -27,7 +27,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 62 corpus vectors", () => {
+  it("matches every manifest outcome across all 69 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -44,9 +44,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(65);
+    expect(results.length).toBe(69);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(65);
+    expect(passed).toBe(69);
   });
 
   it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {

--- a/verifier/conformance-vectors/asqav-17-seq-contiguous/expected.json
+++ b/verifier/conformance-vectors/asqav-17-seq-contiguous/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "seq 8 follows predecessor 7 with nothing missing between them. The baseline the gap vector is measured against."
+}

--- a/verifier/conformance-vectors/asqav-17-seq-contiguous/jwks.json
+++ b/verifier/conformance-vectors/asqav-17-seq-contiguous/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-seq-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "zTmSVd5DfaAncDhLL0aDCTlGaJ+PMX1l7QZLSdSKRb0="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-17-seq-contiguous/predecessor.json
+++ b/verifier/conformance-vectors/asqav-17-seq-contiguous/predecessor.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_1",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 7
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "lpBJ9g+ug5LJiH4YpwfinVegV1YGXkk4QFTCl6yrTAU+8Xo1zLgHmsKgVYRvRJeyiEn/tN0HAQuaxTqdSYJOCg=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-17-seq-contiguous/receipt.json
+++ b/verifier/conformance-vectors/asqav-17-seq-contiguous/receipt.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_2",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "11c3ddff7c593e0168bbe6ba5f682c9d503972f233cf655b7ab1633c9ddaa659",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 8
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "ySZavYGbR3/4OvSa6yFcCo4yHpmgW6YYC7/+L7wLQ/QbXAX+IPoVdTLRPPwUuUJNZhvdL97xmwwYzsNimMB5CA=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-18-seq-gap/expected.json
+++ b/verifier/conformance-vectors/asqav-18-seq-gap/expected.json
@@ -1,0 +1,7 @@
+{
+  "format": "asqav-native",
+  "outcome": "unverified",
+  "failure_class": "invalid",
+  "reason_code": "seq_gap",
+  "notes": "seq jumps 7 -> 11, so three receipts were withheld. Both receipts are correctly signed and the chain link rederives, so the hash chain alone reports nothing wrong; the counter is what makes the omission evidence. A proven omission is a binding failure, not an incomplete recompute, so the class is invalid rather than unverifiable."
+}

--- a/verifier/conformance-vectors/asqav-18-seq-gap/jwks.json
+++ b/verifier/conformance-vectors/asqav-18-seq-gap/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-seq-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "zTmSVd5DfaAncDhLL0aDCTlGaJ+PMX1l7QZLSdSKRb0="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-18-seq-gap/predecessor.json
+++ b/verifier/conformance-vectors/asqav-18-seq-gap/predecessor.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_10",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 7
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "6xT6UcT/E6qEqXGY9b5mtTLpJWVom8OnF0Q7ueKv7OQZ2cpjNk9SxMGnWNF8xV1GeTVigtZ1rgP6igHLNj3OBA=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-18-seq-gap/receipt.json
+++ b/verifier/conformance-vectors/asqav-18-seq-gap/receipt.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_14",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "d75c074fa965f905c2ce3658dfb7c2dcff1e7aa3e1d9d9cda124ba87f8af507f",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 11
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "rdrhSja7Vm8QuQCk4dR75XMBVBR8PPN/B4O6WqQRSLrsraA4tWSfaS6UwAWrZUrkpyjJ1gbIcFlG2GpSsQekCw=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-19-seq-non-monotonic/expected.json
+++ b/verifier/conformance-vectors/asqav-19-seq-non-monotonic/expected.json
@@ -1,0 +1,7 @@
+{
+  "format": "asqav-native",
+  "outcome": "unverified",
+  "failure_class": "invalid",
+  "reason_code": "seq_not_monotonic",
+  "notes": "The counter goes backwards, 9 then 4. A replayed or reordered receipt reaches this before a gap does, and it is refused for the same reason: the series cannot decrease under a server-built monotonic counter."
+}

--- a/verifier/conformance-vectors/asqav-19-seq-non-monotonic/jwks.json
+++ b/verifier/conformance-vectors/asqav-19-seq-non-monotonic/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-seq-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "zTmSVd5DfaAncDhLL0aDCTlGaJ+PMX1l7QZLSdSKRb0="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-19-seq-non-monotonic/predecessor.json
+++ b/verifier/conformance-vectors/asqav-19-seq-non-monotonic/predecessor.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_20",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 9
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "4PkFYPAjLYfN8xpTvP/buPIyYrMDBRBNSxEpRUXgkmj8i/coIt3uPixIzSkVXgLBfULLXdzRvAdXZjyTF2WeAg=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-19-seq-non-monotonic/receipt.json
+++ b/verifier/conformance-vectors/asqav-19-seq-non-monotonic/receipt.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_21",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "385bcfa20627051d9306c4962a2a8400c39fe399b662388f3c25684c66a2ad2c",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 4
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "y7qM7S+sGQhBYPhM1UEYETtB7vecoeIz8gnf241jRbdx81cDIjm7o97Zt/XriuV8I2oYcBB5W+iTopqrWIjtBg=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-20-seq-absent/expected.json
+++ b/verifier/conformance-vectors/asqav-20-seq-absent/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "Neither receipt carries a counter, which is every receipt minted before the member shipped. Absence MUST stay legal: the axis passes with a note rather than skipping, because a blocking skip would regress all of them from verified to unverified."
+}

--- a/verifier/conformance-vectors/asqav-20-seq-absent/jwks.json
+++ b/verifier/conformance-vectors/asqav-20-seq-absent/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-seq-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "zTmSVd5DfaAncDhLL0aDCTlGaJ+PMX1l7QZLSdSKRb0="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-20-seq-absent/predecessor.json
+++ b/verifier/conformance-vectors/asqav-20-seq-absent/predecessor.json
@@ -1,0 +1,23 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_30",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "6MaWrlbWb1VOJH78CL7/R6EFEUqOLYQAJWUETnf7UIUBksuIvzFM0e/N7BW1MDESvFmxLVUcE8XWoP523g7QDQ=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-20-seq-absent/receipt.json
+++ b/verifier/conformance-vectors/asqav-20-seq-absent/receipt.json
@@ -1,0 +1,23 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_31",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "18950e84d7aaf9e258db894062a2a1e4e1ca7be1d061e16a67090a9754b6ca7f",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "7CV4c/PTUtklSjAGAOGn3QBiQ8hAmpP5+cTk4UgHFQSAB2FdUxzXw8RyQJDTgCNl8fUa4z/osF/y2hW5pjzkBw=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/gen_seq_vectors.py
+++ b/verifier/conformance-vectors/gen_seq_vectors.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the seq continuity conformance vectors.
+
+`seq` is a server-built per-agent counter bound into the signed payload, so a
+gap in the series proves receipts were withheld WITHOUT needing the withheld
+receipts. That is the one thing hash linkage cannot show on its own: a chain
+spanning an omission verifies perfectly (see asqav-14-omitted-action-chain),
+because a link only relates the receipts that exist.
+
+Four vectors, each a distinct outcome the axis has to reach:
+
+  asqav-17-seq-contiguous     seq N then N+1; verifies
+  asqav-18-seq-gap            seq N then N+4; three receipts withheld, invalid
+  asqav-19-seq-non-monotonic  a counter that goes backwards, invalid
+  asqav-20-seq-absent         neither receipt carries one; still verifies, because
+                              absence has to stay legal or every receipt minted
+                              before the counter shipped would regress
+
+The signing key is derived from a published phrase so anyone can re-derive it;
+nothing here depends on a secret the corpus does not ship.
+
+Usage: python verifier/conformance-vectors/gen_seq_vectors.py
+Re-freeze the corpus lock afterwards: python verifier/freeze_corpus_lock.py
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+_HERE = Path(__file__).resolve().parent
+
+#: Nothing-up-my-sleeve seed phrase; the key is SHA-256 of these ASCII bytes
+SEED_PHRASE = b"asqav conformance corpus v1 seq-continuity signing seed"
+KID = "asqav-seq-vec-key"
+ISSUER = "Asqav Ltd"
+_ZERO_DIGEST = hashlib.sha256(b"").hexdigest()
+
+
+def _jcs(obj: object) -> bytes:
+    """Canonical JSON bytes, matching the oracle's asqav_jcs."""
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+
+
+def _signing_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(SEED_PHRASE).digest())
+
+
+def _sign(payload: dict, sk: Ed25519PrivateKey) -> dict:
+    """The three-key envelope: signature is over the canonical payload bytes."""
+    return {
+        "payload": payload,
+        "signature": {
+            "alg": "Ed25519",
+            "kid": KID,
+            "sig": base64.b64encode(sk.sign(_jcs(payload))).decode(),
+        },
+        "anchors": [],
+    }
+
+
+def _chain_hash(payload: dict) -> str:
+    """The successor's previousReceiptHash: SHA-256 of the predecessor payload."""
+    return hashlib.sha256(_jcs(payload)).hexdigest()
+
+
+def _payload(action_ref: str, previous: str, **extra) -> dict:
+    payload = {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-08-30T12:00:00+00:00",
+        "issuer_id": ISSUER,
+        "agent_id": "agt_seq_001",
+        "action_ref": action_ref,
+        "payload_digest": {"hash": _ZERO_DIGEST, "size": 0},
+        "policy_digest": f"sha256:{_ZERO_DIGEST}",
+        "previousReceiptHash": previous,
+        "decision": "allow",
+        "tool_name": "demo.action",
+    }
+    payload.update(extra)
+    return payload
+
+
+def _jwks() -> dict:
+    pub = _signing_key().public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return {
+        "keys": [
+            {
+                "kid": KID,
+                "issuer_id": ISSUER,
+                "alg": "Ed25519",
+                "status": "active",
+                "public_key": base64.b64encode(pub).decode(),
+            }
+        ]
+    }
+
+
+def _write(name: str, files: dict[str, object]) -> None:
+    out = _HERE / name
+    out.mkdir(parents=True, exist_ok=True)
+    for fname, obj in files.items():
+        (out / fname).write_text(json.dumps(obj, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {name}")
+
+
+def _pair(sk, first_ref: str, second_ref: str, first_extra: dict, second_extra: dict):
+    """A predecessor and the successor that links to it, both properly signed.
+
+    Both are signed over their real bytes, so a vector never depends on a broken
+    signature to reach its outcome - the seq axis has to be what decides it.
+    """
+    first = _payload(first_ref, "0" * 64, **first_extra)
+    second = _payload(second_ref, _chain_hash(first), **second_extra)
+    return _sign(first, sk), _sign(second, sk)
+
+
+def main() -> int:
+    sk = _signing_key()
+
+    pred, rec = _pair(sk, "act_1", "act_2", {"seq": 7}, {"seq": 8})
+    _write(
+        "asqav-17-seq-contiguous",
+        {
+            "predecessor.json": pred,
+            "receipt.json": rec,
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "verified",
+                "reason_code": "",
+                "notes": (
+                    "seq 8 follows predecessor 7 with nothing missing between them. "
+                    "The baseline the gap vector is measured against."
+                ),
+            },
+        },
+    )
+
+    pred, rec = _pair(sk, "act_10", "act_14", {"seq": 7}, {"seq": 11})
+    _write(
+        "asqav-18-seq-gap",
+        {
+            "predecessor.json": pred,
+            "receipt.json": rec,
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "unverified",
+                "failure_class": "invalid",
+                "reason_code": "seq_gap",
+                "notes": (
+                    "seq jumps 7 -> 11, so three receipts were withheld. Both receipts "
+                    "are correctly signed and the chain link rederives, so the hash "
+                    "chain alone reports nothing wrong; the counter is what makes the "
+                    "omission evidence. A proven omission is a binding failure, not an "
+                    "incomplete recompute, so the class is invalid rather than "
+                    "unverifiable."
+                ),
+            },
+        },
+    )
+
+    pred, rec = _pair(sk, "act_20", "act_21", {"seq": 9}, {"seq": 4})
+    _write(
+        "asqav-19-seq-non-monotonic",
+        {
+            "predecessor.json": pred,
+            "receipt.json": rec,
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "unverified",
+                "failure_class": "invalid",
+                "reason_code": "seq_not_monotonic",
+                "notes": (
+                    "The counter goes backwards, 9 then 4. A replayed or reordered "
+                    "receipt reaches this before a gap does, and it is refused for the "
+                    "same reason: the series cannot decrease under a server-built "
+                    "monotonic counter."
+                ),
+            },
+        },
+    )
+
+    pred, rec = _pair(sk, "act_30", "act_31", {}, {})
+    _write(
+        "asqav-20-seq-absent",
+        {
+            "predecessor.json": pred,
+            "receipt.json": rec,
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "verified",
+                "reason_code": "",
+                "notes": (
+                    "Neither receipt carries a counter, which is every receipt minted "
+                    "before the member shipped. Absence MUST stay legal: the axis "
+                    "passes with a note rather than skipping, because a blocking skip "
+                    "would regress all of them from verified to unverified."
+                ),
+            },
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -487,5 +487,35 @@
     "outcome": "verified",
     "reason_code": "",
     "notes": "A bounded predecessor-lookup timeout blocked emission; the lifecycle receipt naming it links into the chain once emission resumes."
+  },
+  {
+    "dir": "asqav-17-seq-contiguous",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "seq 8 follows predecessor 7 with nothing missing between them. The baseline the gap vector is measured against."
+  },
+  {
+    "dir": "asqav-18-seq-gap",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "failure_class": "invalid",
+    "reason_code": "seq_gap",
+    "notes": "seq jumps 7 -> 11, so three receipts were withheld. Both receipts are correctly signed and the chain link rederives, so the hash chain alone reports nothing wrong; the counter is what makes the omission evidence. A proven omission is a binding failure, not an incomplete recompute, so the class is invalid rather than unverifiable."
+  },
+  {
+    "dir": "asqav-19-seq-non-monotonic",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "failure_class": "invalid",
+    "reason_code": "seq_not_monotonic",
+    "notes": "The counter goes backwards, 9 then 4. A replayed or reordered receipt reaches this before a gap does, and it is refused for the same reason: the series cannot decrease under a server-built monotonic counter."
+  },
+  {
+    "dir": "asqav-20-seq-absent",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "Neither receipt carries a counter, which is every receipt minted before the member shipped. Absence MUST stay legal: the axis passes with a note rather than skipping, because a blocking skip would regress all of them from verified to unverified."
   }
 ]

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -845,6 +845,86 @@
       "bytes": 814
     },
     {
+      "path": "asqav-17-seq-contiguous/expected.json",
+      "sha256": "09f4257b74ad32874c10f3c7a262d3642e5c55bad6f4fa303815030e1bded210",
+      "bytes": 203
+    },
+    {
+      "path": "asqav-17-seq-contiguous/jwks.json",
+      "sha256": "79868ab758a20f67ec0e9b670760c8cde54b62a55754336d0f1b8379f4c42c4b",
+      "bytes": 215
+    },
+    {
+      "path": "asqav-17-seq-contiguous/predecessor.json",
+      "sha256": "1da61225a7cee5d09079eff486a29bef02c36f5be5e9de30ef496e8012e71909",
+      "bytes": 777
+    },
+    {
+      "path": "asqav-17-seq-contiguous/receipt.json",
+      "sha256": "c71620d2bd61bdb798ffae0e99506d868b258d0b88941af8d366d771656de54e",
+      "bytes": 777
+    },
+    {
+      "path": "asqav-18-seq-gap/expected.json",
+      "sha256": "de21db0364ff296d0d3a67ab6f2d26cdceddf24987b84514a2bddeb4ad0ca926",
+      "bytes": 462
+    },
+    {
+      "path": "asqav-18-seq-gap/jwks.json",
+      "sha256": "79868ab758a20f67ec0e9b670760c8cde54b62a55754336d0f1b8379f4c42c4b",
+      "bytes": 215
+    },
+    {
+      "path": "asqav-18-seq-gap/predecessor.json",
+      "sha256": "f064920f6a89ddee4467bf72e4761fa2035a4f9e38b5e9fa1d5991611083f4fc",
+      "bytes": 778
+    },
+    {
+      "path": "asqav-18-seq-gap/receipt.json",
+      "sha256": "06c0eccde138ebcf45b50f205e2799d742cbbfd26df75660f2467213de9b35f3",
+      "bytes": 779
+    },
+    {
+      "path": "asqav-19-seq-non-monotonic/expected.json",
+      "sha256": "727d052e1cf0dac08b9c5bbbd6420dfc1f6e18b955e10d2e296db9d9d9c33aab",
+      "bytes": 348
+    },
+    {
+      "path": "asqav-19-seq-non-monotonic/jwks.json",
+      "sha256": "79868ab758a20f67ec0e9b670760c8cde54b62a55754336d0f1b8379f4c42c4b",
+      "bytes": 215
+    },
+    {
+      "path": "asqav-19-seq-non-monotonic/predecessor.json",
+      "sha256": "882ccd829556439851ecbe8e2a10228a7ca9a1bcdd4be2578cdd2fe9eeae0dec",
+      "bytes": 778
+    },
+    {
+      "path": "asqav-19-seq-non-monotonic/receipt.json",
+      "sha256": "c0dba77d27afce143a3f1597c82d64f0950acc9a3fa40b9aeb0d6ce9a58ac284",
+      "bytes": 778
+    },
+    {
+      "path": "asqav-20-seq-absent/expected.json",
+      "sha256": "9252b33720cdb45e9f777d5af453b286335b2679768cfec46bfdbdffbfa6260f",
+      "bytes": 337
+    },
+    {
+      "path": "asqav-20-seq-absent/jwks.json",
+      "sha256": "79868ab758a20f67ec0e9b670760c8cde54b62a55754336d0f1b8379f4c42c4b",
+      "bytes": 215
+    },
+    {
+      "path": "asqav-20-seq-absent/predecessor.json",
+      "sha256": "e14a964fecdcbaa542f9acb67562dceb7d186a1c2cedb4765e2e846ecbadcda8",
+      "bytes": 764
+    },
+    {
+      "path": "asqav-20-seq-absent/receipt.json",
+      "sha256": "54621d51666b802fd62430ec0bdcec43e9c493db6e5a10a226664d2c0d66e0fa",
+      "bytes": 764
+    },
+    {
       "path": "authproof-01-genesis-real-sdk/expected.json",
       "sha256": "5599a2e6341d4194186cd5c43be8c271c2dd40d8a382f1be536d89488e6378a8",
       "bytes": 274
@@ -915,9 +995,14 @@
       "bytes": 6959
     },
     {
+      "path": "gen_seq_vectors.py",
+      "sha256": "237e4986481f5df7826ebcd0309e824a185c46a71018a60a9d9600b78fb0b499",
+      "bytes": 7712
+    },
+    {
       "path": "manifest.json",
-      "sha256": "c0134b830263efc9ff19820e809288cc655c52591742abf1a9786bfd8b903e2c",
-      "bytes": 21480
+      "sha256": "6ffa041884be67b07501ca4bb35956fe9d7e62d96da0c0ac768dbb91d1c09cc4",
+      "bytes": 23030
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
@@ -1085,5 +1170,5 @@
       ]
     }
   },
-  "digest": "525b0b407d6bf752e51d6bde74e384fd65020362aadf186ab73ed53013229653"
+  "digest": "aec29cc3f2eefb5818214427bae1b575173a0c0119bab7c34710b9a63cf91262"
 }


### PR DESCRIPTION
The `seq` axis shipped with tests that doctor existing vectors in-process. The
corpus had no vector of its own, so the **cross-language parity gate never
exercised the axis** — the two halves could have disagreed about a withheld
receipt and nothing would have noticed.

| vector | outcome |
|---|---|
| `asqav-17-seq-contiguous` | seq 7 then 8 → verified |
| `asqav-18-seq-gap` | seq 7 then 11, three withheld → unverified / invalid |
| `asqav-19-seq-non-monotonic` | counter goes backwards → unverified / invalid |
| `asqav-20-seq-absent` | neither carries one → verified |

## Why these are not vacuous

Every receipt is signed over its real bytes, so the **signature axis PASSes in
all four** and the `seq` axis is what decides each verdict. A vector that
reached its outcome through a broken signature would prove nothing about the
counter.

The gap vector carries the argument: both receipts verify *and* the chain link
rederives, so hash linkage alone reports nothing wrong. Only the counter makes
the omission evidence — which is the entire reason the member exists.
`asqav-14-omitted-action-chain` is the same situation without a counter and
correctly still verifies. The two sit side by side on purpose.

`asqav-20-seq-absent` pins the property that most needs protecting: absence
must stay legal, or every receipt minted before the counter shipped regresses
from verified to unverified.

## Corpus discipline

Existing vectors stay **byte-identical**. The only pins that moved are the
manifest's own and the lock digest, both of which must. The digest is pinned in
`python/tests/test_corpus_lock.py` and updated alongside, as the corpus README
requires. Corpus size assertions in both halves move 65 → 69.

The signing key derives from a published seed phrase in the generator, matching
`gen_selective_omission_vectors.py`, so anyone can re-derive the vectors.

## Verification

Python 2911 passed, TypeScript 1078 passed, and the corpus lock re-derived
through both independent paths (`hashlib` and the `sha256sum` binary). The
TypeScript parity gate independently reaches `invalid` on the gap vector,
matching Python byte for byte.

Criterion 474 (B17), the seq-gap entry.
