### PR TITLE
chore(release): 0.10.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.8] - 2026-09-04
+
+### Added
+
+- **Non-coverage is declared in the output, on every result including passing
+  ones.** Each verification result carries a machine-readable `not_checked` array
+  naming every check the tool does not perform, with the requirement it belongs
+  to, why it is skipped, and the input that would enable it where the caller can
+  close the gap. A verifier that reports only what it checked lets a reader
+  mistake silence for coverage, and a README does not travel with the result.
+- **A published vector-to-requirement mapping**, with the requirements no vector
+  exercises published beside it (`conformance-vectors/requirement-map.json`).
+  Coverage is derived by running each vector and reading the axes off the result,
+  so an axis the verifier skipped is not counted whatever a vector's notes claim.
+  It reports one gap on generation: no vector exercises the anchoring requirement,
+  because the corpus ships no pinned TSA key material.
+- **A probe that checks the published packages**, not the working tree, for every
+  entry point their own pages document, and runs the conformance corpus through
+  the installed package (`verifier/artifact_probe/`).
+
 ## [0.10.7] - 2026-09-03
 
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.7"
+version = "0.10.8"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -192,7 +192,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.7"
+__version__ = "0.10.8"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -3,7 +3,7 @@
  * added under Node, since browsers forbid setting User-Agent on fetch.
  */
 
-export const SDK_VERSION = "0.10.7";
+export const SDK_VERSION = "0.10.8";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
A patch bump, per the pre-1.0 policy, carrying three additions that are all scored against the **distributed artifact** rather than the repository. That is the reason to cut it now: the coverage declaration and the requirement map are on main, and a reader who installs the package does not get them until a release exists.

The artifact probe added in this release is what surfaced the gap. Run against the published wheel it reported that no corpus result carried a coverage declaration, because the declaration lives on main and no release had shipped it.

## Contents

- **Non-coverage declared in the output**, on every result including passing ones — the machine-readable `not_checked` array.
- **The published vector-to-requirement mapping** with its unmapped list, which reports one real gap on generation: no vector exercises the anchoring requirement.
- **The artifact probe**, which checks the published packages for every entry point their own pages document and runs the conformance corpus through the installed package.

## Verification

Five version files moved together (`package.json`, `pyproject.toml`, `__init__.py`, `userAgent.ts`, `CHANGELOG.md`); the version-consistency tests pass. Suite: 3162 passing against a 3151 baseline, with the same 4 environment-only failures before and after.