### PR TITLE
docs(sdk): title the observation section for the wire vocabulary it documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+### Changed
+
+- The README section covering `protectmcp:observation` and
+  `capture_topology=passive_telemetry` is titled for that wire vocabulary, so the
+  heading names the members the section documents.
+
 ## [0.10.6] - 2026-09-02
 
 ### Fixed

--- a/python/README.md
+++ b/python/README.md
@@ -131,7 +131,7 @@ The envelope extensions most callers reach for:
 
 Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): cloud-issued receipts carry an ML-DSA-65 signature (locally signed receipts carry Ed25519/ES256 — the algorithm is per-receipt in `signature.alg`), JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `compliance_mode=False` if you want the older shape.
 
-### Shadow AI capture with passive_telemetry
+### Observation receipts and passive_telemetry
 
 Two `receipt_type` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action. `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block, such as a SIEM forwarder, a browser extension in observe-only mode, or a NetFlow-style proxy with no enforcement hook.
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -123,7 +123,7 @@ The envelope extensions most callers reach for, camelCase on the SDK and snake_c
 
 Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): cloud-issued receipts carry an ML-DSA-65 signature (locally signed receipts carry Ed25519/ES256 — the algorithm is per-receipt in `signature.alg`), JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `complianceMode: false` if you want the older shape.
 
-### Shadow AI capture with passive_telemetry
+### Observation receipts and passive_telemetry
 
 Two `receiptType` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action. `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block, such as a SIEM forwarder, a browser extension in observe-only mode, or a NetFlow-style proxy with no enforcement hook.
 


### PR DESCRIPTION
Both published READMEs carried a heading naming an industry category. The
section under it documents two deployed wire members and nothing else:
`receipt_type=protectmcp:observation` and
`capture_topology=passive_telemetry`, both discoverable at
`https://api.asqav.com/.well-known/governance.json`.

The heading is the only line that changes. The body was accurate and stays
byte-for-byte, so no documented behaviour moves.

Why it matters: the CLI subcommand that carried that name shipped out in
0.10.0, and the SDK exposes no API under it. A reader on npm or PyPI met a
heading that implied a product surface, then found wire vocabulary. The
heading now names what the reader can look up.

Reach: this text is what npm and PyPI render on the package pages, so the
correction lands publicly with the next release rather than on merge.

Scope checked: a sweep of the whole SDK tree finds no other occurrence in
either language half, in the CHANGELOG, or in any test.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
