### PR TITLE
chore(release): 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.4] - 2026-09-01
+
+### Fixed
+
+- **A valid receipt could be reported as provably bad, decided by nothing but the
+  second of the minute it was signed in.** The TypeScript ISO parser range-checked
+  the seconds field as `Number(ss) > 59`. On a fractional stamp that string is
+  `"59.656"`, and `59.656 > 59`, so the parser returned `null` and the axis called
+  the value unreadable. `Date#toISOString` always emits milliseconds, so roughly
+  one receipt in sixty — any minted during the 59th second — was refused. It
+  reached both axes sharing the parser: `expires_at` FAILed as `unverifiable`, and
+  `issued_at` FAILed as **`invalid`**. It was also a cross-language split, since
+  Python range-checks a two-digit capture and verified the same bytes. Fixed to
+  range-check whole seconds only, mirroring Python; second 60 is still refused.
+  **Anyone verifying receipts with the TypeScript half should upgrade.**
+
+### Added
+
+- Four `seq` continuity conformance vectors in the shared corpus, and the
+  fractional-second cases in `verifier/axis-parity-cases.json` — the shared table
+  both language suites drive, so a future divergence of this kind fails in CI
+  rather than in a caller's verdict.
+
 ## [0.10.3] - 2026-09-01
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.3"
+version = "0.10.4"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -186,7 +186,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -3,7 +3,7 @@
  * added under Node, since browsers forbid setting User-Agent on fetch.
  */
 
-export const SDK_VERSION = "0.10.3";
+export const SDK_VERSION = "0.10.4";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Cuts 0.10.4. The five bump files plus the changelog entry.

**Why this should not wait:** the release carries the TypeScript ISO parser fix, which is a live wrong-verdict bug in what the registries serve today. The parser range-checked the seconds field as `Number(ss) > 59`; on a fractional stamp that string is `"59.656"`, and `59.656 > 59`, so it returned null and the axis called the value unreadable. `Date#toISOString` always emits milliseconds, so roughly one receipt in sixty — any minted during the 59th second — was refused. On `expires_at` that FAILs as `unverifiable`; on `issued_at` it FAILs as `invalid`, i.e. a valid receipt reported as provably bad. The Python half range-checks a two-digit capture and accepted the same bytes, so it was also a cross-language split.

Also ships the four seq continuity conformance vectors and the fractional-second cases in the shared axis-parity table both suites drive.

Local verification on this branch: python 2915 passed / 1 skipped, typescript 1087 passed across 65 files. Registries confirmed serving 0.10.3, so the number is free.

Publish is tag-gated; the py- and ts- tags go up after this merges.