### PR TITLE
fix(verifier): order member names by UTF-16 code unit on both verification paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **RFC 8785 member order on the two verification paths that still sorted by code
+  point.** The standalone `verify_receipt.py` (`canonical_json`, the bytes it checks
+  every signature, chain link and carried context against) and the TypeScript
+  verifier's asqav dialect (`asqavJcs`, used by the asqav-native adapter) now order
+  member names by UTF-16 code unit, matching the SDK emitters and the platform. The
+  two agree with the emitter across the Basic Multilingual Plane and diverged for any
+  member name above U+FFFF, which no production receipt has ever carried.
+- **Dated dialect cutover.** `JCS_UTF16_CUTOVER` (Python and TypeScript) pins the
+  instant the platform switched. A receipt issued before it whose member names reach
+  above U+FFFF and whose signature verifies only under the old code-point order is
+  reported as the pre-cutover dialect on the signature axis, never as verified; a
+  receipt issued after it gets no retry.
+- `verifier/differential_fuzz.py` now compares the standalone verifier and the
+  TypeScript verifier bundle as engines, so the fuzz gate covers the bytes the
+  verifiers check rather than only the bytes the emitters produce.
+- `docs/fingerprint-spec.md`, `doors.py` and `demo.py` no longer describe or use
+  code-point key order.
+
+
 ## [0.10.5] - 2026-09-01
 
 ### Added

--- a/docs/fingerprint-spec.md
+++ b/docs/fingerprint-spec.md
@@ -46,7 +46,7 @@ The fingerprint is computed over the combined object `{"action_type": ..., "cont
 
 The same rules expressed in any language:
 
-- **Object keys**: sorted lexicographically by Unicode code point, which is Python's `sorted()` default.
+- **Object keys**: sorted by UTF-16 code unit, as RFC 8785 section 3.2.3 requires. Python's `sorted()` and `json.dumps(sort_keys=True)` order by code point instead, which agrees across the Basic Multilingual Plane and diverges for any key containing a character above U+FFFF; use `asqav._jcs.canonical_json`, which sorts by `key.encode("utf-16-be")`. Example: the keys `＠` (U+FF20) and `😀` (U+1F600) canonicalize to `{"😀":1,"＠":1}` with SHA-256 `425159f5c1f0575fbcbf9d05a8f60cde3d040eae5166aa2136657564048651b6`; the code-point order `{"＠":1,"😀":1}` (SHA-256 `1c314559129cce00bc1b3caa2ee37fa3e81f926aee65b34f8e4e21856b2de83b`) is not conformant. This is conformance vector `asqav-24-jcs-astral-key-order`.
 - **Whitespace**: none, anywhere.
 - **Strings**: emitted verbatim as UTF-8, with no `\uXXXX` escaping for characters above U+001F.
 - **Numbers**: serialized via Python's `json` module rules. Integers stay integers like `42`, and floats use the shortest round-trip form, so `1.5` not `1.50`.

--- a/docs/offline-verification.md
+++ b/docs/offline-verification.md
@@ -208,3 +208,23 @@ changes to `revoked`. The verifier rejects signatures from revoked keys.
 | Ed25519 | Fully validated with real known-answer (tamper) vectors. |
 | ES256 | Fully validated with real known-answer (tamper) vectors. |
 | ML-DSA-65 | Fully proven. Known-answer conformance vector `asqav-06-mldsa65-payload-prod` was minted from a real api.asqav.com payload-mode receipt (2026-06-19, agent `agt_LBe47lJwgA0DfVom`, key `mxYqaLBR_T76ThNw0Kiekw`). Both Python (`test_verify_receipt_offline_mldsa65_real_cloud_kat`) and TypeScript test suites exercise the signature axis against this vector and assert `verified`; tamper tests assert `unverified`/`invalid`. |
+
+## Canonical member order and the dialect cutover
+
+Every signed byte string is JCS (RFC 8785): member names ordered by UTF-16 code unit
+(section 3.2.3), no whitespace, UTF-8, no NaN or Infinity. The standalone verifier's
+`canonical_json`, the SDK's `asqav._jcs.canonical_json`, the TypeScript emitter and the
+TypeScript verifier's `asqavJcs` all produce the same bytes, and the differential fuzzer
+compares all of them on every run. A verifier sorting by code point (Python's
+`json.dumps(sort_keys=True)`, Go and Rust byte order) agrees on every member name inside
+the Basic Multilingual Plane and diverges on any name containing a character above
+U+FFFF; conformance vector `asqav-24-jcs-astral-key-order` pins the difference.
+
+`JCS_UTF16_CUTOVER` (exported by both verifiers) is the instant the issuing platform
+switched to RFC 8785 order on the wire. A receipt issued before it whose member names
+reach above U+FFFF, and whose signature verifies only under the earlier code-point order,
+is reported on the signature axis as the pre-cutover dialect and the verdict stays
+`unverified`. A receipt issued after the cutover gets no such retry. No production receipt
+issued before the cutover carries such a member name (measured over the whole ledger on
+2026-09-02), so the diagnostic exists for completeness rather than for live data.
+

--- a/python/src/asqav/demo.py
+++ b/python/src/asqav/demo.py
@@ -27,6 +27,8 @@ import webbrowser
 from dataclasses import dataclass, field
 from typing import Any
 
+from asqav._jcs import canonical_json as _jcs_canonical
+
 # === Pre-loaded scenarios ===
 
 SCENARIOS: list[dict[str, Any]] = [
@@ -143,13 +145,13 @@ class DemoState:
 
 
 def _canonical(obj: Any) -> bytes:
-    """JCS-style canonical JSON.
+    """JCS canonical JSON, the same bytes production asqav signs.
 
-    We use json.dumps(sort_keys=True) here to keep the demo dependency-free.
-    Production asqav uses the jcs library; behavior matches for the simple
-    JSON-native payloads this demo uses.
+    Delegates to ``asqav._jcs.canonical_json`` (stdlib only), which orders member
+    names by UTF-16 code unit per RFC 8785; ``json.dumps(sort_keys=True)`` would
+    diverge for a key above U+FFFF.
     """
-    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return _jcs_canonical(obj)
 
 
 def _sign(state: DemoState, payload: dict[str, Any]) -> dict[str, Any]:

--- a/python/src/asqav/doors.py
+++ b/python/src/asqav/doors.py
@@ -12,15 +12,14 @@ under ``asqav.receipt``. Every door has an inverse that returns the exact same r
 All functions are pure and offline: no signing, no network, no mutation of the input,
 no wall-clock reads. Timestamps and ids come only from the receipt itself.
 
-Cross-SDK parity scope: for inputs inside the JSON-canonicalization-safe domain the
-Python and TypeScript SDKs emit byte-identical envelope bytes for the same receipt. That
-domain is object keys within the Basic Multilingual Plane (code points up to U+FFFF) and
-integers whose magnitude stays within the IEEE-754 safe range (up to 2**53). Outside it
-the shared JCS core diverges: keys with astral-plane characters (above U+FFFF) sort by
-Python code point vs TypeScript UTF-16 code unit, and integers above 2**53 round in the
-TypeScript number path, so the two SDKs yield different bytes. This is a known limitation
-of the JSON Canonicalization Scheme core, tracked for a versioned migration and not a
-doors bug. The doors parity tests pin both the safe-domain agreement and the divergence.
+Cross-SDK parity scope: the Python and TypeScript SDKs emit byte-identical envelope bytes
+for the same receipt across every object key, including keys with characters above
+U+FFFF, because both order member names by UTF-16 code unit per RFC 8785 section 3.2.3.
+The one remaining divergence is an integer whose magnitude exceeds the IEEE-754 safe range
+(2**53): it stays exact in Python and rounds in the TypeScript number path. Such integers
+are outside the profile's canonical domain (draft section 4 requires strings or rational
+pairs for them) and every parser will reject them outright; until then the doors parity
+tests pin both the agreement and that single divergence.
 
 This is presentation only. A door does NOT re-sign; the authoritative Asqav signature
 stays inside the embedded receipt. A generic VC / C2PA verifier reads the shape but must

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -138,11 +138,63 @@ _BARE_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 MAX_NESTING_DEPTH = 200
 
 
-def canonical_json(obj) -> bytes:
+#: Instant from which the issuing platform emits RFC 8785 member order on the wire. Pinned to
+#: the production deploy of the emitter change; receipts issued later never get the retry below.
+JCS_UTF16_CUTOVER = "2026-09-02T12:00:00+00:00"
+
+
+def _utf16_member_order(name: str) -> bytes:
+    # Big-endian UTF-16 bytes compare in the same order as the code units they encode.
+    return name.encode("utf-16-be")
+
+
+def _member_name(key) -> str:
+    # The member name json.dumps would emit for a non-string key.
+    if key is True:
+        return "true"
+    if key is False:
+        return "false"
+    if key is None:
+        return "null"
+    if isinstance(key, float):
+        return repr(key)
+    return str(key)
+
+
+def _utf16_ordered(obj):
+    # Rebuild obj with every object's members in RFC 8785 section 3.2.3 order.
+    if isinstance(obj, dict):
+        named = [(k if isinstance(k, str) else _member_name(k), k) for k in obj]
+        named.sort(key=lambda pair: _utf16_member_order(pair[0]))
+        return {name: _utf16_ordered(obj[original]) for name, original in named}
+    if isinstance(obj, list):
+        return [_utf16_ordered(v) for v in obj]
+    return obj
+
+
+def canonical_json(obj, default=None) -> bytes:
     """JCS canonical bytes - byte-identical to the server's canonical_json.
 
-    Sorted keys, no whitespace, UTF-8, NaN/Infinity rejected. This is the exact
+    Member names in UTF-16 code-unit order (RFC 8785 section 3.2.3), no whitespace,
+    UTF-8, NaN/Infinity rejected. json.dumps(sort_keys=True) orders by code point
+    instead, which diverges above U+FFFF, so this sorts explicitly. This is the exact
     byte string the server signs and the verifier must reproduce.
+    """
+    return json.dumps(
+        _utf16_ordered(obj),
+        sort_keys=False,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+        default=default,
+    ).encode("utf-8")
+
+
+def canonical_json_pre_cutover(obj) -> bytes:
+    """The code-point member order the platform emitted before JCS_UTF16_CUTOVER.
+
+    Diagnostic only: a signature that verifies solely under these bytes is reported
+    as the pre-cutover dialect and never as verified.
     """
     return json.dumps(
         obj,
@@ -151,6 +203,50 @@ def canonical_json(obj) -> bytes:
         ensure_ascii=False,
         allow_nan=False,
     ).encode("utf-8")
+
+
+def has_supplementary_member_name(obj) -> bool:
+    """True when any object member name, at any depth, carries a character above U+FFFF."""
+    stack = [obj]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if isinstance(k, str) and any(ord(ch) > 0xFFFF for ch in k):
+                    return True
+                stack.append(v)
+        elif isinstance(node, list):
+            stack.extend(node)
+    return False
+
+
+def _issued_before_cutover(payload: dict) -> bool:
+    # An unreadable issued_at earns no retry; the receipt is simply not verified.
+    issued = _parse_stamp(payload.get("issued_at", ""))
+    cutover = _parse_stamp(JCS_UTF16_CUTOVER)
+    return issued is not None and cutover is not None and issued < cutover
+
+
+def _pre_cutover_diagnostic(payload: dict, sig: bytes, candidates, sig_res):
+    """Name the pre-cutover dialect when that is the only reason a signature fails.
+
+    Runs only for a receipt issued before JCS_UTF16_CUTOVER whose member names reach
+    above U+FFFF. The result stays FAIL: the dialect is reported, never accepted.
+    """
+    if not has_supplementary_member_name(payload) or not _issued_before_cutover(payload):
+        return sig_res
+    try:
+        legacy_msg = canonical_json_pre_cutover(payload)
+    except (TypeError, ValueError, RecursionError):
+        return sig_res
+    for pk, alg in candidates:
+        if pk is not None and verify_signature(pk, legacy_msg, sig, alg)[0] == "PASS":
+            return (
+                "FAIL",
+                "pre-cutover dialect: the signature verifies only under code-point member "
+                "order, which is not RFC 8785; reported unverified, never verified",
+            )
+    return sig_res
 
 
 def _describe_value(value) -> str:
@@ -452,8 +548,7 @@ def jwk_thumbprint(jwk: dict) -> str:
     Sorting here is what RFC 7638 section 3 calls for, so the caller cannot change
     the digest by handing the members in a different order.
     """
-    canonical = json.dumps(jwk, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+    return f"sha256:{hashlib.sha256(canonical_json(jwk)).hexdigest()}"
 
 
     # The profile's key_thumbprint value for one ML-DSA public key.
@@ -1856,6 +1951,7 @@ def check_nonce(payload: dict, seen_nonces: set | None = None):
     try:
         identity = hashlib.sha256(canonical_json(payload)).hexdigest()
     except (ValueError, TypeError, RecursionError):
+        # Internal identity for the seen-nonce index only; never externally recomputed.
         identity = hashlib.sha256(
             json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
         ).hexdigest()
@@ -1989,6 +2085,11 @@ def run(
                     eff_issuer = issuer_a
                     eff_revoked_at = resolve_revoked_at(jwks, kid_a)
                     eff_pk, eff_alg = pk_a, alg_a
+            if sig_res[0] != "PASS":
+                cands = [(pk, alg or jwks_alg)]
+                if pk_a is not None:
+                    cands.append((pk_a, alg_a or alg or jwks_alg))
+                sig_res = _pre_cutover_diagnostic(payload, sig, cands, sig_res)
         results.append(("issuer_key", "PASS", f"resolved signing key {eff_kid} (status={eff_status})"))
         # kid picks the key and the attacker picks the kid, so bind the key that
         # actually verified back to the issuer the receipt claims.
@@ -2180,6 +2281,11 @@ def run_structured(
                     eff_issuer = issuer_a
                     eff_revoked_at = resolve_revoked_at(jwks, kid_a)
                     eff_pk, eff_alg = pk_a, alg_a
+            if sig_res[0] != "PASS":
+                cands = [(pk, alg or jwks_alg)]
+                if pk_a is not None:
+                    cands.append((pk_a, alg_a or alg or jwks_alg))
+                sig_res = _pre_cutover_diagnostic(payload, sig_bytes, cands, sig_res)
         axes.append(
             _struct_axis(
                 "issuer_key", "PASS", f"resolved signing key {eff_kid} (status={eff_status})"

--- a/python/tests/test_differential_fuzz.py
+++ b/python/tests/test_differential_fuzz.py
@@ -71,3 +71,31 @@ def test_gate_detects_a_code_point_sorting_engine(monkeypatch: pytest.MonkeyPatc
     assert fuzz.run(iterations=ITERATIONS, seed=0, unsafe_numbers=False), (
         "the fuzz gate passed an engine sorting by code point; it has no bite"
     )
+
+
+    # The engine a customer actually runs offline must be compared, not only the emitter.
+def test_standalone_verifier_is_one_of_the_engines() -> None:
+    assert "standalone" in fuzz.engines_available()
+
+
+    # The verifier's own asqav dialect joins whenever the verifier bundle is built.
+def test_typescript_verifier_engine_joins_when_built() -> None:
+    dist = _ROOT / "typescript" / "dist" / "verifier" / "index.js"
+    if not dist.exists():
+        pytest.skip("typescript/dist/verifier not built")
+    assert "typescript-verifier" in fuzz.engines_available()
+
+
+    # A verification path sorting by code point must be caught, or the gate is blind to it.
+def test_gate_detects_a_code_point_sorting_standalone_verifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    def code_point_canonical(obj: object) -> bytes:
+        return json.dumps(
+            obj, sort_keys=True, separators=(",", ":"),
+            ensure_ascii=False, allow_nan=False,
+        ).encode("utf-8")
+
+    monkeypatch.setattr(fuzz, "standalone_canonical", code_point_canonical)
+    assert fuzz.run(iterations=ITERATIONS, seed=0, unsafe_numbers=False), (
+        "the fuzz gate passed a standalone verifier sorting by code point; it has no bite"
+    )
+

--- a/python/tests/test_verify_receipt_jcs_utf16.py
+++ b/python/tests/test_verify_receipt_jcs_utf16.py
@@ -1,0 +1,123 @@
+"""The standalone verifier reproduces RFC 8785 member order and names the pre-cutover dialect.
+
+Criterion 566. ``verify_receipt.py`` is the tool the exit manifest tells a customer to run,
+so its ``canonical_json`` must produce the bytes the platform signs for every member name,
+including names above U+FFFF where a code-point sort silently diverges.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from asqav.verifier import verify_receipt as v
+from tests.test_verify_receipt import _envelope, _jwks_key, _ml_dsa_65, _valid_payload
+
+ASTRAL = {"＠": 1, "😀": 1}
+RFC8785_BYTES = '{"😀":1,"＠":1}'.encode("utf-8")
+RFC8785_SHA256 = "425159f5c1f0575fbcbf9d05a8f60cde3d040eae5166aa2136657564048651b6"
+CODE_POINT_BYTES = '{"＠":1,"😀":1}'.encode("utf-8")
+CODE_POINT_SHA256 = "1c314559129cce00bc1b3caa2ee37fa3e81f926aee65b34f8e4e21856b2de83b"
+
+
+def test_canonical_json_orders_member_names_by_utf16_code_unit() -> None:
+    out = v.canonical_json(ASTRAL)
+    assert out == RFC8785_BYTES
+    assert hashlib.sha256(out).hexdigest() == RFC8785_SHA256
+
+
+def test_canonical_json_never_reproduces_the_code_point_order() -> None:
+    out = v.canonical_json(ASTRAL)
+    assert out != CODE_POINT_BYTES
+    assert hashlib.sha256(out).hexdigest() != CODE_POINT_SHA256
+
+
+def test_pre_cutover_dialect_is_the_code_point_order() -> None:
+    assert v.canonical_json_pre_cutover(ASTRAL) == CODE_POINT_BYTES
+
+
+def test_canonical_json_matches_the_sdk_core_on_nested_and_coerced_keys() -> None:
+    from asqav._jcs import canonical_json as sdk_canonical
+
+    doc = {"z": [{"😀": {"b": 1, "＠": 2}}, {1: "int key", None: "null key"}], "￿": 0}
+    assert v.canonical_json(doc) == sdk_canonical(doc)
+
+
+def test_jwk_thumbprint_bytes_are_unchanged_for_ascii_members() -> None:
+    jwk = {"pub": "QUFBQQ", "kty": "AKP", "alg": "ML-DSA-65"}
+    expected = hashlib.sha256(
+        json.dumps(jwk, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    assert v.jwk_thumbprint(jwk) == f"sha256:{expected}"
+
+
+def test_has_supplementary_member_name_walks_every_depth() -> None:
+    assert v.has_supplementary_member_name({"a": [{"b": {"😀": 1}}]})
+    assert not v.has_supplementary_member_name({"a": [{"b": {"￿": "😀"}}]})
+
+
+def _astral_payload(issued_at: str) -> dict:
+    payload = _valid_payload("org-legit", "agt_two")
+    payload["issued_at"] = issued_at
+    payload["context"] = {"tool_input": ASTRAL}
+    encoded = v.canonical_json(payload["context"])
+    payload["payload_digest"] = {"hash": hashlib.sha256(encoded).hexdigest(), "size": len(encoded)}
+    return payload
+
+
+def _signature_axis(report: dict) -> tuple[str, str]:
+    axis = next(a for a in report["axes"] if a["name"] == "signature")
+    return axis["result"], axis["note"]
+
+
+def _run(payload: dict, signed_bytes: bytes) -> dict:
+    ml = _ml_dsa_65()
+    pk, sk = ml.keygen()
+    sig = ml.sign(sk, signed_bytes)
+    jwks = {"keys": [_jwks_key("agent-two", "agt_two", "org-legit", pk)]}
+    return v.run_structured(_envelope(payload, sig), jwks, None)
+
+
+@pytest.fixture(autouse=True)
+def _needs_ml_dsa():
+    pytest.importorskip("dilithium_py")
+
+
+def test_receipt_with_supplementary_member_names_verifies_over_rfc8785_bytes() -> None:
+    payload = _astral_payload("2026-06-19T00:00:00+00:00")
+    report = _run(payload, v.canonical_json(payload))
+    result, note = _signature_axis(report)
+    assert result == "PASS", note
+    digest = next(a for a in report["axes"] if a["name"] == "payload_digest")
+    assert digest["result"] == "PASS", digest["note"]
+
+
+def test_pre_cutover_receipt_signed_over_code_point_bytes_is_named_not_verified() -> None:
+    payload = _astral_payload("2026-06-19T00:00:00+00:00")
+    report = _run(payload, v.canonical_json_pre_cutover(payload))
+    result, note = _signature_axis(report)
+    assert result == "FAIL"
+    assert "pre-cutover dialect" in note
+    assert report["verdict"] == v.VERDICT_UNVERIFIED
+
+
+def test_post_cutover_receipt_signed_over_code_point_bytes_gets_no_retry() -> None:
+    cutover = v._parse_stamp(v.JCS_UTF16_CUTOVER)
+    assert cutover is not None
+    later = cutover.replace(year=cutover.year + 1).isoformat()
+    payload = _astral_payload(later)
+    report = _run(payload, v.canonical_json_pre_cutover(payload))
+    result, note = _signature_axis(report)
+    assert result == "FAIL"
+    assert "pre-cutover dialect" not in note
+    assert report["verdict"] == v.VERDICT_UNVERIFIED
+
+
+def test_bmp_only_receipt_is_untouched_by_the_diagnostic() -> None:
+    payload = _valid_payload("org-legit", "agt_two")
+    payload["issued_at"] = "2026-06-19T00:00:00+00:00"
+    report = _run(payload, v.canonical_json_pre_cutover(payload))
+    result, note = _signature_axis(report)
+    assert result == "PASS", note

--- a/typescript/src/verifier/adapter.ts
+++ b/typescript/src/verifier/adapter.ts
@@ -93,4 +93,12 @@ export abstract class FormatAdapter {
   keyedDigest(_doc: Record<string, unknown>): boolean {
     return false;
   }
+
+  /**
+   * Bytes under the format's pre-cutover canonical dialect, or null when no dated dialect applies to
+   * `doc`. A signature passing only under these bytes is reported as that dialect, never as verified.
+   */
+  preCutoverSigningInput(_doc: Record<string, unknown>): Uint8Array | null {
+    return null;
+  }
 }

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -11,7 +11,12 @@ import {
   type KeyProvider,
   type SignatureMaterial,
 } from "../adapter.js";
-import { asqavJcs } from "../canonical.js";
+import {
+  JCS_UTF16_CUTOVER,
+  asqavJcs,
+  asqavJcsPreCutover,
+  hasSupplementaryMemberName,
+} from "../canonical.js";
 import { sha256Hex } from "../crypto.js";
 import { isLowerHex } from "./acta.js";
 import {
@@ -177,6 +182,17 @@ export class AsqavNativeAdapter extends FormatAdapter {
     }
     // Asqav signs the canonical bytes of the payload directly, no pre-hash.
     return asqavJcs(payloadOf(doc));
+  }
+
+  // Only a payload-mode receipt issued before the cutover with a member name above U+FFFF has
+  // a dated dialect; hash-mode members are ASCII, so both orders coincide there.
+  preCutoverSigningInput(doc: Record<string, unknown>): Uint8Array | null {
+    if (isHashMode(doc)) return null;
+    const payload = payloadOf(doc);
+    if (!hasSupplementaryMemberName(payload)) return null;
+    const issued = Date.parse(String(payload.issued_at ?? ""));
+    if (Number.isNaN(issued) || issued >= Date.parse(JCS_UTF16_CUTOVER)) return null;
+    return asqavJcsPreCutover(payload);
   }
 
   private hashModeSigningInput(doc: Record<string, unknown>): Uint8Array {

--- a/typescript/src/verifier/canonical.ts
+++ b/typescript/src/verifier/canonical.ts
@@ -334,9 +334,43 @@ export function jcs(obj: unknown): Uint8Array {
   return new TextEncoder().encode(serialize(nfc(obj), compareCodePoints, true));
 }
 
-/** Asqav cloud JCS bytes (no NFC); byte-identical to the cloud signer. */
+/**
+ * Asqav cloud JCS bytes (no NFC, producer numbers), byte-identical to the cloud signer: member names in
+ * UTF-16 code-unit order per RFC 8785 section 3.2.3, which JS string comparison already gives.
+ */
 export function asqavJcs(obj: unknown): Uint8Array {
+  return new TextEncoder().encode(serialize(obj, utf16CompareKeys, true));
+}
+
+/**
+ * Instant from which the issuing platform emits RFC 8785 member order on the wire. Pinned to the
+ * production deploy of the emitter change; receipts issued later never get the pre-cutover retry.
+ */
+export const JCS_UTF16_CUTOVER = "2026-09-02T12:00:00+00:00";
+
+/**
+ * The code-point member order the cloud emitted before JCS_UTF16_CUTOVER. Diagnostic only: a signature
+ * that verifies solely under these bytes is reported as the pre-cutover dialect, never as verified.
+ */
+export function asqavJcsPreCutover(obj: unknown): Uint8Array {
   return new TextEncoder().encode(serialize(obj, compareCodePoints, true));
+}
+
+/** True when any object member name, at any depth, carries a character above U+FFFF. */
+export function hasSupplementaryMemberName(obj: unknown): boolean {
+  const stack: unknown[] = [obj];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (Array.isArray(node)) {
+      for (const v of node) stack.push(v);
+    } else if (node !== null && typeof node === "object") {
+      for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+        if (/[\uD800-\uDBFF]/.test(k)) return true;
+        stack.push(v);
+      }
+    }
+  }
+  return false;
 }
 
 /** Strict RFC 8785 JCS bytes (UTF-16 code-unit key sort, ECMAScript numbers) with NFC. */

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -177,6 +177,17 @@ function signatureAxis(
   }
   const msg = ad.signingInput(doc);
   const { result, note: why } = verifySignature(sm.alg, pk, msg, sm.sig);
+  if (result !== PASS) {
+    const pre = ad.preCutoverSigningInput(doc);
+    if (pre !== null && verifySignature(sm.alg, pk, pre, sm.sig).result === PASS) {
+      return axis(
+        "signature",
+        FAIL,
+        "pre-cutover dialect: the signature verifies only under code-point member order, " +
+          "which is not RFC 8785; reported unverified, never verified",
+      );
+    }
+  }
   return axis("signature", result, why);
 }
 

--- a/typescript/src/verifier/index.ts
+++ b/typescript/src/verifier/index.ts
@@ -63,6 +63,9 @@ export {
 } from "./vrShim.js";
 export {
   asqavJcs,
+  asqavJcsPreCutover,
+  hasSupplementaryMemberName,
+  JCS_UTF16_CUTOVER,
   DuplicateMemberError,
   jcs,
   jcsRfc8785,

--- a/typescript/tests/verifier-jcs-utf16.test.ts
+++ b/typescript/tests/verifier-jcs-utf16.test.ts
@@ -1,0 +1,120 @@
+// The asqav-native verification path orders member names by UTF-16 code unit (RFC 8785 3.2.3) and
+// names the pre-cutover dialect instead of verifying it. TS half of test_verify_receipt_jcs_utf16.py.
+
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+import { ml_dsa65 } from "@noble/post-quantum/ml-dsa.js";
+
+import { AsqavNativeAdapter } from "../src/verifier/adapters/asqavNative.js";
+import {
+  JCS_UTF16_CUTOVER,
+  asqavJcs,
+  asqavJcsPreCutover,
+  hasSupplementaryMemberName,
+} from "../src/verifier/canonical.js";
+import { verify } from "../src/verifier/core.js";
+
+const ORG = "f94f66c0-c580-432d-a041-29374f7aee07";
+const ASTRAL: Record<string, unknown> = { "＠": 1, "😀": 1 };
+const RFC8785_BYTES = '{"😀":1,"＠":1}';
+const RFC8785_SHA256 = "425159f5c1f0575fbcbf9d05a8f60cde3d040eae5166aa2136657564048651b6";
+const CODE_POINT_BYTES = '{"＠":1,"😀":1}';
+
+const sha256Hex = (b: Uint8Array) => createHash("sha256").update(b).digest("hex");
+const sign = (msg: Uint8Array, sk: Uint8Array) => Buffer.from(ml_dsa65.sign(msg, sk)).toString("base64");
+
+function key(kid: string, agentId: string, publicKey: Uint8Array): Record<string, unknown> {
+  return {
+    kid,
+    agent_id: agentId,
+    issuer_id: ORG,
+    alg: "ML-DSA-65",
+    public_key: Buffer.from(publicKey).toString("base64"),
+    status: "active",
+  };
+}
+
+function astralPayload(issuedAt: string): Record<string, unknown> {
+  const context = { tool_input: ASTRAL };
+  const encoded = asqavJcs(context);
+  return {
+    type: "protectmcp:decision",
+    issued_at: issuedAt,
+    issuer_id: ORG,
+    agent_id: "agt_two",
+    action_ref: `sha256:${"8".repeat(64)}`,
+    payload_digest: { hash: sha256Hex(encoded), size: encoded.length },
+    policy_digest: `sha256:${"3".repeat(64)}`,
+    previousReceiptHash: "0".repeat(64),
+    decision: "allow",
+    context,
+  };
+}
+
+function receipt(p: Record<string, unknown>, sig: string): Record<string, unknown> {
+  return { payload: p, signature: { alg: "ML-DSA-65", kid: ORG, sig }, anchors: [] };
+}
+
+function signatureAxis(p: Record<string, unknown>, signedBytes: Uint8Array) {
+  const agent = ml_dsa65.keygen();
+  const jwks = { keys: [key("agent-two", "agt_two", agent.publicKey)] };
+  const res = verify(receipt(p, sign(signedBytes, agent.secretKey)), [new AsqavNativeAdapter()], jwks);
+  const axis = res.axes.find((a) => a.axis === "signature");
+  if (axis === undefined) throw new Error("no signature axis");
+  return { axis, res };
+}
+
+describe("asqavJcs member order", () => {
+  it("orders supplementary-plane names by UTF-16 code unit", () => {
+    const out = asqavJcs(ASTRAL);
+    expect(new TextDecoder().decode(out)).toBe(RFC8785_BYTES);
+    expect(sha256Hex(out)).toBe(RFC8785_SHA256);
+  });
+
+  it("keeps the code-point order only as the named pre-cutover dialect", () => {
+    expect(new TextDecoder().decode(asqavJcsPreCutover(ASTRAL))).toBe(CODE_POINT_BYTES);
+    expect(new TextDecoder().decode(asqavJcs(ASTRAL))).not.toBe(CODE_POINT_BYTES);
+  });
+
+  it("detects a supplementary member name at any depth and ignores values", () => {
+    expect(hasSupplementaryMemberName({ a: [{ b: { "😀": 1 } }] })).toBe(true);
+    expect(hasSupplementaryMemberName({ a: [{ b: { "￿": "😀" } }] })).toBe(false);
+  });
+});
+
+describe("asqav-native signature axis across the dialect cutover", () => {
+  it("verifies a receipt with supplementary member names signed over RFC 8785 bytes", () => {
+    const p = astralPayload("2026-06-19T00:00:00.000000Z");
+    const { axis, res } = signatureAxis(p, asqavJcs(p));
+    expect(axis.result).toBe("PASS");
+    const digest = res.axes.find((a) => a.axis === "payload_digest");
+    expect(digest?.result).toBe("PASS");
+  });
+
+  it("names the pre-cutover dialect for an older receipt and never verifies it", () => {
+    const p = astralPayload("2026-06-19T00:00:00.000000Z");
+    const { axis, res } = signatureAxis(p, asqavJcsPreCutover(p));
+    expect(axis.result).toBe("FAIL");
+    expect(axis.note).toContain("pre-cutover dialect");
+    expect(res.verdict).toBe("unverified");
+  });
+
+  it("gives a receipt issued after the cutover no retry", () => {
+    const later = new Date(Date.parse(JCS_UTF16_CUTOVER) + 365 * 24 * 3600 * 1000).toISOString();
+    const p = astralPayload(later);
+    const { axis, res } = signatureAxis(p, asqavJcsPreCutover(p));
+    expect(axis.result).toBe("FAIL");
+    expect(axis.note).not.toContain("pre-cutover dialect");
+    expect(res.verdict).toBe("unverified");
+  });
+
+  it("leaves a BMP-only receipt untouched, both orders being the same bytes", () => {
+    const p = astralPayload("2026-06-19T00:00:00.000000Z");
+    p.context = { tool_input: { a: 1, "￿": 2 } };
+    const encoded = asqavJcs(p.context);
+    p.payload_digest = { hash: sha256Hex(encoded), size: encoded.length };
+    const { axis } = signatureAxis(p, asqavJcsPreCutover(p));
+    expect(axis.result).toBe("PASS");
+  });
+});

--- a/verifier/differential_fuzz.py
+++ b/verifier/differential_fuzz.py
@@ -31,6 +31,7 @@ _ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_ROOT / "python" / "src"))
 
 from asqav._jcs import canonical_json as sdk_canonical  # noqa: E402
+from asqav.verifier.verify_receipt import canonical_json as standalone_canonical  # noqa: E402
 
     # The cloud emitter is optional: this repo does not depend on the platform.
 try:
@@ -84,16 +85,22 @@ process.stdout.write(JSON.stringify(out));
 """
 
 
-def ts_canonical_batch(docs: list) -> list[bytes] | None:
-    """Canonicalize every document with the TypeScript SDK, or None when it cannot run."""
-    dist = _ROOT / "typescript" / "dist" / "index.js"
+_TS_VERIFIER_DRIVER = """
+const {asqavJcs} = require(process.argv[2]);
+const docs = JSON.parse(require('fs').readFileSync(process.argv[3], 'utf8'));
+const out = docs.map((d) => Buffer.from(asqavJcs(d)).toString('base64'));
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+def _ts_batch(docs: list, dist: Path, driver_src: str) -> list[bytes] | None:
     if not dist.exists():
         return None
     with tempfile.TemporaryDirectory() as tmp:
         docs_path = Path(tmp) / "docs.json"
         docs_path.write_text(json.dumps(docs, ensure_ascii=False), encoding="utf-8")
         driver = Path(tmp) / "driver.cjs"
-        driver.write_text(_TS_DRIVER, encoding="utf-8")
+        driver.write_text(driver_src, encoding="utf-8")
         proc = subprocess.run(
             ["node", str(driver), str(dist), str(docs_path)],
             capture_output=True, text=True,
@@ -104,13 +111,25 @@ def ts_canonical_batch(docs: list) -> list[bytes] | None:
     return [base64.b64decode(x) for x in json.loads(proc.stdout)]
 
 
+def ts_canonical_batch(docs: list) -> list[bytes] | None:
+    """Canonicalize every document with the TypeScript SDK emitter, or None when it cannot run."""
+    return _ts_batch(docs, _ROOT / "typescript" / "dist" / "index.js", _TS_DRIVER)
+
+
+def ts_verifier_canonical_batch(docs: list) -> list[bytes] | None:
+    """Canonicalize with the TypeScript VERIFIER's asqav dialect (the bytes it checks signatures over)."""
+    return _ts_batch(docs, _ROOT / "typescript" / "dist" / "verifier" / "index.js", _TS_VERIFIER_DRIVER)
+
+
 def engines_available() -> list[str]:
     """Name the canonicalizers this environment can actually compare."""
-    names = ["sdk"]
+    names = ["sdk", "standalone"]
     if cloud_canonical is not None:
         names.append("cloud")
     if ts_canonical_batch([{}]) is not None:
         names.append("typescript")
+    if ts_verifier_canonical_batch([{}]) is not None:
+        names.append("typescript-verifier")
     return names
 
 
@@ -121,15 +140,19 @@ def run(iterations: int, seed: int, unsafe_numbers: bool) -> list[dict]:
     divergences: list[dict] = []
 
     sdk = [sdk_canonical(d) for d in docs]
+    standalone = [standalone_canonical(d) for d in docs]
     cloud = [cloud_canonical(d) for d in docs] if cloud_canonical else None
     ts = ts_canonical_batch(docs)
+    ts_verifier = ts_verifier_canonical_batch(docs)
 
     for i, doc in enumerate(docs):
-        seen = {"sdk": sdk[i]}
+        seen = {"sdk": sdk[i], "standalone": standalone[i]}
         if cloud is not None:
             seen["cloud"] = cloud[i]
         if ts is not None:
             seen["typescript"] = ts[i]
+        if ts_verifier is not None:
+            seen["typescript-verifier"] = ts_verifier[i]
         if len(set(seen.values())) > 1:
             divergences.append({
                 "index": i,


### PR DESCRIPTION
## What

Criterion 566 (founder master prompt item 1.1). Two verification paths still ordered JSON member names by code point:

- `python/src/asqav/verifier/verify_receipt.py` `canonical_json` (the bytes the standalone tool checks every signature, chain link and carried context against; its docstring claimed byte-identity with the server).
- `typescript/src/verifier/canonical.ts` `asqavJcs`, which `adapters/asqavNative.ts` uses for every asqav-native receipt.

Code-point order agrees with the JCS spec across the Basic Multilingual Plane and diverges for any member name above U+FFFF. Both paths now sort by UTF-16 code unit, matching `asqav._jcs`, the TypeScript emitter and the platform signer (asqav PR #1403).

## Dialect cutover

`JCS_UTF16_CUTOVER` (exported by both verifiers) pins the instant the platform switched. A receipt issued before it whose member names reach above U+FFFF, and whose signature verifies only under the old code-point order, is reported on the signature axis as the pre-cutover dialect; the verdict stays `unverified`. A receipt issued after the cutover gets no retry. Measured on the whole production ledger on 2026-09-02: 29,264 signature records, none containing a character above U+FFFF, so no live receipt is affected either way. The constant is provisional until the platform deploy lands and is pinned to that timestamp before the release tag.

## Gate coverage

- `verifier/differential_fuzz.py` gains two engines: the standalone verifier and the TypeScript verifier bundle (`dist/verifier/index.js`, `asqavJcs`). The fuzz gate compared only the emitters before, which is why the divergence survived the astral-key corpus.
- Mutation proof: `test_gate_detects_a_code_point_sorting_standalone_verifier` swaps the standalone engine for a code-point sort and asserts a divergence; a driver calling `asqavJcsPreCutover` in place of `asqavJcs` diverges on 27 of 300 fuzz documents at seed 7 (the documents whose member names reach above U+FFFF) (run locally).
- New tests: `python/tests/test_verify_receipt_jcs_utf16.py` (asqav-24 bytes reproduced, code-point form never reproduced, signed astral-key receipt verifies over the spec bytes, pre-cutover diagnostic named, post-cutover receipt gets no retry, BMP-only receipt untouched) and `typescript/tests/verifier-jcs-utf16.test.ts` (same six cases plus the depth walk).

## Also

- `docs/fingerprint-spec.md` states the UTF-16 rule with the astral example and both digests; `docs/offline-verification.md` documents the cutover.
- `doors.py` stops calling the astral divergence a known limitation (it is closed); the remaining big-integer divergence is stated as the single open item.
- `demo.py` delegates to `asqav._jcs.canonical_json` instead of `json.dumps(sort_keys=True)` and stops claiming production uses the jcs library.

Local: `ruff check src` clean; 1602 targeted Python tests pass on the venv; TypeScript build, typecheck and all 1129 tests pass.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
