### PR TITLE
feat(hook): gate deadline, digest-only default, and verification of the returned receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+### Changed
+
+- **Harness hooks send a digest by default.** `asqav hook pretool` and `asqav hook
+  posttool` now sign in hash-only mode whatever host they talk to: the tool
+  arguments are canonicalised and hashed locally and never leave the machine.
+  `--clear-context` is the opt-in that sends them for the platform to hold, and
+  `--dry-run` prints the exact body either way. Against the Asqav cloud the SDK
+  already resolved to hash-only; self-hosted deployments sent the arguments in
+  clear, and a dry run showed clear context regardless of host.
+- **The gate has a deadline.** `asqav hook pretool` waits
+  `ASQAV_HOOK_DEADLINE_SECONDS` (default 5) for the signer and then blocks with
+  exit 2; the same value is the SDK's per-request timeout (`init(timeout=...)`
+  is new). A hung signer can no longer ride the harness's 600-second default and
+  let the tool run unsigned. The posttool hook proceeds unsigned on the same
+  deadline.
+- **The gate verifies the receipt it is handed.** Before exit 0 the pretool
+  hook runs the returned receipt through the standalone verifier against the
+  platform's published JWK Set (cached 24 hours at `~/.asqav/jwks-cache.json`);
+  a receipt that does not verify blocks the tool call.
+- The pretool hook prints `signed <id>` for the observation the cloud records
+  for in-process capture and reserves `permit <id>` for a wire decision of
+  `allow`; `hooks/README.md` states what the cloud records for an in-process
+  gate today.
+
+
 ### Fixed
 
 - **RFC 8785 member order on the two verification paths that still sorted by code

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -82,7 +82,8 @@ execution continues." So `http` can never be the hard boundary either. It is aud
         "hooks": [
           {
             "type": "command",
-            "command": "asqav hook posttool"
+            "command": "asqav hook posttool",
+            "timeout": 10
           }
         ]
       }
@@ -161,7 +162,8 @@ fail open (see Mode A), so they can never be the hard boundary.
         "hooks": [
           {
             "type": "command",
-            "command": "asqav hook pretool"
+            "command": "asqav hook pretool",
+            "timeout": 10
           }
         ]
       }
@@ -172,6 +174,47 @@ fail open (see Mode A), so they can never be the hard boundary.
 
 There is no `tool_response` before execution, so the pretool receipt binds the decision, not a
 result.
+
+### The gate's deadline, and why the harness timeout alone is not one
+
+Claude Code documents that "A timed-out command, http, or mcp_tool hook doesn't block the tool
+call", and its default command timeout is 600 seconds. A gate that simply waited on a hung signer
+would therefore let the tool run unsigned after ten minutes. `asqav hook pretool` carries its own
+deadline: it waits `ASQAV_HOOK_DEADLINE_SECONDS` (default 5) for the signer and then blocks with
+exit 2 and a reason on stderr; the same value is the SDK's per-request HTTP timeout. Set the hook's
+`timeout` in `settings.json` a little above the deadline, as in the snippet, so the harness never
+reaches its own limit first. The posttool hook uses the same deadline and proceeds unsigned when
+it expires, which is Mode A's fail-open contract.
+
+### The gate verifies the receipt it is given
+
+Before exiting 0, `asqav hook pretool` verifies the returned receipt's signature against the
+platform's published JWK Set with the same standalone verifier a customer runs offline (the
+signature, issuer binding, key status and key thumbprint axes must all pass). The JWK Set is
+cached at `~/.asqav/jwks-cache.json` (`ASQAV_HOOK_JWKS_CACHE` overrides) for 24 hours and
+refreshed once when the signing key is not in the cache. A receipt that does not verify, or that
+cannot be verified inside the deadline, blocks the tool call.
+
+### What leaves the machine
+
+Both hooks send a digest by default. The tool arguments are canonicalised and hashed locally
+(`hash`, `hash_algo`, `payload_size`), and only that digest, the action type, the session id and
+the compliance fields travel to the platform; the arguments themselves stay on the machine that
+ran the tool. `--clear-context` is the opt-in that sends the arguments for the platform to hold,
+for deployments whose policy wants the platform to retain them. `asqav hook pretool --dry-run`
+prints the exact body either way.
+
+### What the cloud records for an in-process gate today
+
+The platform treats every `capture_topology="in_process_sdk"` receipt as self-reported by code
+the agent controls, so it records a pretool `permit` as an observation (`protectmcp:lifecycle`,
+wire `decision: observation`, the response carrying `policy_enforcement` to say so) and rejects
+an in-process `deny` or `rate_limit` with HTTP 412. The gate therefore blocks when it cannot sign,
+and the evidence it leaves is a signed observation of every matched call, not a policy decision.
+The hook prints `signed <id>` for such a receipt and reserves `permit <id>` for a receipt whose
+wire decision is `allow`. Policy decisions through the gate need a capture topology the platform
+accepts as harness-enforced, backed by a deployment attestation; that is tracked work, not a
+flag.
 
 ---
 

--- a/python/src/asqav/cli_hook.py
+++ b/python/src/asqav/cli_hook.py
@@ -15,6 +15,8 @@ import hashlib
 import json as json_mod
 import os
 import sys
+import threading
+import time
 from typing import Any
 
 try:
@@ -40,6 +42,54 @@ REQUIRED_SCOPE = CODE_AUTHORSHIP_WRITE_SCOPE
 _OBSERVATION = "protectmcp:observation"
 _OBSERVATION_RESULT_BOUND = "protectmcp:observation:result_bound"
 _DECISION = "protectmcp:decision"
+_LIFECYCLE = "protectmcp:lifecycle"
+
+#: Seconds the gate waits for the signer before it blocks; ASQAV_HOOK_DEADLINE_SECONDS overrides.
+_DEADLINE_ENV = "ASQAV_HOOK_DEADLINE_SECONDS"
+_DEFAULT_DEADLINE_SECONDS = 5.0
+#: Where the gate keeps the JWK Set it verifies permits against; ASQAV_HOOK_JWKS_CACHE overrides.
+_JWKS_CACHE_ENV = "ASQAV_HOOK_JWKS_CACHE"
+_JWKS_CACHE_MAX_AGE_SECONDS = 24 * 3600
+_JWKS_PAGE_CAP = 64
+
+
+class HookDeadlineExceeded(RuntimeError):
+    """The signer did not answer inside the gate's deadline."""
+
+
+def _deadline_seconds() -> float:
+    raw = os.environ.get(_DEADLINE_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_DEADLINE_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return _DEFAULT_DEADLINE_SECONDS
+    return value if value > 0 else _DEFAULT_DEADLINE_SECONDS
+
+
+def _call_with_deadline(fn, deadline: float, *args: Any, **kwargs: Any) -> Any:
+    """Run fn on a daemon thread and give up after deadline seconds.
+
+    A daemon thread never blocks interpreter exit, so a signer that hangs past the
+    deadline cannot hold the harness hostage until its own 600-second limit.
+    """
+    box: dict[str, Any] = {}
+
+    def _target() -> None:
+        try:
+            box["value"] = fn(*args, **kwargs)
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the caller's thread
+            box["error"] = exc
+
+    worker = threading.Thread(target=_target, name="asqav-hook-sign", daemon=True)
+    worker.start()
+    worker.join(deadline)
+    if worker.is_alive():
+        raise HookDeadlineExceeded(f"signer did not answer within {deadline:g}s")
+    if "error" in box:
+        raise box["error"]
+    return box["value"]
 
 
 def _read_event(*, fail_code: int = 1) -> dict[str, Any]:
@@ -79,16 +129,26 @@ def _build_body(
     session_id: str,
     agent_id: str,
     compliance_fields: dict[str, Any],
+    clear_context: bool = False,
 ) -> dict[str, Any]:
+    from asqav import client as _client
     from asqav.client import _build_sign_body
 
-    return _build_sign_body(
-        action_type=action_type,
-        context=context,
-        session_id=session_id or None,
-        agent_id=agent_id,
-        compliance_fields={k: v for k, v in compliance_fields.items() if v is not None} or None,
-    )
+    # The wire mode is a module global the SDK resolves at init; the hook pins it
+    # explicitly so a dry run shows the bytes the live hook sends.
+    previous = _client._mode
+    _client._mode = "full-payload" if clear_context else "hash-only"
+    try:
+        return _build_sign_body(
+            action_type=action_type,
+            context=context,
+            session_id=session_id or None,
+            agent_id=agent_id,
+            compliance_fields={k: v for k, v in compliance_fields.items() if v is not None}
+            or None,
+        )
+    finally:
+        _client._mode = previous
 
 
 def _map_event(
@@ -151,10 +211,18 @@ def _sign_event(
     compliance_fields: dict[str, Any],
     api_key: str,
     agent_id: str,
+    clear_context: bool = False,
+    timeout: float | None = None,
 ) -> Any:
     import asqav
 
-    asqav.init(api_key=api_key)
+    # Hash-only by default: the tool arguments are digested here and never leave the
+    # machine; --clear-context opts a deployment into sending them for the platform to hold.
+    asqav.init(
+        api_key=api_key,
+        mode="full-payload" if clear_context else "hash-only",
+        timeout=timeout,
+    )
     agent = asqav.Agent.get(agent_id)
     if session_id:
         agent._session_id = session_id  # type: ignore[attr-defined]
@@ -163,12 +231,141 @@ def _sign_event(
     return agent.sign(action_type, context=context, compliance_mode=True, **kwargs)
 
 
+def _jwks_url() -> str:
+    from urllib.parse import urlsplit
+
+    from asqav import client as _client
+
+    parts = urlsplit(_client._api_base)
+    return f"{parts.scheme}://{parts.netloc}/.well-known/jwks.json"
+
+
+def _jwks_cache_path() -> str:
+    return os.environ.get(_JWKS_CACHE_ENV) or os.path.join(
+        os.path.expanduser("~"), ".asqav", "jwks-cache.json"
+    )
+
+
+def _fetch_jwks(timeout: float) -> dict[str, Any]:
+    """Fetch every page of the published JWK Set from the configured API host."""
+    import urllib.request
+
+    base = _jwks_url()
+    keys: list[dict[str, Any]] = []
+    offset = 0
+    for _ in range(_JWKS_PAGE_CAP):
+        url = base if not offset else f"{base}?offset={offset}"
+        request = urllib.request.Request(url, headers={"User-Agent": "asqav-hook"})
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            page = json_mod.loads(response.read().decode("utf-8"))
+        keys.extend(page.get("keys") or [])
+        nxt = page.get("next_offset")
+        if not isinstance(nxt, int) or nxt <= offset:
+            break
+        offset = nxt
+    return {"keys": keys}
+
+
+def _read_jwks_cache() -> dict[str, Any] | None:
+    path = _jwks_cache_path()
+    try:
+        with open(path, encoding="utf-8") as fh:
+            doc = json_mod.load(fh)
+    except (OSError, ValueError):
+        return None
+    fetched_at = doc.get("fetched_at")
+    if not isinstance(fetched_at, (int, float)):
+        return None
+    if time.time() - fetched_at > _JWKS_CACHE_MAX_AGE_SECONDS:
+        return None
+    keys = doc.get("keys")
+    return {"keys": keys} if isinstance(keys, list) else None
+
+
+def _write_jwks_cache(jwks: dict[str, Any]) -> None:
+    path = _jwks_cache_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = f"{path}.tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json_mod.dump({"fetched_at": time.time(), "keys": jwks["keys"]}, fh)
+        os.replace(tmp, path)
+    except OSError:
+        pass
+
+
+def _load_jwks(timeout: float) -> dict[str, Any]:
+    cached = _read_jwks_cache()
+    if cached is not None:
+        return cached
+    fresh = _fetch_jwks(timeout)
+    _write_jwks_cache(fresh)
+    return fresh
+
+
+def _key_present(jwks: dict[str, Any], payload: dict[str, Any]) -> bool:
+    # A cached set may predate the agent's key; the caller refreshes once on a miss.
+    agent_id = payload.get("agent_id")
+    thumb = payload.get("key_thumbprint")
+    for key in jwks.get("keys") or []:
+        if agent_id and key.get("agent_id") == agent_id:
+            return True
+        if thumb and key.get("key_thumbprint") == thumb:
+            return True
+    return False
+
+
+#: Axes that establish the returned receipt really is a platform signature over these bytes.
+_PERMIT_AXES = ("signature", "issuer_bind", "key_status", "key_binding")
+
+
+def _verify_returned_receipt(sig: Any, timeout: float) -> tuple[bool, str]:
+    """Verify the receipt the signer returned against the published JWK Set.
+
+    Returns (ok, reason). The signature-related axes must all PASS; anchors and the
+    chain are outside a single receipt's reach and are not required here.
+    """
+    from asqav.verifier import verify_receipt as _vr
+
+    payload = getattr(sig, "payload", None)
+    signature = getattr(sig, "signature", None)
+    if not isinstance(payload, dict) or not isinstance(signature, dict):
+        return False, "signer returned no verifiable receipt (payload or signature missing)"
+    anchors = getattr(sig, "anchors", None) or []
+    doc = {"payload": payload, "signature": signature, "anchors": anchors}
+    jwks = _load_jwks(timeout)
+    if not _key_present(jwks, payload):
+        jwks = _fetch_jwks(timeout)
+        _write_jwks_cache(jwks)
+    report = _vr.run_structured(doc, jwks, None)
+    axes = {a["name"]: a for a in report.get("axes", [])}
+    for name in _PERMIT_AXES:
+        axis = axes.get(name)
+        if axis is None or axis["result"] != "PASS":
+            note = axis["note"] if axis else "axis missing"
+            return False, f"{name}: {note}"
+    return True, f"signature verified against the published JWK Set (kid {signature.get('kid')})"
+
+
+def _decision_label(sig: Any) -> str:
+    # The platform records in-process capture as an observation (wire decision
+    # "observation"); only a real gate decision earns the word permit.
+    payload = getattr(sig, "payload", None)
+    decision = payload.get("decision") if isinstance(payload, dict) else None
+    return "permit" if decision == "allow" else "signed"
+
+
 @hook_app.command("posttool")
 def hook_posttool(
     bind_result: bool = typer.Option(
         False,
         "--bind-result",
         help="Bind the tool result (observation:result_bound + result_digest).",
+    ),
+    clear_context: bool = typer.Option(
+        False,
+        "--clear-context",
+        help="Send the tool arguments in clear for the platform to hold (default: digest only).",
     ),
     dry_run: bool = typer.Option(
         False,
@@ -201,20 +398,29 @@ def hook_posttool(
             session_id=session_id,
             agent_id=agent_id,
             compliance_fields=fields,
+            clear_context=clear_context,
         )
         print(json_mod.dumps(body, indent=2, default=str))
         return
 
     api_key, agent_id = _require_identity()
+    deadline = _deadline_seconds()
     try:
-        sig = _sign_event(
+        sig = _call_with_deadline(
+            _sign_event,
+            deadline,
             action_type=action_type,
             context=context,
             session_id=session_id,
             compliance_fields=fields,
             api_key=api_key,
             agent_id=agent_id,
+            clear_context=clear_context,
+            timeout=deadline,
         )
+    except HookDeadlineExceeded as exc:
+        print(f"asqav hook: {exc}; proceeding unsigned", file=sys.stderr)
+        return
     except Exception as exc:
         # Fail-open: the tool already ran, so audit failure must not block work.
         print(f"asqav hook: sign failed, proceeding unsigned: {exc}", file=sys.stderr)
@@ -224,6 +430,11 @@ def hook_posttool(
 
 @hook_app.command("pretool")
 def hook_pretool(
+    clear_context: bool = typer.Option(
+        False,
+        "--clear-context",
+        help="Send the tool arguments in clear for the platform to hold (default: digest only).",
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -234,10 +445,13 @@ def hook_pretool(
 
     The host shell decided before the tool ran, so this is a real decision:
     in_process_sdk + protectmcp:decision + policy_decision=permit. Exit 2 BLOCKS
-    the tool call when the signer is unreachable or signing errors. There is no
-    tool result pre-execution, so no result_digest. A malformed/empty event also
-    blocks (exit 2): the gate fails closed on every failure path, never open.
+    the tool call when the signer is unreachable, signing errors, the signer does
+    not answer inside the deadline, or the returned receipt does not verify
+    against the published JWK Set. There is no tool result pre-execution, so no
+    result_digest. A malformed/empty event also blocks (exit 2): the gate fails
+    closed on every failure path, never open.
     """
+    started = time.monotonic()
     event = _read_event(fail_code=2)
     action_type, context, session_id, fields = _map_event(
         event,
@@ -256,6 +470,7 @@ def hook_pretool(
             session_id=session_id,
             agent_id=agent_id,
             compliance_fields=fields,
+            clear_context=clear_context,
         )
         print(json_mod.dumps(body, indent=2, default=str))
         return
@@ -270,19 +485,40 @@ def hook_pretool(
             file=sys.stderr,
         )
         raise typer.Exit(code=2)
+    deadline = _deadline_seconds()
     try:
-        sig = _sign_event(
+        sig = _call_with_deadline(
+            _sign_event,
+            deadline,
             action_type=action_type,
             context=context,
             session_id=session_id,
             compliance_fields=fields,
             api_key=api_key,
             agent_id=agent_id,
+            clear_context=clear_context,
+            timeout=deadline,
         )
+    except HookDeadlineExceeded as exc:
+        print(f"asqav hook: {exc}; blocking tool call", file=sys.stderr)
+        raise typer.Exit(code=2) from exc
     except Exception as exc:
         print(f"asqav hook: signer unreachable, blocking tool call: {exc}", file=sys.stderr)
         raise typer.Exit(code=2) from exc
-    print(f"permit {sig.signature_id}", file=sys.stderr)
+
+    # The permit is only as good as its signature; verify it before letting the tool run.
+    remaining = max(deadline - (time.monotonic() - started), 0.5)
+    try:
+        ok, reason = _verify_returned_receipt(sig, remaining)
+    except Exception as exc:  # noqa: BLE001 - any failure here is a blocked call
+        ok, reason = False, f"could not verify the returned receipt: {exc}"
+    if not ok:
+        print(
+            f"asqav hook: receipt {sig.signature_id} did not verify ({reason}); blocking tool call",
+            file=sys.stderr,
+        )
+        raise typer.Exit(code=2)
+    print(f"{_decision_label(sig)} {sig.signature_id}", file=sys.stderr)
 
 
 @hook_app.command("code-authorship")

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -134,6 +134,8 @@ _client: Any = None
 # Hybrid GDPR mode: resolved at init() time, overridable per-call. See _mode.py.
 _mode: str = "full-payload"
 _org_salt: bytes | None = None
+#: Per-request HTTP timeout in seconds; init(timeout=...) overrides it.
+_timeout: float = 30.0
 #: Hash-only request metadata allowlist; mirrors the server-enforced whitelist.
 _HASH_ONLY_METADATA_WHITELIST: frozenset[str] = frozenset(
     {"agent_id", "session_id", "action_type", "model_name", "tool_name", "parent_id"}
@@ -2859,6 +2861,7 @@ def init(
     *,
     mode: str = "auto",
     org_salt: bytes | None = None,
+    timeout: float | None = None,
 ) -> None:
     """Initialize the Asqav SDK.
 
@@ -2878,6 +2881,9 @@ def init(
             Salted digests still travel labelled ``sha256``, so a third
             party recomputing per ``docs/fingerprint-spec.md`` sees a
             mismatch even though the signature verifies.
+        timeout: Per-request HTTP timeout in seconds (default 30). The
+            harness hook passes its own deadline here so a hung signer
+            cannot outlive the gate.
 
     Raises:
         AuthenticationError: If no API key is provided.
@@ -2895,7 +2901,7 @@ def init(
         # Force hash-only against a custom URL
         asqav.init(api_key="sk_...", mode="hash-only", org_salt=bytes.fromhex("..."))
     """
-    global _api_key, _api_base, _client, _mode, _org_salt
+    global _api_key, _api_base, _client, _mode, _org_salt, _timeout
 
     _api_key = resolve_api_key(api_key)
 
@@ -2916,12 +2922,13 @@ def init(
         explicit=mode,
     )
     _org_salt = org_salt
+    _timeout = float(timeout) if timeout else 30.0
 
     if _HTTPX_AVAILABLE:
         _client = httpx.Client(
             base_url=_api_base,
             headers={"X-API-Key": _api_key, "User-Agent": USER_AGENT},
-            timeout=30.0,
+            timeout=_timeout,
         )
 
 
@@ -3094,7 +3101,7 @@ def _urllib_request(
 
     def _do_request() -> dict[str, Any]:
         request = urllib.request.Request(url, data=body, headers=headers, method=method)
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with urllib.request.urlopen(request, timeout=_timeout) as response:
             # Strict ingest (419): a duplicated member name fails the response.
             from . import strict_json
 

--- a/python/tests/test_cli_hook.py
+++ b/python/tests/test_cli_hook.py
@@ -46,9 +46,18 @@ def test_posttool_dry_run_action_type() -> None:
     assert body["action_type"] == "tool:Bash"
 
 
-    # context carries the tool_input dict.
-def test_posttool_dry_run_context() -> None:
+    # Digest only by default: the tool arguments never leave the machine.
+def test_posttool_dry_run_sends_a_digest_not_the_arguments() -> None:
     body = _invoke_hook("posttool", _POSTTOOL_EVENT)
+    assert "context" not in body
+    assert body["hash"].startswith("sha256:")
+    assert body["payload_size"] > 0
+    assert "ls" not in json.dumps(body)
+
+
+    # --clear-context is the opt-in that sends the arguments for the platform to hold.
+def test_posttool_dry_run_clear_context_sends_the_arguments() -> None:
+    body = _invoke_hook("posttool", _POSTTOOL_EVENT, ["--clear-context"])
     assert body["context"] == {"tool_input": {"command": "ls"}}
 
 

--- a/python/tests/test_cli_hook_gate.py
+++ b/python/tests/test_cli_hook_gate.py
@@ -1,0 +1,286 @@
+"""The PreToolUse gate's deadline, hash-only default and receipt verification.
+
+Criteria 575, 578 and 579. Every path here is offline: the signer is a stub and the JWK Set is
+minted in the test, so a green run says nothing about api.asqav.com and everything about the gate.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import time
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav import cli_hook  # noqa: E402
+from asqav.cli import app  # noqa: E402
+from asqav.verifier import verify_receipt as vr  # noqa: E402
+
+runner = CliRunner()
+
+_PRETOOL_EVENT = {
+    "session_id": "s2",
+    "tool_name": "Write",
+    "tool_input": {"file_path": "/tmp/f", "content": "hi"},
+}
+_POSTTOOL_EVENT = {
+    "session_id": "s1",
+    "tool_name": "Bash",
+    "tool_input": {"command": "ls"},
+    "tool_response": "x",
+}
+ORG = "org-hook"
+
+
+@pytest.fixture(autouse=True)
+def _identity(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv("ASQAV_API_KEY", "sk_test_hook")
+    monkeypatch.setenv("ASQAV_AGENT_ID", "agt_hook")
+    monkeypatch.setenv(cli_hook._JWKS_CACHE_ENV, str(tmp_path / "jwks-cache.json"))
+    monkeypatch.delenv(cli_hook._DEADLINE_ENV, raising=False)
+
+
+class _Sig:
+    def __init__(self, signature_id: str, payload: Any = None, signature: Any = None, anchors=None):
+        self.signature_id = signature_id
+        self.payload = payload
+        self.signature = signature
+        self.anchors = anchors
+
+
+def _sleepy_signer(seconds: float):
+    def _sign(**_kwargs: Any) -> _Sig:
+        time.sleep(seconds)
+        return _Sig("sig_late")
+
+    return _sign
+
+
+# === hash-only default (579) ===
+
+
+def test_pretool_dry_run_sends_a_digest_not_the_arguments() -> None:
+    result = runner.invoke(app, ["hook", "pretool", "--dry-run"], input=json.dumps(_PRETOOL_EVENT))
+    assert result.exit_code == 0, result.output
+    body = json.loads(result.output)
+    assert "context" not in body
+    assert body["hash"].startswith("sha256:")
+    assert body["hash_algo"] == "sha256"
+    assert "/tmp/f" not in result.output and "hi" not in json.dumps(body.get("metadata", {}))
+
+
+def test_pretool_dry_run_clear_context_sends_the_arguments() -> None:
+    result = runner.invoke(
+        app, ["hook", "pretool", "--dry-run", "--clear-context"], input=json.dumps(_PRETOOL_EVENT)
+    )
+    assert result.exit_code == 0, result.output
+    body = json.loads(result.output)
+    assert body["context"] == {"tool_input": {"file_path": "/tmp/f", "content": "hi"}}
+
+
+def test_sign_event_inits_hash_only_by_default_and_carries_the_deadline(monkeypatch) -> None:
+    import asqav
+
+    seen: dict[str, Any] = {}
+
+    def fake_init(**kwargs: Any) -> None:
+        seen.update(kwargs)
+
+    class _Agent:
+        agent_id = "agt_hook"
+
+        def sign(self, *_a: Any, **_k: Any) -> _Sig:
+            return _Sig("sig_ok")
+
+    monkeypatch.setattr(asqav, "init", fake_init)
+    monkeypatch.setattr(asqav.Agent, "get", staticmethod(lambda _id: _Agent()))
+    cli_hook._sign_event(
+        action_type="tool:Write", context={"tool_input": {}}, session_id="s",
+        compliance_fields={"compliance_mode": True}, api_key="k", agent_id="agt_hook", timeout=2.5,
+    )
+    assert seen["mode"] == "hash-only" and seen["timeout"] == 2.5
+    cli_hook._sign_event(
+        action_type="tool:Write", context={"tool_input": {}}, session_id="s",
+        compliance_fields={"compliance_mode": True}, api_key="k", agent_id="agt_hook",
+        clear_context=True,
+    )
+    assert seen["mode"] == "full-payload"
+
+
+# === deadline (575) ===
+
+
+def test_pretool_blocks_when_the_signer_outlives_the_deadline(monkeypatch) -> None:
+    monkeypatch.setenv(cli_hook._DEADLINE_ENV, "0.2")
+    monkeypatch.setattr(cli_hook, "_sign_event", _sleepy_signer(5.0))
+    started = time.monotonic()
+    result = runner.invoke(app, ["hook", "pretool"], input=json.dumps(_PRETOOL_EVENT))
+    elapsed = time.monotonic() - started
+    assert result.exit_code == 2, result.output
+    assert "did not answer within 0.2s" in result.output
+    assert elapsed < 2.0, f"gate took {elapsed:.2f}s; the deadline did not fire"
+
+
+def test_posttool_proceeds_unsigned_when_the_signer_outlives_the_deadline(monkeypatch) -> None:
+    monkeypatch.setenv(cli_hook._DEADLINE_ENV, "0.2")
+    monkeypatch.setattr(cli_hook, "_sign_event", _sleepy_signer(5.0))
+    started = time.monotonic()
+    result = runner.invoke(app, ["hook", "posttool"], input=json.dumps(_POSTTOOL_EVENT))
+    assert result.exit_code == 0, result.output
+    assert "proceeding unsigned" in result.output
+    assert time.monotonic() - started < 2.0
+
+
+def test_deadline_env_falls_back_to_the_default_on_garbage(monkeypatch) -> None:
+    monkeypatch.setenv(cli_hook._DEADLINE_ENV, "soon")
+    assert cli_hook._deadline_seconds() == cli_hook._DEFAULT_DEADLINE_SECONDS
+    monkeypatch.setenv(cli_hook._DEADLINE_ENV, "-3")
+    assert cli_hook._deadline_seconds() == cli_hook._DEFAULT_DEADLINE_SECONDS
+    monkeypatch.setenv(cli_hook._DEADLINE_ENV, "7.5")
+    assert cli_hook._deadline_seconds() == 7.5
+
+
+# === receipt verification (578) ===
+
+
+def _ml_dsa_65():
+    pytest.importorskip("dilithium_py")
+    from dilithium_py.ml_dsa import ML_DSA_65
+
+    return ML_DSA_65
+
+
+def _payload(decision: str = "allow") -> dict:
+    return {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-06-19T00:00:00+00:00",
+        "issuer_id": ORG,
+        "agent_id": "agt_hook",
+        "action_ref": "sha256:" + "8" * 64,
+        "payload_digest": {"hash": "8" * 64, "size": 512},
+        "policy_digest": "sha256:" + "3" * 64,
+        "previousReceiptHash": "0" * 64,
+        "decision": decision,
+    }
+
+
+def _signed(payload: dict, sk: bytes, ml) -> dict:
+    sig = ml.sign(sk, vr.canonical_json(payload))
+    return {"alg": "ML-DSA-65", "kid": ORG, "sig": base64.b64encode(sig).decode()}
+
+
+def _jwks(pk: bytes) -> dict:
+    return {
+        "keys": [
+            {
+                "kid": "k-hook",
+                "agent_id": "agt_hook",
+                "issuer_id": ORG,
+                "org_id": ORG,
+                "alg": "ML-DSA-65",
+                "kty": "AKP",
+                "public_key": base64.b64encode(pk).decode(),
+                "status": "active",
+                "revoked_at": None,
+            }
+        ]
+    }
+
+
+def _gate_with(monkeypatch, sig: _Sig, jwks: dict, fetch_calls: list | None = None):
+    monkeypatch.setattr(cli_hook, "_sign_event", lambda **_k: sig)
+
+    def fake_fetch(_timeout: float) -> dict:
+        if fetch_calls is not None:
+            fetch_calls.append(_timeout)
+        return jwks
+
+    monkeypatch.setattr(cli_hook, "_fetch_jwks", fake_fetch)
+    return runner.invoke(app, ["hook", "pretool"], input=json.dumps(_PRETOOL_EVENT))
+
+
+def test_pretool_accepts_a_receipt_that_verifies_and_labels_a_permit(monkeypatch) -> None:
+    ml = _ml_dsa_65()
+    pk, sk = ml.keygen()
+    payload = _payload("allow")
+    sig = _Sig("sig_ok", payload, _signed(payload, sk, ml), [])
+    result = _gate_with(monkeypatch, sig, _jwks(pk))
+    assert result.exit_code == 0, result.output
+    assert "permit sig_ok" in result.output
+
+
+def test_pretool_labels_an_observation_as_signed_not_permit(monkeypatch) -> None:
+    ml = _ml_dsa_65()
+    pk, sk = ml.keygen()
+    payload = _payload("observation")
+    payload["type"] = "protectmcp:lifecycle"
+    sig = _Sig("sig_obs", payload, _signed(payload, sk, ml), [])
+    result = _gate_with(monkeypatch, sig, _jwks(pk))
+    assert result.exit_code == 0, result.output
+    assert "signed sig_obs" in result.output
+    assert "permit" not in result.output
+
+
+def test_pretool_blocks_a_forged_receipt(monkeypatch) -> None:
+    ml = _ml_dsa_65()
+    pk, _sk = ml.keygen()
+    _pk2, forger_sk = ml.keygen()
+    payload = _payload("allow")
+    sig = _Sig("sig_forged", payload, _signed(payload, forger_sk, ml), [])
+    result = _gate_with(monkeypatch, sig, _jwks(pk))
+    assert result.exit_code == 2, result.output
+    assert "did not verify" in result.output
+
+
+def test_pretool_blocks_when_the_signer_returns_no_receipt_bytes(monkeypatch) -> None:
+    result = _gate_with(monkeypatch, _Sig("sig_bare"), {"keys": []})
+    assert result.exit_code == 2, result.output
+    assert "no verifiable receipt" in result.output
+
+
+def test_pretool_blocks_when_the_jwks_cannot_be_fetched(monkeypatch) -> None:
+    ml = _ml_dsa_65()
+    _pk, sk = ml.keygen()
+    payload = _payload("allow")
+    monkeypatch.setattr(cli_hook, "_sign_event", lambda **_k: _Sig("sig_x", payload, _signed(payload, sk, ml), []))
+
+    def broken(_timeout: float) -> dict:
+        raise OSError("network down")
+
+    monkeypatch.setattr(cli_hook, "_fetch_jwks", broken)
+    result = runner.invoke(app, ["hook", "pretool"], input=json.dumps(_PRETOOL_EVENT))
+    assert result.exit_code == 2, result.output
+    assert "could not verify" in result.output
+
+
+def test_jwks_cache_is_reused_and_refreshed_once_on_a_key_miss(monkeypatch) -> None:
+    ml = _ml_dsa_65()
+    pk, sk = ml.keygen()
+    payload = _payload("allow")
+    sig = _Sig("sig_c", payload, _signed(payload, sk, ml), [])
+    calls: list = []
+    first = _gate_with(monkeypatch, sig, _jwks(pk), calls)
+    assert first.exit_code == 0, first.output
+    assert len(calls) == 1
+    # Second run: the cache holds the key, so no fetch happens.
+    second = _gate_with(monkeypatch, sig, _jwks(pk), calls)
+    assert second.exit_code == 0, second.output
+    assert len(calls) == 1
+    # A stale cache that lacks the key triggers exactly one refresh.
+    cli_hook._write_jwks_cache({"keys": []})
+    third = _gate_with(monkeypatch, sig, _jwks(pk), calls)
+    assert third.exit_code == 0, third.output
+    assert len(calls) == 2
+
+
+def test_jwks_url_derives_from_the_api_base(monkeypatch) -> None:
+    from asqav import client as c
+
+    monkeypatch.setattr(c, "_api_base", "https://api.example.test/api/v1")
+    assert cli_hook._jwks_url() == "https://api.example.test/.well-known/jwks.json"


### PR DESCRIPTION
## What

Criteria 575, 578 and 579 (founder master prompt items 2.1, 2.3 and 2.4), all in the Python harness hook.

- **Deadline (575).** `asqav hook pretool` waits `ASQAV_HOOK_DEADLINE_SECONDS` (default 5) for the signer on a daemon thread and then blocks with exit 2 and a reason on stderr. The same value becomes the SDK's per-request HTTP timeout through a new `init(timeout=...)` keyword (httpx and the urllib fallback). The posttool hook proceeds unsigned on the same deadline. The README snippets now set the harness `timeout` above the deadline and quote the harness fact that a timed-out hook does not block the tool call.
- **Digest-only default (579).** Both hooks pin hash-only mode whatever host they talk to; `--clear-context` is the opt-in that sends the tool arguments for the platform to hold. `--dry-run` now prints the bytes the live hook sends. Against the cloud the SDK already resolved to hash-only, so this closes the self-hosted case and the misleading dry run.
- **Verification of the returned receipt (578).** Before exit 0 the gate builds `{payload, signature, anchors}` from the sign response and runs it through the standalone verifier against the platform's published JWK Set (every page followed, cached 24 h at `~/.asqav/jwks-cache.json`, refreshed once on a key miss). The signature, issuer binding, key status and key thumbprint axes must all pass; anything else, including an unreachable JWK Set, blocks the call.

## What the probe found on the way

A live hash-mode compliance sign on the seq-wire canary, verified offline with the standalone verifier against the live JWK Set (agent `agt_DAsgntrbV_VAIBbl`, receipt `sig_51pGPbPB6gPG1fKm2dgaPA`):

- The platform records every `in_process_sdk` permit as an observation (`protectmcp:lifecycle`, wire `decision: observation`) and rejects an in-process deny with 412 (server rule P4). The hook was printing `permit <id>` for a receipt that asserts no decision. It now prints `signed <id>` and reserves `permit` for a wire decision of `allow`; the README states what the cloud records for an in-process gate today. Policy decisions through the gate need a harness-enforced topology backed by a deployment attestation (criteria 576, 577, 605).
- The bare `kid` resolved to a revoked sibling key first (criterion 564), and the verifier could not check the canary's ML-DSA-44 signature at all (criterion 571 rotates it), so the fallback never ran. The resolver order is the next verifier change.

## Tests

`python/tests/test_cli_hook_gate.py` (offline, stubbed signer, minted JWK Set): digest-only default and `--clear-context`; init called with `mode="hash-only"` and the deadline as timeout; a signer sleeping 5 s exits 2 in under 2 s with a 0.2 s deadline (posttool exits 0 unsigned); garbage deadline values fall back; a verifying receipt exits 0 and a wire `allow` is labelled `permit`; an observation is labelled `signed`; a forged signature, a response without receipt bytes and an unreachable JWK Set each exit 2; the cache is reused and refreshed exactly once on a key miss; the JWK Set URL derives from the API base.

`ruff check src` clean; the whole Python suite passes on the venv.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
