### PR TITLE
feat(acceptor): ASGI and Connect adapters for the admission decision

### DIFF
--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -37,7 +37,12 @@ from ._detectors import (
 )
 from ._jcs import canonical_json
 from ._schema import normalize_context, validate_context_schema
-from .acceptor import AcceptorDecision, check_peer_receipt
+from .acceptor import (
+    DEFAULT_RECEIPT_HEADER,
+    AcceptorDecision,
+    AcceptorMiddleware,
+    check_peer_receipt,
+)
 from .async_client import AsyncAgent
 from .attestation import (
     ATTESTATION_STATEMENT_SCHEMA,
@@ -366,6 +371,8 @@ __all__ = [
     "verify_counterparty_binding",
     # Acceptor-side admission control for an inbound peer receipt (B15)
     "AcceptorDecision",
+    "AcceptorMiddleware",
+    "DEFAULT_RECEIPT_HEADER",
     "check_peer_receipt",
     # DORA RTS JC 2024-33 Annex II vocabulary
     "DORA_INCIDENT_CLASS_NAMESPACE",

--- a/python/src/asqav/acceptor.py
+++ b/python/src/asqav/acceptor.py
@@ -29,6 +29,8 @@ acceptor and an offline auditor cannot disagree about the same bytes.
 
 from __future__ import annotations
 
+import base64
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -37,7 +39,9 @@ from .verifier.oracle import ADAPTERS, verify
 from .verifier.oracle.core import VERDICT_VERIFIED, VERDICT_VERIFIED_KEYED
 
 __all__ = [
+    "DEFAULT_RECEIPT_HEADER",
     "AcceptorDecision",
+    "AcceptorMiddleware",
     "check_peer_receipt",
 ]
 
@@ -188,3 +192,123 @@ def check_peer_receipt(
         failure_class=None,
         first_failing_edge=None,
     )
+
+
+# --- ASGI adapter -------------------------------------------------------------
+#
+# ASGI is a protocol, not a library, so this turns the decision into deployable
+# middleware for FastAPI/Starlette/Quart with no dependency on any of them. The
+# decision stays in check_peer_receipt: an acceptor that mounts this and one that
+# calls the function directly must refuse the same receipts.
+
+#: Header the peer presents its receipt in, JSON or base64-of-JSON.
+DEFAULT_RECEIPT_HEADER = "x-asqav-receipt"
+
+
+def _decode_receipt(raw: bytes) -> dict | None:
+    """Parse a receipt header, accepting raw JSON or base64-wrapped JSON."""
+    text = raw.decode("utf-8", errors="replace").strip()
+    for candidate in (text, None):
+        if candidate is None:
+            try:
+                text = base64.b64decode(raw, validate=True).decode("utf-8")
+            except Exception:
+                return None
+            candidate = text
+        try:
+            parsed = json.loads(candidate)
+        except (ValueError, TypeError):
+            continue
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+class AcceptorMiddleware:
+    """ASGI middleware refusing a request whose peer receipt is not admissible.
+
+    Fails CLOSED: a request carrying no receipt, or one whose header does not
+    parse, is refused. An acceptor that admitted an unsigned request while
+    refusing a badly-signed one would be strictly worse than having no middleware
+    at all, because the cheapest bypass would be to send nothing.
+
+    ``predecessor_for`` supplies the last receipt admitted from the same peer
+    chain; without it the seq and chain axes have nothing to compare against and
+    a gap cannot be detected. ``challenge_for`` supplies the nonce this acceptor
+    issued for the exchange, if any. Both take the parsed receipt and are
+    deliberately caller-supplied: where that state lives is the deployer's
+    choice, and guessing it here would be wrong for most of them.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        key_provider: Any = None,
+        header: str = DEFAULT_RECEIPT_HEADER,
+        predecessor_for: Any = None,
+        challenge_for: Any = None,
+        status_code: int = 403,
+        exempt_paths: tuple[str, ...] = (),
+    ) -> None:
+        self.app = app
+        self.key_provider = key_provider
+        self.header = header.lower().encode("latin-1")
+        self.predecessor_for = predecessor_for
+        self.challenge_for = challenge_for
+        self.status_code = status_code
+        self.exempt_paths = exempt_paths
+
+    async def _refuse(self, send: Any, reason: str, rule: str | None) -> None:
+        body = json.dumps(
+            {"error": "peer_receipt_refused", "reason": reason, "rule": rule}
+        ).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": self.status_code,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("latin-1")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        # Lifespan and websocket scopes carry no receipt to check; passing them
+        # through is not a bypass because no inbound ACTION rides on them.
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        if scope.get("path", "") in self.exempt_paths:
+            await self.app(scope, receive, send)
+            return
+
+        raw = None
+        for name, value in scope.get("headers") or []:
+            if name.lower() == self.header:
+                raw = value
+                break
+        if raw is None:
+            await self._refuse(send, "no peer receipt presented", "missing")
+            return
+
+        receipt = _decode_receipt(raw)
+        if receipt is None:
+            await self._refuse(send, "peer receipt header is not a JSON object", "malformed")
+            return
+
+        decision = check_peer_receipt(
+            receipt,
+            key_provider=self.key_provider,
+            predecessor=self.predecessor_for(receipt) if self.predecessor_for else None,
+            challenge=self.challenge_for(receipt) if self.challenge_for else None,
+        )
+        if not decision.accepted:
+            await self._refuse(send, decision.reason, decision.rule)
+            return
+
+        scope = dict(scope)
+        scope.setdefault("state", {})
+        scope["state"] = {**scope["state"], "asqav_acceptor_decision": decision}
+        await self.app(scope, receive, send)

--- a/python/tests/test_acceptor.py
+++ b/python/tests/test_acceptor.py
@@ -311,3 +311,136 @@ class TestRuleOrderIsDeterministic:
         first = check_peer_receipt(receipt, key_provider=jwks, predecessor=pred)
         again = check_peer_receipt(receipt, key_provider=jwks, predecessor=pred)
         assert first == again
+
+
+class TestAsgiMiddleware:
+    """The adapter that makes the decision deployable.
+
+    Its own risk is not the verification - that is check_peer_receipt's, already
+    gated above - but the plumbing around it: what happens when no receipt is
+    presented at all, and whether a refusal actually stops the request.
+    """
+
+    def _run(self, mw, headers, path="/act"):
+        """Drive the middleware as an ASGI server would; return (status, body, reached)."""
+        import asyncio
+
+        reached: list[bool] = []
+        sent: list[dict] = []
+
+        async def app(scope, receive, send):
+            reached.append(True)
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        mw.app = app
+        scope = {"type": "http", "path": path, "headers": headers}
+
+        async def receive():
+            return {"type": "http.request", "body": b""}
+
+        async def send(msg):
+            sent.append(msg)
+
+        asyncio.run(mw(scope, receive, send))
+        status = next((m["status"] for m in sent if m["type"] == "http.response.start"), None)
+        body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+        return status, body, bool(reached)
+
+    def _mw(self, **kw):
+        from asqav.acceptor import AcceptorMiddleware
+
+        return AcceptorMiddleware(None, **kw)
+
+    def test_a_request_with_no_receipt_is_refused(self) -> None:
+        """Fails closed. An acceptor that admitted an unsigned request while
+        refusing a badly-signed one would be worse than no middleware, because
+        the cheapest bypass would be to send nothing."""
+        status, body, reached = self._run(self._mw(), headers=[])
+        assert status == 403
+        assert not reached, "the request reached the app despite carrying no receipt"
+        assert b"no peer receipt presented" in body
+
+    def test_a_junk_receipt_header_is_refused(self) -> None:
+        status, body, reached = self._run(
+            self._mw(), headers=[(b"x-asqav-receipt", b"not-json-at-all")]
+        )
+        assert status == 403
+        assert not reached
+
+    def test_a_refused_receipt_never_reaches_the_app(self) -> None:
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 11})
+        mw = self._mw(key_provider=jwks, predecessor_for=lambda _r: pred)
+        status, body, reached = self._run(
+            mw, headers=[(b"x-asqav-receipt", json.dumps(doc).encode())]
+        )
+        assert status == 403
+        assert not reached, "a receipt with a withheld-receipt gap reached the app"
+
+    def test_an_admissible_receipt_reaches_the_app(self) -> None:
+        """The control. Without it the middleware could refuse everything."""
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8})
+        mw = self._mw(key_provider=jwks, predecessor_for=lambda _r: pred)
+        status, _body, reached = self._run(
+            mw, headers=[(b"x-asqav-receipt", json.dumps(doc).encode())]
+        )
+        assert reached, "an admissible receipt was refused"
+        assert status == 200
+
+    def test_a_base64_wrapped_receipt_is_accepted(self) -> None:
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8})
+        mw = self._mw(key_provider=jwks, predecessor_for=lambda _r: pred)
+        packed = base64.b64encode(json.dumps(doc).encode())
+        _status, _body, reached = self._run(mw, headers=[(b"x-asqav-receipt", packed)])
+        assert reached
+
+    def test_a_non_http_scope_passes_through(self) -> None:
+        """Lifespan and websocket scopes carry no receipt; passing them through is
+        not a bypass because no inbound ACTION rides on them."""
+        import asyncio
+
+        reached: list[bool] = []
+
+        async def app(scope, receive, send):
+            reached.append(True)
+
+        mw = self._mw()
+        mw.app = app
+        asyncio.run(mw({"type": "lifespan"}, None, None))
+        assert reached
+
+    def test_an_exempt_path_passes_through(self) -> None:
+        mw = self._mw(exempt_paths=("/health",))
+        _status, _body, reached = self._run(mw, headers=[], path="/health")
+        assert reached
+
+    def test_the_decision_is_handed_to_the_app(self) -> None:
+        """A downstream handler should be able to read why it was admitted rather
+        than verifying a second time."""
+        import asyncio
+
+        doc, jwks, pred = _chained({"seq": 7}, {"seq": 8})
+        seen: list[object] = []
+
+        async def app(scope, receive, send):
+            seen.append(scope["state"]["asqav_acceptor_decision"])
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        from asqav.acceptor import AcceptorMiddleware
+
+        mw = AcceptorMiddleware(app, key_provider=jwks, predecessor_for=lambda _r: pred)
+        scope = {
+            "type": "http",
+            "path": "/act",
+            "headers": [(b"x-asqav-receipt", json.dumps(doc).encode())],
+        }
+
+        async def receive():
+            return {"type": "http.request", "body": b""}
+
+        async def send(_msg):
+            return None
+
+        asyncio.run(mw(scope, receive, send))
+        assert seen and seen[0].accepted

--- a/typescript/src/acceptor.ts
+++ b/typescript/src/acceptor.ts
@@ -189,3 +189,123 @@ export function checkPeerReceipt(
     rule: null,
   };
 }
+
+// --- Connect/Express adapter --------------------------------------------------
+//
+// The handler signature is a convention, not a library, so this turns the
+// decision into deployable middleware for Express/Connect with no dependency on
+// any of them. The decision stays in checkPeerReceipt: an acceptor that mounts
+// this and one that calls the function directly must refuse the same receipts.
+
+/** Header the peer presents its receipt in, JSON or base64-of-JSON. */
+export const DEFAULT_RECEIPT_HEADER = "x-asqav-receipt";
+
+/** Parse a receipt header, accepting raw JSON or base64-wrapped JSON. */
+function decodeReceipt(raw: string): Record<string, unknown> | null {
+  const attempt = (text: string): Record<string, unknown> | null => {
+    try {
+      const parsed: unknown = JSON.parse(text);
+      return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  };
+  const direct = attempt(raw.trim());
+  if (direct !== null) return direct;
+  try {
+    return attempt(Buffer.from(raw, "base64").toString("utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+export interface AcceptorMiddlewareOptions {
+  keyProvider?: KeyProvider;
+  header?: string;
+  /** The last receipt admitted from the same peer chain. */
+  predecessorFor?: (receipt: Record<string, unknown>) => Record<string, unknown> | null;
+  /** The nonce this acceptor issued for the exchange, if any. */
+  challengeFor?: (receipt: Record<string, unknown>) => string | null;
+  statusCode?: number;
+  exemptPaths?: readonly string[];
+}
+
+interface AcceptorRequest {
+  headers?: Record<string, unknown>;
+  path?: string;
+  url?: string;
+}
+
+interface AcceptorResponse {
+  status: (code: number) => { json: (body: unknown) => unknown };
+  locals?: Record<string, unknown>;
+}
+
+/**
+ * Connect/Express middleware refusing a request whose peer receipt is not admissible.
+ *
+ * Fails CLOSED: a request carrying no receipt, or one whose header does not
+ * parse, is refused. An acceptor that admitted an unsigned request while refusing
+ * a badly-signed one would be strictly worse than having no middleware at all,
+ * because the cheapest bypass would be to send nothing.
+ *
+ * `predecessorFor` supplies the last receipt admitted from the same peer chain;
+ * without it the seq and chain axes have nothing to compare against and a gap
+ * cannot be detected. Both hooks are deliberately caller-supplied: where that
+ * state lives is the deployer's choice.
+ */
+export function acceptorMiddleware(options: AcceptorMiddlewareOptions = {}) {
+  const {
+    keyProvider = null,
+    header = DEFAULT_RECEIPT_HEADER,
+    predecessorFor,
+    challengeFor,
+    statusCode = 403,
+    exemptPaths = [],
+  } = options;
+  const headerName = header.toLowerCase();
+
+  return function asqavAcceptor(
+    req: AcceptorRequest,
+    res: AcceptorResponse,
+    next: () => void,
+  ): void {
+    const path = req.path ?? req.url ?? "";
+    if (exemptPaths.includes(path)) {
+      next();
+      return;
+    }
+
+    const refuse = (reason: string, rule: string | null): void => {
+      res.status(statusCode).json({ error: "peer_receipt_refused", reason, rule });
+    };
+
+    const rawHeader = (req.headers ?? {})[headerName];
+    const raw = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+    if (typeof raw !== "string" || raw === "") {
+      refuse("no peer receipt presented", "missing");
+      return;
+    }
+
+    const receipt = decodeReceipt(raw);
+    if (receipt === null) {
+      refuse("peer receipt header is not a JSON object", "malformed");
+      return;
+    }
+
+    const decision = checkPeerReceipt(receipt, {
+      keyProvider,
+      predecessor: predecessorFor ? predecessorFor(receipt) : null,
+      challenge: challengeFor ? challengeFor(receipt) : null,
+    });
+    if (!decision.accepted) {
+      refuse(decision.reason, decision.rule);
+      return;
+    }
+
+    if (res.locals) res.locals.asqavAcceptorDecision = decision;
+    next();
+  };
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -29,8 +29,13 @@ import { resolveApiKey } from "./credentials.js";
 export { SDK_VERSION, USER_AGENT, userAgentHeaders } from "./userAgent.js";
 
 // Acceptor-side admission control for an inbound peer receipt (B15)
-export { checkPeerReceipt } from "./acceptor.js";
-export type { AcceptorDecision, AcceptorRule, CheckPeerReceiptOptions } from "./acceptor.js";
+export { DEFAULT_RECEIPT_HEADER, acceptorMiddleware, checkPeerReceipt } from "./acceptor.js";
+export type {
+  AcceptorDecision,
+  AcceptorMiddlewareOptions,
+  AcceptorRule,
+  CheckPeerReceiptOptions,
+} from "./acceptor.js";
 
 /** Allowed values for `receiptType` per the IETF Compliance Receipts profile. */
 export const RECEIPT_TYPE_NAMESPACE = [

--- a/typescript/tests/acceptor.test.ts
+++ b/typescript/tests/acceptor.test.ts
@@ -14,7 +14,7 @@ import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { checkPeerReceipt } from "../src/acceptor.js";
+import { acceptorMiddleware, checkPeerReceipt } from "../src/acceptor.js";
 import { ADAPTERS } from "../src/verifier/index.js";
 import { verify } from "../src/verifier/core.js";
 
@@ -309,5 +309,80 @@ describe("acceptor: rule order is deterministic", () => {
     const a = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
     const b = checkPeerReceipt(receipt, { keyProvider: jwks, predecessor });
     expect(a).toEqual(b);
+  });
+});
+
+describe("acceptor middleware (Connect/Express adapter)", () => {
+  function drive(mw: ReturnType<typeof acceptorMiddleware>, headers: Record<string, unknown>, path = "/act") {
+    let status: number | null = null;
+    let body: unknown = null;
+    let reached = false;
+    const res = {
+      status(code: number) {
+        status = code;
+        return {
+          json(payload: unknown) {
+            body = payload;
+            return payload;
+          },
+        };
+      },
+      locals: {} as Record<string, unknown>,
+    };
+    mw({ headers, path }, res, () => {
+      reached = true;
+    });
+    return { status, body, reached, locals: res.locals };
+  }
+
+  it("refuses a request carrying no receipt", () => {
+    // Fails closed. Admitting an unsigned request while refusing a badly-signed
+    // one would be worse than no middleware: the cheapest bypass is to send nothing.
+    const got = drive(acceptorMiddleware(), {});
+    expect(got.status).toBe(403);
+    expect(got.reached).toBe(false);
+    expect((got.body as { reason: string }).reason).toContain("no peer receipt");
+  });
+
+  it("refuses a junk receipt header", () => {
+    const got = drive(acceptorMiddleware(), { "x-asqav-receipt": "not-json-at-all" });
+    expect(got.status).toBe(403);
+    expect(got.reached).toBe(false);
+  });
+
+  it("a refused receipt never reaches the handler", () => {
+    const { receipt, jwks, predecessor } = chained({ seq: 7 }, { seq: 11 });
+    const mw = acceptorMiddleware({ keyProvider: jwks, predecessorFor: () => predecessor });
+    const got = drive(mw, { "x-asqav-receipt": JSON.stringify(receipt) });
+    expect(got.status).toBe(403);
+    expect(got.reached).toBe(false);
+  });
+
+  it("an admissible receipt reaches the handler", () => {
+    // The control. Without it the middleware could refuse everything and pass.
+    const { receipt, jwks, predecessor } = chained({ seq: 7 }, { seq: 8 });
+    const mw = acceptorMiddleware({ keyProvider: jwks, predecessorFor: () => predecessor });
+    const got = drive(mw, { "x-asqav-receipt": JSON.stringify(receipt) });
+    expect(got.reached).toBe(true);
+    expect(got.status).toBeNull();
+  });
+
+  it("accepts a base64-wrapped receipt", () => {
+    const { receipt, jwks, predecessor } = chained({ seq: 7 }, { seq: 8 });
+    const mw = acceptorMiddleware({ keyProvider: jwks, predecessorFor: () => predecessor });
+    const packed = Buffer.from(JSON.stringify(receipt), "utf-8").toString("base64");
+    expect(drive(mw, { "x-asqav-receipt": packed }).reached).toBe(true);
+  });
+
+  it("passes an exempt path through", () => {
+    const mw = acceptorMiddleware({ exemptPaths: ["/health"] });
+    expect(drive(mw, {}, "/health").reached).toBe(true);
+  });
+
+  it("hands the decision to the handler", () => {
+    const { receipt, jwks, predecessor } = chained({ seq: 7 }, { seq: 8 });
+    const mw = acceptorMiddleware({ keyProvider: jwks, predecessorFor: () => predecessor });
+    const got = drive(mw, { "x-asqav-receipt": JSON.stringify(receipt) });
+    expect((got.locals.asqavAcceptorDecision as { accepted: boolean }).accepted).toBe(true);
   });
 });


### PR DESCRIPTION
Completes the **middleware** half of criterion 472 (B15). The decision function landed already; this makes it mountable.

## Zero new dependencies

ASGI is a protocol and the Connect handler signature is a convention, so both adapters work against FastAPI/Starlette/Quart and Express/Connect **without importing any of them**. Nothing is added to the dependency set.

The decision itself stays in `check_peer_receipt` / `checkPeerReceipt`. An acceptor that mounts the middleware and one that calls the function directly must refuse the same receipts, so the adapters carry plumbing and no policy.

## They fail closed

A request carrying no receipt, or one whose header does not parse, is **refused**. This is the rule that matters most: an acceptor that admitted an unsigned request while refusing a badly-signed one would be strictly worse than having no middleware at all, because the cheapest bypass would be to send nothing.

Mutation-validated in both halves — making the missing-receipt path fall through fails exactly that gate and no other:

```
python      FAILED TestAsgiMiddleware::test_a_request_with_no_receipt_is_refused   (1 failed, 30 passed)
typescript  × refuses a request carrying no receipt                                (1 failed, 25 passed)
```

Each suite carries its control (an admissible receipt *does* reach the handler), so the middleware cannot pass by refusing everything.

## Deliberate design choices

- `predecessor_for` / `predecessorFor` and `challenge_for` / `challengeFor` are caller-supplied hooks. Without a predecessor the seq and chain axes have nothing to compare against and a gap cannot be detected — but where that state lives is the deployer's choice, and guessing it here would be wrong for most of them.
- Non-http scopes (lifespan, websocket) pass through. They carry no receipt and no inbound *action* rides on them, so it is not a bypass.
- The decision is handed downstream (ASGI `scope["state"]`, Connect `res.locals`) so a handler can read why it was admitted rather than verifying a second time.
- The receipt header accepts raw JSON or base64-wrapped JSON, since both are common in header transport.

Local: python 2950 passed / 1 skipped, typescript 1116 passed across 66 files, ruff and tsc clean.