### PR TITLE
feat(verifier): declare non-coverage on every TypeScript verify() result

### DIFF
--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -5,6 +5,7 @@
 
 import type { FormatAdapter, KeyProvider } from "./adapter.js";
 import { FAIL, PASS, SKIPPED, verifySignature, type VerifyState } from "./crypto.js";
+import { notCheckedDeclaration, type NotCheckedEntry } from "./not-checked.js";
 
 /**
  * Public verdict vocabulary (criteria 418/438). The per-axis PASS/FAIL/SKIPPED
@@ -55,6 +56,8 @@ export interface VerifyResult {
    * disagreeing about WHICH check failed first is as visible as disagreeing about the verdict.
    */
   firstFailingEdge: string | null;
+  /** The checks this result does not claim, beside the claim it makes. */
+  notChecked: NotCheckedEntry[];
 }
 
 /** Axes whose FAIL proves a cryptographic/policy binding failure (invalid). */
@@ -296,6 +299,7 @@ export function verify(
       failureClass,
       signer: null,
       firstFailingEdge: firstFailingEdge(axes),
+      notChecked: notCheckedDeclaration(),
     };
   }
   // An over-nested receipt would crash the recursive JCS encoder. Cap it here and
@@ -306,7 +310,7 @@ export function verify(
   ) {
     const axes = [axis("structure", FAIL, TOO_DEEP_NOTE)];
     const [verdict, failureClass] = foldVerdict(axes, false);
-    return { fmt: ad.name, axes, verdict, failureClass, signer: null, firstFailingEdge: firstFailingEdge(axes) };
+    return { fmt: ad.name, axes, verdict, failureClass, signer: null, firstFailingEdge: firstFailingEdge(axes), notChecked: notCheckedDeclaration() };
   }
 
   const [structResult, structNote] = ad.schema(doc);
@@ -325,5 +329,5 @@ export function verify(
   const [verdict, failureClass] = foldVerdict(axes, ad.keyedDigest(doc));
   const signerVal = ad.attestation(doc).signer;
   const signer = typeof signerVal === "string" ? signerVal : null;
-  return { fmt: ad.name, axes, verdict, failureClass, signer, firstFailingEdge: firstFailingEdge(axes) };
+  return { fmt: ad.name, axes, verdict, failureClass, signer, firstFailingEdge: firstFailingEdge(axes), notChecked: notCheckedDeclaration() };
 }

--- a/typescript/src/verifier/index.ts
+++ b/typescript/src/verifier/index.ts
@@ -51,6 +51,8 @@ export {
   verify,
 } from "./core.js";
 export type { AxisResult, FailureClass, Verdict, VerifyResult } from "./core.js";
+export { NOT_CHECKED, notCheckedDeclaration } from "./not-checked.js";
+export type { NotCheckedEntry } from "./not-checked.js";
 // The axes the oracle leaves out by design, so a TypeScript caller runs what a
 // Python caller runs. normaliseEnvelope ships too: skip it and you digest other bytes.
 export {

--- a/typescript/src/verifier/not-checked.ts
+++ b/typescript/src/verifier/not-checked.ts
@@ -1,0 +1,129 @@
+/**
+ * The non-coverage declaration every `verify()` result carries, a mirror of the Python
+ * verifier's `NOT_CHECKED`. A verifier that reports only what it checked lets a reader
+ * mistake silence for coverage.
+ *
+ * `condition` is null when the check is never performed at any invocation, and names the
+ * input that would enable it when the gap is one this caller can close. This list is longer
+ * than the Python one: this port runs no anchor cryptography at all, so the checks Python
+ * performs partially are declared here as never performed.
+ */
+
+/** One declared gap between what this verifier checks and what a receipt claims. */
+export interface NotCheckedEntry {
+  /** The check not performed (snake_case, stable across languages). */
+  check: string;
+  /** The requirement family the check belongs to. */
+  requirement: string;
+  /** Why it is not performed. */
+  reason: string;
+  /** The caller input that would enable it, or null when never performed. */
+  condition: string | null;
+}
+
+export const NOT_CHECKED: readonly NotCheckedEntry[] = [
+  {
+    check: "tsa_signature_verification",
+    requirement: "anchor trust",
+    reason:
+      "the RFC 3161 CMS signature over the receipt digest is never verified; an anchor " +
+      "entry is shape-checked and reported unverifiable",
+    condition: null,
+  },
+  {
+    check: "tsa_certificate_path",
+    requirement: "anchor trust",
+    reason:
+      "no X.509 chain walk from the RFC 3161 signing certificate to a public root, and " +
+      "no pinned TSA key input exists to trust one through",
+    condition: null,
+  },
+  {
+    check: "tsa_certificate_revocation",
+    requirement: "anchor trust",
+    reason: "no CRL or OCSP lookup, so a revoked TSA certificate is not detected",
+    condition: null,
+  },
+  {
+    check: "policy_digest_resolution",
+    requirement: "verifier check on policy_digest",
+    reason:
+      "the referenced policy artefact is not fetched or rehashed; the digest is checked " +
+      "for shape only, and resolving it needs the Audit Pack manifest",
+    condition: null,
+  },
+  {
+    check: "aggregate_anchor_inclusion",
+    requirement: "aggregate anchoring",
+    reason:
+      "where an anchor covers a batch rather than this receipt, the inclusion proof " +
+      "linking this receipt to that aggregate is not walked",
+    condition: null,
+  },
+  {
+    check: "framework_mapping_claims",
+    requirement: "taxonomy extension fields",
+    reason:
+      "the caller-supplied taxonomy lists are carried under the signature but their " +
+      "content is not evaluated against any framework; a receipt can name a control it " +
+      "never satisfied and this tool will not say so",
+    condition: null,
+  },
+  {
+    check: "receipt_set_completeness",
+    requirement: "selective omission",
+    reason:
+      "this tool verifies the receipt it is handed; it cannot tell that a receipt was " +
+      "withheld from the set it belongs to",
+    condition: "the seq axis detects a gap only when the predecessor is supplied",
+  },
+  {
+    check: "key_revocation_freshness",
+    requirement: "key resolution",
+    reason:
+      "revocation state is read from the key directory as supplied; the tool does not " +
+      "re-fetch it, so a key revoked after that snapshot reads current",
+    condition: "the key directory passed by the caller is trusted as given",
+  },
+  {
+    check: "opentimestamps_merkle_path",
+    requirement: "anchor cryptographic re-verification",
+    reason:
+      "the proof's op chain is not evaluated to a merkle root over the receipt digest; " +
+      "anchor entries are shape-checked only",
+    condition: null,
+  },
+  {
+    check: "opentimestamps_block_placement",
+    requirement: "anchor cryptographic re-verification",
+    reason:
+      "no merkle path is computed, so there is nothing to land in a bitcoin block; the " +
+      "tool carries no block-header input",
+    condition: null,
+  },
+  {
+    check: "counterparty_receipt_resolution",
+    requirement: "counterparty binding",
+    reason:
+      "the bound peer envelope is not resolved from any store and this API accepts no " +
+      "envelope to check against; the axis reports the claim unresolved rather than " +
+      "checking the digest",
+    condition: null,
+  },
+  {
+    check: "chain_predecessor_retrieval",
+    requirement: "hash-chain linkage",
+    reason: "the predecessor receipt is not fetched; the link is checked only against one supplied",
+    condition: "the predecessor payload passed by the caller",
+  },
+];
+
+/**
+ * Return the non-coverage declaration as a fresh list of fresh entries.
+ *
+ * Copied on every call so a caller mutating one result cannot narrow what later
+ * results declare.
+ */
+export function notCheckedDeclaration(): NotCheckedEntry[] {
+  return NOT_CHECKED.map((entry) => ({ ...entry }));
+}

--- a/typescript/tests/verifier-not-checked.test.ts
+++ b/typescript/tests/verifier-not-checked.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Non-coverage is declared on every `verify()` result, passing ones included.
+ * A port of python/tests/test_not_checked_declaration.py.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import * as ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { verify } from "../src/verifier/core.js";
+import { ADAPTERS } from "../src/verifier/index.js";
+import { NOT_CHECKED, notCheckedDeclaration } from "../src/verifier/not-checked.js";
+
+const VECTORS = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
+const REQUIRED_KEYS = ["check", "condition", "reason", "requirement"];
+
+function loadVector(name: string): [Record<string, unknown>, Record<string, unknown>] {
+  const dir = join(VECTORS, name);
+  return [
+    JSON.parse(readFileSync(join(dir, "receipt.json"), "utf-8")) as Record<string, unknown>,
+    JSON.parse(readFileSync(join(dir, "jwks.json"), "utf-8")) as Record<string, unknown>,
+  ];
+}
+
+describe("notChecked declaration", () => {
+  it("is non-empty and well-formed", () => {
+    expect(NOT_CHECKED.length, "an empty declaration claims total coverage").toBeGreaterThan(0);
+    for (const entry of NOT_CHECKED) {
+      expect(Object.keys(entry).sort(), entry.check).toEqual(REQUIRED_KEYS);
+      expect(entry.check).toBeTruthy();
+      expect(entry.check).toBe(entry.check.toLowerCase());
+      expect(entry.reason.trim()).toBeTruthy();
+      // `condition` is deliberately nullable: null means never performed.
+      expect(entry.condition === null || entry.condition.trim().length > 0).toBe(true);
+    }
+  });
+
+  it("names no check twice", () => {
+    const names = NOT_CHECKED.map((e) => e.check);
+    expect(new Set(names).size, names.join(",")).toBe(names.length);
+  });
+
+  it("rides a rejected input", () => {
+    const result = verify({ hello: "world" }, ADAPTERS, null);
+    expect(result.verdict).toBe("unverified");
+    expect(result.notChecked).toHaveLength(NOT_CHECKED.length);
+  });
+
+  it("rides a passing result", () => {
+    const [receipt, jwks] = loadVector("asqav-01-genesis-permit");
+    const result = verify(receipt, ADAPTERS, jwks);
+    const signature = result.axes.find((a) => a.axis === "signature");
+    // PASS here proves the crypto ran, so the declaration rides a real verified.
+    expect(signature?.result).toBe("PASS");
+    expect(result.verdict).toBe("verified");
+    expect(result.notChecked).toHaveLength(NOT_CHECKED.length);
+  });
+
+  it("cannot be narrowed by a caller mutating an earlier result", () => {
+    const first = verify({ hello: "world" }, ADAPTERS, null);
+    first.notChecked.length = 0;
+    const firstEntry = notCheckedDeclaration()[0];
+    firstEntry.reason = "mutated";
+    expect(verify({ hello: "world" }, ADAPTERS, null).notChecked).toHaveLength(NOT_CHECKED.length);
+    expect(notCheckedDeclaration()[0].reason).not.toBe("mutated");
+  });
+
+  it("is on every return path of verify(), parsed from source", () => {
+    // Parsed rather than exercised: the path no test reaches would ship undeclared.
+    const source = readFileSync(resolve(__dirname, "..", "src", "verifier", "core.ts"), "utf-8");
+    const file = ts.createSourceFile("core.ts", source, ts.ScriptTarget.Latest, true);
+    let verifyBody: ts.Block | undefined;
+    ts.forEachChild(file, (node) => {
+      if (ts.isFunctionDeclaration(node) && node.name?.text === "verify" && node.body) {
+        verifyBody = node.body;
+      }
+    });
+    expect(verifyBody, "verify() not found; the gate is vacuous").toBeDefined();
+
+    const returns: ts.ReturnStatement[] = [];
+    const visit = (node: ts.Node): void => {
+      if (ts.isReturnStatement(node)) returns.push(node);
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(verifyBody as ts.Block, visit);
+    expect(returns.length, "verify() has no returns; the gate is vacuous").toBeGreaterThan(0);
+
+    for (const ret of returns) {
+      const expr = ret.expression;
+      const line = file.getLineAndCharacterOfPosition(ret.getStart()).line + 1;
+      expect(expr !== undefined && ts.isObjectLiteralExpression(expr), `line ${line}: not an object`).toBe(true);
+      const names = (expr as ts.ObjectLiteralExpression).properties
+        .filter(ts.isPropertyAssignment)
+        .map((p) => (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name) ? p.name.text : ""));
+      expect(names, `verify() returns at line ${line} without notChecked`).toContain("notChecked");
+    }
+  });
+});


### PR DESCRIPTION
Adds notChecked to every VerifyResult, on all three return paths of verify(), mirroring the Python not_checked declaration so the boundary of the claim travels with the claim on both distributed halves. Twelve entries, two more than Python, because this port performs no anchor verification (no TSA signature check, no OpenTimestamps merkle evaluation) and the declaration has to be true of the tool it ships in. Tests: a source-parse gate over every return statement of verify(), copy-per-result, well-formedness, uniqueness. Rubric axis 2.6.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4