### PR TITLE
feat(cli): let an Audit Pack export ask for verifiable receipts

### DIFF
--- a/python/src/asqav/cli.py
+++ b/python/src/asqav/cli.py
@@ -1564,6 +1564,12 @@ def audit_pack_export(
         "--only-compliance/--no-only-compliance",
         help="When true (default), only IETF Compliance Receipts are exported.",
     ),
+    include_signed_bytes: bool = typer.Option(
+        False,
+        "--include-signed-bytes",
+        help="Include each receipt's signed bytes so the pack's signatures can be verified. "
+        "Off by default: the pack then carries digests only and no signature in it is checkable.",
+    ),
     output_file: str = typer.Option(
         ..., "--output-file", help="Path to write the signed bundle JSON."
     ),
@@ -1573,6 +1579,15 @@ def audit_pack_export(
     Calls POST `/audit-pack/export`. The bundle is signed with the org's
     most-recent active agent key over the JCS-canonical bundle bytes, so
     a verifier can rederive the digest and check the signature offline.
+
+    THE BUNDLE SIGNATURE AND THE RECEIPT SIGNATURES ARE DIFFERENT THINGS. By
+    default every receipt's signed bytes are withheld and `content_disclosure.mode`
+    reads `digest_only`, so a recipient can check the bundle's own signature but
+    cannot verify a single receipt inside it: the preimage is absent. Pass
+    ``--include-signed-bytes`` when the recipient is expected to verify the
+    receipts themselves, which is the usual reason for sending a pack to an
+    auditor. Content minimisation is the reason for the default, so choose it
+    deliberately rather than by omission.
     """
     import json as json_mod
 
@@ -1583,6 +1598,7 @@ def audit_pack_export(
         "start": start,
         "end": end,
         "only_compliance": only_compliance,
+        "include_signed_bytes": include_signed_bytes,
     }
     if organization_id:
         body["organization_id"] = organization_id

--- a/python/tests/test_audit_pack_export_signed_bytes.py
+++ b/python/tests/test_audit_pack_export_signed_bytes.py
@@ -1,0 +1,70 @@
+"""The Audit Pack CLI can ask for a pack whose receipts are verifiable.
+
+The export sent no `include_signed_bytes`, so it took the server default and every
+receipt came back with its signed bytes withheld. The recipient could check the
+bundle's own signature and not one receipt inside it, because the preimage was
+absent. There was no flag to ask for anything else.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import pytest
+
+import asqav.cli as cli
+import asqav.client as client
+
+
+@pytest.fixture
+def sent() -> dict[str, Any]:
+    """Capture the body the CLI puts on the wire."""
+    return {}
+
+
+def _export(sent: dict[str, Any], **overrides: Any) -> None:
+    def fake_post(path: str, body: dict[str, Any], **_: Any) -> dict[str, Any]:
+        sent["path"] = path
+        sent["body"] = dict(body)
+        return {"receipts": [], "bundle_digest": "sha256:x"}
+
+    kwargs: dict[str, Any] = {
+        "start": "2026-09-03T00:00:00Z",
+        "end": "2026-09-04T00:00:00Z",
+        "organization_id": "",
+        "only_compliance": True,
+        "include_signed_bytes": False,
+        "output_file": "/dev/null",
+    }
+    kwargs.update(overrides)
+    with (
+        mock.patch.object(client, "_post", fake_post),
+        mock.patch.object(cli, "_init_sdk", lambda: None),
+    ):
+        cli.audit_pack_export(**kwargs)
+
+
+class TestTheFlagReachesTheWire:
+    def test_the_member_is_always_sent(self, sent: dict[str, Any]) -> None:
+        """Its absence was the defect: the export inherited whatever the server defaulted to."""
+        _export(sent)
+        assert "include_signed_bytes" in sent["body"], sent["body"]
+
+    def test_the_default_is_the_minimising_one(self, sent: dict[str, Any]) -> None:
+        """Content minimisation stays the default; the caller opts in deliberately."""
+        _export(sent)
+        assert sent["body"]["include_signed_bytes"] is False
+
+    def test_asking_for_signed_bytes_is_carried(self, sent: dict[str, Any]) -> None:
+        """The whole point: a pack an auditor can actually verify receipts in."""
+        _export(sent, include_signed_bytes=True)
+        assert sent["body"]["include_signed_bytes"] is True
+
+    def test_the_other_members_are_unchanged(self, sent: dict[str, Any]) -> None:
+        """The added member must not disturb the window or the compliance filter."""
+        _export(sent, include_signed_bytes=True)
+        assert sent["body"]["start"] == "2026-09-03T00:00:00Z"
+        assert sent["body"]["end"] == "2026-09-04T00:00:00Z"
+        assert sent["body"]["only_compliance"] is True
+        assert sent["path"] == "/audit-pack/export"


### PR DESCRIPTION
## What was wrong

The Audit Pack export sent no `include_signed_bytes`, so it took the server default. That default
withholds every receipt's signed bytes and sets `content_disclosure.mode` to `digest_only`, which
means the recipient can check the bundle's own signature and **not one receipt inside it** — the
preimage is absent. The CLI offered no way to ask for anything else.

The bundle signature and the receipt signatures are different things, and the export's own docstring
left that unsaid.

## Measured against production before changing anything

A default export of a one-day window returned **252 receipts with `signed_bytes_withheld: true` on
all 252**, carrying `signature_b64`, `public_key_b64` and `message_sha256` but no message.
Re-running with the member set returned `message_b64` and **0 of 252 withheld**, after which
ML-DSA-65 verified **25 of 25** sampled receipts against each receipt's own key and bytes.

So the pack is verifiable; the CLI just could not ask for the form that is.

## The change

An opt-in `--include-signed-bytes` flag, and the member is now always present on the wire rather
than inherited from whatever the server defaults to. The default stays the minimising one, because
content minimisation is a deliberate privacy posture rather than an oversight. What changes is that
the choice is made deliberately instead of by omission.

The docstring now states that the two signatures are different things and that the usual reason for
sending a pack to an auditor is for them to verify the receipts themselves.

## Verification

Four tests, mutation-proved: removing the body member at its production call site reddens three of
them, and the fourth stays green because it only asserts the members this change does not touch.

435 passed across the CLI and audit selection. Three failures are pre-existing and unrelated,
confirmed by reproducing them identically on unmodified HEAD: the local `dilithium-py` subprocess
gap that skips the ML-DSA-65 check, which CI installs.

A matching correction to the auditor-facing docs page, which states the pack "verifies against the
public key, offline" without qualifying the default, is left for its own change in the platform repo.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4
