### PR TITLE
fix(verifier): range-check whole seconds, not the fractional part

### DIFF
--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -459,7 +459,12 @@ function parseIsoMs(issuedAt: unknown): number | null {
   const [, date, time, zone] = m;
   if (time !== undefined) {
     const [hh, mm, ss] = time.split(":");
-    if (Number(hh) > 23 || Number(mm) > 59 || Number(ss ?? "0") > 59) return null;
+    // Range-check the WHOLE seconds only. Number("59.656") is 59.656, which is
+    // > 59, so a fractional stamp in the 59th second read as out of range and
+    // the receipt failed closed - one second in every sixty. Python range-checks
+    // a two-digit capture, so this is also what keeps the two halves agreeing.
+    const wholeSeconds = (ss ?? "0").split(".")[0];
+    if (Number(hh) > 23 || Number(mm) > 59 || Number(wholeSeconds) > 59) return null;
   }
   let tz = zone ?? "Z";
   if (tz !== "Z") {

--- a/typescript/tests/verifier-expiry-offline.test.ts
+++ b/typescript/tests/verifier-expiry-offline.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { checkExpiry } from "../src/verifier/index.js";
+import { checkExpiry, checkSkew } from "../src/verifier/index.js";
 
 function stampAt(offsetSeconds: number): string {
   return new Date(Date.now() + offsetSeconds * 1000).toISOString();
@@ -31,5 +31,37 @@ describe("the offline expiry axis", () => {
   it("fails closed on an unreadable expires_at", () => {
     const [result] = checkExpiry({ expires_at: "not-a-stamp" });
     expect(result).toBe("FAIL");
+  });
+});
+
+// A stamp in the 59th second with a fractional part is ordinary: Date#toISOString
+// always emits milliseconds, so roughly one receipt in sixty lands here. Range-
+// checking Number("59.656") read it as out of range and failed the receipt closed,
+// while the Python half range-checks a two-digit capture and passed the same bytes.
+// A verdict that depends on which half you run, and on the second of the minute.
+describe("a fractional second in the 59th second (cross-language parity)", () => {
+  const STAMPS = [
+    "2099-01-01T06:30:59.656Z",
+    "2099-01-01T00:00:59.001Z",
+    "2099-12-31T23:59:59.999Z",
+  ];
+
+  for (const stamp of STAMPS) {
+    it(`reads ${stamp} as a real expiry, not as unreadable`, () => {
+      const [result, note] = checkExpiry({ expires_at: stamp });
+      expect(note).not.toContain("unreadable");
+      expect(result).toBe("PASS");
+    });
+  }
+
+  it("still refuses a genuinely out-of-range second", () => {
+    const [result] = checkExpiry({ expires_at: "2099-01-01T06:30:60.500Z" });
+    expect(result).toBe("FAIL");
+  });
+
+  it("applies to issued_at as well, where the class would be invalid", () => {
+    const [result, note] = checkSkew("2026-01-01T00:00:59.500Z");
+    expect(note).not.toContain("unparseable");
+    expect(result).toBe("PASS");
   });
 });

--- a/verifier/axis-parity-cases.json
+++ b/verifier/axis-parity-cases.json
@@ -1267,6 +1267,14 @@
         "result": "FAIL",
         "note_contains": "unparseable issued_at"
       }
+    },
+    {
+      "name": "fractional second in the 59th second parses",
+      "issued_at": "2026-01-01T00:00:59.500Z",
+      "expect": {
+        "result": "PASS",
+        "note_contains": "within bound"
+      }
     }
   ],
   "normalise": [
@@ -1618,6 +1626,36 @@
         "result": "FAIL",
         "note_contains": "unreadable expires_at"
       }
+    },
+    {
+      "name": "future, fractional second in the 59th second",
+      "payload": {
+        "expires_at": "2099-01-01T06:30:59.656Z"
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "expires_at 2099-01-01T06:30:59.656Z is "
+      }
+    },
+    {
+      "name": "future, fractional second at the last second of the year",
+      "payload": {
+        "expires_at": "2099-12-31T23:59:59.999Z"
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "expires_at 2099-12-31T23:59:59.999Z is "
+      }
+    },
+    {
+      "name": "second 60 is genuinely out of range and still fails closed",
+      "payload": {
+        "expires_at": "2099-01-01T06:30:60.500Z"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "unreadable expires_at"
+      }
     }
   ],
   "chain_prev_hash_note": "pipelock-evidence-v2 chain_prev_hash cases, run over verifier/conformance-vectors/pipelock-ev2-01-proxy-decision with the field substituted. Expectations are the output of the Python oracle. Only an absent, null, or sentinel string is a genesis link; every other value is producer-set and must not read as an absent link. The field sits inside the signed preimage, so any substitution also FAILs the signature.",
@@ -1849,512 +1887,512 @@
       "why": "The control: an honest token over the right digest. Python verifies it to PASS, TS still reports unverifiable, so the divergence above is the absence of anchor cryptography in TS and not a quirk of a forged token."
     }
   ],
-    "key_thumbprint_vectors_note": "RFC 7638 JWK Thumbprint vectors over the draft-ietf-cose-dilithium AKP form: the digest is taken over {alg, kty, pub} sorted, separator-tight, with pub in UNPADDED BASE64URL. The all-0xff ML-DSA-87 vector is the alphabet trap: its pub is all '_' in base64url where standard base64 gives '/', so an implementation that reuses the directory's public_key alphabet produces a digest no other verifier reproduces.",
-    "key_thumbprint_vectors": [
-      {
-        "name": "ML-DSA-44 all-zero key",
-        "key": {
-          "alg": "ML-DSA-44",
-          "fill": 0,
-          "len": 1312
-        },
-        "thumbprint": "sha256:d822401dad5b6a8832b186e94c3be90b0918823b9f24dae4720432d208bfd9f5"
+  "key_thumbprint_vectors_note": "RFC 7638 JWK Thumbprint vectors over the draft-ietf-cose-dilithium AKP form: the digest is taken over {alg, kty, pub} sorted, separator-tight, with pub in UNPADDED BASE64URL. The all-0xff ML-DSA-87 vector is the alphabet trap: its pub is all '_' in base64url where standard base64 gives '/', so an implementation that reuses the directory's public_key alphabet produces a digest no other verifier reproduces.",
+  "key_thumbprint_vectors": [
+    {
+      "name": "ML-DSA-44 all-zero key",
+      "key": {
+        "alg": "ML-DSA-44",
+        "fill": 0,
+        "len": 1312
       },
-      {
-        "name": "ML-DSA-65 all-zero key",
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 0,
-          "len": 1952
-        },
-        "thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+      "thumbprint": "sha256:d822401dad5b6a8832b186e94c3be90b0918823b9f24dae4720432d208bfd9f5"
+    },
+    {
+      "name": "ML-DSA-65 all-zero key",
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 0,
+        "len": 1952
       },
-      {
-        "name": "ML-DSA-65 all-0x01 key",
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 1,
-          "len": 1952
-        },
-        "thumbprint": "sha256:f1c75378c00886a8c6b2df96564b21e5c189e2b4366fa78c8e42fb207c34c2ac"
+      "thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+    },
+    {
+      "name": "ML-DSA-65 all-0x01 key",
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 1,
+        "len": 1952
       },
-      {
-        "name": "ML-DSA-87 all-0xff key (base64url alphabet: pub is all '_', standard base64 would be '/')",
-        "key": {
-          "alg": "ML-DSA-87",
-          "fill": 255,
-          "len": 2592
-        },
-        "thumbprint": "sha256:95078132ec612bea77887e77a1652ee0df411afd32596dd647a15e378ea8dd92"
+      "thumbprint": "sha256:f1c75378c00886a8c6b2df96564b21e5c189e2b4366fa78c8e42fb207c34c2ac"
+    },
+    {
+      "name": "ML-DSA-87 all-0xff key (base64url alphabet: pub is all '_', standard base64 would be '/')",
+      "key": {
+        "alg": "ML-DSA-87",
+        "fill": 255,
+        "len": 2592
+      },
+      "thumbprint": "sha256:95078132ec612bea77887e77a1652ee0df411afd32596dd647a15e378ea8dd92"
+    }
+  ],
+  "key_binding_note": "key_thumbprint binding axis parity table (criterion 458). Expectations are the output of the Python check_key_binding in python/src/asqav/verifier/verify_receipt.py; both suites feed every case through their own implementation. `key` describes the key the signature axis resolved, expanded by each suite as a byte of value `fill` repeated `len` times, so the table stays small and identical in both languages; `key: null` means nothing resolved. ABSENCE is PASS, not SKIPPED: a skip blocks the verdict, and every receipt issued before the field existed omits it. A mismatch is FAIL and key_binding is in _INVALID_FAIL_AXES, so the verdict is unverified with failure_class invalid, never a warning. The two unrecomputable cases report SKIPPED, which also blocks, so an unverifiable binding cannot read as verified.",
+  "key_binding": [
+    {
+      "name": "no key_thumbprint bound",
+      "payload": {},
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 0,
+        "len": 1952
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "receipt binds no key_thumbprint; binding not checked"
       }
-    ],
-    "key_binding_note": "key_thumbprint binding axis parity table (criterion 458). Expectations are the output of the Python check_key_binding in python/src/asqav/verifier/verify_receipt.py; both suites feed every case through their own implementation. `key` describes the key the signature axis resolved, expanded by each suite as a byte of value `fill` repeated `len` times, so the table stays small and identical in both languages; `key: null` means nothing resolved. ABSENCE is PASS, not SKIPPED: a skip blocks the verdict, and every receipt issued before the field existed omits it. A mismatch is FAIL and key_binding is in _INVALID_FAIL_AXES, so the verdict is unverified with failure_class invalid, never a warning. The two unrecomputable cases report SKIPPED, which also blocks, so an unverifiable binding cannot read as verified.",
-    "key_binding": [
-      {
-        "name": "no key_thumbprint bound",
-        "payload": {},
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 0,
-          "len": 1952
-        },
-        "expect": {
-          "result": "PASS",
-          "note_contains": "receipt binds no key_thumbprint; binding not checked"
-        }
+    },
+    {
+      "name": "bound thumbprint rederives from the resolved key",
+      "payload": {
+        "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
       },
-      {
-        "name": "bound thumbprint rederives from the resolved key",
-        "payload": {
-          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
-        },
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 0,
-          "len": 1952
-        },
-        "expect": {
-          "result": "PASS",
-          "note_contains": "rederives from the resolved ML-DSA-65 key"
-        }
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 0,
+        "len": 1952
       },
-      {
-        "name": "ML-DSA-44 binding rederives",
-        "payload": {
-          "key_thumbprint": "sha256:d822401dad5b6a8832b186e94c3be90b0918823b9f24dae4720432d208bfd9f5"
-        },
-        "key": {
-          "alg": "ML-DSA-44",
-          "fill": 0,
-          "len": 1312
-        },
-        "expect": {
-          "result": "PASS",
-          "note_contains": "rederives from the resolved ML-DSA-44 key"
-        }
-      },
-      {
-        "name": "ML-DSA-87 binding rederives over the base64url alphabet",
-        "payload": {
-          "key_thumbprint": "sha256:95078132ec612bea77887e77a1652ee0df411afd32596dd647a15e378ea8dd92"
-        },
-        "key": {
-          "alg": "ML-DSA-87",
-          "fill": 255,
-          "len": 2592
-        },
-        "expect": {
-          "result": "PASS",
-          "note_contains": "rederives from the resolved ML-DSA-87 key"
-        }
-      },
-      {
-        "name": "key substituted under the same identifier",
-        "payload": {
-          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
-        },
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 1,
-          "len": 1952
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "key_substituted"
-        }
-      },
-      {
-        "name": "alg participates in the digest: a 44 key cannot satisfy a 65 binding",
-        "payload": {
-          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
-        },
-        "key": {
-          "alg": "ML-DSA-44",
-          "fill": 0,
-          "len": 1312
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "key_substituted"
-        }
-      },
-      {
-        "name": "standard-base64 pub yields a digest the AKP form never produces",
-        "payload": {
-          "key_thumbprint": "sha256:e187b36fdf876583a6a6429591900efd1b636ce6a6d00f48c85451a4278d2650"
-        },
-        "key": {
-          "alg": "ML-DSA-87",
-          "fill": 255,
-          "len": 2592
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "key_substituted"
-        }
-      },
-      {
-        "name": "malformed: digest too short",
-        "payload": {
-          "key_thumbprint": "sha256:abc"
-        },
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 0,
-          "len": 1952
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "is not sha256:<64 lowercase hex>"
-        }
-      },
-      {
-        "name": "malformed: uppercase hex",
-        "payload": {
-          "key_thumbprint": "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-        },
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 0,
-          "len": 1952
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "is not sha256:<64 lowercase hex>"
-        }
-      },
-      {
-        "name": "malformed: wrong digest prefix",
-        "payload": {
-          "key_thumbprint": "sha1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 0,
-          "len": 1952
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "is not sha256:<64 lowercase hex>"
-        }
-      },
-      {
-        "name": "malformed: bare hex with no prefix",
-        "payload": {
-          "key_thumbprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 0,
-          "len": 1952
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "is not sha256:<64 lowercase hex>"
-        }
-      },
-      {
-        "name": "malformed: not a string",
-        "payload": {
-          "key_thumbprint": 42
-        },
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 0,
-          "len": 1952
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "is not sha256:<64 lowercase hex>"
-        }
-      },
-      {
-        "name": "no key resolved, so nothing to rederive from",
-        "payload": {
-          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
-        },
-        "key": null,
-        "expect": {
-          "result": "SKIPPED",
-          "note_contains": "no signing key resolved"
-        }
-      },
-      {
-        "name": "resolved key is not raw ML-DSA material (the KMS PEM row)",
-        "payload": {
-          "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
-        },
-        "key": {
-          "alg": "ML-DSA-65",
-          "fill": 0,
-          "len": 800
-        },
-        "expect": {
-          "result": "SKIPPED",
-          "note_contains": "not raw ML-DSA material"
-        }
-      },
-      {
-        "name": "absence stays conformant even when no key resolved",
-        "payload": {},
-        "key": null,
-        "expect": {
-          "result": "PASS",
-          "note_contains": "binding not checked"
-        }
+      "expect": {
+        "result": "PASS",
+        "note_contains": "rederives from the resolved ML-DSA-65 key"
       }
-    ],
-    "receipt_integrity_note": "Receipt-internal integrity axes (payload_digest, counterparty). Expectations are the output of the Python check_payload_digest / check_counterparty_binding in python/src/asqav/verifier/verify_receipt.py; both suites feed every case through their own implementation. payload_digest is recomputable with NO external data whenever the receipt carries both a context and a digest over it, so the two disagreeing proves one of them is a lie. counterparty_binding is caller-supplied corroboration: absence PASSes, a claim the verifier cannot resolve reports SKIPPED (which blocks, so it never reads as corroborated), and malformed or mismatched FAILs.",
-    "payload_digest": [
-      {
-        "name": "no payload_digest bound",
-        "payload": {
-          "context": {
-            "amount": 100,
-            "currency": "EUR"
-          }
-        },
-        "expect": {
-          "result": "PASS",
-          "note_contains": "binds no payload_digest"
-        }
+    },
+    {
+      "name": "ML-DSA-44 binding rederives",
+      "payload": {
+        "key_thumbprint": "sha256:d822401dad5b6a8832b186e94c3be90b0918823b9f24dae4720432d208bfd9f5"
       },
-      {
-        "name": "digest rederives from the carried context",
-        "payload": {
-          "context": {
-            "amount": 100,
-            "currency": "EUR"
-          },
-          "payload_digest": {
-            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
-            "size": 31
-          }
-        },
-        "expect": {
-          "result": "PASS",
-          "note_contains": "rederives from the carried context"
-        }
+      "key": {
+        "alg": "ML-DSA-44",
+        "fill": 0,
+        "len": 1312
       },
-      {
-        "name": "digest commits to something the context does not hash to",
-        "payload": {
-          "context": {
-            "amount": 100,
-            "currency": "EUR"
-          },
-          "payload_digest": {
-            "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            "size": 31
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "payload_digest_mismatch"
-        }
-      },
-      {
-        "name": "size disagrees with the canonical context",
-        "payload": {
-          "context": {
-            "amount": 100,
-            "currency": "EUR"
-          },
-          "payload_digest": {
-            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
-            "size": 99999
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "payload_digest_mismatch"
-        }
-      },
-      {
-        "name": "no context carried, nothing to recompute against",
-        "payload": {
-          "payload_digest": {
-            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
-            "size": 31
-          }
-        },
-        "expect": {
-          "result": "PASS",
-          "note_contains": "no context carried"
-        }
-      },
-      {
-        "name": "explicit null context reads as absent",
-        "payload": {
-          "context": null,
-          "payload_digest": {
-            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e"
-          }
-        },
-        "expect": {
-          "result": "PASS",
-          "note_contains": "no context carried"
-        }
-      },
-      {
-        "name": "payload_digest is not an object",
-        "payload": {
-          "context": {
-            "amount": 100,
-            "currency": "EUR"
-          },
-          "payload_digest": "nope"
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "not an object"
-        }
-      },
-      {
-        "name": "hash is not 64 lowercase hex",
-        "payload": {
-          "context": {
-            "amount": 100,
-            "currency": "EUR"
-          },
-          "payload_digest": {
-            "hash": "ABC"
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "not 64 lowercase hex"
-        }
-      },
-      {
-        "name": "hash is uppercase hex",
-        "payload": {
-          "context": {
-            "amount": 100,
-            "currency": "EUR"
-          },
-          "payload_digest": {
-            "hash": "F50D36C1739463E571DA8E929FDEB3BC35C5BF86051C653D6A61DEEDCB10944E"
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "not 64 lowercase hex"
-        }
-      },
-      {
-        "name": "size is negative",
-        "payload": {
-          "context": {
-            "amount": 100,
-            "currency": "EUR"
-          },
-          "payload_digest": {
-            "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
-            "size": -1
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "non-negative integer"
-        }
+      "expect": {
+        "result": "PASS",
+        "note_contains": "rederives from the resolved ML-DSA-44 key"
       }
-    ],
-    "counterparty_binding": [
-      {
-        "name": "no counterparty binding claimed",
-        "payload": {},
-        "expect": {
-          "result": "PASS",
-          "note_contains": "unilaterally asserted"
-        }
+    },
+    {
+      "name": "ML-DSA-87 binding rederives over the base64url alphabet",
+      "payload": {
+        "key_thumbprint": "sha256:95078132ec612bea77887e77a1652ee0df411afd32596dd647a15e378ea8dd92"
       },
-      {
-        "name": "claimed but no originating receipt supplied",
-        "payload": {
-          "counterparty_binding": {
-            "receipt_ref": "sig_X",
-            "envelope_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-          }
-        },
-        "expect": {
-          "result": "SKIPPED",
-          "note_contains": "corroboration is unchecked"
-        }
+      "key": {
+        "alg": "ML-DSA-87",
+        "fill": 255,
+        "len": 2592
       },
-      {
-        "name": "binding is not an object",
-        "payload": {
-          "counterparty_binding": "nope"
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "not an object"
-        }
-      },
-      {
-        "name": "receipt_ref missing",
-        "payload": {
-          "counterparty_binding": {
-            "envelope_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "receipt_ref missing"
-        }
-      },
-      {
-        "name": "envelope_hash missing",
-        "payload": {
-          "counterparty_binding": {
-            "receipt_ref": "sig_X"
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "envelope_hash missing"
-        }
-      },
-      {
-        "name": "envelope_hash is not base64",
-        "payload": {
-          "counterparty_binding": {
-            "receipt_ref": "sig_X",
-            "envelope_hash": "!!!not-b64!!!"
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "is not base64"
-        }
-      },
-      {
-        "name": "envelope_hash is not a sha-256 width",
-        "payload": {
-          "counterparty_binding": {
-            "receipt_ref": "sig_X",
-            "envelope_hash": "c2hvcnQ="
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "not a sha-256"
-        }
-      },
-      {
-        "name": "expect_ack_from is not a string",
-        "payload": {
-          "counterparty_binding": {
-            "receipt_ref": "sig_X",
-            "envelope_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-            "expect_ack_from": 7
-          }
-        },
-        "expect": {
-          "result": "FAIL",
-          "note_contains": "expect_ack_from is not a string"
-        }
+      "expect": {
+        "result": "PASS",
+        "note_contains": "rederives from the resolved ML-DSA-87 key"
       }
-    ]
+    },
+    {
+      "name": "key substituted under the same identifier",
+      "payload": {
+        "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+      },
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 1,
+        "len": 1952
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "key_substituted"
+      }
+    },
+    {
+      "name": "alg participates in the digest: a 44 key cannot satisfy a 65 binding",
+      "payload": {
+        "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+      },
+      "key": {
+        "alg": "ML-DSA-44",
+        "fill": 0,
+        "len": 1312
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "key_substituted"
+      }
+    },
+    {
+      "name": "standard-base64 pub yields a digest the AKP form never produces",
+      "payload": {
+        "key_thumbprint": "sha256:e187b36fdf876583a6a6429591900efd1b636ce6a6d00f48c85451a4278d2650"
+      },
+      "key": {
+        "alg": "ML-DSA-87",
+        "fill": 255,
+        "len": 2592
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "key_substituted"
+      }
+    },
+    {
+      "name": "malformed: digest too short",
+      "payload": {
+        "key_thumbprint": "sha256:abc"
+      },
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 0,
+        "len": 1952
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "is not sha256:<64 lowercase hex>"
+      }
+    },
+    {
+      "name": "malformed: uppercase hex",
+      "payload": {
+        "key_thumbprint": "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      },
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 0,
+        "len": 1952
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "is not sha256:<64 lowercase hex>"
+      }
+    },
+    {
+      "name": "malformed: wrong digest prefix",
+      "payload": {
+        "key_thumbprint": "sha1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 0,
+        "len": 1952
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "is not sha256:<64 lowercase hex>"
+      }
+    },
+    {
+      "name": "malformed: bare hex with no prefix",
+      "payload": {
+        "key_thumbprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 0,
+        "len": 1952
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "is not sha256:<64 lowercase hex>"
+      }
+    },
+    {
+      "name": "malformed: not a string",
+      "payload": {
+        "key_thumbprint": 42
+      },
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 0,
+        "len": 1952
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "is not sha256:<64 lowercase hex>"
+      }
+    },
+    {
+      "name": "no key resolved, so nothing to rederive from",
+      "payload": {
+        "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+      },
+      "key": null,
+      "expect": {
+        "result": "SKIPPED",
+        "note_contains": "no signing key resolved"
+      }
+    },
+    {
+      "name": "resolved key is not raw ML-DSA material (the KMS PEM row)",
+      "payload": {
+        "key_thumbprint": "sha256:6c5527f63dbf9e252375ad2bf114074d995a389a0d818cce38b3a25794f875de"
+      },
+      "key": {
+        "alg": "ML-DSA-65",
+        "fill": 0,
+        "len": 800
+      },
+      "expect": {
+        "result": "SKIPPED",
+        "note_contains": "not raw ML-DSA material"
+      }
+    },
+    {
+      "name": "absence stays conformant even when no key resolved",
+      "payload": {},
+      "key": null,
+      "expect": {
+        "result": "PASS",
+        "note_contains": "binding not checked"
+      }
+    }
+  ],
+  "receipt_integrity_note": "Receipt-internal integrity axes (payload_digest, counterparty). Expectations are the output of the Python check_payload_digest / check_counterparty_binding in python/src/asqav/verifier/verify_receipt.py; both suites feed every case through their own implementation. payload_digest is recomputable with NO external data whenever the receipt carries both a context and a digest over it, so the two disagreeing proves one of them is a lie. counterparty_binding is caller-supplied corroboration: absence PASSes, a claim the verifier cannot resolve reports SKIPPED (which blocks, so it never reads as corroborated), and malformed or mismatched FAILs.",
+  "payload_digest": [
+    {
+      "name": "no payload_digest bound",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        }
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "binds no payload_digest"
+      }
+    },
+    {
+      "name": "digest rederives from the carried context",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        },
+        "payload_digest": {
+          "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+          "size": 31
+        }
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "rederives from the carried context"
+      }
+    },
+    {
+      "name": "digest commits to something the context does not hash to",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        },
+        "payload_digest": {
+          "hash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "size": 31
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "payload_digest_mismatch"
+      }
+    },
+    {
+      "name": "size disagrees with the canonical context",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        },
+        "payload_digest": {
+          "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+          "size": 99999
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "payload_digest_mismatch"
+      }
+    },
+    {
+      "name": "no context carried, nothing to recompute against",
+      "payload": {
+        "payload_digest": {
+          "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+          "size": 31
+        }
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "no context carried"
+      }
+    },
+    {
+      "name": "explicit null context reads as absent",
+      "payload": {
+        "context": null,
+        "payload_digest": {
+          "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e"
+        }
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "no context carried"
+      }
+    },
+    {
+      "name": "payload_digest is not an object",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        },
+        "payload_digest": "nope"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "not an object"
+      }
+    },
+    {
+      "name": "hash is not 64 lowercase hex",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        },
+        "payload_digest": {
+          "hash": "ABC"
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "not 64 lowercase hex"
+      }
+    },
+    {
+      "name": "hash is uppercase hex",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        },
+        "payload_digest": {
+          "hash": "F50D36C1739463E571DA8E929FDEB3BC35C5BF86051C653D6A61DEEDCB10944E"
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "not 64 lowercase hex"
+      }
+    },
+    {
+      "name": "size is negative",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        },
+        "payload_digest": {
+          "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+          "size": -1
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "non-negative integer"
+      }
+    }
+  ],
+  "counterparty_binding": [
+    {
+      "name": "no counterparty binding claimed",
+      "payload": {},
+      "expect": {
+        "result": "PASS",
+        "note_contains": "unilaterally asserted"
+      }
+    },
+    {
+      "name": "claimed but no originating receipt supplied",
+      "payload": {
+        "counterparty_binding": {
+          "receipt_ref": "sig_X",
+          "envelope_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        }
+      },
+      "expect": {
+        "result": "SKIPPED",
+        "note_contains": "corroboration is unchecked"
+      }
+    },
+    {
+      "name": "binding is not an object",
+      "payload": {
+        "counterparty_binding": "nope"
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "not an object"
+      }
+    },
+    {
+      "name": "receipt_ref missing",
+      "payload": {
+        "counterparty_binding": {
+          "envelope_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "receipt_ref missing"
+      }
+    },
+    {
+      "name": "envelope_hash missing",
+      "payload": {
+        "counterparty_binding": {
+          "receipt_ref": "sig_X"
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "envelope_hash missing"
+      }
+    },
+    {
+      "name": "envelope_hash is not base64",
+      "payload": {
+        "counterparty_binding": {
+          "receipt_ref": "sig_X",
+          "envelope_hash": "!!!not-b64!!!"
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "is not base64"
+      }
+    },
+    {
+      "name": "envelope_hash is not a sha-256 width",
+      "payload": {
+        "counterparty_binding": {
+          "receipt_ref": "sig_X",
+          "envelope_hash": "c2hvcnQ="
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "not a sha-256"
+      }
+    },
+    {
+      "name": "expect_ack_from is not a string",
+      "payload": {
+        "counterparty_binding": {
+          "receipt_ref": "sig_X",
+          "envelope_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "expect_ack_from": 7
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "expect_ack_from is not a string"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
The TypeScript ISO parser range-checked the seconds field as `Number(ss) > 59`.
With a fractional stamp that string is `"59.656"`, and `59.656 > 59`, so the
parser returned `null` and the axis reported the value **unreadable**.
`Date#toISOString` always emits milliseconds, so roughly **one receipt in sixty**
lands in the 59th second and was refused.

## Blast radius

Both axes share the parser:

| field | reported as | failure class |
|---|---|---|
| `expires_at` | `unreadable expires_at …` FAIL | `unverifiable` |
| `issued_at` | `unparseable issued_at …` FAIL | **`invalid`** |

So a perfectly valid receipt could be reported as *provably bad*, depending only
on which second of the minute it was minted in.

## It is also a cross-language split

Python range-checks a two-digit regex capture, so `int("59")` is `59` and the
same bytes verify there. Confirmed both directions:

```
2099-01-01T06:30:59.656Z   Python: PASS      TypeScript: FAIL "unreadable"
2099-01-01T06:30:58.656Z   Python: PASS      TypeScript: PASS
```

The fix range-checks whole seconds only, mirroring Python exactly — second `60`
is still refused.

## Gated so it cannot come back

Three expiry cases and one skew case were added to
`verifier/axis-parity-cases.json`, the shared table **both** suites drive, so a
regression in either language fails a suite. Reverting the fix fails exactly
those three cases in TypeScript while Python stays green — the split reproduced
on demand.

Python 2915 passed, TypeScript 1087 passed, `tsc` clean.

## How it surfaced

A corpus run tripped it at `06:30:59` UTC on the CI clock. Nothing in the corpus
carries a 59th-second fractional stamp, which is why it survived this long.
