### PR TITLE
Publish the asqav-25 number vectors and pin refused documents

### DIFF
--- a/conformance/manifest.lock.json
+++ b/conformance/manifest.lock.json
@@ -16,8 +16,8 @@
     },
     {
       "path": "vectors.json",
-      "sha256": "67ccb14b62cc301a37872ddc81d0da0b9ab11e12dcf6a369e502935b78e3a1ae",
-      "bytes": 34440
+      "sha256": "d0c3f50c090580252b754d4631b49490ab783a0c9dee68899b9ccb80c97b9cfb",
+      "bytes": 37575
     }
   ],
   "signing": {
@@ -35,5 +35,5 @@
     },
     "known_answer_message_note": "the 32-byte SHA-256 digest of the canonical bytes of vector 'minimal_read': the hash is what ML-DSA-65 signs"
   },
-  "digest": "84c3f8e621539efb11169fe123c7e78b946935604acd84a91644cb4f37e4b23e"
+  "digest": "f4c6871f2930dc8f759f473e95a95b31050153631218c0fbc6d94f7e3e394837"
 }

--- a/conformance/vectors.json
+++ b/conformance/vectors.json
@@ -531,6 +531,47 @@
       "non_conformant_sha256": "1c314559129cce00bc1b3caa2ee37fa3e81f926aee65b34f8e4e21856b2de83b",
       "expected_verify": false,
       "reason": "Code point key order is not RFC 8785; a canonicalizer emitting non_conformant_canonical fails this vector."
+    },
+    {
+      "name": "asqav-25-number-above-safe-range-rejected",
+      "description": "A digest-covered integer with no exact IEEE-754 double. Python's json.loads keeps 9007199254740993 exactly and JavaScript's JSON.parse rounds it to 9007199254740992, neither raising, so the same document would canonicalize to two different byte strings and carry two different SHA-256 digests. A conformant implementation MUST refuse this document as a parse failure reported unverifiable, and MUST NOT round, truncate or re-serialize the value. The document is given as input_text, not as a parsed input, because a refused document has no canonical form and because a corpus file carrying the bare literal would itself be refused by the rule it describes.",
+      "input_text": "{\"n\":9007199254740993}",
+      "expected_verify": false,
+      "reason": "9007199254740993 is outside the canonical integer range +/-2**53. The check MUST read the source digits, not the parsed value: Number(\"9007199254740993\") is already 9007199254740992, so a magnitude test on the parsed number accepts the exact case the rule exists to refuse.",
+      "expected": {
+        "refused_at": "parse",
+        "bound": "+/-2**53",
+        "max_canonical_integer": 9007199254740992,
+        "positive_twin": "asqav-25-number-above-safe-range-as-string"
+      }
+    },
+    {
+      "name": "asqav-25-number-above-safe-range-as-string",
+      "description": "Positive twin of asqav-25-number-above-safe-range-rejected: the same numeric value carried the conformant way, as a JSON string. A caller with an identifier or a nanosecond timestamp above 2**53 serializes it like this, and every implementation then agrees on the bytes because no number parsing is involved.",
+      "input": {
+        "n": "9007199254740993"
+      },
+      "expected_verify": true,
+      "reason": "A string carries the digits verbatim through every JSON reader, so the canonical bytes and their digest are identical across implementations.",
+      "expected": {
+        "negative_twin": "asqav-25-number-above-safe-range-rejected"
+      },
+      "canonical": "{\"n\":\"9007199254740993\"}",
+      "sha256": "3bbb752b000e9ac58b939c07bb99307d18ccc5be92189d3c32738ec24c98579f"
+    },
+    {
+      "name": "asqav-25-number-at-safe-range-boundary",
+      "description": "2**53 = 9007199254740992 is exactly representable as an IEEE-754 double and every reader emits the same digits for it, so it is INSIDE the canonical range and MUST be accepted. The bound is deliberately one above JavaScript's Number.isSafeInteger, which is 2**53 - 1: the upstream interop vector number_2_to_53 pins this value as canonical, so a verifier using isSafeInteger as its bound fails upstream conformance.",
+      "input": {
+        "n": 9007199254740992
+      },
+      "expected_verify": true,
+      "reason": "The largest integer both implementations canonicalize identically.",
+      "expected": {
+        "negative_twin": "asqav-25-number-above-safe-range-rejected"
+      },
+      "canonical": "{\"n\":9007199254740992}",
+      "sha256": "66c87d9cb3014e05a11baa97df62282d89d425f22ee15816577c84534e2ef1bb"
     }
   ]
 }

--- a/python/tests/test_canonicalize.py
+++ b/python/tests/test_canonicalize.py
@@ -25,7 +25,9 @@ VECTORS_PATH = Path(__file__).parent.parent.parent / "conformance" / "vectors.js
 
 
 def _load_vectors() -> list[dict]:
-    return json.loads(VECTORS_PATH.read_text())["vectors"]
+    # A refused-document vector (asqav-25) has no parsed input and so no canonical bytes
+    # for the helpers to reproduce; the refusal itself is pinned in test_strict_json.py.
+    return [v for v in json.loads(VECTORS_PATH.read_text())["vectors"] if "input" in v]
 
 
     # The SDK's canonicalize() must produce the same bytes as vectors.json.

--- a/python/tests/test_conformance_vectors.py
+++ b/python/tests/test_conformance_vectors.py
@@ -55,9 +55,35 @@ def test_vectors_schema_metadata() -> None:
     assert len(d["vectors"]) >= 3
 
 
-def test_each_vector_canonical_matches_input() -> None:
+
+    # A vector whose DOCUMENT is refused (asqav-25) carries `input_text` and no parsed
+    # `input`, because a document that never parses has no canonical form to pin.
+def _canonicalizing_vectors(d: dict) -> list[dict]:
+    out = [v for v in d["vectors"] if "input" in v]
+    assert out, "no canonicalizing vectors found"
+    return out
+
+
+    # Every vector carries exactly one of `input` or `input_text`, never both, never neither.
+def test_every_vector_declares_its_input_form() -> None:
     d = json.loads(VECTORS_PATH.read_text())
     for v in d["vectors"]:
+        has_parsed = "input" in v
+        has_text = "input_text" in v
+        assert has_parsed != has_text, (
+            f"{v['name']}: needs exactly one of input / input_text"
+        )
+        if has_text:
+            assert v["expected_verify"] is False, (
+                f"{v['name']}: an input_text vector pins a refusal, so expected_verify is False"
+            )
+            assert "canonical" not in v and "sha256" not in v, (
+                f"{v['name']}: a refused document has no canonical form"
+            )
+
+def test_each_vector_canonical_matches_input() -> None:
+    d = json.loads(VECTORS_PATH.read_text())
+    for v in _canonicalizing_vectors(d):
         expected_canon = _jcs(v["input"])
         assert v["canonical"] == expected_canon, (
             f"{v['name']}: canonical drift. Regenerate vectors.json."
@@ -66,7 +92,7 @@ def test_each_vector_canonical_matches_input() -> None:
 
 def test_each_vector_sha256_matches_canonical() -> None:
     d = json.loads(VECTORS_PATH.read_text())
-    for v in d["vectors"]:
+    for v in _canonicalizing_vectors(d):
         expected_hash = hashlib.sha256(v["canonical"].encode("utf-8")).hexdigest()
         assert v["sha256"] == expected_hash, (
             f"{v['name']}: sha256 drift. Regenerate vectors.json."

--- a/python/tests/test_corpus_integrity.py
+++ b/python/tests/test_corpus_integrity.py
@@ -94,6 +94,10 @@ PINNED_SHA256 = {
         "425159f5c1f0575fbcbf9d05a8f60cde3d040eae5166aa2136657564048651b6",
     "asqav-24-jcs-astral-key-order-codepoint-rejected":
         "425159f5c1f0575fbcbf9d05a8f60cde3d040eae5166aa2136657564048651b6",
+    "asqav-25-number-above-safe-range-as-string":
+        "3bbb752b000e9ac58b939c07bb99307d18ccc5be92189d3c32738ec24c98579f",
+    "asqav-25-number-at-safe-range-boundary":
+        "66c87d9cb3014e05a11baa97df62282d89d425f22ee15816577c84534e2ef1bb",
 }
 
 #: Length of each canonical string, so a published ``canonical`` cannot be swapped
@@ -121,7 +125,9 @@ PINNED_CANONICAL_LENGTH = {
     "counterparty_binding_missing_envelope_hash_rejected": 704,
     "receipt_v2_signer_canary": 873,
     "asqav-24-jcs-astral-key-order": 13,
-    "asqav-24-jcs-astral-key-order-codepoint-rejected": 13
+    "asqav-24-jcs-astral-key-order-codepoint-rejected": 13,
+    "asqav-25-number-above-safe-range-as-string": 24,
+    "asqav-25-number-at-safe-range-boundary": 22
 }
 
 #: The wire ``counterparty_binding.envelope_hash`` string, exactly as published,
@@ -215,6 +221,12 @@ PINNED_SIGNATURES = {
         "kid": "00000000000000000098",
         "sig": "AAAA_synthetic_signature_bytes_base64_placeholder_for_vector_only_AAAA"
     }
+}
+
+#: The exact document each refused-parse vector publishes, verbatim. A vector that pins a
+#: REFUSAL has no canonical form, so its contract with implementers is these bytes.
+PINNED_REFUSED_DOCUMENT = {
+    "asqav-25-number-above-safe-range-rejected": "{\"n\":9007199254740993}",
 }
 
 #: Every derived member name this file claims to pin. A derived member added to the
@@ -324,6 +336,21 @@ def test_every_counterparty_vector_names_its_originating_envelope() -> None:
         assert ref in vectors, f"{name}: originating_envelope_ref {ref!r} names no vector"
 
 
+@pytest.mark.parametrize("name,document", sorted(PINNED_REFUSED_DOCUMENT.items()))
+def test_refused_document_is_the_pinned_literal(name: str, document: str) -> None:
+    assert _vectors()[name]["input_text"] == document
+
+
+    # The corpus says these documents are refused, so the shipped parser must refuse them.
+    # Without this the corpus could publish a refusal the code does not implement.
+@pytest.mark.parametrize("name,document", sorted(PINNED_REFUSED_DOCUMENT.items()))
+def test_the_shipped_parser_actually_refuses_it(name: str, document: str) -> None:
+    from asqav import strict_json
+
+    with pytest.raises(ValueError):
+        strict_json.loads(document)
+
+
 def test_no_derived_member_escapes_a_pin() -> None:
     """A new derived member must arrive with a literal pin, not silently."""
     pinned_here = (
@@ -332,8 +359,16 @@ def test_no_derived_member_escapes_a_pin() -> None:
         | set(PINNED_PAYLOAD_MEMBERS)
         | set(PINNED_SIGNATURES)
         | set(PINNED_ENVELOPE_HASH_RENDERINGS)
+        | set(PINNED_REFUSED_DOCUMENT)
     )
     for name, vector in _vectors().items():
+        if "input_text" in vector:
+            # A refused document has no canonical form; its bytes are pinned instead.
+            assert name in PINNED_REFUSED_DOCUMENT, f"{name}: refused document not pinned"
+            assert "canonical" not in vector and "sha256" not in vector, (
+                f"{name}: a refused document must not publish a canonical form"
+            )
+            continue
         assert name in pinned_here, f"{name}: vector has no literal pin in this file"
         for member in ("canonical", "sha256"):
             assert member in vector, f"{name}: missing {member}"

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -23,7 +23,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
-FINGERPRINT_LOCK_DIGEST = "84c3f8e621539efb11169fe123c7e78b946935604acd84a91644cb4f37e4b23e"
+FINGERPRINT_LOCK_DIGEST = "f4c6871f2930dc8f759f473e95a95b31050153631218c0fbc6d94f7e3e394837"
 VERIFIER_LOCK_DIGEST = "1b030a79ebc34f08556877c134d320aef93317abcbf47f2d012c58a04814ba59"
 
 try:

--- a/typescript/tests/canonicalize.test.ts
+++ b/typescript/tests/canonicalize.test.ts
@@ -20,9 +20,13 @@ interface Vector {
 }
 
 const vectorsPath = resolve(__dirname, "..", "..", "conformance", "vectors.json");
-const { vectors } = JSON.parse(readFileSync(vectorsPath, "utf8")) as {
+const { vectors: allVectors } = JSON.parse(readFileSync(vectorsPath, "utf8")) as {
   vectors: Vector[];
 };
+// A refused-document vector (asqav-25) carries `input_text` and no parsed `input`, so it
+// has no canonical bytes for these helpers to reproduce. Its refusal is pinned in
+// verifier-parity.test.ts instead.
+const vectors = allVectors.filter((v) => "input" in v);
 
 // Closed Literal mirrored from the cloud SignRequest. passive_telemetry is observation-only;
 // github_sha_pull is the server-stamped authoritative code-authorship capture layer.

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -222,6 +222,34 @@ describe("integers beyond +/-2**53 are refused at ingest (no cross-SDK divergenc
       /canonical integer range/,
     );
   });
+
+  // The corpus publishes documents it says are refused. Both SDKs must actually refuse
+  // them, or the corpus advertises a rule the shipped code does not implement. The Python
+  // half of this pairing lives in test_corpus_integrity.py.
+  it("refuses every document the corpus pins as refused", () => {
+    const path = resolve(__dirname, "..", "..", "conformance", "vectors.json");
+    const { vectors } = JSON.parse(readFileSync(path, "utf8")) as {
+      vectors: Array<{ name: string; input_text?: string; expected_verify: boolean }>;
+    };
+    const refused = vectors.filter((v) => typeof v.input_text === "string");
+    expect(refused.length).toBeGreaterThan(0);
+    for (const v of refused) {
+      expect(v.expected_verify).toBe(false);
+      expect(() => parseJsonPreservingFloats(v.input_text as string), v.name).toThrow();
+    }
+  });
+
+  // The boundary the corpus pins as INSIDE the range must actually parse and canonicalize.
+  it("accepts every in-range vector the corpus pins, including 2**53", () => {
+    const path = resolve(__dirname, "..", "..", "conformance", "vectors.json");
+    const { vectors } = JSON.parse(readFileSync(path, "utf8")) as {
+      vectors: Array<{ name: string; canonical?: string; input?: unknown }>;
+    };
+    const boundary = vectors.find((v) => v.name === "asqav-25-number-at-safe-range-boundary");
+    expect(boundary, "boundary vector missing from the corpus").toBeDefined();
+    const parsed = parseJsonPreservingFloats('{"n":9007199254740992}');
+    expect(dec.decode(asqavJcs(parsed))).toBe(boundary!.canonical);
+  });
 });
 
 // --- A29: ordered first-bad-edge reporting (criterion 490) ---


### PR DESCRIPTION
Completes round-5 finding 8's corpus half. The rule shipped in #453; this gives implementers the worked forms.

## Three vectors

| Vector | What it pins |
|---|---|
| `asqav-25-number-above-safe-range-rejected` | the document that MUST be refused |
| `asqav-25-number-above-safe-range-as-string` | the same value carried the conformant way, as a JSON string |
| `asqav-25-number-at-safe-range-boundary` | 2**53 itself, ACCEPTED |

## Why the negative vector carries `input_text`, not `input`

Two reasons, both load-bearing:

1. A document that never parses has **no canonical form**, so publishing one would be a fiction.
2. A corpus file holding the bare literal `9007199254740993` **would itself be refused** by the rule it describes, making the file unreadable to a conformant reader.

So it publishes the exact bytes an implementer feeds their parser, and declares no `canonical` or `sha256`.

## The boundary vector earns its place

It pins 2**53 as accepted and says why the bound sits one above JavaScript's `isSafeInteger`: the upstream interop vector `number_2_to_53` pins that value as canonical, so a verifier that uses `isSafeInteger` as its bound fails upstream conformance. That trap is now documented in the corpus rather than only in a commit message.

## The corpus now has two kinds of vector, and every consumer says so

Rather than assuming all vectors canonicalize, the walkers filter explicitly, and a new check requires each vector to carry exactly one of `input` or `input_text` — and requires an `input_text` vector to pin a refusal and publish no canonical form. That closes the gap where a future vector could quietly arrive in a third shape.

## Both directions are kept honest

- the published document is asserted as a **literal string**, and
- the **shipped parser is required to actually refuse it**, in Python and in TypeScript.

Without the second, the corpus could advertise a rule the code does not implement — the mirror image of the defect that started round 5, where the code supplied the expectation. Both were mutation-proved by pointing the vector at a document the parser accepts, which reddens each.

## Verification

3141 Python passed, 1 skipped; 1150 TypeScript passed; both corpus lock paths re-derive; corpus integrity green over 26 vectors; `ruff` clean.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
