### PR TITLE
fix(verifier): resolve the signing key by the signed thumbprint, then kid, agent bind, issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,24 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   `allow`; `hooks/README.md` states what the cloud records for an in-process
   gate today.
 
-
 ### Fixed
+
+- **Signing-key resolution on the standalone verifier.** `verify_receipt.py`'s
+  `run()` and `run_structured()` resolved the envelope `kid` through the loose
+  issuer match, which on a multi-key organisation returns whichever sibling is
+  listed first, and only fell back to the agent bind after a signature failure.
+  A receipt whose signature could not be checked at all (an algorithm outside the
+  profile) therefore reported the sibling's revocation status and a
+  `key_substituted` binding failure that were both artefacts of the wrong entry.
+  Every path now resolves through one matcher: the signed `key_thumbprint` first
+  (it names the exact key even after a rotation leaves an agent with two published
+  keys), then the exact key id, then the agent bind, then the bare-kid issuer
+  match. The TypeScript verifier and the Python oracle adapter take the same
+  order. A thumbprint naming a key the signature was not made with is still
+  caught: the signature fails against it and `key_binding` reports the
+  substitution.
+
+
 
 - **RFC 8785 member order on the two verification paths that still sorted by code
   point.** The standalone `verify_receipt.py` (`canonical_json`, the bytes it checks
@@ -49,7 +65,6 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   verifiers check rather than only the bytes the emitters produce.
 - `docs/fingerprint-spec.md`, `doors.py` and `demo.py` no longer describe or use
   code-point key order.
-
 
 ## [0.10.5] - 2026-09-01
 

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -160,6 +160,7 @@ class AsqavNativeAdapter(FormatAdapter):
             payload.get("agent_id") or doc.get("agent_id"),
             payload.get("issuer_id"),
             payload.get("org_id") or doc.get("org_id"),
+            payload.get("key_thumbprint"),
         )
 
     def resolve_key(self, doc: dict, key_provider: Any) -> tuple[bytes | None, str]:

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -1368,23 +1368,52 @@ def _match_key_by_agent(jwks: dict, agent_id, issuer_id, org_id=None):
     return None
 
 
-def match_signing_key(jwks: dict, kid: str, agent_id=None, issuer_id=None, org_id=None):
+def _match_key_by_thumbprint(jwks: dict, thumbprint):
+    """Return the first usable jwks entry publishing exactly this key_thumbprint.
+
+    The thumbprint sits inside the signed bytes and names one key in one step, so it
+    outranks every unsigned or set-valued identifier. A directory that publishes no
+    thumbprints simply never matches here.
+    """
+    if not isinstance(thumbprint, str) or not is_well_formed(thumbprint):
+        return None
+    keys = jwks.get("keys") if isinstance(jwks, dict) else None
+    if not isinstance(keys, list):
+        return None
+    for k in keys:
+        if not isinstance(k, dict):
+            continue
+        if k.get("key_thumbprint") == thumbprint and isinstance(k.get("public_key"), str):
+            return k
+    return None
+
+
+def match_signing_key(
+    jwks: dict, kid: str, agent_id=None, issuer_id=None, org_id=None, key_thumbprint=None
+):
     """Return the one jwks entry a receipt's signature is checked against.
 
-    Exact key id, then the agent bind, then the bare-kid issuer match. Every caller
-    resolves through here so the key that verifies a signature and the key whose
-    status and issuer the axes weigh are one entry; resolving them separately lets a
-    receipt verify against a key found one way while revocation and issuer read a
-    key found the other.
+    Signed key_thumbprint, then exact key id, then the agent bind, then the bare-kid
+    issuer match. Every caller resolves through here so the key that verifies a
+    signature and the key whose status and issuer the axes weigh are one entry;
+    resolving them separately lets a receipt verify against a key found one way
+    while revocation and issuer read a key found the other.
 
     Order carries the security. A cloud receipt puts the org id in kid and the
     directory publishes issuer_id on every key that org owns, so an org-shaped kid
     matches each sibling alike and list position picks one. Position binds nothing -
-    agent_id and issuer_id both sit inside the signed bytes - while the sibling it
-    lands on holds other key bytes, another revocation status and another agent. The
-    agent bind carries the org_id a hash-mode receipt signs, so the correct sibling
-    resolves before the loose match.
+    key_thumbprint, agent_id and issuer_id all sit inside the signed bytes - while
+    the sibling it lands on holds other key bytes, another revocation status and
+    another agent. The thumbprint names the exact key even after a rotation leaves
+    an agent with two published keys; the agent bind carries the org_id a hash-mode
+    receipt signs; both resolve before the loose match. A thumbprint that names a
+    key the signature was not made with is caught downstream: the signature fails
+    against it, the agent bind finds the real signer, and key_binding reports the
+    substitution.
     """
+    entry = _match_key_by_thumbprint(jwks, key_thumbprint)
+    if entry is not None:
+        return entry
     entry = _match_key_by_id(jwks, kid)
     if entry is not None:
         return entry
@@ -1392,6 +1421,25 @@ def match_signing_key(jwks: dict, kid: str, agent_id=None, issuer_id=None, org_i
     if entry is not None:
         return entry
     return _match_key(jwks, kid)
+
+
+def _entry_material(entry):
+    # (public_key_bytes, status, alg) of a matched entry, or three Nones for a miss.
+    if entry is None:
+        return None, None, None
+    return _b64decode(entry["public_key"]), entry.get("status"), entry.get("alg")
+
+
+def _signing_key_entry(jwks: dict, kid: str, payload: dict, envelope: dict):
+    # The standalone paths resolve exactly as the oracle adapter does, one entry for every axis.
+    return match_signing_key(
+        jwks,
+        kid,
+        payload.get("agent_id") or envelope.get("agent_id"),
+        payload.get("issuer_id"),
+        payload.get("org_id") or envelope.get("org_id"),
+        payload.get("key_thumbprint"),
+    )
 
 
     # Return the issuer id a jwks entry publishes, or None when it names no string.
@@ -2054,7 +2102,8 @@ def run(
         envelope, trusted_tsa_keys=trusted_tsa_keys, bitcoin_headers=bitcoin_headers
     )
 
-    pk, status, jwks_alg = resolve_key(jwks, kid)
+    entry = _signing_key_entry(jwks, kid, payload, envelope)
+    pk, status, jwks_alg = _entry_material(entry)
     # The key the signature axis actually verified against, which is what the
     # key_binding axis has to rederive the bound thumbprint from.
     eff_pk, eff_alg = None, None
@@ -2065,9 +2114,10 @@ def run(
         _raw_sig = sig_obj.get("sig", "")
         sig = _b64decode(_raw_sig) if isinstance(_raw_sig, str) else b""
         sig_res = verify_signature(pk, msg, sig, alg or jwks_alg)
-        eff_status, eff_kid = status, kid
-        eff_issuer = resolve_key_issuer(jwks, kid)
-        eff_revoked_at = resolve_revoked_at(jwks, kid)
+        eff_status = status
+        eff_kid = kid if kid and kid in (entry.get("issuer_id"), entry.get("kid")) else entry.get("kid")
+        eff_issuer = key_issuer_of(entry)
+        eff_revoked_at = revoked_at_of(entry)
         eff_pk, eff_alg = pk, jwks_alg
         # Cloud receipts sign with the agent key though kid is the issuer id; fall back.
         # agent_id is attacker-controlled, so trust only a key whose issuer_id matches.
@@ -2250,7 +2300,8 @@ def run_structured(
         envelope, trusted_tsa_keys=trusted_tsa_keys, bitcoin_headers=bitcoin_headers
     )
 
-    pk, status, jwks_alg = resolve_key(jwks, kid)
+    entry = _signing_key_entry(jwks, kid, payload, envelope)
+    pk, status, jwks_alg = _entry_material(entry)
     # The key the signature axis actually verified against, which is what the
     # key_binding axis has to rederive the bound thumbprint from.
     eff_pk, eff_alg = None, None
@@ -2261,9 +2312,10 @@ def run_structured(
         _raw_sig = sig_obj.get("sig", "")
         sig_bytes = _b64decode(_raw_sig) if isinstance(_raw_sig, str) else b""
         sig_res = verify_signature(pk, msg, sig_bytes, alg or jwks_alg)
-        eff_status, eff_kid = status, kid
-        eff_issuer = resolve_key_issuer(jwks, kid)
-        eff_revoked_at = resolve_revoked_at(jwks, kid)
+        eff_status = status
+        eff_kid = kid if kid and kid in (entry.get("issuer_id"), entry.get("kid")) else entry.get("kid")
+        eff_issuer = key_issuer_of(entry)
+        eff_revoked_at = revoked_at_of(entry)
         eff_pk, eff_alg = pk, jwks_alg
         # Cloud receipts sign with the agent key though kid is the issuer id; fall back,
         # mirroring run(). agent_id is attacker-controlled, so match on issuer_id.

--- a/python/tests/test_signing_key_resolution_order.py
+++ b/python/tests/test_signing_key_resolution_order.py
@@ -1,0 +1,181 @@
+"""The standalone verifier resolves the signing key by what the receipt signed, not list position.
+
+Criterion 564. The envelope kid of a cloud receipt is the org id, which every sibling key of the
+org publishes as issuer_id, so a loose match answers with whichever sibling is listed first. The
+signed key_thumbprint and the signed agent_id name the real key; the matcher reads them first.
+Every directory here publishes more than one key under one issuer, the shape that exposes a
+matcher which returns whatever it reaches first.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from asqav.verifier import verify_receipt as v
+from asqav.verifier.oracle.adapters.asqav_native import AsqavNativeAdapter
+from asqav.verifier.oracle.core import verify as oracle_verify
+
+ORG = "f94f66c0-c580-432d-a041-29374f7aee07"
+OTHER_ORG = "0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38"
+
+
+def _ml_dsa_65():
+    return pytest.importorskip("dilithium_py.ml_dsa").ML_DSA_65
+
+
+def _key(kid: str, agent_id: str, pk: bytes, *, issuer_id: str = ORG, status: str = "active",
+         thumbprint: bool = True) -> dict:
+    entry = {
+        "kid": kid,
+        "agent_id": agent_id,
+        "issuer_id": issuer_id,
+        "org_id": issuer_id,
+        "alg": "ML-DSA-65",
+        "kty": "AKP",
+        "public_key": base64.b64encode(pk).decode(),
+        "status": status,
+        "revoked_at": "2026-07-11T14:57:49Z" if status == "revoked" else None,
+    }
+    if thumbprint:
+        entry["key_thumbprint"] = v.thumbprint_for_key(alg="ML-DSA-65", public_key=pk)
+    return entry
+
+
+def _payload(agent_id: str = "agt_two", issuer_id: str = ORG, thumbprint: str | None = None) -> dict:
+    p = {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-06-19T00:00:00+00:00",
+        "issuer_id": issuer_id,
+        "agent_id": agent_id,
+        "action_ref": "sha256:" + "8" * 64,
+        "payload_digest": {"hash": "8" * 64, "size": 512},
+        "policy_digest": "sha256:" + "3" * 64,
+        "previousReceiptHash": "0" * 64,
+        "decision": "allow",
+    }
+    if thumbprint is not None:
+        p["key_thumbprint"] = thumbprint
+    return p
+
+
+def _envelope(payload: dict, sig: bytes, alg: str = "ML-DSA-65", kid: str = ORG) -> dict:
+    return {
+        "payload": payload,
+        "signature": {"alg": alg, "kid": kid, "sig": base64.b64encode(sig).decode()},
+        "anchors": [],
+    }
+
+
+def _axes(report: dict) -> dict[str, tuple[str, str]]:
+    return {a["name"]: (a["result"], a["note"]) for a in report["axes"]}
+
+
+def test_unsupported_alg_resolves_the_named_agent_key_not_the_revoked_sibling() -> None:
+    """Signature SKIPPED (an algorithm outside the profile), so no failure ever triggered the
+    old agent-bind fallback and the revoked sibling's status was reported. Mirrors the live
+    canary of 2026-09-02."""
+    ml44 = pytest.importorskip("dilithium_py.ml_dsa").ML_DSA_44
+    old_pk, _ = ml44.keygen()
+    two_pk, two_sk = ml44.keygen()
+    payload = _payload("agt_two")
+    sig = ml44.sign(two_sk, v.canonical_json(payload))
+    old = _key("k-old", "agt_one", old_pk, status="revoked", thumbprint=False)
+    two = _key("k-two", "agt_two", two_pk, thumbprint=False)
+    old["alg"] = two["alg"] = "ML-DSA-44"
+    jwks = {"keys": [old, two]}
+    report = v.run_structured(_envelope(payload, sig, alg="ML-DSA-44"), jwks, None)
+    axes = _axes(report)
+    assert axes["signature"][0] == "SKIPPED"
+    assert axes["key_status"][0] == "PASS", axes["key_status"]
+    assert axes["issuer_bind"][0] == "PASS"
+
+
+def test_rotated_agent_resolves_by_signed_thumbprint_across_two_published_keys() -> None:
+    """Two active keys for one agent, the stale one listed first; the thumbprint picks the signer."""
+    ml = _ml_dsa_65()
+    stale_pk, _ = ml.keygen()
+    new_pk, new_sk = ml.keygen()
+    thumb = v.thumbprint_for_key(alg="ML-DSA-65", public_key=new_pk)
+    payload = _payload("agt_two", thumbprint=thumb)
+    sig = ml.sign(new_sk, v.canonical_json(payload))
+    jwks = {"keys": [_key("k-stale", "agt_two", stale_pk), _key("k-new", "agt_two", new_pk)]}
+    report = v.run_structured(_envelope(payload, sig), jwks, None)
+    axes = _axes(report)
+    assert axes["signature"][0] == "PASS", axes["signature"]
+    assert axes["key_binding"][0] == "PASS", axes["key_binding"]
+    assert axes["key_status"][0] == "PASS"
+
+
+def test_rotated_agent_without_a_thumbprint_still_lands_on_the_first_key() -> None:
+    """The documented remaining limit: without the signed thumbprint the agent bind picks by position."""
+    ml = _ml_dsa_65()
+    stale_pk, _ = ml.keygen()
+    new_pk, new_sk = ml.keygen()
+    payload = _payload("agt_two")
+    sig = ml.sign(new_sk, v.canonical_json(payload))
+    jwks = {"keys": [_key("k-stale", "agt_two", stale_pk), _key("k-new", "agt_two", new_pk)]}
+    report = v.run_structured(_envelope(payload, sig), jwks, None)
+    assert _axes(report)["signature"][0] == "FAIL"
+
+
+def test_thumbprint_naming_an_unused_key_is_reported_as_substitution() -> None:
+    """A thumbprint for key D while key C signed: C verifies, D was bound, the binding breaks."""
+    ml = _ml_dsa_65()
+    c_pk, c_sk = ml.keygen()
+    d_pk, _ = ml.keygen()
+    payload = _payload("agt_two", thumbprint=v.thumbprint_for_key(alg="ML-DSA-65", public_key=d_pk))
+    sig = ml.sign(c_sk, v.canonical_json(payload))
+    jwks = {"keys": [_key("k-c", "agt_two", c_pk), _key("k-d", "agt_two", d_pk)]}
+    report = v.run_structured(_envelope(payload, sig), jwks, None)
+    axes = _axes(report)
+    assert axes["signature"][0] == "PASS"
+    assert axes["key_binding"][0] == "FAIL" and "key_substituted" in axes["key_binding"][1]
+    assert report["verdict"] == v.VERDICT_UNVERIFIED
+    assert report["failure_class"] == v.FAILURE_INVALID
+
+
+def test_thumbprint_of_a_foreign_org_key_cannot_pass_the_issuer_bind() -> None:
+    """An attacker binding their own published key's thumbprint verifies the signature and fails the bind."""
+    ml = _ml_dsa_65()
+    attacker_pk, attacker_sk = ml.keygen()
+    victim_pk, _ = ml.keygen()
+    payload = _payload("agt_attacker", issuer_id=ORG,
+                       thumbprint=v.thumbprint_for_key(alg="ML-DSA-65", public_key=attacker_pk))
+    sig = ml.sign(attacker_sk, v.canonical_json(payload))
+    jwks = {"keys": [_key("k-victim", "agt_victim", victim_pk),
+                     _key("k-attacker", "agt_attacker", attacker_pk, issuer_id=OTHER_ORG)]}
+    report = v.run_structured(_envelope(payload, sig), jwks, None)
+    axes = _axes(report)
+    assert axes["issuer_bind"][0] == "FAIL", axes["issuer_bind"]
+    assert report["verdict"] == v.VERDICT_UNVERIFIED
+
+
+def test_match_signing_key_order_is_thumbprint_kid_agent_then_issuer() -> None:
+    ml = _ml_dsa_65()
+    a_pk, _ = ml.keygen()
+    b_pk, _ = ml.keygen()
+    a, b = _key("k-a", "agt_a", a_pk), _key("k-b", "agt_b", b_pk)
+    jwks = {"keys": [a, b]}
+    thumb_b = b["key_thumbprint"]
+    # The signed thumbprint outranks an exact kid that names another key.
+    assert v.match_signing_key(jwks, "k-a", "agt_a", ORG, ORG, thumb_b) is b
+    assert v.match_signing_key(jwks, "k-a", "agt_b", ORG, ORG) is a
+    assert v.match_signing_key(jwks, ORG, "agt_b", ORG, ORG) is b
+    assert v.match_signing_key(jwks, ORG, None, ORG, ORG) is a
+    # A malformed thumbprint never matches and never crashes.
+    assert v.match_signing_key(jwks, ORG, "agt_b", ORG, ORG, "sha256:nope") is b
+
+
+def test_oracle_adapter_agrees_with_the_standalone_on_the_rotated_agent() -> None:
+    ml = _ml_dsa_65()
+    stale_pk, _ = ml.keygen()
+    new_pk, new_sk = ml.keygen()
+    thumb = v.thumbprint_for_key(alg="ML-DSA-65", public_key=new_pk)
+    payload = _payload("agt_two", thumbprint=thumb)
+    sig = ml.sign(new_sk, v.canonical_json(payload))
+    jwks = {"keys": [_key("k-stale", "agt_two", stale_pk), _key("k-new", "agt_two", new_pk)]}
+    res = oracle_verify(_envelope(payload, sig), [AsqavNativeAdapter()], jwks)
+    by_name = {a.axis: a.result for a in res.axes}
+    assert by_name["signature"] == "PASS", res.axes

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -155,6 +155,7 @@ export class AsqavNativeAdapter extends FormatAdapter {
       payload.agent_id ?? doc.agent_id,
       payload.issuer_id,
       payload.org_id ?? doc.org_id,
+      payload.key_thumbprint,
     );
   }
 

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -262,9 +262,27 @@ function matchKeyByAgent(
   return null;
 }
 
+// The signed key_thumbprint names one key in one step (mirrors `_match_key_by_thumbprint`), so it
+// outranks every unsigned or set-valued identifier; a directory publishing none never matches here.
+function matchKeyByThumbprint(
+  jwks: Record<string, unknown> | null,
+  thumbprint: unknown,
+): Record<string, unknown> | null {
+  if (typeof thumbprint !== "string" || !isWellFormedThumbprint(thumbprint)) return null;
+  const keys = jwks?.keys;
+  if (!Array.isArray(keys)) return null;
+  for (const k of keys as Array<Record<string, unknown>>) {
+    if (k === null || typeof k !== "object") continue;
+    if (k.key_thumbprint === thumbprint && typeof k.public_key === "string") return k;
+  }
+  return null;
+}
+
 /**
  * The one JWKS entry a receipt's signature is checked against (mirrors `match_signing_key`).
- * Order carries the security: exact key id, then the agent bind, then the bare-kid issuer match.
+ * Order carries the security: the signed key_thumbprint, then the exact key id, then the agent bind,
+ * then the bare-kid issuer match. A thumbprint naming a key the signature was not made with fails
+ * the signature axis against that key, which is the substitution the binding exists to catch.
  */
 export function matchSigningKey(
   jwks: Record<string, unknown> | null,
@@ -272,8 +290,10 @@ export function matchSigningKey(
   agentId?: unknown,
   issuerId?: unknown,
   orgId?: unknown,
+  keyThumbprint?: unknown,
 ): Record<string, unknown> | null {
   return (
+    matchKeyByThumbprint(jwks, keyThumbprint) ??
     matchKeyById(jwks, kid) ??
     matchKeyByAgent(jwks, agentId, issuerId, orgId) ??
     matchKey(jwks, kid)

--- a/typescript/tests/signing-key-resolution-order.test.ts
+++ b/typescript/tests/signing-key-resolution-order.test.ts
@@ -1,0 +1,137 @@
+// The asqav-native adapter resolves the signing key by the signed key_thumbprint first. TS half of
+// test_signing_key_resolution_order.py: two published keys under one issuer in every directory.
+
+import { describe, expect, it } from "vitest";
+import { ml_dsa44, ml_dsa65 } from "@noble/post-quantum/ml-dsa.js";
+
+import { AsqavNativeAdapter } from "../src/verifier/adapters/asqavNative.js";
+import { asqavJcs } from "../src/verifier/canonical.js";
+import { verify } from "../src/verifier/core.js";
+import { matchSigningKey, thumbprintForKey } from "../src/verifier/vrShim.js";
+
+const ORG = "f94f66c0-c580-432d-a041-29374f7aee07";
+const OTHER_ORG = "0b6c2b1e-9f7a-4d3c-8a11-5c2e7d904f38";
+
+const sign = (msg: Uint8Array, sk: Uint8Array) => Buffer.from(ml_dsa65.sign(msg, sk)).toString("base64");
+
+function key(
+  kid: string,
+  agentId: string,
+  pk: Uint8Array,
+  opts: { issuerId?: string; status?: string; thumbprint?: boolean } = {},
+): Record<string, unknown> {
+  const issuer = opts.issuerId ?? ORG;
+  const entry: Record<string, unknown> = {
+    kid,
+    agent_id: agentId,
+    issuer_id: issuer,
+    org_id: issuer,
+    alg: "ML-DSA-65",
+    kty: "AKP",
+    public_key: Buffer.from(pk).toString("base64"),
+    status: opts.status ?? "active",
+    revoked_at: opts.status === "revoked" ? "2026-07-11T14:57:49Z" : null,
+  };
+  if (opts.thumbprint !== false) entry.key_thumbprint = thumbprintForKey("ML-DSA-65", pk);
+  return entry;
+}
+
+function payload(agentId = "agt_two", thumbprint?: string, issuerId = ORG): Record<string, unknown> {
+  const p: Record<string, unknown> = {
+    type: "protectmcp:decision",
+    issued_at: "2026-06-19T00:00:00.000000Z",
+    issuer_id: issuerId,
+    agent_id: agentId,
+    action_ref: `sha256:${"8".repeat(64)}`,
+    payload_digest: { hash: "8".repeat(64), size: 512 },
+    policy_digest: `sha256:${"3".repeat(64)}`,
+    previousReceiptHash: "0".repeat(64),
+    decision: "allow",
+  };
+  if (thumbprint !== undefined) p.key_thumbprint = thumbprint;
+  return p;
+}
+
+function receipt(p: Record<string, unknown>, sig: string, alg = "ML-DSA-65"): Record<string, unknown> {
+  return { payload: p, signature: { alg, kid: ORG, sig }, anchors: [] };
+}
+
+function axesOf(doc: Record<string, unknown>, jwks: Record<string, unknown>) {
+  const res = verify(doc, [new AsqavNativeAdapter()], jwks);
+  const axes: Record<string, { result: string; note: string }> = {};
+  for (const a of res.axes) axes[a.axis] = { result: a.result, note: a.note };
+  return { res, axes };
+}
+
+describe("signing-key resolution order", () => {
+  it("resolves the named agent key, not the revoked sibling, when the signature cannot be checked", () => {
+    // An algorithm outside the profile, as the live ML-DSA-44 canary of 2026-09-02 was.
+    const old = ml_dsa44.keygen();
+    const two = ml_dsa44.keygen();
+    const p = payload("agt_two");
+    const oldKey = key("k-old", "agt_one", old.publicKey, { status: "revoked", thumbprint: false });
+    const twoKey = key("k-two", "agt_two", two.publicKey, { thumbprint: false });
+    oldKey.alg = "ML-DSA-44";
+    twoKey.alg = "ML-DSA-44";
+    const jwks = { keys: [oldKey, twoKey] };
+    const sig44 = Buffer.from(ml_dsa44.sign(asqavJcs(p), two.secretKey)).toString("base64");
+    const { axes } = axesOf(receipt(p, sig44, "ML-DSA-44"), jwks);
+    expect(axes.signature.result).toBe("SKIPPED");
+    expect(axes.key_status.result).toBe("PASS");
+    expect(axes.issuer_bind.result).toBe("PASS");
+  });
+
+  it("resolves a rotated agent by the signed thumbprint across two published keys", () => {
+    const stale = ml_dsa65.keygen();
+    const fresh = ml_dsa65.keygen();
+    const p = payload("agt_two", thumbprintForKey("ML-DSA-65", fresh.publicKey));
+    const jwks = { keys: [key("k-stale", "agt_two", stale.publicKey), key("k-new", "agt_two", fresh.publicKey)] };
+    const { axes } = axesOf(receipt(p, sign(asqavJcs(p), fresh.secretKey)), jwks);
+    expect(axes.signature.result).toBe("PASS");
+    expect(axes.key_binding.result).toBe("PASS");
+    expect(axes.key_status.result).toBe("PASS");
+  });
+
+  it("without a signed thumbprint a rotated agent still lands on the first key", () => {
+    const stale = ml_dsa65.keygen();
+    const fresh = ml_dsa65.keygen();
+    const p = payload("agt_two");
+    const jwks = { keys: [key("k-stale", "agt_two", stale.publicKey), key("k-new", "agt_two", fresh.publicKey)] };
+    const { axes } = axesOf(receipt(p, sign(asqavJcs(p), fresh.secretKey)), jwks);
+    expect(axes.signature.result).toBe("FAIL");
+  });
+
+  it("keeps a thumbprint naming an unused key from verifying", () => {
+    const c = ml_dsa65.keygen();
+    const d = ml_dsa65.keygen();
+    const p = payload("agt_two", thumbprintForKey("ML-DSA-65", d.publicKey));
+    const jwks = { keys: [key("k-c", "agt_two", c.publicKey), key("k-d", "agt_two", d.publicKey)] };
+    const { res, axes } = axesOf(receipt(p, sign(asqavJcs(p), c.secretKey)), jwks);
+    expect(axes.signature.result).toBe("FAIL");
+    expect(res.verdict).toBe("unverified");
+    expect(res.failureClass).toBe("invalid");
+  });
+
+  it("cannot pass the issuer bind with a foreign org's thumbprint", () => {
+    const attacker = ml_dsa65.keygen();
+    const victim = ml_dsa65.keygen();
+    const p = payload("agt_attacker", thumbprintForKey("ML-DSA-65", attacker.publicKey));
+    const jwks = {
+      keys: [key("k-victim", "agt_victim", victim.publicKey), key("k-attacker", "agt_attacker", attacker.publicKey, { issuerId: OTHER_ORG })],
+    };
+    const { res, axes } = axesOf(receipt(p, sign(asqavJcs(p), attacker.secretKey)), jwks);
+    expect(axes.issuer_bind.result).toBe("FAIL");
+    expect(res.verdict).toBe("unverified");
+  });
+
+  it("orders thumbprint, then kid, then agent bind, then issuer", () => {
+    const a = key("k-a", "agt_a", ml_dsa65.keygen().publicKey);
+    const b = key("k-b", "agt_b", ml_dsa65.keygen().publicKey);
+    const jwks = { keys: [a, b] };
+    expect(matchSigningKey(jwks, "k-a", "agt_a", ORG, ORG, b.key_thumbprint)).toBe(b);
+    expect(matchSigningKey(jwks, "k-a", "agt_b", ORG, ORG)).toBe(a);
+    expect(matchSigningKey(jwks, ORG, "agt_b", ORG, ORG)).toBe(b);
+    expect(matchSigningKey(jwks, ORG, undefined, ORG, ORG)).toBe(a);
+    expect(matchSigningKey(jwks, ORG, "agt_b", ORG, ORG, "sha256:nope")).toBe(b);
+  });
+});


### PR DESCRIPTION
## What

Criterion 564 (live-wire finding: the bare envelope `kid` resolves ambiguously on a multi-key organisation) and the resolver asymmetry the audit brief flagged under item 5.2.

`verify_receipt.py`'s `run()` and `run_structured()` resolved the envelope `kid` through the loose issuer match (`resolve_key`), which answers with whichever sibling is listed first, and only fell back to the agent bind after a signature failure. The oracle adapters already resolved through `match_signing_key` (exact kid, then agent bind, then issuer). Both halves now resolve through one matcher with one order:

1. the signed `key_thumbprint` (names the exact key even after a rotation leaves an agent with two published keys; the directory publishes it from asqav PR #1401 on),
2. the exact key id,
3. the agent bind (agent_id plus the claimed issuer or org),
4. the bare-kid issuer match.

The Python standalone, the Python oracle adapter and the TypeScript adapter all take this order; `resolveKey` in TypeScript's `dsse.ts` (service identity, unique kid) is untouched.

## What it fixes, measured

A fresh hash-mode receipt on the seq-wire canary (`sig_51pGPbPB6gPG1fKm2dgaPA`, 2026-09-02), verified offline with the standalone verifier against the live JWK Set: the bare kid resolved to a revoked sibling, the ML-DSA-44 signature could not be checked, so the fallback never ran and the report showed `key_status FAIL` and `key_binding FAIL key_substituted` for a key that never signed it. With this change the agent bind resolves the canary's own key.

## Tests

`python/tests/test_signing_key_resolution_order.py` and `typescript/tests/signing-key-resolution-order.test.ts`, every directory holding two keys under one issuer:

- an algorithm outside the profile resolves the named agent's key, not the revoked sibling (signature SKIPPED, key_status PASS);
- a rotated agent with two published keys resolves by the signed thumbprint (signature, key_binding and key_status PASS);
- without a signed thumbprint the rotated agent still lands on the first key (the documented remaining limit; every receipt since the thumbprint shipped carries one);
- a thumbprint naming an unused key: Python verifies against the real signer via the agent bind and reports `key_substituted`; TypeScript fails the signature against the named key; both `unverified` / `invalid`;
- a foreign org's thumbprint cannot pass the issuer bind;
- the matcher order itself, including a malformed thumbprint never matching.

Mutation proof: five of the seven Python tests fail against the resolver on main (run in a worktree of `origin/main`), including the two behavioural ones: the unsupported-algorithm case reports the revoked sibling, and the rotated agent fails its signature.

`ruff check src` and `tsc --noEmit` clean; the targeted Python suites and the TypeScript verifier suites pass.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
