### PR TITLE
Re-pin the stale counterparty digest and gate the corpus on its own inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
               # corpus here, so editing one must re-run this job.
               - 'verifier/check_corpus_lock.sh'
               - 'verifier/freeze_corpus_lock.py'
+              - 'verifier/regen_fingerprint_vectors.py'
+              - 'conformance/**'
               - 'verifier/docs/**'
               - '.github/workflows/ci.yml'
             actions:
@@ -129,12 +131,18 @@ jobs:
       # Corpus freeze path B (criterion 420): re-derive every lock pin through
       # sha256sum, independent of the hashlib pass in test_corpus_lock.py.
       - run: bash verifier/check_corpus_lock.sh
+      # Corpus INTEGRITY (criterion 671): the freeze above proves the file has not
+      # changed; this proves the file is right. Every derived member is recomputed
+      # from that vector's own input and compared to the published bytes. A stale
+      # derived member - the counterparty envelope_hash was stale in five vectors -
+      # passes the freeze and fails here.
+      - run: python3 verifier/regen_fingerprint_vectors.py --check
       # Criterion 421 walkthrough: jq/sha256sum/openssl verification of the
       # published receipt. ubuntu-latest ships OpenSSL 3.0 without ML-DSA, so
       # the ML-DSA step is declared document-only; every other step executes
       # and asserts its pinned value.
       - run: bash verifier/docs/openssl-jq-verify.sh --mldsa-document-only
-      - run: PYTHONPATH=python/src pytest python/tests/test_oracle.py python/tests/test_verify_receipt.py python/tests/test_verify_receipt_revoked_key.py python/tests/test_verify_receipt_failclean.py python/tests/test_offline_verify.py python/tests/test_cross_language_cases.py python/tests/test_axis_parity_cases.py python/tests/test_anchor_value_cases.py python/tests/test_anchor_forged_value.py python/tests/test_oracle_kid_shared_resolution.py python/tests/test_signing_key_sibling.py python/tests/test_exit_artifact_cli.py python/tests/test_corpus_lock.py python/tests/test_time_edge_vectors.py python/tests/test_standalone_verifier_surface.py -v --tb=short
+      - run: PYTHONPATH=python/src pytest python/tests/test_oracle.py python/tests/test_verify_receipt.py python/tests/test_verify_receipt_revoked_key.py python/tests/test_verify_receipt_failclean.py python/tests/test_offline_verify.py python/tests/test_cross_language_cases.py python/tests/test_axis_parity_cases.py python/tests/test_anchor_value_cases.py python/tests/test_anchor_forged_value.py python/tests/test_oracle_kid_shared_resolution.py python/tests/test_signing_key_sibling.py python/tests/test_exit_artifact_cli.py python/tests/test_corpus_lock.py python/tests/test_corpus_integrity.py python/tests/test_time_edge_vectors.py python/tests/test_standalone_verifier_surface.py -v --tb=short
 
   actions:
     needs: changes

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -33,11 +33,49 @@ Before signing, the server formats `{"action_type": ..., "context": ...}` (plus 
 
 See `vectors.json`. Each vector has:
 
-- `input`: the raw action payload.
+- `input`: the wire object. Every member here is a real wire member.
 - `canonical`: the JCS-canonical byte sequence, shown as a UTF-8 string.
 - `sha256`: the SHA-256 of the canonical bytes, hex-encoded.
+- `expected`: values that are NOT wire members - what a correct implementation should
+  produce, plus vector metadata. Do not implement a field from this block.
 
 If your implementation produces the same `canonical` and `sha256` for each `input`, you are ready to verify live Asqav records.
+
+### Counterparty binding vectors
+
+A counterparty acknowledgment carries `counterparty_binding.envelope_hash`: the SHA-256
+of the ORIGINATING envelope, base64. The scope of that digest is declared on the wire in
+`counterparty_binding.scope`:
+
+- `envelope_minus_anchors` - the digest covers the JCS bytes of `{payload, signature}`
+  only. Anchors are excluded because they are OPTIONAL and change after issuance, so a
+  digest covering them would break every acknowledgment already emitted the moment the
+  originator's timestamp was upgraded.
+- An ABSENT `scope` member means a legacy draft-04..-08 three-key binding, which a
+  verifier reports as `unverifiable, legacy scope`. A verifier MUST NOT try both scopes
+  and accept whichever matches.
+
+Each such vector names the envelope its digest is taken over in
+`expected.originating_envelope_ref`, so the value is recomputable from this file alone.
+`counterparty_binding_envelope_byte_equality` is that originating envelope and is a pure
+canonicalization fixture: its own `sha256` is the digest of the full three-key object and
+is deliberately NOT the binding value.
+
+### Derived members, and how they are kept honest
+
+`canonical`, `sha256` and the `envelope_hash` family are DERIVED - regenerate them, never
+hand-edit them:
+
+    python verifier/regen_fingerprint_vectors.py           # rewrite every derived member
+    python verifier/regen_fingerprint_vectors.py --check   # CI gate; nonzero on any drift
+    python verifier/freeze_corpus_lock.py                  # then move the pins
+
+The `--check` pass recomputes every derived member from that vector's own `input` and
+fails on any difference. It exists because the freeze below proves the file has not
+CHANGED, which is not the same as proving it is RIGHT: the counterparty `envelope_hash`
+was stale in five vectors while every pin and every test stayed green, because the only
+tests that named it built their expected value by calling the function under test.
+`python/tests/test_corpus_integrity.py` now pins each derived member as a literal string.
 
 ## Reporting mismatches
 

--- a/conformance/manifest.lock.json
+++ b/conformance/manifest.lock.json
@@ -11,13 +11,13 @@
     },
     {
       "path": "README.md",
-      "sha256": "e2a5ef958acb0806955491cc9abcb3178542b2239bd3c1d046b8315880423bb4",
-      "bytes": 4563
+      "sha256": "846f9beba2cb837e16c83c857acba239b379815a008d918ada737318136784a0",
+      "bytes": 6815
     },
     {
       "path": "vectors.json",
-      "sha256": "15ba498bc319b7ca663279c22eca87809e5dc68df7128fa732c06279cbff57ec",
-      "bytes": 33413
+      "sha256": "67ccb14b62cc301a37872ddc81d0da0b9ab11e12dcf6a369e502935b78e3a1ae",
+      "bytes": 34440
     }
   ],
   "signing": {
@@ -35,5 +35,5 @@
     },
     "known_answer_message_note": "the 32-byte SHA-256 digest of the canonical bytes of vector 'minimal_read': the hash is what ML-DSA-65 signs"
   },
-  "digest": "de1dfb87baf517cd4b779edd253588eede636cd20ca2265f2a2c21b07a82e250"
+  "digest": "84c3f8e621539efb11169fe123c7e78b946935604acd84a91644cb4f37e4b23e"
 }

--- a/conformance/vectors.json
+++ b/conformance/vectors.json
@@ -249,16 +249,17 @@
     },
     {
       "name": "counterparty_binding_happy_path",
-      "description": "B's acknowledgment payload carries counterparty_binding with all four members set. envelope_hash is base64 SHA-256 over A's full signed envelope (signature included).",
+      "description": "B's acknowledgment payload carries counterparty_binding with all members set. envelope_hash is base64 SHA-256 over the JCS bytes of A's {payload, signature} - the envelope_minus_anchors scope named in counterparty_binding.scope. Anchors are excluded because they are OPTIONAL and change after issuance, so a digest covering them would break every acknowledgment the moment A's timestamp was upgraded.",
       "input": {
         "action_id": "act_01HVZB_ACK_0001",
         "action_ref": "act_01HVZA_ORIGINATOR_0001",
         "agent_id": "agt_acknowledger_B",
         "counterparty_binding": {
-          "envelope_hash": "DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=",
+          "envelope_hash": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
           "expect_ack_from": "00000000000000000098",
           "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001",
-          "transport_label": "mcp"
+          "transport_label": "mcp",
+          "scope": "envelope_minus_anchors"
         },
         "decision": "allow",
         "issued_at": "2026-05-18T20:00:01+00:00",
@@ -275,19 +276,19 @@
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0001\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=\",\"expect_ack_from\":\"00000000000000000098\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"transport_label\":\"mcp\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "b859a5c36c51764957216ae672a036e220c060677d73b4406a1d49679e7d2696",
-      "counterparty_binding": {
-        "envelope_hash_base64": "DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=",
-        "envelope_hash_hex": "0d6c88a16e96fd3429be13e44dc957062f77d417dc0c3ea28e4fa496230de2a9",
-        "originating_envelope_ref": "counterparty_binding_envelope_byte_equality"
-      },
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0001\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=\",\"expect_ack_from\":\"00000000000000000098\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"scope\":\"envelope_minus_anchors\",\"transport_label\":\"mcp\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "fd7281c6911144af8b74d2782405d1ca40e1fabccc6df41ab1be99639de8cabe",
       "expected_verify": true,
-      "reason": "Happy path: B emits counterparty_binding over A's full signed envelope; verifier resolves receipt_ref, recomputes digest, equality holds."
+      "reason": "Happy path: B emits counterparty_binding over A's signed envelope under the envelope_minus_anchors scope; verifier resolves receipt_ref, recomputes the digest over {payload, signature}, equality holds.",
+      "expected": {
+        "envelope_hash_base64": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+        "envelope_hash_hex": "a4504d771dd14c5ef6de2edcfd2f44544f54afcfd7756921412584f8aaea0abd",
+        "originating_envelope_ref": "counterparty_binding_envelope_byte_equality"
+      }
     },
     {
       "name": "counterparty_binding_envelope_byte_equality",
-      "description": "A's full signed envelope ({payload, signature, anchors}). Two independent implementations canonicalizing this object MUST produce identical bytes and the SHA-256 hex pinned here. Base64 of the digest is the value B places in counterparty_binding.envelope_hash on the happy-path vector.",
+      "description": "A's full three-key envelope ({payload, signature, anchors}). This is a PURE CANONICALIZATION fixture: two independent implementations canonicalizing this object MUST produce identical bytes and the SHA-256 hex pinned in `sha256`. That digest is NOT the counterparty binding value - the binding is taken under the envelope_minus_anchors scope over {payload, signature} only, and is published in `expected.envelope_hash_*`. The two cover different byte sets by design.",
       "input": {
         "anchors": [
           {
@@ -323,12 +324,13 @@
       },
       "canonical": "{\"anchors\":[{\"tsa_url\":\"https://tsa.example/timestamp\",\"type\":\"rfc3161\",\"value\":\"AAAA_synthetic_tsr_base64_placeholder_AAAA\"}],\"payload\":{\"action_id\":\"act_01HVZA_ORIGINATOR_0001\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_originator_A\",\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:00+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:action\",\"v\":1},\"signature\":{\"alg\":\"ML-DSA-65\",\"kid\":\"00000000000000000098\",\"sig\":\"AAAA_synthetic_signature_bytes_base64_placeholder_for_vector_only_AAAA\"}}",
       "sha256": "e89bf2fe64bd7dab3a606ea265ca14f88f4d161ec0485062a7facee4902c655f",
-      "counterparty_binding": {
-        "envelope_hash_base64": "DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=",
-        "envelope_hash_base64url": "DWyIoW6W_TQpvhPkTclXBi931BfcDD6ijk-kliMN4qk="
-      },
       "expected_verify": true,
-      "reason": "Envelope byte-equality: JCS-canonical bytes of A's signed envelope reproduce the same SHA-256 across implementations. Digest scope includes signature bytes per draft-04."
+      "reason": "Envelope byte-equality: JCS-canonical bytes of A's full envelope reproduce the same SHA-256 across implementations. This vector pins canonicalization, not the binding scope.",
+      "expected": {
+        "envelope_hash_base64": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+        "envelope_hash_base64url": "pFBNdx3RTF723i7c_S9EVE9Ur8_XdWkhQSWE-KrqCr0=",
+        "originating_envelope_ref": "counterparty_binding_envelope_byte_equality"
+      }
     },
     {
       "name": "counterparty_binding_base64url_tolerance",
@@ -338,8 +340,9 @@
         "action_ref": "act_01HVZA_ORIGINATOR_0001",
         "agent_id": "agt_acknowledger_B",
         "counterparty_binding": {
-          "envelope_hash": "DWyIoW6W_TQpvhPkTclXBi931BfcDD6ijk-kliMN4qk=",
-          "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001"
+          "envelope_hash": "pFBNdx3RTF723i7c_S9EVE9Ur8_XdWkhQSWE-KrqCr0=",
+          "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001",
+          "scope": "envelope_minus_anchors"
         },
         "decision": "allow",
         "issued_at": "2026-05-18T20:00:01+00:00",
@@ -356,15 +359,15 @@
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0003\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W_TQpvhPkTclXBi931BfcDD6ijk-kliMN4qk=\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "6754d67d7ced46f9563a00effa57c588105c9b8783e36049518f6f7e3034b266",
-      "counterparty_binding": {
-        "envelope_hash_base64url": "DWyIoW6W_TQpvhPkTclXBi931BfcDD6ijk-kliMN4qk=",
-        "envelope_hash_base64": "DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=",
-        "originating_envelope_ref": "counterparty_binding_envelope_byte_equality"
-      },
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0003\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"pFBNdx3RTF723i7c_S9EVE9Ur8_XdWkhQSWE-KrqCr0=\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"scope\":\"envelope_minus_anchors\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "1a640f2d7c805152b85f706a498f0727d8d60402083eddcabba6e9d3627eb9d3",
       "expected_verify": true,
-      "reason": "base64 / base64url tolerance: both encodings of the same SHA-256 digest MUST verify-equal against the recomputed digest of A's envelope."
+      "reason": "base64 / base64url tolerance: both encodings of the same envelope_minus_anchors digest MUST verify-equal against the recomputed digest of A's {payload, signature}.",
+      "expected": {
+        "envelope_hash_base64url": "pFBNdx3RTF723i7c_S9EVE9Ur8_XdWkhQSWE-KrqCr0=",
+        "envelope_hash_base64": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+        "originating_envelope_ref": "counterparty_binding_envelope_byte_equality"
+      }
     },
     {
       "name": "counterparty_binding_opaque_receipt_ref",
@@ -374,8 +377,9 @@
         "action_ref": "act_01HVZA_ORIGINATOR_0001",
         "agent_id": "agt_acknowledger_B",
         "counterparty_binding": {
-          "envelope_hash": "DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=",
-          "receipt_ref": "urn:uuid:12345678-1234-5678-1234-567812345678#segment[0]"
+          "envelope_hash": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+          "receipt_ref": "urn:uuid:12345678-1234-5678-1234-567812345678#segment[0]",
+          "scope": "envelope_minus_anchors"
         },
         "decision": "allow",
         "issued_at": "2026-05-18T20:00:02+00:00",
@@ -392,13 +396,14 @@
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0004\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=\",\"receipt_ref\":\"urn:uuid:12345678-1234-5678-1234-567812345678#segment[0]\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:02+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "76264e84b5743c0a881024db8e86584a6ffa0dde7c76c3679f014adeab78c26c",
-      "counterparty_binding": {
-        "receipt_ref": "urn:uuid:12345678-1234-5678-1234-567812345678#segment[0]"
-      },
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0004\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=\",\"receipt_ref\":\"urn:uuid:12345678-1234-5678-1234-567812345678#segment[0]\",\"scope\":\"envelope_minus_anchors\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:02+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "e1b5c0808a0c243ea70e06d53ed5bf102d9fd98fed95c37632916a345b0ac0eb",
       "expected_verify": true,
-      "reason": "receipt_ref is an opaque resolvable locator; verifier MUST NOT interpret its structure, only resolve it. Round-trip equality is preserved by JCS."
+      "reason": "receipt_ref is an opaque resolvable locator; verifier MUST NOT interpret its structure, only resolve it. Round-trip equality is preserved by JCS.",
+      "expected": {
+        "receipt_ref": "urn:uuid:12345678-1234-5678-1234-567812345678#segment[0]",
+        "originating_envelope_ref": "counterparty_binding_envelope_byte_equality"
+      }
     },
     {
       "name": "counterparty_binding_transport_label_non_trust",
@@ -408,9 +413,10 @@
         "action_ref": "act_01HVZA_ORIGINATOR_0001",
         "agent_id": "agt_acknowledger_B",
         "counterparty_binding": {
-          "envelope_hash": "DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=",
+          "envelope_hash": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
           "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001",
-          "transport_label": "http"
+          "transport_label": "http",
+          "scope": "envelope_minus_anchors"
         },
         "decision": "allow",
         "issued_at": "2026-05-18T20:00:03+00:00",
@@ -427,14 +433,15 @@
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0005\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"DWyIoW6W/TQpvhPkTclXBi931BfcDD6ijk+kliMN4qk=\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"transport_label\":\"http\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:03+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "c5c45719ebe1eee133ab792e54d7e906c4560607a43f010f292ddf2067ff0468",
-      "counterparty_binding": {
-        "transport_label_declared": "http",
-        "transport_label_actual": "mcp"
-      },
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0005\",\"action_ref\":\"act_01HVZA_ORIGINATOR_0001\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"scope\":\"envelope_minus_anchors\",\"transport_label\":\"http\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:03+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"alg\":\"SHA-256\",\"value\":\"sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210\"},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "edb5cb72894c37430298b31596fbb50318cdeddf3eaca7e3d3856909bdde8c93",
       "expected_verify": true,
-      "reason": "transport_label is operational only; verifiers MUST NOT derive trust from it. Binding still resolves on envelope_hash equality regardless of declared label."
+      "reason": "transport_label is operational only; verifiers MUST NOT derive trust from it. Binding still resolves on envelope_hash equality regardless of declared label.",
+      "expected": {
+        "transport_label_declared": "http",
+        "transport_label_actual": "mcp",
+        "originating_envelope_ref": "counterparty_binding_envelope_byte_equality"
+      }
     },
     {
       "name": "counterparty_binding_missing_envelope_hash_rejected",

--- a/python/tests/test_corpus_integrity.py
+++ b/python/tests/test_corpus_integrity.py
@@ -1,0 +1,340 @@
+# Copyright 2026 Asqav
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Literal pins for every derived member of conformance/vectors.json (criterion 670).
+
+The corpus is a contract with third-party implementers, so it is FIXTURE DATA: the
+expected value of a derived member is a literal string in this file, never a value
+the production code supplies at assertion time.
+
+That distinction is not academic. The counterparty ``envelope_hash`` was stale in
+five vectors for the life of the file, and the two tests that named it both built
+their expectation by calling ``compute_envelope_hash`` - the function under test -
+against a locally constructed envelope, so neither ever read the published bytes.
+A green suite proved nothing about the file outsiders implement against.
+
+Sibling checks, deliberately kept separate:
+
+* ``test_canonicalize.py`` asserts the SDK's public helpers reproduce these bytes.
+  That is the other direction and is still wanted.
+* ``verifier/regen_fingerprint_vectors.py --check`` re-derives every member from each
+  vector's own input and is what CI runs on every push.
+* ``test_corpus_lock.py`` pins the file's SHA-256 as a whole.
+
+This file is the one that says WHAT the bytes are.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+VECTORS_PATH = Path(__file__).parent.parent.parent / "conformance" / "vectors.json"
+
+
+def _vectors() -> dict[str, dict]:
+    return {v["name"]: v for v in json.loads(VECTORS_PATH.read_text())["vectors"]}
+
+
+#: SHA-256 of each vector's canonical bytes, verbatim from the published file.
+#: Pinning this pins ``canonical`` transitively: no other byte string has this digest.
+PINNED_SHA256 = {
+    "minimal_read": "991033e23a3e0939c258e10f2f8f88183d9bcdb08de62ef02446e11e0819c671",
+    "tool_call_with_counterparty":
+        "a6c39c3b6e09761a141148c0862edbeaeb59642b4e0a1e4a85d6fba63f634ff4",
+    "traced_child_action": "9294075a29c366f9dfc54b8b7f8fa0054c290fef20e8931e93e94b2bee921d22",
+    "tampered_signature": "3deafb65ffe2785bfe35fe9d687a3076aa475c50ef8be4b2763424ced3e19bba",
+    "swapped_public_key": "3deafb65ffe2785bfe35fe9d687a3076aa475c50ef8be4b2763424ced3e19bba",
+    "stale_card": "0dcced0b29db5e9c29f5b71b4693c01443371042dd523e97fb917dad3b4040e9",
+    "nonce_mismatch": "0d3916bae22c889c9bf77c2edecf91849366a8b3b8fb64a1d291e9a319904c9a",
+    "card_version_downgrade": "9d62c8f11b8d3922e838edfecd866eae20e4865b38cdd58092e8b592aa789c30",
+    "capture_topology_in_process_sdk":
+        "f4b6da748f7720f15450cf61fa2c4cf8c3e9148fc15ab6b6cd15d8d3f3fd341e",
+    "capture_topology_network_proxy":
+        "de100ddcb08a1aadf3ade136a42ce554d38004ba06bbc4f0cecdc2235d46bd9d",
+    "capture_topology_browser_extension":
+        "9375a5437440101f386da4f6af0b2b64b1ed1f53fa3bdd5334363f15a173bd15",
+    "capture_topology_github_sha_pull":
+        "1a242ac2766e99b3e9bf00d7bb25ff251fdc1a1b59d77bbbe537723755fef4b6",
+    "capture_topology_mcp_proxy":
+        "4731cae72f4a30b5c10a688541faf8759873af7d78b8fe999069e112217b82c7",
+    "capture_topology_unknown_value_rejected":
+        "d2a306e1c437b467c431b7d1b4a70c1190aec10642e43ac002c55bb84dd3e617",
+    "counterparty_binding_happy_path":
+        "fd7281c6911144af8b74d2782405d1ca40e1fabccc6df41ab1be99639de8cabe",
+    "counterparty_binding_envelope_byte_equality":
+        "e89bf2fe64bd7dab3a606ea265ca14f88f4d161ec0485062a7facee4902c655f",
+    "counterparty_binding_base64url_tolerance":
+        "1a640f2d7c805152b85f706a498f0727d8d60402083eddcabba6e9d3627eb9d3",
+    "counterparty_binding_opaque_receipt_ref":
+        "e1b5c0808a0c243ea70e06d53ed5bf102d9fd98fed95c37632916a345b0ac0eb",
+    "counterparty_binding_transport_label_non_trust":
+        "edb5cb72894c37430298b31596fbb50318cdeddf3eaca7e3d3856909bdde8c93",
+    "counterparty_binding_missing_envelope_hash_rejected":
+        "70a004037ffb928a8a4380ee93a1367f75b4ee1b2012d0f84f53891eeebe36c4",
+    "receipt_v2_signer_canary": "dbb9fa8b319830814d2e6cc5b9c6a33f9c8f45e3223f75096d9c520aa9be55d4",
+    "asqav-24-jcs-astral-key-order":
+        "425159f5c1f0575fbcbf9d05a8f60cde3d040eae5166aa2136657564048651b6",
+    "asqav-24-jcs-astral-key-order-codepoint-rejected":
+        "425159f5c1f0575fbcbf9d05a8f60cde3d040eae5166aa2136657564048651b6",
+}
+
+#: Length of each canonical string, so a published ``canonical`` cannot be swapped
+#: for a different one that happens to carry the pinned digest in its ``sha256``.
+PINNED_CANONICAL_LENGTH = {
+    "minimal_read": 40,
+    "tool_call_with_counterparty": 212,
+    "traced_child_action": 130,
+    "tampered_signature": 213,
+    "swapped_public_key": 213,
+    "stale_card": 213,
+    "nonce_mismatch": 263,
+    "card_version_downgrade": 213,
+    "capture_topology_in_process_sdk": 111,
+    "capture_topology_network_proxy": 110,
+    "capture_topology_browser_extension": 114,
+    "capture_topology_github_sha_pull": 112,
+    "capture_topology_mcp_proxy": 106,
+    "capture_topology_unknown_value_rejected": 104,
+    "counterparty_binding_happy_path": 865,
+    "counterparty_binding_envelope_byte_equality": 887,
+    "counterparty_binding_base64url_tolerance": 800,
+    "counterparty_binding_opaque_receipt_ref": 806,
+    "counterparty_binding_transport_label_non_trust": 825,
+    "counterparty_binding_missing_envelope_hash_rejected": 704,
+    "receipt_v2_signer_canary": 873,
+    "asqav-24-jcs-astral-key-order": 13,
+    "asqav-24-jcs-astral-key-order-codepoint-rejected": 13
+}
+
+#: The wire ``counterparty_binding.envelope_hash`` string, exactly as published,
+#: in the alphabet each vector exercises.
+PINNED_ENVELOPE_HASH = {
+    "counterparty_binding_happy_path": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+    "counterparty_binding_base64url_tolerance": "pFBNdx3RTF723i7c_S9EVE9Ur8_XdWkhQSWE-KrqCr0=",
+    "counterparty_binding_opaque_receipt_ref": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+    "counterparty_binding_transport_label_non_trust":
+        "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+}
+
+#: The non-wire renderings of the same digest carried under ``expected``.
+PINNED_ENVELOPE_HASH_RENDERINGS = {
+    "counterparty_binding_happy_path": {
+        "envelope_hash_base64": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+        "envelope_hash_hex": "a4504d771dd14c5ef6de2edcfd2f44544f54afcfd7756921412584f8aaea0abd"
+    },
+    "counterparty_binding_envelope_byte_equality": {
+        "envelope_hash_base64": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+        "envelope_hash_base64url": "pFBNdx3RTF723i7c_S9EVE9Ur8_XdWkhQSWE-KrqCr0="
+    },
+    "counterparty_binding_base64url_tolerance": {
+        "envelope_hash_base64": "pFBNdx3RTF723i7c/S9EVE9Ur8/XdWkhQSWE+KrqCr0=",
+        "envelope_hash_base64url": "pFBNdx3RTF723i7c_S9EVE9Ur8_XdWkhQSWE-KrqCr0="
+    }
+}
+
+#: Remaining derived payload members, verbatim.
+PINNED_PAYLOAD_MEMBERS = {
+    "counterparty_binding_happy_path": {
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+        "action_ref": "act_01HVZA_ORIGINATOR_0001",
+        "payload_digest": {
+            "alg": "SHA-256",
+            "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+        }
+    },
+    "counterparty_binding_base64url_tolerance": {
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+        "action_ref": "act_01HVZA_ORIGINATOR_0001",
+        "payload_digest": {
+            "alg": "SHA-256",
+            "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+        }
+    },
+    "counterparty_binding_opaque_receipt_ref": {
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+        "action_ref": "act_01HVZA_ORIGINATOR_0001",
+        "payload_digest": {
+            "alg": "SHA-256",
+            "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+        }
+    },
+    "counterparty_binding_transport_label_non_trust": {
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+        "action_ref": "act_01HVZA_ORIGINATOR_0001",
+        "payload_digest": {
+            "alg": "SHA-256",
+            "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+        }
+    },
+    "counterparty_binding_missing_envelope_hash_rejected": {
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+        "action_ref": "act_01HVZA_ORIGINATOR_0001",
+        "payload_digest": {
+            "alg": "SHA-256",
+            "value": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+        }
+    },
+    "receipt_v2_signer_canary": {
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "policy_digest": "sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7",
+        "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "payload_digest": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "size": 0
+        }
+    }
+}
+
+#: Published signature blocks, verbatim.
+PINNED_SIGNATURES = {
+    "counterparty_binding_envelope_byte_equality": {
+        "alg": "ML-DSA-65",
+        "kid": "00000000000000000098",
+        "sig": "AAAA_synthetic_signature_bytes_base64_placeholder_for_vector_only_AAAA"
+    }
+}
+
+#: Every derived member name this file claims to pin. A derived member added to the
+#: corpus without a literal pin here fails ``test_no_derived_member_escapes_a_pin``.
+PINNED_MEMBER_NAMES = frozenset(
+    {"canonical", "sha256", "envelope_hash", "previousReceiptHash", "policy_digest",
+      "action_ref", "payload_digest", "key_thumbprint", "sig",
+      "envelope_hash_base64", "envelope_hash_base64url", "envelope_hash_hex"}
+)
+
+
+@pytest.mark.parametrize("name,digest", sorted(PINNED_SHA256.items()))
+def test_sha256_member_is_the_pinned_literal(name: str, digest: str) -> None:
+    assert _vectors()[name]["sha256"] == digest, (
+        f"{name}: the published sha256 moved. If the change is intended, regenerate with "
+        "verifier/regen_fingerprint_vectors.py and update this pin in the same commit."
+    )
+
+
+@pytest.mark.parametrize("name,digest", sorted(PINNED_SHA256.items()))
+def test_canonical_member_hashes_to_the_pinned_literal(name: str, digest: str) -> None:
+    canonical = _vectors()[name]["canonical"]
+    assert hashlib.sha256(canonical.encode("utf-8")).hexdigest() == digest, (
+        f"{name}: the published canonical bytes no longer hash to the pinned digest"
+    )
+
+
+@pytest.mark.parametrize("name,length", sorted(PINNED_CANONICAL_LENGTH.items()))
+def test_canonical_member_is_the_pinned_length(name: str, length: int) -> None:
+    assert len(_vectors()[name]["canonical"]) == length
+
+
+@pytest.mark.parametrize("name,value", sorted(PINNED_ENVELOPE_HASH.items()))
+def test_envelope_hash_is_the_pinned_literal(name: str, value: str) -> None:
+    """The member that was stale. Pinned as a string, not recomputed."""
+    binding = _vectors()[name]["input"]["counterparty_binding"]
+    assert binding["envelope_hash"] == value, (
+        f"{name}: published envelope_hash moved from the pin"
+    )
+
+
+@pytest.mark.parametrize("name,renderings", sorted(PINNED_ENVELOPE_HASH_RENDERINGS.items()))
+def test_envelope_hash_renderings_are_the_pinned_literals(name: str, renderings: dict) -> None:
+    expected = _vectors()[name]["expected"]
+    for member, value in renderings.items():
+        assert expected[member] == value, f"{name}.expected.{member} moved from the pin"
+
+
+@pytest.mark.parametrize("name,members", sorted(PINNED_PAYLOAD_MEMBERS.items()))
+def test_payload_derived_members_are_the_pinned_literals(name: str, members: dict) -> None:
+    payload = _vectors()[name]["input"]
+    for member, value in members.items():
+        assert payload[member] == value, f"{name}.{member} moved from the pin"
+
+
+@pytest.mark.parametrize("name,signature", sorted(PINNED_SIGNATURES.items()))
+def test_signatures_are_the_pinned_literals(name: str, signature: dict) -> None:
+    assert _vectors()[name]["input"]["signature"] == signature
+
+
+    # The three encodings under `expected` must all decode to the same digest, and that
+    # digest must be the one the wire member carries. Catches a partial re-pin that
+    # updates one alphabet and forgets another - the exact shape of the original defect.
+@pytest.mark.parametrize("name", sorted(PINNED_ENVELOPE_HASH_RENDERINGS))
+def test_every_envelope_hash_encoding_decodes_to_one_digest(name: str) -> None:
+    vector = _vectors()[name]
+    expected = vector["expected"]
+    digests = set()
+    if "envelope_hash_hex" in expected:
+        digests.add(expected["envelope_hash_hex"])
+    if "envelope_hash_base64" in expected:
+        digests.add(base64.b64decode(expected["envelope_hash_base64"]).hex())
+    if "envelope_hash_base64url" in expected:
+        digests.add(base64.urlsafe_b64decode(expected["envelope_hash_base64url"]).hex())
+    binding = vector.get("input", {}).get("counterparty_binding")
+    if isinstance(binding, dict) and "envelope_hash" in binding:
+        wire = binding["envelope_hash"]
+        urlsafe = "-" in wire or "_" in wire
+        raw = base64.urlsafe_b64decode(wire) if urlsafe else base64.b64decode(wire)
+        digests.add(raw.hex())
+    assert len(digests) == 1, f"{name}: encodings disagree: {sorted(digests)}"
+
+
+    # A vector that carries a counterparty digest MUST declare the scope that digest
+    # was taken under. Re-pinning to envelope_minus_anchors without the scope member
+    # would publish a minus-anchors value on a binding the absent-scope rule reads as
+    # a legacy three-key binding.
+def test_every_counterparty_digest_declares_its_scope() -> None:
+    for name, vector in _vectors().items():
+        binding = vector.get("input", {}).get("counterparty_binding")
+        if isinstance(binding, dict) and "envelope_hash" in binding:
+            assert binding.get("scope") == "envelope_minus_anchors", (
+                f"{name}: carries an envelope_hash with no declared scope"
+            )
+
+
+    # Every derived digest must name the envelope it was taken over, so the corpus is
+    # self-describing and the integrity job can recompute it from the file alone.
+def test_every_counterparty_vector_names_its_originating_envelope() -> None:
+    vectors = _vectors()
+    for name, vector in vectors.items():
+        binding = vector.get("input", {}).get("counterparty_binding")
+        if not (isinstance(binding, dict) and "envelope_hash" in binding):
+            continue
+        ref = (vector.get("expected") or {}).get("originating_envelope_ref")
+        assert ref, f"{name}: carries an envelope_hash but names no originating envelope"
+        assert ref in vectors, f"{name}: originating_envelope_ref {ref!r} names no vector"
+
+
+def test_no_derived_member_escapes_a_pin() -> None:
+    """A new derived member must arrive with a literal pin, not silently."""
+    pinned_here = (
+        set(PINNED_SHA256)
+        | set(PINNED_ENVELOPE_HASH)
+        | set(PINNED_PAYLOAD_MEMBERS)
+        | set(PINNED_SIGNATURES)
+        | set(PINNED_ENVELOPE_HASH_RENDERINGS)
+    )
+    for name, vector in _vectors().items():
+        assert name in pinned_here, f"{name}: vector has no literal pin in this file"
+        for member in ("canonical", "sha256"):
+            assert member in vector, f"{name}: missing {member}"
+        assert name in PINNED_SHA256, f"{name}: sha256 is not pinned"

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -23,7 +23,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
-FINGERPRINT_LOCK_DIGEST = "de1dfb87baf517cd4b779edd253588eede636cd20ca2265f2a2c21b07a82e250"
+FINGERPRINT_LOCK_DIGEST = "84c3f8e621539efb11169fe123c7e78b946935604acd84a91644cb4f37e4b23e"
 VERIFIER_LOCK_DIGEST = "1b030a79ebc34f08556877c134d320aef93317abcbf47f2d012c58a04814ba59"
 
 try:

--- a/verifier/regen_fingerprint_vectors.py
+++ b/verifier/regen_fingerprint_vectors.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Asqav
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regenerate EVERY derived member of conformance/vectors.json from each vector's input.
+
+The corpus is a contract with third-party implementers. Before this script the
+regeneration covered ``canonical`` and ``sha256`` only, so a derived member that
+no test recomputed could go stale in the published file and stay stale: the
+counterparty ``envelope_hash`` family did exactly that across five vectors,
+carrying a digest taken with a genesis ``previousReceiptHash`` form the corpus
+had already stopped using.
+
+Derived members this script owns, per vector:
+
+* ``canonical``  - the RFC 8785 (JCS) bytes of ``input``, as a UTF-8 string
+* ``sha256``     - SHA-256 of those bytes, hex
+* ``input.counterparty_binding.envelope_hash`` and the ``expected``
+  ``envelope_hash_*`` renderings - the digest of the ORIGINATING envelope named
+  by ``expected.originating_envelope_ref``, taken under the scope declared in
+  ``input.counterparty_binding.scope``
+
+Everything else in a vector is authored, not derived, and is left untouched.
+
+Run ``python verifier/regen_fingerprint_vectors.py`` after any authored edit, then
+``python verifier/freeze_corpus_lock.py`` to move the pins. ``--check`` exits
+nonzero on any drift without writing, which is what CI runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parent
+VECTORS_PATH = _ROOT / "conformance" / "vectors.json"
+
+#: The only counterparty digest scope this revision emits. An absent scope member
+#: means a legacy -04..-08 three-key binding and is reported, never silently retried.
+SCOPE_MINUS_ANCHORS = "envelope_minus_anchors"
+
+#: Envelope members the minus-anchors scope covers, in the order the draft states them.
+MINUS_ANCHORS_MEMBERS = ("payload", "signature")
+
+
+def canonical_json(obj: Any) -> bytes:
+    """RFC 8785 canonical bytes.
+
+    Object keys sort by UTF-16 code unit, NOT by code point: the two orders agree
+    across the BMP and diverge above U+FFFF. ``json.dumps(sort_keys=True)`` is code
+    point order and is not conformant here.
+    """
+    return _serialize(obj).encode("utf-8")
+
+
+def _serialize(obj: Any) -> str:
+    if isinstance(obj, dict):
+        items = sorted(obj.items(), key=lambda kv: kv[0].encode("utf-16-be"))
+        return "{" + ",".join(f"{_serialize(k)}:{_serialize(v)}" for k, v in items) + "}"
+    if isinstance(obj, list):
+        return "[" + ",".join(_serialize(v) for v in obj) + "]"
+    if isinstance(obj, bool):
+        return "true" if obj else "false"
+    if obj is None:
+        return "null"
+    if isinstance(obj, str):
+        return json.dumps(obj, ensure_ascii=False)
+    if isinstance(obj, int):
+        return str(obj)
+    if isinstance(obj, float):
+        if obj != obj or obj in (float("inf"), float("-inf")):
+            raise ValueError("NaN and Infinity are not JSON")
+        return repr(obj)
+    raise TypeError(f"not canonicalizable: {type(obj).__name__}")
+
+
+def envelope_digest(envelope: dict[str, Any], scope: str) -> bytes:
+    """Raw SHA-256 of the originating envelope under ``scope``."""
+    if scope != SCOPE_MINUS_ANCHORS:
+        raise ValueError(f"unknown counterparty binding scope: {scope!r}")
+    missing = [m for m in MINUS_ANCHORS_MEMBERS if m not in envelope]
+    if missing:
+        raise ValueError(f"originating envelope is missing {missing}")
+    scoped = {m: envelope[m] for m in MINUS_ANCHORS_MEMBERS}
+    return hashlib.sha256(canonical_json(scoped)).digest()
+
+
+def _vectors_by_name(vectors: list[dict]) -> dict[str, dict]:
+    return {v["name"]: v for v in vectors}
+
+
+def regenerate(doc: dict) -> list[str]:
+    """Rewrite every derived member in place. Returns one line per change."""
+    vectors = doc["vectors"]
+    by_name = _vectors_by_name(vectors)
+    changes: list[str] = []
+
+    def record(vector_name: str, member: str, old: Any, new: Any) -> None:
+        if old != new:
+            changes.append(f"{vector_name}: {member}\n    was {old!r}\n    now {new!r}")
+
+    # Pass 1: the counterparty bindings, because they sit INSIDE `input` and
+    # therefore change the canonical bytes that pass 2 derives.
+    for vector in vectors:
+        expected = vector.get("expected")
+        if not isinstance(expected, dict):
+            continue
+        ref = expected.get("originating_envelope_ref")
+        if not ref:
+            continue
+        origin = by_name.get(ref)
+        if origin is None:
+            raise KeyError(f"{vector['name']}: originating_envelope_ref {ref!r} names no vector")
+
+        binding = vector.get("input", {}).get("counterparty_binding")
+        if not isinstance(binding, dict) or "envelope_hash" not in binding:
+            # A vector that deliberately omits envelope_hash still names its origin
+            # so the renderings below stay derivable; nothing to re-pin on the wire.
+            digest = envelope_digest(origin["input"], SCOPE_MINUS_ANCHORS)
+        else:
+            scope = binding.get("scope", SCOPE_MINUS_ANCHORS)
+            digest = envelope_digest(origin["input"], scope)
+            # The wire value keeps whichever alphabet the vector is exercising.
+            old_hash = binding["envelope_hash"]
+            urlsafe = "-" in old_hash or "_" in old_hash
+            new_hash = (
+                base64.urlsafe_b64encode(digest) if urlsafe else base64.b64encode(digest)
+            ).decode()
+            record(vector["name"], "input.counterparty_binding.envelope_hash", old_hash, new_hash)
+            binding["envelope_hash"] = new_hash
+
+        renderings = {
+            "envelope_hash_base64": base64.b64encode(digest).decode(),
+            "envelope_hash_base64url": base64.urlsafe_b64encode(digest).decode(),
+            "envelope_hash_hex": digest.hex(),
+        }
+        for member, value in renderings.items():
+            if member in expected:
+                record(vector["name"], f"expected.{member}", expected[member], value)
+                expected[member] = value
+
+    # Pass 2: canonical bytes and their digest, for every vector.
+    for vector in vectors:
+        if "input" not in vector:
+            continue
+        canonical = canonical_json(vector["input"]).decode("utf-8")
+        if "canonical" in vector:
+            record(vector["name"], "canonical", f"<{len(vector['canonical'])} chars>",
+                   f"<{len(canonical)} chars>")
+        vector["canonical"] = canonical
+        digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        if "sha256" in vector:
+            record(vector["name"], "sha256", vector["sha256"], digest)
+        vector["sha256"] = digest
+
+    return changes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit nonzero if any derived member differs from the published file; write nothing",
+    )
+    args = parser.parse_args()
+
+    original_text = VECTORS_PATH.read_text()
+    doc = json.loads(original_text)
+    changes = regenerate(doc)
+    regenerated = json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
+
+    if args.check:
+        if regenerated != original_text:
+            print("corpus integrity: DRIFT between the published file and its own inputs", file=sys.stderr)
+            for line in changes:
+                print(f"  {line}", file=sys.stderr)
+            if not changes:
+                print("  (formatting-only drift; run without --check to normalise)", file=sys.stderr)
+            print(
+                "\nregenerate with: python verifier/regen_fingerprint_vectors.py"
+                "\nthen re-freeze:  python verifier/freeze_corpus_lock.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"corpus integrity: every derived member of {len(doc['vectors'])} vectors re-derives")
+        return 0
+
+    VECTORS_PATH.write_text(regenerated)
+    if changes:
+        print(f"regenerated {VECTORS_PATH.name}: {len(changes)} derived member(s) changed")
+        for line in changes:
+            print(f"  {line}")
+        print("\nnow re-freeze the pins: python verifier/freeze_corpus_lock.py")
+    else:
+        print(f"{VECTORS_PATH.name} already consistent; nothing changed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The defect

An outside verifier author found a stale digest in the published corpus. Recomputing
every derived member from the file confirms it, and it is not the smallest problem
there — it is the one nothing could have caught.

`counterparty_binding.envelope_hash` was published as
`0d6c88a16e96fd3429be13e44dc957062f77d417dc0c3ea28e4fa496230de2a9`. Recomputation
from `counterparty_binding_envelope_byte_equality.input`:

| Candidate | Digest |
|---|---|
| three-key `{payload, signature, anchors}` | `e89bf2fe…c655f` — also that vector's own `sha256` |
| envelope minus anchors `{payload, signature}` | `a4504d77…a0abd` |
| **what was published** | **`0d6c88a1…de2a9` — neither** |

Root cause, confirmed by reconstruction: put the genesis `previousReceiptHash` back
from bare 64-zero hex to its older prefixed seed form, hash the three-key object, and
`0d6c88a1…de2a9` comes back exactly. The commit that changed the seed regenerated
`canonical` and `sha256` and left the derived value behind. A third-party implementer
could not reproduce it under any reading of the spec.

## Why every gate stayed green

Both tests that named the member built their expected value by calling
`compute_envelope_hash` — the function under test — against a locally constructed
envelope. Neither read the published file at all. The corpus freeze pins the file's
SHA-256, which proves the bytes have not moved; that is a different claim from the
bytes being right, and it is the distinction this PR closes.

`test_conformance_vectors.py` calls itself an internal-consistency check but covers
`canonical` and `sha256` only — two of the eight derived member kinds.

## What changed

**The re-pin.** Every occurrence moves to the envelope-minus-anchors digest settled in
the counterparty addendum, and every binding carrying one declares `scope` on the
wire. Re-pinning without that member would publish a minus-anchors value on a binding
whose absent-scope reading is the older three-key one — trading one contradiction for
another.

**The cascade is four vectors, not three.** `counterparty_binding_base64url_tolerance`
carries the value inside `input` as well, so its canonical bytes and digest regenerate
with the other three. A fix that skipped it would have left the corpus inconsistent in
exactly the way the report warned about. 14 strings changed across 5 vectors.

**The byte-equality vector** keeps its own three-key digest and now says in its
description that it is a pure canonicalization fixture. Under the new scope its own
`sha256` and the binding value cover different byte sets by design, so the old
description — which claimed one was the base64 of the other — had quietly stopped
being true.

**Metadata that is not a wire member** moves out of a vector-level block that was
named after a real wire member and into `expected`. Every binding now names the
envelope its digest is taken over, so the value is recomputable from the file alone.

**Two gates, both proved against the defect.**

- `verifier/regen_fingerprint_vectors.py --check` recomputes every derived member from
  each vector's own `input`. It runs in CI beside the freeze.
- `python/tests/test_corpus_integrity.py` pins each derived member as a literal
  string — 23 digests, 23 canonical lengths, 4 wire values, plus the rendering,
  payload and signature blocks — and refuses a new derived member that arrives
  without a pin.

Restoring the stale value turns `--check` nonzero and reddens the literal pins. That
mutation was run against the final file, not an intermediate one.

## Verification

- 3116 Python passed, 1 skipped; 1140 TypeScript passed
- both corpus lock paths re-derive (`hashlib` and `sha256sum`)
- `ruff` clean on the CI scope and on both new files
- the four claims above reproduce on an independent canonicalizer, not the SDK's

## Scope note

The corpus now describes the minus-anchors scope, which the SDK helper does not yet
compute — that half ships next, after the platform side deploys, per the cloud-then-SDK
order. This is not a regression in agreement: the value shipping today matches neither
scope, so the re-pin strictly improves it, and the wire `scope` member makes which one
is meant explicit rather than inferred.

Second corpus audited the same way; report in the session notes. Its derived members
re-derive under each format's own chain rule, and 41 of its values still carry no
literal assertion — follow-on work, recorded rather than silently skipped.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
