### PR TITLE
test(verifier): corpus vectors carrying both context and payload_digest

### DIFF
--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -24,7 +24,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
 FINGERPRINT_LOCK_DIGEST = "2a4996574669abcb65f4ae6942984a8108b4f0da4043d3042ca87b29d866e397"
-VERIFIER_LOCK_DIGEST = "e5cb2fa08935333a5e97c577562f558af4036b8885d6f9d201b5f7ffe647f657"
+VERIFIER_LOCK_DIGEST = "d62921b37e3b8ac54561f4cffba928b5ab5459d53534724e5c4e42c09829bd70"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -240,7 +240,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 71
+    assert len(results) == 73
     # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -28,7 +28,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 71 corpus vectors", () => {
+  it("matches every manifest outcome across all 73 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -45,9 +45,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(71);
+    expect(results.length).toBe(73);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(71);
+    expect(passed).toBe(73);
   });
 
   it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {

--- a/verifier/conformance-vectors/asqav-25-payload-digest-rederives/expected.json
+++ b/verifier/conformance-vectors/asqav-25-payload-digest-rederives/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "Payload-mode genesis carrying BOTH context and payload_digest, the one pair no other vector has: hash is SHA-256 over the JCS of the carried context and size its byte length (25), so the payload_digest axis recomputes and PASSes rather than passing on absence. The digest is computed with stdlib json.dumps in JCS shape, never through the verifier's canonical_json."
+}

--- a/verifier/conformance-vectors/asqav-25-payload-digest-rederives/jwks.json
+++ b/verifier/conformance-vectors/asqav-25-payload-digest-rederives/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-payload-digest-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "Ue6hnp+1BaIOW/U9+SrZCN1PwZFUtvG4phowntuHJtE="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-25-payload-digest-rederives/receipt.json
+++ b/verifier/conformance-vectors/asqav-25-payload-digest-rederives/receipt.json
@@ -1,0 +1,27 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-09-01T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_pd_001",
+    "action_ref": "act_pd_1",
+    "mode": "payload",
+    "context": {
+      "probe": "criterion-462"
+    },
+    "payload_digest": {
+      "hash": "86d65b5861dc755628c20ccd0fe8c3015af78e2856d614557e3427264f294ca9",
+      "size": 25
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-payload-digest-vec-key",
+    "sig": "ABsGHN1qPXiAhrRf/TGu2V0ISov0Uh4I5Fe7c7KI3Refe2GdFmp+BNY1AG5onPuPFiy2fjgUjyVs8FlBUa+EBw=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-26-payload-digest-mismatch/expected.json
+++ b/verifier/conformance-vectors/asqav-26-payload-digest-mismatch/expected.json
@@ -1,0 +1,7 @@
+{
+  "format": "asqav-native",
+  "outcome": "unverified",
+  "failure_class": "invalid",
+  "reason_code": "payload_digest_mismatch",
+  "notes": "The asqav-25 receipt with only payload_digest.hash changed: it commits to a DIFFERENT context ({'n': 3}) than the one carried, and the receipt is re-signed over the lying payload, so the signature axis PASSes and the digest is the only lie. The payload_digest axis recomputes from the carried context and FAILs - a proven internal inconsistency, so the class is invalid, not unverifiable."
+}

--- a/verifier/conformance-vectors/asqav-26-payload-digest-mismatch/jwks.json
+++ b/verifier/conformance-vectors/asqav-26-payload-digest-mismatch/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-payload-digest-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "Ue6hnp+1BaIOW/U9+SrZCN1PwZFUtvG4phowntuHJtE="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-26-payload-digest-mismatch/receipt.json
+++ b/verifier/conformance-vectors/asqav-26-payload-digest-mismatch/receipt.json
@@ -1,0 +1,27 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-09-01T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_pd_001",
+    "action_ref": "act_pd_1",
+    "mode": "payload",
+    "context": {
+      "probe": "criterion-462"
+    },
+    "payload_digest": {
+      "hash": "215ddd5567ca2590efd4ea109b4e56cbe591e2676fbf54a9262692c539166da6",
+      "size": 25
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-payload-digest-vec-key",
+    "sig": "Zk/8MtObv3FE9qz9p8OmwDRoeMVkJOoFOvZKBXsIVRtpSdqRx1oHt52Tx08p3GHZBY/yuZudKCE+jrTt/S6bBg=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/gen_payload_digest_vectors.py
+++ b/verifier/conformance-vectors/gen_payload_digest_vectors.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the payload_digest-over-context conformance vectors.
+
+-09 §10.2: a receipt carrying BOTH `context` and `payload_digest` is checkable
+from its own bytes - `hash` is SHA-256 over the JCS canonicalisation of the
+carried context, `size` that canonical form's byte length. Every other
+digest-carrying vector omits the context, so the recompute path had no fixture.
+
+Two vectors, minted as asqav-25/26 because asqav-23/24 were minted by the
+anchor-entry task ahead of this one (next free id at mint time, never reused):
+
+  asqav-25-payload-digest-rederives  honest digest beside its context; verifies
+  asqav-26-payload-digest-mismatch   the same receipt signed over a digest of a
+                                     DIFFERENT context; the signature PASSes and
+                                     the payload_digest axis is what FAILs
+
+The digest is computed with stdlib json.dumps in JCS shape, never by importing
+the verifier's canonical_json: an expectation must not come from the function
+under test.
+
+Usage: python verifier/conformance-vectors/gen_payload_digest_vectors.py
+Re-freeze the corpus lock afterwards: python verifier/freeze_corpus_lock.py
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+_HERE = Path(__file__).resolve().parent
+
+#: Nothing-up-my-sleeve seed phrase; the key is SHA-256 of these ASCII bytes
+SEED_PHRASE = b"asqav conformance corpus v1 payload-digest signing seed"
+KID = "asqav-payload-digest-vec-key"
+ISSUER = "Asqav Ltd"
+_ZERO_DIGEST = hashlib.sha256(b"").hexdigest()
+
+#: The two production context shapes measured 2026-09-03 (task T-005): ASCII,
+#: no raw-content keys. The honest vector carries the first; the lying digest
+#: commits to the second.
+HONEST_CONTEXT = {"probe": "criterion-462"}
+OTHER_CONTEXT = {"n": 3}
+
+
+def _jcs(obj: object) -> bytes:
+    """Canonical JSON bytes: sorted keys, tight separators, UTF-8."""
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+
+
+def _signing_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(SEED_PHRASE).digest())
+
+
+def _sign(payload: dict, sk: Ed25519PrivateKey) -> dict:
+    """The three-key envelope: signature is over the canonical payload bytes."""
+    return {
+        "payload": payload,
+        "signature": {
+            "alg": "Ed25519",
+            "kid": KID,
+            "sig": base64.b64encode(sk.sign(_jcs(payload))).decode(),
+        },
+        "anchors": [],
+    }
+
+
+def _digest_of(context: dict) -> dict:
+    """payload_digest over `context`, computed independently of the verifier."""
+    encoded = _jcs(context)
+    return {"hash": hashlib.sha256(encoded).hexdigest(), "size": len(encoded)}
+
+
+def _payload(digest: dict) -> dict:
+    """A genesis payload-mode receipt carrying BOTH context and payload_digest."""
+    return {
+        "type": "protectmcp:decision",
+        "issued_at": "2026-09-01T12:00:00+00:00",
+        "issuer_id": ISSUER,
+        "agent_id": "agt_pd_001",
+        "action_ref": "act_pd_1",
+        "mode": "payload",
+        "context": HONEST_CONTEXT,
+        "payload_digest": digest,
+        "policy_digest": f"sha256:{_ZERO_DIGEST}",
+        "previousReceiptHash": "0" * 64,
+        "decision": "allow",
+        "tool_name": "demo.action",
+    }
+
+
+def _jwks() -> dict:
+    pub = _signing_key().public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return {
+        "keys": [
+            {
+                "kid": KID,
+                "issuer_id": ISSUER,
+                "alg": "Ed25519",
+                "status": "active",
+                "public_key": base64.b64encode(pub).decode(),
+            }
+        ]
+    }
+
+
+def _write(name: str, files: dict[str, object]) -> None:
+    out = _HERE / name
+    out.mkdir(parents=True, exist_ok=True)
+    for fname, obj in files.items():
+        (out / fname).write_text(json.dumps(obj, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {name}")
+
+
+def main() -> int:
+    sk = _signing_key()
+    honest = _digest_of(HONEST_CONTEXT)
+    assert honest["size"] == 25, honest  # the measured production shape
+
+    _write(
+        "asqav-25-payload-digest-rederives",
+        {
+            "receipt.json": _sign(_payload(honest), sk),
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "verified",
+                "reason_code": "",
+                "notes": (
+                    "Payload-mode genesis carrying BOTH context and payload_digest, the "
+                    "one pair no other vector has: hash is SHA-256 over the JCS of the "
+                    "carried context and size its byte length (25), so the payload_digest "
+                    "axis recomputes and PASSes rather than passing on absence. The digest "
+                    "is computed with stdlib json.dumps in JCS shape, never through the "
+                    "verifier's canonical_json."
+                ),
+            },
+        },
+    )
+
+    lying = dict(honest)
+    lying["hash"] = _digest_of(OTHER_CONTEXT)["hash"]
+    _write(
+        "asqav-26-payload-digest-mismatch",
+        {
+            "receipt.json": _sign(_payload(lying), sk),
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "unverified",
+                "failure_class": "invalid",
+                "reason_code": "payload_digest_mismatch",
+                "notes": (
+                    "The asqav-25 receipt with only payload_digest.hash changed: it "
+                    "commits to a DIFFERENT context ({'n': 3}) than the one carried, and "
+                    "the receipt is re-signed over the lying payload, so the signature "
+                    "axis PASSes and the digest is the only lie. The payload_digest axis "
+                    "recomputes from the carried context and FAILs - a proven internal "
+                    "inconsistency, so the class is invalid, not unverifiable."
+                ),
+            },
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -532,5 +532,20 @@
     "failure_class": "invalid",
     "reason_code": "key_substituted",
     "notes": "The receipt is correctly signed and the signature verifies against the key the directory publishes, so the signature axis PASSes and reports nothing wrong. The bound digest names a different key, which is what a swap under the same kid looks like from outside. A key that cannot be the one the issuer committed to is a proven binding break, so the class is invalid rather than unverifiable."
+  },
+  {
+    "dir": "asqav-25-payload-digest-rederives",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "Payload-mode genesis carrying BOTH context and payload_digest (the pair no other vector has): hash is SHA-256 over the JCS of the carried context, size its byte length, so the payload_digest axis recomputes and PASSes rather than passing on absence. Minted by gen_payload_digest_vectors.py from a published seed phrase."
+  },
+  {
+    "dir": "asqav-26-payload-digest-mismatch",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "failure_class": "invalid",
+    "reason_code": "payload_digest_mismatch",
+    "notes": "The asqav-25 receipt with only payload_digest.hash changed - it commits to a different context than the one carried, and the receipt is re-signed over the lying payload, so the signature axis PASSes and the payload_digest axis is what FAILs. A proven internal inconsistency: unverified, invalid."
   }
 ]

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-verifier-conformance-vectors",
-  "corpus_version": 8,
+  "corpus_version": 9,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -43,6 +43,11 @@
       "version": 7,
       "files": 234,
       "digest": "f9c5c90f4329caf651e2c3b2b2a3b309c3f01c0a73cbd916c40249a8694a5cb9"
+    },
+    {
+      "version": 8,
+      "files": 235,
+      "digest": "e5cb2fa08935333a5e97c577562f558af4036b8885d6f9d201b5f7ffe647f657"
     }
   ],
   "files": [
@@ -997,6 +1002,36 @@
       "bytes": 5201
     },
     {
+      "path": "asqav-25-payload-digest-rederives/expected.json",
+      "sha256": "5aeb74111a4e430cd1f8a67fc0083d88474ff68ce5f083d39cd1d99105e59dba",
+      "bytes": 457
+    },
+    {
+      "path": "asqav-25-payload-digest-rederives/jwks.json",
+      "sha256": "07cda346c9a4383c6dc38259da13c78b63ea95936ce449c687071f8b5ab7add5",
+      "bytes": 226
+    },
+    {
+      "path": "asqav-25-payload-digest-rederives/receipt.json",
+      "sha256": "00b0b2730c3ce3de5b2723dc2f98fba371f9f7d4a89b3e1559f7ef0c9f5747a6",
+      "bytes": 855
+    },
+    {
+      "path": "asqav-26-payload-digest-mismatch/expected.json",
+      "sha256": "52945991f4fc899d4fb62ea44fe32ddecd3c23bf4857548d24cff85c035575e1",
+      "bytes": 535
+    },
+    {
+      "path": "asqav-26-payload-digest-mismatch/jwks.json",
+      "sha256": "07cda346c9a4383c6dc38259da13c78b63ea95936ce449c687071f8b5ab7add5",
+      "bytes": 226
+    },
+    {
+      "path": "asqav-26-payload-digest-mismatch/receipt.json",
+      "sha256": "e07fd475edffb5d12b79b268c17ae609ab251f14c3587fa9ece02d8b2f4f130a",
+      "bytes": 855
+    },
+    {
       "path": "authproof-01-genesis-real-sdk/expected.json",
       "sha256": "5599a2e6341d4194186cd5c43be8c271c2dd40d8a382f1be536d89488e6378a8",
       "bytes": 274
@@ -1067,6 +1102,11 @@
       "bytes": 6860
     },
     {
+      "path": "gen_payload_digest_vectors.py",
+      "sha256": "4744ae07bc324cf409835d5f832d62ac0ce622530336c39f36c14d90b3403437",
+      "bytes": 6407
+    },
+    {
       "path": "gen_selective_omission_vectors.py",
       "sha256": "7e3cd796f549466afe4cbcb5e23dec205e537d42041de412ea16483805ac0cde",
       "bytes": 6959
@@ -1078,8 +1118,8 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "7b59814a644ec593c2eb58efa09ae41718b34c54edb1a70e5f33aec4b21c8ac0",
-      "bytes": 23948
+      "sha256": "ef6b3dff397b95da0d3917396f1a1e263741e591453467659555f2e068a797af",
+      "bytes": 24924
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
@@ -1113,8 +1153,8 @@
     },
     {
       "path": "requirement-map.json",
-      "sha256": "92b258ea6aae74b2f6b0ef6d6944e4eeebf92e3ba529e5be1ef9af578fb9355b",
-      "bytes": 35824
+      "sha256": "94926b5780d1fbbf41bbdfebacf7d5b333672d50d18fb204d207f7a220b4d53c",
+      "bytes": 37792
     },
     {
       "path": "w3c-vc-01-didweb-happy-path/did_map.json",
@@ -1252,5 +1292,5 @@
       ]
     }
   },
-  "digest": "e5cb2fa08935333a5e97c577562f558af4036b8885d6f9d201b5f7ffe647f657"
+  "digest": "d62921b37e3b8ac54561f4cffba928b5ab5459d53534724e5c4e42c09829bd70"
 }

--- a/verifier/conformance-vectors/requirement-map.json
+++ b/verifier/conformance-vectors/requirement-map.json
@@ -528,6 +528,48 @@
       "not_exercised": [
         "REQ-ANCHOR"
       ]
+    },
+    "asqav-25-payload-digest-rederives": {
+      "declared_outcome": "verified",
+      "observed_verdict": "unverified",
+      "exercises": [
+        "REQ-CHAIN",
+        "REQ-COUNTERPARTY",
+        "REQ-EXPIRY",
+        "REQ-ISSUER-BIND",
+        "REQ-KEY-RESOLUTION",
+        "REQ-KEY-STATUS",
+        "REQ-KEY-THUMBPRINT",
+        "REQ-NONCE",
+        "REQ-PAYLOAD-DIGEST",
+        "REQ-SKEW",
+        "REQ-STRUCTURE"
+      ],
+      "not_exercised": [
+        "REQ-ANCHOR",
+        "REQ-SIGNATURE"
+      ]
+    },
+    "asqav-26-payload-digest-mismatch": {
+      "declared_outcome": "unverified",
+      "observed_verdict": "unverified",
+      "exercises": [
+        "REQ-CHAIN",
+        "REQ-COUNTERPARTY",
+        "REQ-EXPIRY",
+        "REQ-ISSUER-BIND",
+        "REQ-KEY-RESOLUTION",
+        "REQ-KEY-STATUS",
+        "REQ-KEY-THUMBPRINT",
+        "REQ-NONCE",
+        "REQ-PAYLOAD-DIGEST",
+        "REQ-SKEW",
+        "REQ-STRUCTURE"
+      ],
+      "not_exercised": [
+        "REQ-ANCHOR",
+        "REQ-SIGNATURE"
+      ]
     }
   },
   "interop_fixtures": {
@@ -809,7 +851,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-ISSUER-BIND": [
       "asqav-01-genesis-permit",
@@ -831,7 +875,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-KEY-STATUS": [
       "asqav-01-genesis-permit",
@@ -853,7 +899,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-KEY-THUMBPRINT": [
       "asqav-01-genesis-permit",
@@ -875,7 +923,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-CHAIN": [
       "asqav-01-genesis-permit",
@@ -897,7 +947,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-ANCHOR": [],
     "REQ-SKEW": [
@@ -920,7 +972,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-EXPIRY": [
       "asqav-01-genesis-permit",
@@ -942,7 +996,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-NONCE": [
       "asqav-01-genesis-permit",
@@ -964,7 +1020,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-PAYLOAD-DIGEST": [
       "asqav-01-genesis-permit",
@@ -986,7 +1044,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-COUNTERPARTY": [
       "asqav-01-genesis-permit",
@@ -1008,7 +1068,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-STRUCTURE": [
       "asqav-01-genesis-permit",
@@ -1030,7 +1092,9 @@
       "asqav-19-seq-non-monotonic",
       "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
-      "asqav-22-key-substituted"
+      "asqav-22-key-substituted",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ]
   },
   "unmapped_requirements": [
@@ -1052,7 +1116,7 @@
   },
   "unmapped_note": "These are normative requirements no vector in this corpus exercises. They are published because an unmapped requirement stays unmapped however many vectors exist, so growing the corpus does not remove one from this list; writing a vector that reaches it does.",
   "counts": {
-    "asqav_native_vectors": 22,
+    "asqav_native_vectors": 24,
     "interop_fixtures": 50,
     "requirements": 13,
     "requirements_covered": 12,

--- a/verifier/first-bad-edge-cases.json
+++ b/verifier/first-bad-edge-cases.json
@@ -72,6 +72,8 @@
     "asqav-19-seq-non-monotonic": "seq",
     "asqav-20-seq-absent": null,
     "asqav-21-key-thumbprint-binds": null,
-    "asqav-22-key-substituted": "key_binding"
+    "asqav-22-key-substituted": "key_binding",
+    "asqav-25-payload-digest-rederives": null,
+    "asqav-26-payload-digest-mismatch": "payload_digest"
   }
 }


### PR DESCRIPTION
Two asqav-native vectors from a checked-in generator: asqav-25 carries a context and an honest payload_digest (rederives, verified); asqav-26 carries the same context with a lying hash (unverified, invalid, payload_digest_mismatch). These are the first vectors to exercise the recompute path of REQ-PAYLOAD-DIGEST. TypeScript parity confirmed, lock re-frozen, requirement map regenerated. Criterion 627.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4