### PR TITLE
chore(release): 0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.5] - 2026-09-01
+
+### Added
+
+- **Acceptor-side admission control, in both halves.** `check_peer_receipt` /
+  `checkPeerReceipt` answer whether an inbound agent-to-agent action may be
+  admitted given the receipt the peer presented, returning an `AcceptorDecision`
+  that names one refusal edge rather than a wall of axes. It runs off the same
+  shared oracle the offline verifier uses, so an acceptor and an auditor cannot
+  disagree about the same bytes.
+- Three of its rules deliberately do **not** follow from the verdict, because a
+  peer can weaken the evidence without ever producing an unverified receipt.
+  *Expiry*: the verifier reports expiry on its own axis and never folds it, which
+  is right for a verifier and wrong for a party deciding about an action happening
+  now, so a lapsed receipt is refused here. *Seq downgrade*: absence of a counter
+  stays legal in general, but an acceptor holding a predecessor that carried one
+  is watching the exact transition that hides a withheld receipt. *Challenge*: a
+  challenge the acceptor issued and the receipt does not answer proved nothing, so
+  it is required once issued rather than checked only when present. Refusals are
+  ordered, so the reason is deterministic for the same inputs.
+- **Framework adapters for that decision**: `AcceptorMiddleware` (ASGI, Python)
+  and `acceptorMiddleware` (Connect-style, TypeScript), plus
+  `DEFAULT_RECEIPT_HEADER`. They add plumbing and no policy — an acceptor that
+  mounts the middleware and one that calls the function directly refuse the same
+  receipts. They **fail closed**: a request carrying no receipt, or one whose
+  header does not parse, is refused, since middleware that admitted an unsigned
+  request while refusing a badly-signed one would make sending nothing the
+  cheapest bypass. Non-HTTP scopes (lifespan, websocket) pass through, carrying no
+  receipt and no inbound action. `predecessor_for` and `challenge_for` are
+  caller-supplied hooks, because where that state lives is the deployer's choice.
+- **The verifier now reports which check failed first**: `first_failing_edge` /
+  `firstFailingEdge` on the result. A verdict alone hides an ordering divergence —
+  two verifiers can agree a receipt is unverified while disagreeing about which
+  check failed first, which is the difference between a debuggable report and a
+  guess. The definition is not "the first non-PASS axis"; it mirrors
+  `fold_verdict`'s two exclusions, since the expiry axis never folds the verdict
+  and a SKIPPED chain is tolerated where any other SKIPPED blocks. An edge is
+  named for exactly the unverified verdicts, and the shared axis prefix order is
+  pinned so a refactor that reorders the checks fails a gate instead of quietly
+  renaming which edge is first.
+- Two key-binding conformance vectors in the shared corpus (`asqav-21`
+  key thumbprint binds, `asqav-22` key substituted), with a generator that mints
+  them from a published seed.
+
 ## [0.10.4] - 2026-09-01
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.4"
+version = "0.10.5"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -192,7 +192,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.4"
+__version__ = "0.10.5"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -3,7 +3,7 @@
  * added under Node, since browsers forbid setting User-Agent on fetch.
  */
 
-export const SDK_VERSION = "0.10.4";
+export const SDK_VERSION = "0.10.5";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Cuts 0.10.5. Four merged PRs landed past the 0.10.4 tag without a release, so npm and PyPI carry neither the acceptor surface nor first-bad-edge reporting.

Bumped in the five files the version-consistency gate covers: typescript/package.json, python/pyproject.toml, python/src/asqav/__init__.py, typescript/src/userAgent.ts, CHANGELOG.md.

What the release carries:

- Acceptor-side admission control, both halves: check_peer_receipt / checkPeerReceipt returning an AcceptorDecision off the shared oracle, with three rules that do not follow from the verdict (expiry, seq downgrade, unanswered challenge).
- ASGI and Connect adapters for that decision. They fail closed: a request with no receipt, or an unparseable header, is refused.
- first_failing_edge / firstFailingEdge on the verifier result, defined to mirror fold_verdict exclusions rather than the first non-PASS axis.
- Two key-binding conformance vectors, asqav-21 and asqav-22.

Verified by running: ruff check python/src and ruff check python/src/asqav/verifier both pass on the 0.15.20 pin CI uses, and the version-consistency test passes against the bumped files.

Publish is tag-gated; the py- and ts- release tags go up after this merges.