### PR TITLE
fix(verifier): nonce axis on the structured surface, and say what the offline entry points leave out

### DIFF
--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -422,10 +422,20 @@ def verify_receipt_offline(
 ) -> dict:
     """Verify a receipt fully offline against an in-memory JWKS snapshot.
 
-    Runs the full oracle: structure, signature (Ed25519/ES256/ML-DSA-65),
+    Runs the oracle axes: structure, signature (Ed25519/ES256/ML-DSA-65),
     hash-chain link. No network call is made; all crypto happens in-process.
     ML-DSA-65 requires ``pip install asqav[verify]``; without it the signature
     axis is SKIPPED and the verdict is unverified/unverifiable, never verified.
+
+    THE ANCHOR-BINDING AND CLOCK-SKEW AXES ARE NOT EVALUATED HERE, by design and
+    identically in the TypeScript ``verifyReceiptOffline``, so the two languages
+    report the same axes. A ``verified`` verdict from this function therefore
+    means the axes above passed, NOT that the receipt's anchors were checked:
+    ``anchors`` sits outside the signed bytes, so an altered envelope can move it
+    without breaking the signature. Run ``check_anchors`` and ``check_skew`` from
+    ``asqav.verifier.verify_receipt`` on the normalised envelope when you need
+    them, or use the standalone verifier, which reports every axis. See
+    docs/offline-verification.md.
 
     Args:
         receipt: Parsed receipt envelope dict (``{payload, signature, anchors}``).

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -2337,11 +2337,16 @@ def run_structured(
     trusted_tsa_keys=None,
     bitcoin_headers=None,
     counterparty: dict | None = None,
+    seen_nonces: set | None = None,
 ) -> dict:
     """Verify a receipt offline and return a structured result dict.
 
     Same logic as ``run()`` but returns a dict instead of printing and exiting; the
     public SDK uses the oracle adapter path for multi-format support.
+
+    ``seen_nonces`` is the caller's replay index, exactly as ``run()`` takes it: pass
+    one to have the nonce axis flag a different receipt reusing an (issuer_id, nonce)
+    pair. Without it the axis still reports, and says it holds no index.
 
     Keys: ``verdict`` ("verified" | "unverified", criteria 418/438);
     ``failure_class`` ("invalid" | "unverifiable" when unverified, else None - the
@@ -2423,6 +2428,7 @@ def run_structured(
 
     axes: list[dict] = []
     axes.append(_struct_axis("structure", *check_structure(payload)))
+    axes.append(_struct_axis("nonce", *check_nonce(payload, seen_nonces)))
     # Evaluated once, up front: the anchors axis reports it, and the key_status
     # axis weighs its cryptographically-proven timing against any revoked_at.
     anchor_eval = evaluate_anchors(

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -2116,7 +2116,7 @@ def check_nonce(payload: dict, seen_nonces: set | None = None):
         return "PASS", (
             "nonce present; this surface holds no seen-nonce index, so "
             "duplicate_emission_candidate stays false (cloud passthrough axis, "
-            "draft 10.3)"
+            "draft 10.4)"
         )
     try:
         identity = hashlib.sha256(canonical_json(payload)).hexdigest()

--- a/python/tests/test_run_structured_nonce_axis.py
+++ b/python/tests/test_run_structured_nonce_axis.py
@@ -1,0 +1,93 @@
+"""run_structured reports the nonce axis that run() reports.
+
+run() took a seen_nonces index and reported a nonce axis; run_structured took no
+index and reported no such axis, so the same receipt checked through the two
+documented surfaces produced different axis lists, and a caller using the
+structured surface got no replay signal at all.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from asqav.verifier.verify_receipt import run_structured
+
+_VECTOR = (
+    Path(__file__).parent.parent.parent
+    / "verifier"
+    / "conformance-vectors"
+    / "asqav-01-genesis-permit"
+)
+
+
+@pytest.fixture
+def receipt() -> dict:
+    return json.loads((_VECTOR / "receipt.json").read_text())
+
+
+@pytest.fixture
+def jwks() -> dict:
+    return json.loads((_VECTOR / "jwks.json").read_text())
+
+
+def _nonce_axis(report: dict) -> dict:
+    return next(a for a in report["axes"] if a["name"] == "nonce")
+
+
+def _with_nonce(receipt: dict, nonce: str, issuer: str = "iss-1") -> dict:
+    doc = copy.deepcopy(receipt)
+    doc["payload"]["nonce"] = nonce
+    doc["payload"]["issuer_id"] = issuer
+    return doc
+
+
+class TestTheNonceAxisIsReported:
+    def test_the_axis_is_present_at_all(self, receipt: dict, jwks: dict) -> None:
+        """Its absence was the defect: the structured surface reported no nonce axis."""
+        names = [a["name"] for a in run_structured(receipt, jwks, None)["axes"]]
+        assert "nonce" in names, names
+
+    def test_it_sits_where_run_puts_it(self, receipt: dict, jwks: dict) -> None:
+        """run() appends nonce directly after structure; the two surfaces agree on order."""
+        names = [a["name"] for a in run_structured(receipt, jwks, None)["axes"]]
+        assert names[:2] == ["structure", "nonce"], names
+
+    def test_without_an_index_it_says_so(self, receipt: dict, jwks: dict) -> None:
+        """No seen-nonce index is a passthrough, never a silent omission of the axis."""
+        axis = _nonce_axis(run_structured(_with_nonce(receipt, "n-1"), jwks, None))
+        assert axis["result"] == "PASS"
+        assert "no seen-nonce index" in axis["note"]
+
+
+class TestReplayIsActuallyDetected:
+    def test_a_different_receipt_reusing_the_pair_fails(self, receipt: dict, jwks: dict) -> None:
+        """The point of the axis: a DIFFERENT receipt on the same (issuer, nonce)."""
+        seen: set = set()
+        first = _with_nonce(receipt, "n-1")
+        replay = copy.deepcopy(first)
+        replay["payload"]["action_id"] = "act_DIFFERENT"
+
+        assert _nonce_axis(run_structured(first, jwks, None, seen_nonces=seen))["result"] == "PASS"
+        axis = _nonce_axis(run_structured(replay, jwks, None, seen_nonces=seen))
+        assert axis["result"] == "FAIL", axis
+        assert axis["failure_class"] == "invalid", axis
+
+    def test_re_verifying_the_identical_receipt_is_not_a_replay(
+        self, receipt: dict, jwks: dict
+    ) -> None:
+        """Checking one receipt twice must not manufacture a duplicate-emission finding."""
+        seen: set = set()
+        doc = _with_nonce(receipt, "n-2")
+        run_structured(doc, jwks, None, seen_nonces=seen)
+        axis = _nonce_axis(run_structured(copy.deepcopy(doc), jwks, None, seen_nonces=seen))
+        assert axis["result"] == "PASS", axis
+
+    def test_a_receipt_with_no_nonce_passes(self, receipt: dict, jwks: dict) -> None:
+        """Most receipts declare no nonce; the axis must not punish them."""
+        seen: set = set()
+        axis = _nonce_axis(run_structured(receipt, jwks, None, seen_nonces=seen))
+        assert axis["result"] == "PASS", axis

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -2463,8 +2463,15 @@ import { ADAPTERS as _ADAPTERS, verify as _oracleVerify } from "./verifier/index
 import type { VerifyResult } from "./verifier/core.js";
 
 /**
- * Verify a receipt fully offline against an in-memory JWKS snapshot, running the full oracle
+ * Verify a receipt fully offline against an in-memory JWKS snapshot, running the oracle axes
  * (structure, signature, hash-chain link). No network call is made.
+ *
+ * The anchor-binding and clock-skew axes are NOT evaluated here, by design and identically in the
+ * Python `verify_receipt_offline`, so the two languages report the same axes. A `verified` verdict
+ * therefore means the axes above passed, NOT that the receipt's anchors were checked: `anchors`
+ * sits outside the signed bytes, so an altered envelope can move it without breaking the
+ * signature. Run `checkAnchors` and `checkSkew` from the verifier entry point on the normalised
+ * envelope when you need them. See docs/offline-verification.md.
  */
 export function verifyReceiptOffline(
   receipt: Record<string, unknown>,

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -160,7 +160,7 @@ export function checkNonce(
   if (seenNonces === undefined) {
     return [
       "PASS",
-      "nonce present; this surface holds no seen-nonce index, so duplicate_emission_candidate stays false (cloud passthrough axis, draft 10.3)",
+      "nonce present; this surface holds no seen-nonce index, so duplicate_emission_candidate stays false (cloud passthrough axis, draft 10.4)",
     ];
   }
   let identity: string;


### PR DESCRIPTION
Three related fixes to the offline verification surfaces, all found by measuring what the three
documented entry points actually report rather than by reading their docs.

## 1. The structured surface reported no nonce axis

`run()` took a `seen_nonces` index and reported a nonce axis. `run_structured()` took no index and
reported no such axis, so one receipt checked through the two documented surfaces produced
different axis lists, and a caller on the structured surface got no replay signal at all. The
TypeScript verifier already reports the axis, so the structured Python surface was the odd one out
of three implementations.

It now takes the same index and appends the axis directly after `structure`, which is where `run()`
puts it, so the orderings agree as well as the contents. Without an index the axis still reports
and says it holds none, rather than vanishing.

Six tests, bound to the change: removing the single appended line at its production call site
reddens all six. The replay case is proved, not asserted. A different receipt reusing an
`(issuer_id, nonce)` pair FAILs with `failure_class: invalid`; the identical receipt re-verified
PASSes and is not reported as a duplicate emission.

## 2. The docstrings claimed more coverage than the functions deliver

`docs/offline-verification.md` already says these entry points cover structure, signature and the
hash chain, with anchor binding and clock skew checked on request. The docstrings said "the full
oracle" and returned a bare `verified`, which reads as though every axis had run. A developer reads
the docstring.

Both now name the two axes they leave out, say the omission is deliberate and identical across the
two languages, and point at the functions to call. The anchors point is the one that matters:
`anchors` sits outside the signed bytes, so an altered envelope can move it without breaking the
signature. Names were checked rather than assumed: `check_anchors`, `check_skew` and
`normalise_envelope` import from `asqav.verifier.verify_receipt`, and `checkAnchors` and `checkSkew`
are exported from the TypeScript verifier entry point.

## 3. The nonce note cited the wrong reporting section

Both verifiers told the reader that `duplicate_emission_candidate` lives in draft 10.3. It lives in
10.4, the Reporting section; 10.3 is Optional Checks. Confirmed against the published -08 render as
well as the working -09, so the citation was wrong on the artifact third parties hold. The string is
user-facing verifier output, not a comment.

## Verification

Full suite 3048 passed, `tsc --noEmit` exits 0. Four failures are pre-existing and unrelated,
confirmed by reproducing them identically on unmodified HEAD: the local `dilithium-py` subprocess
gap that skips the ML-DSA-65 check, which CI installs.

The anchors-axis verdict question is deliberately left alone, because what a surface that skips the
anchoring axis may report depends on the anchoring rewrite still to come.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4