### PR TITLE
release: cut the SDK at 0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.7] - 2026-09-03
+
+### Changed
+
+- **A whole-number value outside the canonical range is refused rather than
+  reshaped.** The two halves canonicalized such a value differently: Python kept
+  every digit, JavaScript rounded to the nearest representable double, and the
+  disagreement was pinned as an expected divergence. A receipt carrying one
+  therefore produced two different canonical byte strings and two different
+  digests, so its signature verified in one implementation and failed in the
+  other. Both halves now refuse the value where the document is parsed, beside
+  the duplicate-member door, and both canonicalizers refuse it again for values
+  assembled in process. The check reads the digits as written, never the parsed
+  double, so a value that arrives already rounded cannot pass as exact. The bound
+  is the closed range plus or minus two to the fifty-third, one above the
+  JavaScript safe-integer limit, because that endpoint is exactly representable,
+  both languages print it identically, and the upstream interop corpus pins it as
+  canonical. **Callers who send a nanosecond timestamp or a Snowflake-style
+  identifier as a bare number will now see a refusal at the parse boundary; send
+  the value as a JSON string instead.**
+- The README section covering `protectmcp:observation` and
+  `capture_topology=passive_telemetry` is titled for that wire vocabulary, so the
+  heading names the members the section documents.
+
 ### Fixed
 
 - **Both READMEs told readers a replay control does not exist when it does.** The
@@ -13,12 +37,31 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
   agent in the same organisation already holds and answers HTTP 409. The text now
   states what the field bounds and when the token frees, in both language halves
   and in the four source docstrings that repeated it.
+- **The published counterparty digest was unreproducible in five vectors.** The
+  value on the wire was taken over the three-key object while the chain seed was
+  still in its prefixed form; the change that moved the seed to bare hex
+  regenerated the canonical bytes and their digest and left the derived value
+  behind, so it matched neither scope and an outside implementer could not
+  reproduce it under any reading. It is re-pinned to the envelope-minus-anchors
+  scope, and every binding that carries one declares `scope` on the wire so the
+  value is read under the scope it was taken over. Nothing caught this because
+  both tests naming the member built their expectation by calling the production
+  helper against a locally built envelope, so neither read the published file; a
+  corpus integrity gate now checks the published inputs against their own
+  canonical forms and digests.
 
-### Changed
+### Added
 
-- The README section covering `protectmcp:observation` and
-  `capture_topology=passive_telemetry` is titled for that wire vocabulary, so the
-  heading names the members the section documents.
+- Worked forms for the canonical-range rule in the conformance corpus, so an
+  implementer can copy what a conformant document looks like instead of reading
+  only a prohibition: the document that must be refused, carried as text because
+  a document that never parses has no canonical form to pin; the same numeric
+  value carried the conformant way, as a JSON string; and the boundary value
+  itself pinned as accepted. A corpus check requires each vector to carry exactly
+  one of a parsed input or a text input, and requires a text-input vector to pin
+  a refusal and publish no canonical form. Tests assert the published document as
+  a literal and require the shipped parser to refuse it, in both languages, so
+  the corpus cannot advertise a rule the code does not implement.
 
 ## [0.10.6] - 2026-09-02
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.6"
+version = "0.10.7"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -192,7 +192,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.6"
+__version__ = "0.10.7"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.0",
+  "version": "0.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@asqav/sdk",
-      "version": "0.10.0",
+      "version": "0.10.7",
       "license": "LicenseRef-Elastic-License-2.0",
       "dependencies": {
         "@noble/post-quantum": "^0.6.1"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -3,7 +3,7 @@
  * added under Node, since browsers forbid setting User-Agent on fetch.
  */
 
-export const SDK_VERSION = "0.10.6";
+export const SDK_VERSION = "0.10.7";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Five merged changes sit unreleased, so the package pages on npm and PyPI still render
text this repository has already corrected. A published version is immutable, so a
merge does not move those pages; only a release does.

## What ships

| Change | Effect on the published page |
|---|---|
| the replay-control correction | the READMEs stop denying a control the platform enforces |
| the observation-section retitle | the heading names the wire members it documents |
| the canonical-range rule | a whole-number input beyond the range is refused, not reshaped |
| the counterparty digest re-pin | the published digest becomes reproducible by an outsider |
| the number vectors | worked conformant forms, not only a prohibition |

## Version files

All five version-carrying files move together. The TypeScript lockfile root version
had drifted behind its package across six releases; it is realigned here and `npm ci`
accepts it.

## Release notes

Three of the five landed with no changelog entry. They are written here. The
canonical-range rule gets the most detail because it is a behaviour change: a caller
sending a nanosecond timestamp or a Snowflake-style identifier as a bare number now
sees a refusal at the parse boundary. The entry says to send the value as a JSON
string instead.

## Rule 2.14: the end-user install, reproduced before tagging

Run from OUTSIDE the source tree, so the dev tree cannot mask a packaging gap.

**Python** - built the sdist and wheel, installed the wheel into a fresh 3.11 venv,
imported at 0.10.7, confirmed the verifier module ships inside the wheel, then
installed the `verify` and `cli` extras: their dependencies import and the console
script runs.

**TypeScript** - `npm ci`, build, pack, then installed that tarball into an empty
project. CJS and ESM main exports both report 0.10.7; the `cli` and `extras` subpaths
resolve.

## The behaviour is proven from the installed artifacts, not the working tree

Both halves agree case for case, raising the same error type:

| Case | Python | TypeScript |
|---|---|---|
| boundary value | accepted | accepted |
| boundary + 1 | refused | refused |
| negative side | refused | refused |
| 1e21-scale | refused | refused |
| deeply nested | refused | refused |

The boundary sits one above the JavaScript safe-integer limit on purpose: that
endpoint is exactly representable, both languages print it identically, and the
upstream interop corpus pins it as canonical.

## After merge

The py- and ts- release tags are pushed to trigger the publish, then the PyPI JSON and
the npm dist-tags are re-read to confirm both report the new version and that the
rendered descriptions carry the corrected text.

comment hygiene clean

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
