### PR TITLE
Pin the dialect cutover to the platform deploy and cut the next patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.6] - 2026-09-02
+
+### Fixed
+
+- **The anchors axis called genuine receipts invalid.** It hashed every top-level
+  member of an Audit Pack entry, while the signer commits
+  `sha256(JCS({payload, signature}))` over the wire signature string. An untouched
+  production receipt therefore verified as `unverified` with
+  `failure_class: invalid`, the class reserved for a binding proven broken, and
+  exited 1. The envelope is now projected to exactly the three canonical members
+  and the anchored bytes are the two committed ones. Where an export carries the
+  signature in the other base64 alphabet, the commitment is checked against the
+  alphabet the signer used and the report says which one matched; that tolerance
+  is a migration measure and never launders a tamper, because a changed payload
+  fails under both alphabets. Pinned against a real production receipt.
+- **The gate's cache predicate ignored a key rotation.** It tested the agent bind
+  before the signed key thumbprint, so a stale cache answered "present" after a
+  rotation and the gate blocked every tool call for up to a day.
+- **Receipt verification could outlive the gate's deadline.** The verification and
+  any key-set refresh now run inside the same budget, so the gate answers before
+  the harness timeout it documents.
+- **A deny or rate_limit decision read as `signed` and exited 0.** It now blocks
+  with the decision and a reason on stderr.
+- **A shared key thumbprint resolved by row order.** It is broken by the signed
+  agent id and then the envelope kid, so a receipt naming a revoked duplicate
+  still reaches the key-status axis with that row.
+- **The agent-bind fallback took the first row rather than the right one.** It now
+  keeps the candidate whose signature verifies, leaving revocation to the
+  key-status axis where it belongs.
+- **The two languages disagreed on three inputs.** The thumbprint pattern uses
+  fullmatch, an empty identifier counts as missing on both sides, and a lone
+  surrogate is no longer read as a supplementary member name.
+
+### Changed
+
+- `JCS_UTF16_CUTOVER` is pinned to `2026-09-02T18:05:09+00:00`, the measured
+  instant the platform deploy carrying the RFC 8785 emitter went live.
+- Offline verification is documented from the Audit Pack export. The hosted
+  verify response is a display projection that omits identifier members of the
+  signed payload, so a receipt saved from it can never reproduce the signature.
+- The differential fuzzer prints the engine roster it compared, because engines
+  that are absent cannot disagree and a degraded roster otherwise reads as green.
+- The JWK Set cache trust boundary is written down in the hooks guide, and every
+  quotation of the harness documentation there is verbatim with its source and
+  access date.
+
+
 ### Changed
 
 - **Harness hooks send a digest by default.** `asqav hook pretool` and `asqav hook

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.5"
+version = "0.10.6"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -192,7 +192,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.5"
+__version__ = "0.10.6"
 __all__ = [
     # Initialization
     "init",

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -141,7 +141,7 @@ MAX_NESTING_DEPTH = 200
 
 #: Instant from which the issuing platform emits RFC 8785 member order on the wire. Pinned to
 #: the production deploy of the emitter change; receipts issued later never get the retry below.
-JCS_UTF16_CUTOVER = "2026-09-02T12:00:00+00:00"
+JCS_UTF16_CUTOVER = "2026-09-02T18:05:09+00:00"
 
 
 def _utf16_member_order(name: str) -> bytes:

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -3,7 +3,7 @@
  * added under Node, since browsers forbid setting User-Agent on fetch.
  */
 
-export const SDK_VERSION = "0.10.5";
+export const SDK_VERSION = "0.10.6";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 

--- a/typescript/src/verifier/canonical.ts
+++ b/typescript/src/verifier/canonical.ts
@@ -346,7 +346,7 @@ export function asqavJcs(obj: unknown): Uint8Array {
  * Instant from which the issuing platform emits RFC 8785 member order on the wire. Pinned to the
  * production deploy of the emitter change; receipts issued later never get the pre-cutover retry.
  */
-export const JCS_UTF16_CUTOVER = "2026-09-02T12:00:00+00:00";
+export const JCS_UTF16_CUTOVER = "2026-09-02T18:05:09+00:00";
 
 /**
  * The code-point member order the cloud emitted before JCS_UTF16_CUTOVER. Diagnostic only: a signature


### PR DESCRIPTION
The cutover constant held a provisional value while the platform change was still in flight. It now carries the measured instant that deploy went live, 2026-09-02T18:05:09+00:00, so the pre-cutover diagnostic covers exactly the receipts issued before it and nothing after. The five version files move together and the changelog opens its section.

Verified against the packaged artifact, not the source tree, because a registry publish is a one-way door: the wheel installs into a clean environment, reports the new version and the pinned cutover, and its standalone verifier reads a real production receipt with the signature axis passing and the timestamp-token imprint MATCHING. Before this branch's parent the same receipt was reported invalid, the class reserved for a binding proven broken.

Suites: 3027 Python passed, 1 skipped; 1140 TypeScript passed.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
