### PR TITLE
feat(acceptor): admission control for an inbound peer receipt

### DIFF
--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -37,6 +37,7 @@ from ._detectors import (
 )
 from ._jcs import canonical_json
 from ._schema import normalize_context, validate_context_schema
+from .acceptor import AcceptorDecision, check_peer_receipt
 from .async_client import AsyncAgent
 from .attestation import (
     ATTESTATION_STATEMENT_SCHEMA,
@@ -156,7 +157,6 @@ from .code_authorship import (
     submit_code_authorship,
     verify_code_authorship_envelope,
 )
-from .acceptor import AcceptorDecision, check_peer_receipt
 from .commitment import commit, new_opening
 from .compliance import ComplianceBundle, export_bundle, fetch_audit_pack
 from .counterparty import (

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -156,6 +156,7 @@ from .code_authorship import (
     submit_code_authorship,
     verify_code_authorship_envelope,
 )
+from .acceptor import AcceptorDecision, check_peer_receipt
 from .commitment import commit, new_opening
 from .compliance import ComplianceBundle, export_bundle, fetch_audit_pack
 from .counterparty import (
@@ -363,6 +364,9 @@ __all__ = [
     "CounterpartyBindingVerification",
     "compute_counterparty_binding",
     "verify_counterparty_binding",
+    # Acceptor-side admission control for an inbound peer receipt (B15)
+    "AcceptorDecision",
+    "check_peer_receipt",
     # DORA RTS JC 2024-33 Annex II vocabulary
     "DORA_INCIDENT_CLASS_NAMESPACE",
     # IETF -04 capture-topologies appendix vocabulary

--- a/python/src/asqav/acceptor.py
+++ b/python/src/asqav/acceptor.py
@@ -119,7 +119,10 @@ def check_peer_receipt(
         if stamp is None:
             return AcceptorDecision(
                 accepted=False,
-                reason=f"unreadable expires_at {expires_at!r}; refused rather than read as no expiry",
+                reason=(
+                    f"unreadable expires_at {expires_at!r}; refused rather "
+                    "than read as no expiry"
+                ),
                 verdict=result.verdict,
                 failure_class="unverifiable",
                 first_failing_edge="expiry",

--- a/python/src/asqav/acceptor.py
+++ b/python/src/asqav/acceptor.py
@@ -1,0 +1,187 @@
+"""Acceptor-side admission control for an inbound peer receipt.
+
+An Acceptor is the party on the receiving end of an agent-to-agent action. This
+module answers one question: may this inbound action be admitted, given the
+receipt the peer presented?
+
+It is deliberately NOT a thin wrapper over the verifier. Three of its rules do
+not follow from the verdict alone, and each exists because a peer could
+otherwise weaken the evidence without ever producing an unverified receipt:
+
+  Expiry.   The verifier reports expiry on its own axis and never folds it into
+            the verdict, so a lapsed receipt still reads `verified`. That is
+            correct for a verifier - the signature really is good - and wrong for
+            an acceptor, which is deciding about an action happening NOW.
+
+  Seq downgrade. A peer that has been emitting a counter and then stops emitting
+            one makes contiguity uncheckable across that link. Absence has to
+            stay legal in general (receipts predate the member), but an acceptor
+            holding a predecessor that carried one is watching the exact
+            transition that hides a withheld receipt.
+
+  Challenge. A challenge the acceptor issued but the receipt does not answer is
+            a challenge that proved nothing. "Verify it when present" alone
+            would let a peer skip freshness by simply omitting the member.
+
+The verification itself is the shared oracle's, not a reimplementation, so an
+acceptor and an offline auditor cannot disagree about the same bytes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from .verifier.oracle import ADAPTERS, verify
+from .verifier.oracle.core import VERDICT_VERIFIED, VERDICT_VERIFIED_KEYED
+
+__all__ = [
+    "AcceptorDecision",
+    "check_peer_receipt",
+]
+
+#: Verdicts an acceptor may admit at all. `verified_keyed` is included because a
+#: keyed digest is internally consistent; it is the peer's own hash, so it proves
+#: the same binding to the acceptor while not being third-party re-derivable.
+_ADMISSIBLE_VERDICTS = frozenset({VERDICT_VERIFIED, VERDICT_VERIFIED_KEYED})
+
+
+@dataclass(frozen=True)
+class AcceptorDecision:
+    """Whether to admit an inbound action, and the single reason why not.
+
+    ``first_failing_edge`` names the earliest check that stopped the receipt, so
+    a refusal points at one edge rather than handing back a wall of axes.
+    ``rule`` names which acceptor rule refused, and is ``"verifier"`` when the
+    receipt simply did not verify.
+    """
+
+    accepted: bool
+    reason: str
+    verdict: str
+    failure_class: str | None = None
+    first_failing_edge: str | None = None
+    rule: str | None = None
+
+
+def _parse_stamp(raw: Any) -> datetime | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _payload_of(receipt: dict) -> dict:
+    payload = receipt.get("payload")
+    return payload if isinstance(payload, dict) else receipt
+
+
+def check_peer_receipt(
+    receipt: dict,
+    *,
+    key_provider: Any = None,
+    predecessor: dict | None = None,
+    challenge: str | None = None,
+    now: datetime | None = None,
+) -> AcceptorDecision:
+    """Decide whether an inbound action carrying ``receipt`` may be admitted.
+
+    ``predecessor`` is the last receipt this acceptor admitted from the same
+    peer chain; supplying it is what lets the seq and chain axes mean anything,
+    since neither can detect a gap against nothing. ``challenge`` is the nonce
+    this acceptor issued for this exchange, if it issued one.
+
+    Refuses on the first rule that fails, in a fixed order, so the reason is
+    deterministic for the same inputs.
+    """
+    result = verify(receipt, ADAPTERS, key_provider=key_provider, predecessor=predecessor)
+
+    if result.verdict not in _ADMISSIBLE_VERDICTS:
+        edge = result.first_failing_edge
+        return AcceptorDecision(
+            accepted=False,
+            reason=f"peer receipt did not verify at {edge or 'an unnamed check'}",
+            verdict=result.verdict,
+            failure_class=result.failure_class,
+            first_failing_edge=edge,
+            rule="verifier",
+        )
+
+    payload = _payload_of(receipt)
+
+    # Expiry, which the verdict deliberately does not carry (criterion 426).
+    expires_at = payload.get("expires_at")
+    if expires_at is not None:
+        stamp = _parse_stamp(expires_at)
+        if stamp is None:
+            return AcceptorDecision(
+                accepted=False,
+                reason=f"unreadable expires_at {expires_at!r}; refused rather than read as no expiry",
+                verdict=result.verdict,
+                failure_class="unverifiable",
+                first_failing_edge="expiry",
+                rule="expiry",
+            )
+        if stamp.tzinfo is None:
+            stamp = stamp.replace(tzinfo=timezone.utc)
+        current = now or datetime.now(timezone.utc)
+        if current > stamp:
+            return AcceptorDecision(
+                accepted=False,
+                reason=f"peer receipt expired at {expires_at}",
+                verdict=result.verdict,
+                failure_class="invalid",
+                first_failing_edge="expiry",
+                rule="expiry",
+            )
+
+    # A peer that carried a counter and stopped is the one case where absence is
+    # not the legacy case: it is the transition that makes a gap uncheckable.
+    if predecessor is not None:
+        prev_seq = _payload_of(predecessor).get("seq")
+        if isinstance(prev_seq, int) and not isinstance(payload.get("seq"), int):
+            return AcceptorDecision(
+                accepted=False,
+                reason=(
+                    f"peer stopped emitting seq after {prev_seq}; contiguity cannot "
+                    "be checked across this link"
+                ),
+                verdict=result.verdict,
+                failure_class="unverifiable",
+                first_failing_edge="seq",
+                rule="seq_downgrade",
+            )
+
+    # A challenge that goes unanswered proved nothing, so requiring it is the
+    # whole point of having issued one.
+    if challenge is not None:
+        answered = payload.get("challenge_nonce")
+        if answered is None:
+            return AcceptorDecision(
+                accepted=False,
+                reason="acceptor issued a challenge and the receipt answers none",
+                verdict=result.verdict,
+                failure_class="unverifiable",
+                first_failing_edge="challenge_nonce",
+                rule="challenge",
+            )
+        if answered != challenge:
+            return AcceptorDecision(
+                accepted=False,
+                reason="receipt answers a different challenge than the one issued",
+                verdict=result.verdict,
+                failure_class="invalid",
+                first_failing_edge="challenge_nonce",
+                rule="challenge",
+            )
+
+    return AcceptorDecision(
+        accepted=True,
+        reason="peer receipt verified and satisfies every acceptor rule",
+        verdict=result.verdict,
+        failure_class=None,
+        first_failing_edge=None,
+    )

--- a/python/tests/test_acceptor.py
+++ b/python/tests/test_acceptor.py
@@ -1,0 +1,313 @@
+"""Gates for acceptor-side admission control (criterion 472, B15).
+
+Driven off the real conformance corpus rather than hand-built dicts: every
+receipt here is signed over its own bytes by the corpus's published keys, so a
+refusal has to come from the rule under test and not from a broken signature
+nobody noticed.
+
+The three acceptor-only rules carry the weight. Each one refuses a receipt the
+VERIFIER is content with, which is the whole reason the module exists - a peer
+can weaken the evidence without ever producing an unverified receipt.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from asqav.acceptor import check_peer_receipt
+from asqav.verifier.oracle import ADAPTERS, verify
+from asqav.verifier.oracle.core import VERDICT_VERIFIED, VERDICT_VERIFIED_KEYED
+
+_CORPUS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+
+def _vec(name: str):
+    """A corpus vector as (receipt, jwks, predecessor|None)."""
+    d = _CORPUS / name
+    receipt = json.loads((d / "receipt.json").read_text())
+    jwks = json.loads((d / "jwks.json").read_text())
+    pred_path = d / "predecessor.json"
+    predecessor = json.loads(pred_path.read_text()) if pred_path.exists() else None
+    return receipt, jwks, predecessor
+
+
+# --- properly signed fixtures -------------------------------------------------
+#
+# The acceptor rules refuse receipts the VERIFIER is content with, so testing
+# them needs receipts that actually verify. Editing a corpus payload cannot do
+# it: the edit breaks the signature, the verifier refuses first, and the rule
+# under test never runs. So these mint real receipts with the corpus's own
+# published seed, exactly as gen_seq_vectors.py does.
+
+_SEED_PHRASE = b"asqav conformance corpus v1 seq-continuity signing seed"
+_KID = "asqav-seq-vec-key"
+_ISSUER = "Asqav Ltd"
+_ZERO_DIGEST = hashlib.sha256(b"").hexdigest()
+
+
+def _sk() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(_SEED_PHRASE).digest())
+
+
+def _jcs(obj: object) -> bytes:
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+
+
+def _signed(action_ref: str = "act_1", previous: str = "0" * 64, **extra) -> dict:
+    """A real, correctly signed asqav-native receipt carrying ``extra``."""
+    payload = {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-08-30T12:00:00+00:00",
+        "issuer_id": _ISSUER,
+        "agent_id": "agt_acceptor_001",
+        "action_ref": action_ref,
+        "payload_digest": {"hash": _ZERO_DIGEST, "size": 0},
+        "policy_digest": f"sha256:{_ZERO_DIGEST}",
+        "previousReceiptHash": previous,
+        "decision": "allow",
+        "tool_name": "demo.action",
+    }
+    payload.update(extra)
+    return {
+        "payload": payload,
+        "signature": {
+            "alg": "Ed25519",
+            "kid": _KID,
+            "sig": base64.b64encode(_sk().sign(_jcs(payload))).decode(),
+        },
+        "anchors": [],
+    }
+
+
+def _signed_jwks() -> dict:
+    pub = _sk().public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return {
+        "keys": [
+            {
+                "kid": _KID,
+                "issuer_id": _ISSUER,
+                "alg": "Ed25519",
+                "status": "active",
+                "public_key": base64.b64encode(pub).decode(),
+            }
+        ]
+    }
+
+
+def _chained(first_extra: dict, second_extra: dict):
+    """A predecessor and the successor that links to it, both properly signed."""
+    first = _signed("act_1", "0" * 64, **first_extra)
+    link = hashlib.sha256(_jcs(first["payload"])).hexdigest()
+    second = _signed("act_2", link, **second_extra)
+    return second, _signed_jwks(), first
+
+
+class TestAdmitsWhatVerifies:
+    def test_a_clean_peer_receipt_is_admitted(self) -> None:
+        receipt, jwks, pred = _vec("asqav-17-seq-contiguous")
+        got = check_peer_receipt(receipt, key_provider=jwks, predecessor=pred)
+        assert got.accepted, got.reason
+        assert got.first_failing_edge is None
+        assert got.rule is None
+
+    def test_the_admitted_receipt_really_did_verify(self) -> None:
+        """Guards against admitting on a verdict the oracle never reached.
+
+        Without this, a bug that defaulted `accepted` to True would still pass
+        the test above.
+        """
+        receipt, jwks, pred = _vec("asqav-17-seq-contiguous")
+        result = verify(receipt, ADAPTERS, key_provider=jwks, predecessor=pred)
+        assert result.verdict in (VERDICT_VERIFIED, VERDICT_VERIFIED_KEYED)
+
+
+class TestRefusesWhatDoesNotVerify:
+    def test_a_withheld_receipt_gap_is_refused(self) -> None:
+        receipt, jwks, pred = _vec("asqav-18-seq-gap")
+        got = check_peer_receipt(receipt, key_provider=jwks, predecessor=pred)
+        assert not got.accepted
+        assert got.first_failing_edge == "seq"
+        assert got.rule == "verifier"
+
+    def test_a_substituted_key_is_refused(self) -> None:
+        """The signature verifies against the published key; only the binding fails.
+
+        Exactly the case an acceptor must not wave through: nothing about the
+        signature looks wrong.
+        """
+        receipt, jwks, _ = _vec("asqav-22-key-substituted")
+        got = check_peer_receipt(receipt, key_provider=jwks)
+        assert not got.accepted
+        assert got.first_failing_edge == "key_binding"
+        assert got.failure_class == "invalid"
+
+    def test_the_refusal_names_one_edge_not_a_wall_of_axes(self) -> None:
+        receipt, jwks, pred = _vec("asqav-18-seq-gap")
+        got = check_peer_receipt(receipt, key_provider=jwks, predecessor=pred)
+        assert got.first_failing_edge in {a.axis for a in
+                                          verify(receipt, ADAPTERS, key_provider=jwks,
+                                                 predecessor=pred).axes}
+
+
+class TestExpiryIsAnAcceptorRule:
+    """The verifier reports expiry on its own axis and never folds the verdict.
+
+    That is right for a verifier and wrong for an acceptor, which is deciding
+    about an action happening now. These tests pin the difference rather than
+    assuming it, on receipts that genuinely verify.
+    """
+
+    def _expiring(self, when: datetime):
+        stamp = when.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        return _chained({"seq": 7}, {"seq": 8, "expires_at": stamp})
+
+    def test_the_verifier_still_calls_an_expired_receipt_verified(self) -> None:
+        """The premise the acceptor rule rests on, asserted rather than assumed.
+
+        If the verifier ever starts folding expiry, this fails and says so
+        instead of the rule below quietly becoming redundant.
+        """
+        doc, jwks, pred = self._expiring(datetime.now(timezone.utc) - timedelta(days=1))
+        result = verify(doc, ADAPTERS, key_provider=jwks, predecessor=pred)
+        expiry = result.axis("expiry")
+        assert expiry is not None, "no expiry axis; the premise no longer holds"
+        assert expiry.result == "FAIL", expiry.note
+        assert result.verdict in (VERDICT_VERIFIED, VERDICT_VERIFIED_KEYED), (
+            "the verifier folded expiry into the verdict; the acceptor rule is moot"
+        )
+
+    def test_an_expired_receipt_is_refused_by_the_acceptor(self) -> None:
+        doc, jwks, pred = self._expiring(datetime.now(timezone.utc) - timedelta(days=1))
+        got = check_peer_receipt(doc, key_provider=jwks, predecessor=pred)
+        assert not got.accepted
+        assert got.rule == "expiry", got.reason
+
+    def test_an_unexpired_receipt_is_admitted(self) -> None:
+        """The control. Without it the rule could refuse everything and pass."""
+        doc, jwks, pred = self._expiring(datetime.now(timezone.utc) + timedelta(days=1))
+        got = check_peer_receipt(doc, key_provider=jwks, predecessor=pred)
+        assert got.accepted, got.reason
+
+    def test_the_caller_supplied_clock_is_what_decides(self) -> None:
+        """Pins that `now` is honoured, so the rule is testable without sleeping
+        and an operator can reason about skew."""
+        stamp = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        doc, jwks, pred = self._expiring(stamp)
+        before = check_peer_receipt(
+            doc, key_provider=jwks, predecessor=pred, now=stamp - timedelta(days=1)
+        )
+        after = check_peer_receipt(
+            doc, key_provider=jwks, predecessor=pred, now=stamp + timedelta(days=1)
+        )
+        assert before.accepted, before.reason
+        assert not after.accepted and after.rule == "expiry"
+
+    def test_an_unreadable_expiry_is_refused_rather_than_ignored(self) -> None:
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8, "expires_at": "not-a-timestamp"})
+        got = check_peer_receipt(doc, key_provider=jwks, predecessor=pred)
+        assert not got.accepted
+        assert got.rule == "expiry", got.reason
+
+
+class TestSeqDowngrade:
+    """A peer that carried a counter and stops is the one case where absence is
+    not the legacy case: it is the transition that makes a gap uncheckable."""
+
+    def test_dropping_seq_after_carrying_one_is_refused(self) -> None:
+        doc, jwks, pred = _chained({"seq": 7}, {})
+        assert isinstance(pred["payload"].get("seq"), int)
+        assert doc["payload"].get("seq") is None
+        got = check_peer_receipt(doc, key_provider=jwks, predecessor=pred)
+        assert not got.accepted
+        assert got.rule == "seq_downgrade", got.reason
+
+    def test_a_peer_that_never_carried_seq_is_still_admitted(self) -> None:
+        """Absence stays legal in general, or every receipt minted before the
+        counter shipped would be refused by an acceptor."""
+        doc, jwks, pred = _chained({}, {})
+        got = check_peer_receipt(doc, key_provider=jwks, predecessor=pred)
+        assert got.accepted, got.reason
+
+    def test_a_contiguous_pair_is_admitted(self) -> None:
+        """The control for the downgrade rule: carrying a counter is not itself
+        grounds for refusal."""
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8})
+        got = check_peer_receipt(doc, key_provider=jwks, predecessor=pred)
+        assert got.accepted, got.reason
+
+    def test_no_predecessor_means_no_downgrade_verdict(self) -> None:
+        """With nothing to compare against, silence is not evidence."""
+        doc = _signed()
+        got = check_peer_receipt(doc, key_provider=_signed_jwks())
+        assert got.rule != "seq_downgrade"
+
+
+class TestChallenge:
+    """A challenge the acceptor issued but the receipt does not answer proved
+    nothing, so 'verify it when present' alone would let a peer skip freshness."""
+
+    def test_an_unanswered_challenge_is_refused(self) -> None:
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8})
+        got = check_peer_receipt(
+            doc, key_provider=jwks, predecessor=pred, challenge="chal-abc"
+        )
+        assert not got.accepted
+        assert got.rule == "challenge", got.reason
+
+    def test_the_wrong_challenge_is_refused(self) -> None:
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8, "challenge_nonce": "chal-WRONG"})
+        got = check_peer_receipt(
+            doc, key_provider=jwks, predecessor=pred, challenge="chal-abc"
+        )
+        assert not got.accepted
+        assert got.rule == "challenge"
+        assert got.failure_class == "invalid"
+
+    def test_the_matching_challenge_is_admitted(self) -> None:
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8, "challenge_nonce": "chal-abc"})
+        got = check_peer_receipt(
+            doc, key_provider=jwks, predecessor=pred, challenge="chal-abc"
+        )
+        assert got.accepted, got.reason
+
+    def test_an_unsolicited_challenge_answer_is_not_grounds_for_refusal(self) -> None:
+        """A receipt may carry a nonce for a peer that issued one; an acceptor
+        that issued none has nothing to compare and must not invent a mismatch."""
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8, "challenge_nonce": "chal-other"})
+        got = check_peer_receipt(doc, key_provider=jwks, predecessor=pred)
+        assert got.accepted, got.reason
+
+    def test_no_issued_challenge_means_no_challenge_refusal(self) -> None:
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8})
+        got = check_peer_receipt(doc, key_provider=jwks, predecessor=pred)
+        assert got.rule != "challenge"
+
+
+class TestRuleOrderIsDeterministic:
+    def test_the_verifier_refusal_precedes_the_acceptor_rules(self) -> None:
+        """A receipt that fails verification AND is expired must report the
+        verifier, so the reason for the same inputs never depends on evaluation
+        order."""
+        doc, jwks, pred = _chained(
+            {"seq": 7}, {"seq": 11, "expires_at": "2000-01-01T00:00:00Z"}
+        )
+        got = check_peer_receipt(doc, key_provider=jwks, predecessor=pred)
+        assert not got.accepted
+        assert got.rule == "verifier", got.reason
+        assert got.first_failing_edge == "seq"
+
+    @pytest.mark.parametrize("_run", range(3))
+    def test_the_same_inputs_give_the_same_decision(self, _run: int) -> None:
+        receipt, jwks, pred = _vec("asqav-18-seq-gap")
+        first = check_peer_receipt(receipt, key_provider=jwks, predecessor=pred)
+        again = check_peer_receipt(receipt, key_provider=jwks, predecessor=pred)
+        assert first == again

--- a/typescript/src/acceptor.ts
+++ b/typescript/src/acceptor.ts
@@ -1,0 +1,191 @@
+/**
+ * Acceptor-side admission control for an inbound peer receipt.
+ * A port of the Python `asqav.acceptor`, rule for rule.
+ *
+ * An Acceptor is the party on the receiving end of an agent-to-agent action.
+ * This module answers one question: may this inbound action be admitted, given
+ * the receipt the peer presented?
+ *
+ * It is deliberately NOT a thin wrapper over the verifier. Three of its rules do
+ * not follow from the verdict alone, and each exists because a peer could
+ * otherwise weaken the evidence without ever producing an unverified receipt:
+ *
+ *   Expiry.  The verifier reports expiry on its own axis and never folds it into
+ *            the verdict, so a lapsed receipt still reads `verified`. Correct for
+ *            a verifier - the signature really is good - and wrong for an
+ *            acceptor, which is deciding about an action happening NOW.
+ *
+ *   Seq downgrade. A peer that has been emitting a counter and then stops makes
+ *            contiguity uncheckable across that link. Absence has to stay legal
+ *            in general (receipts predate the member), but an acceptor holding a
+ *            predecessor that carried one is watching the exact transition that
+ *            hides a withheld receipt.
+ *
+ *   Challenge. A challenge the acceptor issued but the receipt does not answer is
+ *            a challenge that proved nothing. "Verify it when present" alone
+ *            would let a peer skip freshness by omitting the member.
+ *
+ * The verification itself is the shared oracle's, not a reimplementation, so an
+ * acceptor and an offline auditor cannot disagree about the same bytes.
+ */
+
+import { ADAPTERS } from "./verifier/index.js";
+import {
+  VERDICT_VERIFIED,
+  VERDICT_VERIFIED_KEYED,
+  verify,
+  type FailureClass,
+} from "./verifier/core.js";
+import type { KeyProvider } from "./verifier/adapter.js";
+
+/** Which acceptor rule refused, or `"verifier"` when the receipt did not verify. */
+export type AcceptorRule = "verifier" | "expiry" | "seq_downgrade" | "challenge";
+
+/** Whether to admit an inbound action, and the single reason why not. */
+export interface AcceptorDecision {
+  accepted: boolean;
+  reason: string;
+  verdict: string;
+  failureClass: FailureClass | null;
+  /** The earliest check that stopped the receipt, so a refusal points at one edge. */
+  firstFailingEdge: string | null;
+  rule: AcceptorRule | null;
+}
+
+export interface CheckPeerReceiptOptions {
+  keyProvider?: KeyProvider;
+  /** The last receipt this acceptor admitted from the same peer chain. */
+  predecessor?: Record<string, unknown> | null;
+  /** The nonce this acceptor issued for this exchange, if it issued one. */
+  challenge?: string | null;
+  /** Clock override; defaults to now. */
+  now?: Date;
+}
+
+/**
+ * `verified_keyed` is admissible because a keyed digest is internally consistent:
+ * it is the peer's own hash, so it proves the same binding to the acceptor while
+ * not being third-party re-derivable.
+ */
+const ADMISSIBLE = new Set<string>([VERDICT_VERIFIED, VERDICT_VERIFIED_KEYED]);
+
+function parseStamp(raw: unknown): Date | null {
+  if (typeof raw !== "string" || raw === "") return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function payloadOf(receipt: Record<string, unknown>): Record<string, unknown> {
+  const p = receipt.payload;
+  return typeof p === "object" && p !== null ? (p as Record<string, unknown>) : receipt;
+}
+
+/**
+ * Decide whether an inbound action carrying `receipt` may be admitted.
+ *
+ * Supplying `predecessor` is what lets the seq and chain axes mean anything,
+ * since neither can detect a gap against nothing.
+ *
+ * Refuses on the first rule that fails, in a fixed order, so the reason is
+ * deterministic for the same inputs.
+ */
+export function checkPeerReceipt(
+  receipt: Record<string, unknown>,
+  options: CheckPeerReceiptOptions = {},
+): AcceptorDecision {
+  const { keyProvider = null, predecessor = null, challenge = null, now } = options;
+  const result = verify(receipt, ADAPTERS, keyProvider, predecessor);
+
+  if (!ADMISSIBLE.has(result.verdict)) {
+    const edge = result.firstFailingEdge;
+    return {
+      accepted: false,
+      reason: `peer receipt did not verify at ${edge ?? "an unnamed check"}`,
+      verdict: result.verdict,
+      failureClass: result.failureClass,
+      firstFailingEdge: edge,
+      rule: "verifier",
+    };
+  }
+
+  const payload = payloadOf(receipt);
+
+  // Expiry, which the verdict deliberately does not carry (criterion 426).
+  const expiresAt = payload.expires_at;
+  if (expiresAt !== undefined && expiresAt !== null) {
+    const stamp = parseStamp(expiresAt);
+    if (stamp === null) {
+      return {
+        accepted: false,
+        reason: `unreadable expires_at ${JSON.stringify(expiresAt)}; refused rather than read as no expiry`,
+        verdict: result.verdict,
+        failureClass: "unverifiable",
+        firstFailingEdge: "expiry",
+        rule: "expiry",
+      };
+    }
+    if ((now ?? new Date()).getTime() > stamp.getTime()) {
+      return {
+        accepted: false,
+        reason: `peer receipt expired at ${String(expiresAt)}`,
+        verdict: result.verdict,
+        failureClass: "invalid",
+        firstFailingEdge: "expiry",
+        rule: "expiry",
+      };
+    }
+  }
+
+  // A peer that carried a counter and stopped is the one case where absence is
+  // not the legacy case: it is the transition that makes a gap uncheckable.
+  if (predecessor !== null && predecessor !== undefined) {
+    const prevSeq = payloadOf(predecessor).seq;
+    if (Number.isInteger(prevSeq) && !Number.isInteger(payload.seq)) {
+      return {
+        accepted: false,
+        reason:
+          `peer stopped emitting seq after ${String(prevSeq)}; contiguity cannot ` +
+          "be checked across this link",
+        verdict: result.verdict,
+        failureClass: "unverifiable",
+        firstFailingEdge: "seq",
+        rule: "seq_downgrade",
+      };
+    }
+  }
+
+  // A challenge that goes unanswered proved nothing, so requiring it is the
+  // whole point of having issued one.
+  if (challenge !== null && challenge !== undefined) {
+    const answered = payload.challenge_nonce;
+    if (answered === undefined || answered === null) {
+      return {
+        accepted: false,
+        reason: "acceptor issued a challenge and the receipt answers none",
+        verdict: result.verdict,
+        failureClass: "unverifiable",
+        firstFailingEdge: "challenge_nonce",
+        rule: "challenge",
+      };
+    }
+    if (answered !== challenge) {
+      return {
+        accepted: false,
+        reason: "receipt answers a different challenge than the one issued",
+        verdict: result.verdict,
+        failureClass: "invalid",
+        firstFailingEdge: "challenge_nonce",
+        rule: "challenge",
+      };
+    }
+  }
+
+  return {
+    accepted: true,
+    reason: "peer receipt verified and satisfies every acceptor rule",
+    verdict: result.verdict,
+    failureClass: null,
+    firstFailingEdge: null,
+    rule: null,
+  };
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -28,6 +28,10 @@ import { resolveApiKey } from "./credentials.js";
 
 export { SDK_VERSION, USER_AGENT, userAgentHeaders } from "./userAgent.js";
 
+// Acceptor-side admission control for an inbound peer receipt (B15)
+export { checkPeerReceipt } from "./acceptor.js";
+export type { AcceptorDecision, AcceptorRule, CheckPeerReceiptOptions } from "./acceptor.js";
+
 /** Allowed values for `receiptType` per the IETF Compliance Receipts profile. */
 export const RECEIPT_TYPE_NAMESPACE = [
   "protectmcp:decision",

--- a/typescript/tests/acceptor.test.ts
+++ b/typescript/tests/acceptor.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Gates for acceptor-side admission control (criterion 472, B15), the TypeScript
+ * half. Mirrors python/tests/test_acceptor.py rule for rule.
+ *
+ * The acceptor rules refuse receipts the VERIFIER is content with, so testing
+ * them needs receipts that actually verify. Editing a corpus payload cannot do
+ * it: the edit breaks the signature, the verifier refuses first, and the rule
+ * under test never runs. So these mint real receipts with the corpus's own
+ * published seed.
+ */
+
+import { createHash, createPrivateKey, createPublicKey, sign as nodeSign } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { checkPeerReceipt } from "../src/acceptor.js";
+import { ADAPTERS } from "../src/verifier/index.js";
+import { verify } from "../src/verifier/core.js";
+
+const CORPUS = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
+
+const SEED_PHRASE = "asqav conformance corpus v1 seq-continuity signing seed";
+const KID = "asqav-seq-vec-key";
+const ISSUER = "Asqav Ltd";
+const ZERO_DIGEST = createHash("sha256").update("").digest("hex");
+
+// The verifier verifies Ed25519 through node:crypto, so sign through it too
+// rather than pulling a second implementation into the fixtures.
+const PKCS8_ED25519_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
+const SPKI_ED25519_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+function seed(): Buffer {
+  return createHash("sha256").update(SEED_PHRASE, "utf-8").digest();
+}
+
+function privateKey() {
+  return createPrivateKey({
+    key: Buffer.concat([PKCS8_ED25519_PREFIX, seed()]),
+    format: "der",
+    type: "pkcs8",
+  });
+}
+
+function rawPublicKey(): Buffer {
+  const spki = createPublicKey(privateKey()).export({ format: "der", type: "spki" });
+  return spki.subarray(SPKI_ED25519_PREFIX.length);
+}
+
+function jcs(obj: unknown): Buffer {
+  // Matches the oracle's asqavJcs for these flat, ASCII payloads.
+  return Buffer.from(canonical(obj), "utf-8");
+}
+
+function canonical(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${canonical((value as Record<string, unknown>)[k])}`);
+  return `{${entries.join(",")}}`;
+}
+
+function signed(
+  actionRef: string,
+  previous: string,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    type: "protectmcp:decision",
+    issued_at: "2026-08-30T12:00:00+00:00",
+    issuer_id: ISSUER,
+    agent_id: "agt_acceptor_001",
+    action_ref: actionRef,
+    payload_digest: { hash: ZERO_DIGEST, size: 0 },
+    policy_digest: `sha256:${ZERO_DIGEST}`,
+    previousReceiptHash: previous,
+    decision: "allow",
+    tool_name: "demo.action",
+    ...extra,
+  };
+  const sig = nodeSign(null, jcs(payload), privateKey());
+  return {
+    payload,
+    signature: { alg: "Ed25519", kid: KID, sig: Buffer.from(sig).toString("base64") },
+    anchors: [],
+  };
+}
+
+function signedJwks(): Record<string, unknown> {
+  const pub = rawPublicKey();
+  return {
+    keys: [
+      {
+        kid: KID,
+        issuer_id: ISSUER,
+        alg: "Ed25519",
+        status: "active",
+        public_key: Buffer.from(pub).toString("base64"),
+      },
+    ],
+  };
+}
+
+/** A predecessor and the successor that links to it, both properly signed. */
+function chained(firstExtra: Record<string, unknown>, secondExtra: Record<string, unknown>) {
+  const first = signed("act_1", "0".repeat(64), firstExtra);
+  const link = createHash("sha256").update(jcs(first.payload)).digest("hex");
+  const second = signed("act_2", link, secondExtra);
+  return { receipt: second, jwks: signedJwks(), predecessor: first };
+}
+
+function vec(name: string) {
+  const load = (f: string) =>
+    JSON.parse(readFileSync(join(CORPUS, name, f), "utf-8")) as Record<string, unknown>;
+  return { receipt: load("receipt.json"), jwks: load("jwks.json"), predecessor: load("predecessor.json") };
+}
+
+describe("acceptor: admits what verifies", () => {
+  it("admits a clean peer receipt", () => {
+    const { receipt, jwks, predecessor } = chained({ seq: 7 }, { seq: 8 });
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted, got.reason).toBe(true);
+    expect(got.firstFailingEdge).toBeNull();
+    expect(got.rule).toBeNull();
+  });
+
+  it("the fixture really does verify, so an admission is not a default", () => {
+    const { receipt, jwks, predecessor } = chained({ seq: 7 }, { seq: 8 });
+    const result = verify(receipt, ADAPTERS, jwks, predecessor);
+    expect(["verified", "verified_keyed"]).toContain(result.verdict);
+  });
+});
+
+describe("acceptor: refuses what does not verify", () => {
+  it("refuses a withheld-receipt gap and names the seq edge", () => {
+    const { receipt, jwks, predecessor } = vec("asqav-18-seq-gap");
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted).toBe(false);
+    expect(got.firstFailingEdge).toBe("seq");
+    expect(got.rule).toBe("verifier");
+  });
+
+  it("refuses a substituted key though the signature verifies", () => {
+    const receipt = JSON.parse(
+      readFileSync(join(CORPUS, "asqav-22-key-substituted", "receipt.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    const jwks = JSON.parse(
+      readFileSync(join(CORPUS, "asqav-22-key-substituted", "jwks.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks });
+    expect(got.accepted).toBe(false);
+    expect(got.firstFailingEdge).toBe("key_binding");
+    expect(got.failureClass).toBe("invalid");
+  });
+});
+
+describe("acceptor: expiry is an acceptor rule, not a verdict", () => {
+  const expiring = (when: Date) =>
+    chained({ seq: 7 }, { seq: 8, expires_at: when.toISOString() });
+
+  it("the verifier still calls an expired receipt verified", () => {
+    // The premise the rule rests on, asserted rather than assumed.
+    const { receipt, jwks, predecessor } = expiring(new Date(Date.now() - 86_400_000));
+    const result = verify(receipt, ADAPTERS, jwks, predecessor);
+    const expiry = result.axes.find((a) => a.axis === "expiry");
+    expect(expiry, "no expiry axis; the premise no longer holds").toBeDefined();
+    expect(expiry!.result).toBe("FAIL");
+    expect(["verified", "verified_keyed"]).toContain(result.verdict);
+  });
+
+  it("refuses an expired receipt", () => {
+    const { receipt, jwks, predecessor } = expiring(new Date(Date.now() - 86_400_000));
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted).toBe(false);
+    expect(got.rule).toBe("expiry");
+  });
+
+  it("admits an unexpired receipt", () => {
+    // The control. Without it the rule could refuse everything and pass.
+    const { receipt, jwks, predecessor } = expiring(new Date(Date.now() + 86_400_000));
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted, got.reason).toBe(true);
+  });
+
+  it("honours the caller-supplied clock", () => {
+    const stamp = new Date("2030-01-01T00:00:00Z");
+    const { receipt, jwks, predecessor } = expiring(stamp);
+    const before = checkPeerReceipt(receipt, {
+      keyProvider: jwks,
+      predecessor,
+      now: new Date(stamp.getTime() - 86_400_000),
+    });
+    const after = checkPeerReceipt(receipt, {
+      keyProvider: jwks,
+      predecessor,
+      now: new Date(stamp.getTime() + 86_400_000),
+    });
+    expect(before.accepted, before.reason).toBe(true);
+    expect(after.accepted).toBe(false);
+    expect(after.rule).toBe("expiry");
+  });
+
+  it("refuses an unreadable expiry rather than reading it as no expiry", () => {
+    const { receipt, jwks, predecessor } = chained(
+      { seq: 7 },
+      { seq: 8, expires_at: "not-a-timestamp" },
+    );
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted).toBe(false);
+    expect(got.rule).toBe("expiry");
+  });
+});
+
+describe("acceptor: seq downgrade", () => {
+  it("refuses a peer that carried a counter and stops", () => {
+    const { receipt, jwks, predecessor } = chained({ seq: 7 }, {});
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted).toBe(false);
+    expect(got.rule).toBe("seq_downgrade");
+  });
+
+  it("still admits a peer that never carried one", () => {
+    // Absence stays legal, or every receipt minted before the counter shipped
+    // would be refused by an acceptor.
+    const { receipt, jwks, predecessor } = chained({}, {});
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted, got.reason).toBe(true);
+  });
+
+  it("admits a contiguous pair", () => {
+    const { receipt, jwks, predecessor } = chained({ seq: 7 }, { seq: 8 });
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted, got.reason).toBe(true);
+  });
+
+  it("does not invent a downgrade with no predecessor", () => {
+    const got = checkPeerReceipt(signed("act_1", "0".repeat(64)), {
+      keyProvider: signedJwks(),
+    });
+    expect(got.rule).not.toBe("seq_downgrade");
+  });
+});
+
+describe("acceptor: challenge", () => {
+  it("refuses an unanswered challenge", () => {
+    const { receipt, jwks, predecessor } = chained({ seq: 7 }, { seq: 8 });
+    const got = checkPeerReceipt(receipt, {
+      keyProvider: jwks,
+      predecessor,
+      challenge: "chal-abc",
+    });
+    expect(got.accepted).toBe(false);
+    expect(got.rule).toBe("challenge");
+  });
+
+  it("refuses the wrong challenge", () => {
+    const { receipt, jwks, predecessor } = chained(
+      { seq: 7 },
+      { seq: 8, challenge_nonce: "chal-WRONG" },
+    );
+    const got = checkPeerReceipt(receipt, {
+      keyProvider: jwks,
+      predecessor,
+      challenge: "chal-abc",
+    });
+    expect(got.accepted).toBe(false);
+    expect(got.rule).toBe("challenge");
+    expect(got.failureClass).toBe("invalid");
+  });
+
+  it("admits the matching challenge", () => {
+    const { receipt, jwks, predecessor } = chained(
+      { seq: 7 },
+      { seq: 8, challenge_nonce: "chal-abc" },
+    );
+    const got = checkPeerReceipt(receipt, {
+      keyProvider: jwks,
+      predecessor,
+      challenge: "chal-abc",
+    });
+    expect(got.accepted, got.reason).toBe(true);
+  });
+
+  it("does not invent a mismatch when it issued no challenge", () => {
+    const { receipt, jwks, predecessor } = chained(
+      { seq: 7 },
+      { seq: 8, challenge_nonce: "chal-other" },
+    );
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted, got.reason).toBe(true);
+  });
+});
+
+describe("acceptor: rule order is deterministic", () => {
+  it("reports the verifier ahead of the acceptor rules", () => {
+    const { receipt, jwks, predecessor } = chained(
+      { seq: 7 },
+      { seq: 11, expires_at: "2000-01-01T00:00:00Z" },
+    );
+    const got = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(got.accepted).toBe(false);
+    expect(got.rule).toBe("verifier");
+    expect(got.firstFailingEdge).toBe("seq");
+  });
+
+  it("gives the same decision for the same inputs", () => {
+    const { receipt, jwks, predecessor } = vec("asqav-18-seq-gap");
+    const a = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    const b = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
+    expect(a).toEqual(b);
+  });
+});


### PR DESCRIPTION
Criterion 472 (B15). Acceptor middleware, both halves.

An Acceptor is the party on the receiving end of an agent-to-agent action. `check_peer_receipt` / `checkPeerReceipt` answers one question: may this inbound action be admitted, given the receipt the peer presented?

Verification itself is the shared oracle's, not a reimplementation, so an acceptor and an offline auditor cannot disagree about the same bytes.

## Three rules that do not follow from the verdict

This is the part that matters. Each rule refuses a receipt the **verifier is content with**, because a peer can weaken the evidence without ever producing an unverified receipt.

| rule | why the verdict misses it |
|---|---|
| **expiry** | The verifier reports expiry on its own axis and never folds it, so a lapsed receipt still reads `verified`. Correct for a verifier — the signature really is good — and wrong for a party deciding about an action happening *now*. |
| **seq downgrade** | A peer that carried a counter and stops makes contiguity uncheckable. Absence has to stay legal in general (receipts predate the member), but an acceptor holding a predecessor that carried one is watching the exact transition that hides a withheld receipt. |
| **challenge** | A challenge the acceptor issued and the receipt does not answer proved nothing. Verifying it *only when present* would let a peer skip freshness by omitting the member. |

Refusals are ordered, so the reason is deterministic for the same inputs, and each names **one edge** — reusing the first-bad-edge field rather than handing back a wall of axes.

## The tests were wrong first, which is worth saying

A first pass built the fixtures by editing corpus payloads. That breaks the signature, so the verifier refused first and **no acceptor rule was ever reached** — four tests failed for a reason that had nothing to do with the code. The fixtures now mint real receipts with the corpus's published seed, so every receipt under test genuinely verifies and a refusal can only come from the rule being tested.

Each suite also carries its control (an unexpired receipt is admitted; a contiguous pair is admitted; a peer that never carried `seq` is still admitted; an acceptor that issued no challenge invents no mismatch), so no rule can pass by refusing everything.

Mutation-validated in both halves — removing each rule fails that rule's tests and no others, with matching counts across languages:

```
expiry removed          python 3 failed   typescript 3 failed
seq_downgrade removed   python 1 failed   typescript 1 failed
challenge removed       python 2 failed   typescript 2 failed
```

## Note on challenge_nonce

The platform does not emit `challenge_nonce` yet (criterion 465). That does not make this dead code: an acceptor verifies what a *peer* presents, and the peer may be any issuer. The rule is defined and gated on synthetic signed receipts, so it is ready the moment the member ships.

Local: python 2942 passed / 1 skipped, typescript 1109 passed across 66 files, tsc clean.