### PR TITLE
fix(verifier): verify the ACTA -03 chain-link form alongside the -02 one

### DIFF
--- a/python/src/asqav/verifier/oracle/adapters/acta.py
+++ b/python/src/asqav/verifier/oracle/adapters/acta.py
@@ -23,11 +23,14 @@ asqav-native adapter also imports so neither claims the other's receipts.
 
 The chain field previousReceiptHash is SHA-256 of the JCS of the FULL predecessor
 receipt INCLUDING its signature (the inverse of AERF, which excludes the
-signature). It lives inside `payload`, so it is covered by the signature; removing
-or altering it breaks the signature. Genesis OMITS the field; a present
-`previousReceiptHash: null` is a malformed genesis, not a link. Keys resolve from
-an injected JWK Set (OKP/Ed25519, base64url `x`), the same no-live-fetch model the
-other adapters use.
+signature). Two carried forms verify: bare lowercase hex (draft -02) and, per
+ACTA -03 §6.7, the string "sha256:" followed by that hex; the carried value
+selects the recomputed form, and any other prefix fails the comparison rather
+than being normalised into a pass. It lives inside `payload`, so it is covered
+by the signature; removing or altering it breaks the signature. Genesis OMITS
+the field; a present `previousReceiptHash: null` is a malformed genesis, not a
+link. Keys resolve from an injected JWK Set (OKP/Ed25519, base64url `x`), the
+same no-live-fetch model the other adapters use.
 """
 from __future__ import annotations
 
@@ -108,10 +111,17 @@ class ActaAdapter(FormatAdapter):
         prev = payload.get("previousReceiptHash")
         is_genesis = "previousReceiptHash" not in payload
         # Chain hash covers the full predecessor receipt, signature included.
+        # The carried value selects the recomputed form: ACTA -03 §6.7 carries
+        # "sha256:" + hex, -02 the bare hex. An unknown prefix never normalises
+        # into a pass - the comparison just fails, as a wrong digest does.
         return ChainStep(
             prev_field=prev,
             is_genesis=is_genesis,
-            recompute=lambda pred: sha256_hex(jcs(pred)),
+            recompute=lambda pred: (
+                "sha256:" + sha256_hex(jcs(pred))
+                if isinstance(prev, str) and prev.startswith("sha256:")
+                else sha256_hex(jcs(pred))
+            ),
         )
 
     def schema(self, doc: dict) -> tuple[str, str]:

--- a/python/tests/test_acta_chain_form.py
+++ b/python/tests/test_acta_chain_form.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""The ACTA chain recompute follows the form of the carried link (ACTA -03 §6.7).
+
+The corpus vectors acta-06/07 pin the end-to-end outcomes; these unit tests pin
+the adapter mechanics: prefixed carried value gets a prefixed recompute, bare
+gets bare, and an unknown prefix is never normalised into a pass.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from asqav.verifier.oracle.adapters.acta import ActaAdapter
+from asqav.verifier.oracle.core import verify
+
+_CORPUS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+
+def _acta_06():
+    d = _CORPUS / "acta-06-chain-link-03-prefixed"
+    return (
+        json.loads((d / "receipt.json").read_text()),
+        json.loads((d / "predecessor.json").read_text()),
+        json.loads((d / "acta-keys.json").read_text()),
+    )
+
+
+def test_chain_recompute_matches_the_carried_form() -> None:
+    receipt, pred, _keys = _acta_06()
+    adapter = ActaAdapter()
+    step = adapter.chain_step(receipt)
+
+    prefixed = step.recompute(pred)
+    assert prefixed.startswith("sha256:")
+
+    bare = dict(receipt["payload"])
+    bare["previousReceiptHash"] = prefixed[len("sha256:"):]
+    bare_step = adapter.chain_step({"payload": bare, "signature": receipt["signature"]})
+    bare_recompute = bare_step.recompute(pred)
+    assert not bare_recompute.startswith("sha256:")
+    assert bare_recompute == prefixed[len("sha256:"):]
+
+
+def test_unknown_prefix_fails_the_chain_axis() -> None:
+    """A carried `sha512:` link is compared, not normalised: it must FAIL."""
+    receipt, pred, keys = _acta_06()
+    mutated = json.loads(json.dumps(receipt))
+    carried = mutated["payload"]["previousReceiptHash"]
+    assert carried.startswith("sha256:")
+    mutated["payload"]["previousReceiptHash"] = "sha512:" + carried[len("sha256:"):]
+
+    result = verify(mutated, [ActaAdapter()], key_provider=keys, predecessor=pred)
+    chain = next(a for a in result.axes if a.axis == "chain")
+    assert chain.result == "FAIL"
+    assert result.verdict == "unverified"

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -24,7 +24,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
 FINGERPRINT_LOCK_DIGEST = "2a4996574669abcb65f4ae6942984a8108b4f0da4043d3042ca87b29d866e397"
-VERIFIER_LOCK_DIGEST = "bd51a3f9f0c606e9df151e9cc01c2fb6cfc96a869bc3b86f1625bd0698f4ceaa"
+VERIFIER_LOCK_DIGEST = "da40f506f477b438087358a1f30c34043cb864d299a47aeef6a54fb878f5ab7f"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -240,7 +240,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 75
+    assert len(results) == 77
     # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/typescript/src/verifier/adapters/acta.ts
+++ b/typescript/src/verifier/adapters/acta.ts
@@ -88,10 +88,16 @@ export class ActaAdapter extends FormatAdapter {
     const prev = payload.previousReceiptHash;
     const isGenesis = !("previousReceiptHash" in payload);
     // Chain hash covers the full predecessor receipt, signature included.
+    // The carried value selects the recomputed form: ACTA -03 §6.7 carries
+    // "sha256:" + hex, -02 the bare hex. An unknown prefix never normalises
+    // into a pass - the comparison just fails, as a wrong digest does.
     return {
       prevField: (prev as string | null) ?? null,
       isGenesis,
-      recompute: (pred) => sha256Hex(jcs(pred)),
+      recompute: (pred) => {
+        const hex = sha256Hex(jcs(pred));
+        return typeof prev === "string" && prev.startsWith("sha256:") ? `sha256:${hex}` : hex;
+      },
     };
   }
 

--- a/typescript/tests/verifier-acta-chain-form.test.ts
+++ b/typescript/tests/verifier-acta-chain-form.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The ACTA chain recompute follows the form of the carried link (ACTA -03 §6.7).
+ * Mirrors python/tests/test_acta_chain_form.py.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { ActaAdapter } from "../src/verifier/adapters/acta.js";
+import { verify } from "../src/verifier/core.js";
+
+const CORPUS = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
+
+function acta06(): [Record<string, unknown>, Record<string, unknown>, Record<string, unknown>] {
+  const dir = join(CORPUS, "acta-06-chain-link-03-prefixed");
+  return [
+    JSON.parse(readFileSync(join(dir, "receipt.json"), "utf-8")),
+    JSON.parse(readFileSync(join(dir, "predecessor.json"), "utf-8")),
+    JSON.parse(readFileSync(join(dir, "acta-keys.json"), "utf-8")),
+  ];
+}
+
+describe("ACTA chain link forms", () => {
+  it("recompute matches the carried form", () => {
+    const [receipt, pred] = acta06();
+    const adapter = new ActaAdapter();
+    const step = adapter.chainStep(receipt);
+
+    const prefixed = step.recompute(pred);
+    expect(prefixed.startsWith("sha256:")).toBe(true);
+
+    const barePayload = { ...(receipt.payload as Record<string, unknown>) };
+    barePayload.previousReceiptHash = prefixed.slice("sha256:".length);
+    const bareStep = adapter.chainStep({ payload: barePayload, signature: receipt.signature });
+    const bareRecompute = bareStep.recompute(pred);
+    expect(bareRecompute.startsWith("sha256:")).toBe(false);
+    expect(bareRecompute).toBe(prefixed.slice("sha256:".length));
+  });
+
+  it("an unknown prefix fails the chain axis rather than being normalised", () => {
+    const [receipt, pred, keys] = acta06();
+    const mutated = JSON.parse(JSON.stringify(receipt)) as Record<string, unknown>;
+    const payload = mutated.payload as Record<string, unknown>;
+    const carried = payload.previousReceiptHash as string;
+    expect(carried.startsWith("sha256:")).toBe(true);
+    payload.previousReceiptHash = "sha512:" + carried.slice("sha256:".length);
+
+    const result = verify(mutated, [new ActaAdapter()], keys, pred);
+    const chain = result.axes.find((a) => a.axis === "chain");
+    expect(chain?.result).toBe("FAIL");
+    expect(result.verdict).toBe("unverified");
+  });
+});

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -28,7 +28,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 75 corpus vectors", () => {
+  it("matches every manifest outcome across all 77 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -45,9 +45,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(75);
+    expect(results.length).toBe(77);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(75);
+    expect(passed).toBe(77);
   });
 
   it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {

--- a/verifier/conformance-vectors/acta-06-chain-link-03-prefixed/acta-keys.json
+++ b/verifier/conformance-vectors/acta-06-chain-link-03-prefixed/acta-keys.json
@@ -1,0 +1,10 @@
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "kid": "sb:issuer:acta-oracle-vec-key",
+      "x": "PM0kHP_Js2GARLl9A22GFFk9iwF8NA8d7odzOFUXZUs"
+    }
+  ]
+}

--- a/verifier/conformance-vectors/acta-06-chain-link-03-prefixed/expected.json
+++ b/verifier/conformance-vectors/acta-06-chain-link-03-prefixed/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "acta",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "ACTA -03 \u00a76.7 chain form: previousReceiptHash carries the 'sha256:' prefix over SHA-256 of the JCS of the full signed predecessor. Both receipts are Ed25519-signed by the corpus seed key; the adapter reads the form from the carried value and verifies."
+}

--- a/verifier/conformance-vectors/acta-06-chain-link-03-prefixed/predecessor.json
+++ b/verifier/conformance-vectors/acta-06-chain-link-03-prefixed/predecessor.json
@@ -1,0 +1,15 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-05-04T12:00:00+00:00",
+    "issuer_id": "sb:issuer:acta-oracle-vec-key",
+    "agent_id": "agt_acta_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "decision": "allow"
+  },
+  "signature": {
+    "alg": "EdDSA",
+    "kid": "sb:issuer:acta-oracle-vec-key",
+    "sig": "41f33fa62edaa5bec6aaab86f5046f52866d2a84947afa7d8d12241e4e7a798280a7bc03518ac9d8a54039bb42ff64a4d47465b1314e4bee3e63c6ee3b5e1005"
+  }
+}

--- a/verifier/conformance-vectors/acta-06-chain-link-03-prefixed/receipt.json
+++ b/verifier/conformance-vectors/acta-06-chain-link-03-prefixed/receipt.json
@@ -1,0 +1,16 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-05-04T12:00:00+00:00",
+    "issuer_id": "sb:issuer:acta-oracle-vec-key",
+    "agent_id": "agt_acta_006",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "decision": "allow",
+    "previousReceiptHash": "sha256:2ac1941ca92e32ca8f5599f6acfabe3b7ca338b258734716fad1c7ddba70b28a"
+  },
+  "signature": {
+    "alg": "EdDSA",
+    "kid": "sb:issuer:acta-oracle-vec-key",
+    "sig": "8da504872742518bf79d6687137614d8d61f1025f5fb9869470437ab2d65e2e2712444a52e6b56db00e42c1aed25d92fc4d60cf17c4964f815efcbf2d4cfe300"
+  }
+}

--- a/verifier/conformance-vectors/acta-07-chain-link-03-wrong-digest/acta-keys.json
+++ b/verifier/conformance-vectors/acta-07-chain-link-03-wrong-digest/acta-keys.json
@@ -1,0 +1,10 @@
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "kid": "sb:issuer:acta-oracle-vec-key",
+      "x": "PM0kHP_Js2GARLl9A22GFFk9iwF8NA8d7odzOFUXZUs"
+    }
+  ]
+}

--- a/verifier/conformance-vectors/acta-07-chain-link-03-wrong-digest/expected.json
+++ b/verifier/conformance-vectors/acta-07-chain-link-03-wrong-digest/expected.json
@@ -1,0 +1,7 @@
+{
+  "format": "acta",
+  "outcome": "unverified",
+  "reason_code": "chain",
+  "notes": "The -03 prefixed form with one wrong hex nibble, re-signed so the signature PASSes and the chain axis is what FAILs. A proven break, so the class is invalid; the reason code is the corpus's 'chain' token (aerf-04's), the acta family having no older broken-link vector.",
+  "failure_class": "invalid"
+}

--- a/verifier/conformance-vectors/acta-07-chain-link-03-wrong-digest/predecessor.json
+++ b/verifier/conformance-vectors/acta-07-chain-link-03-wrong-digest/predecessor.json
@@ -1,0 +1,15 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-05-04T12:00:00+00:00",
+    "issuer_id": "sb:issuer:acta-oracle-vec-key",
+    "agent_id": "agt_acta_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "decision": "allow"
+  },
+  "signature": {
+    "alg": "EdDSA",
+    "kid": "sb:issuer:acta-oracle-vec-key",
+    "sig": "41f33fa62edaa5bec6aaab86f5046f52866d2a84947afa7d8d12241e4e7a798280a7bc03518ac9d8a54039bb42ff64a4d47465b1314e4bee3e63c6ee3b5e1005"
+  }
+}

--- a/verifier/conformance-vectors/acta-07-chain-link-03-wrong-digest/receipt.json
+++ b/verifier/conformance-vectors/acta-07-chain-link-03-wrong-digest/receipt.json
@@ -1,0 +1,16 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-05-04T12:00:00+00:00",
+    "issuer_id": "sb:issuer:acta-oracle-vec-key",
+    "agent_id": "agt_acta_006",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "decision": "allow",
+    "previousReceiptHash": "sha256:0ac1941ca92e32ca8f5599f6acfabe3b7ca338b258734716fad1c7ddba70b28a"
+  },
+  "signature": {
+    "alg": "EdDSA",
+    "kid": "sb:issuer:acta-oracle-vec-key",
+    "sig": "858782511055b721c6dff7a4d35f0b5e6d32f1e94c4f25de6991c87af1ddc1a0a30a3812dbdb2b960ba2e1cf71f9078d375b04518a8b650286cb3bb8587cb60d"
+  }
+}

--- a/verifier/conformance-vectors/gen_acta_vectors.py
+++ b/verifier/conformance-vectors/gen_acta_vectors.py
@@ -1,26 +1,28 @@
 """Generate the ACTA conformance vectors for the oracle corpus.
 
 Deterministic: a fixed Ed25519 test seed so the vectors are reproducible and
-reviewable. Produces genesis (PASS), chain-link (PASS), tamper-sig (FAIL), and a
-commitment-mode receipt (FAIL under the baseline verifier - the honest outcome
-for an unsupported optional mode). Signs exactly what the ACTA adapter verifies:
-Ed25519 over jcs(payload), hex-encoded.
+reviewable. Produces genesis (verified), chain-link (verified), tamper-sig
+(unverified), a commitment-mode receipt (unverified under the baseline
+verifier - the honest outcome for an unsupported optional mode), and the two
+chain-form vectors for ACTA -03 §6.7: a prefixed link that verifies and a
+prefixed link whose hex is wrong. Signs exactly what the ACTA adapter
+verifies: Ed25519 over jcs(payload), hex-encoded.
 
-Run from the verifier/ dir: python conformance-vectors/gen_acta_vectors.py
+Owns the numbered acta-0N entries of manifest.json and rewrites them in place
+at their existing position; the acta-up-* entries (minted by
+gen_acta_upstream_vectors.py) and every other family pass through untouched.
+
+Run from the repo root: python verifier/conformance-vectors/gen_acta_vectors.py
+Re-freeze the corpus lock afterwards: python verifier/freeze_corpus_lock.py
 """
 from __future__ import annotations
 
 import base64
 import hashlib
 import json
-import os
-import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from oracle.canonical import jcs  # noqa: E402
-
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 _HERE = Path(__file__).resolve().parent
 _SEED = bytes.fromhex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
@@ -28,6 +30,24 @@ _KID = "sb:issuer:acta-oracle-vec-key"
 
 _sk = Ed25519PrivateKey.from_private_bytes(_SEED)
 _pk_raw = _sk.public_key().public_bytes_raw()
+
+#: The directories this generator owns, in manifest order. Everything else in
+#: manifest.json passes through untouched.
+_OWNED = [
+    "acta-01-genesis",
+    "acta-02-chain-link",
+    "acta-03-tamper-sig",
+    "acta-05-commitment-mode-unsupported",
+    "acta-06-chain-link-03-prefixed",
+    "acta-07-chain-link-03-wrong-digest",
+]
+
+
+def _jcs(obj: object) -> bytes:
+    """Canonical JSON bytes: sorted keys, tight separators, UTF-8."""
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
 
 
 def _b64url(b: bytes) -> str:
@@ -39,7 +59,7 @@ def _keyset() -> dict:
 
 
 def _sign(payload: dict) -> dict:
-    sig = _sk.sign(jcs(payload))
+    sig = _sk.sign(_jcs(payload))
     return {"payload": payload, "signature": {"alg": "EdDSA", "kid": _KID, "sig": sig.hex()}}
 
 
@@ -54,25 +74,54 @@ def _genesis_payload() -> dict:
     }
 
 
+def _chain_hash(receipt: dict) -> str:
+    """The link preimage: SHA-256 hex of the full signed predecessor."""
+    return hashlib.sha256(_jcs(receipt)).hexdigest()
+
+
+def _expected(outcome: str, reason_code: str, notes: str, failure_class: str | None = None) -> dict:
+    entry = {"format": "acta", "outcome": outcome, "reason_code": reason_code, "notes": notes}
+    if failure_class is not None:
+        entry["failure_class"] = failure_class
+    return entry
+
+
 def _write(name: str, files: dict) -> None:
     d = _HERE / name
     d.mkdir(exist_ok=True)
     for fname, obj in files.items():
         (d / fname).write_text(json.dumps(obj, indent=2) + "\n")
+    print(f"wrote {name}")
+
+
+def _manifest_entry(dir_name: str, outcome: str, reason_code: str, notes: str,
+                    failure_class: str | None = None) -> dict:
+    entry = {"dir": dir_name, "format": "acta", "outcome": outcome}
+    if failure_class is not None:
+        entry["failure_class"] = failure_class
+    entry["reason_code"] = reason_code
+    entry["notes"] = notes
+    return entry
 
 
 def main() -> None:
     keyset = _keyset()
-
     genesis = _sign(_genesis_payload())
+
     _write(
         "acta-01-genesis",
-        {"receipt.json": genesis, "acta-keys.json": keyset, "expected.json": {"verdict": "PASS"}},
+        {
+            "receipt.json": genesis,
+            "acta-keys.json": keyset,
+            "expected.json": _expected(
+                "verified", "", "Valid ACTA genesis; Ed25519 over JCS(payload) verifies."
+            ),
+        },
     )
 
     succ_payload = _genesis_payload()
     succ_payload["agent_id"] = "agt_acta_002"
-    succ_payload["previousReceiptHash"] = hashlib.sha256(jcs(genesis)).hexdigest()
+    succ_payload["previousReceiptHash"] = _chain_hash(genesis)
     successor = _sign(succ_payload)
     _write(
         "acta-02-chain-link",
@@ -80,7 +129,11 @@ def main() -> None:
             "receipt.json": successor,
             "predecessor.json": genesis,
             "acta-keys.json": keyset,
-            "expected.json": {"verdict": "PASS"},
+            "expected.json": _expected(
+                "verified",
+                "",
+                "ACTA successor links via SHA-256 of the JCS of the full predecessor receipt.",
+            ),
         },
     )
 
@@ -90,36 +143,120 @@ def main() -> None:
     tampered["signature"]["sig"] = bad.hex()
     _write(
         "acta-03-tamper-sig",
-        {"receipt.json": tampered, "acta-keys.json": keyset, "expected.json": {"verdict": "FAIL"}},
+        {
+            "receipt.json": tampered,
+            "acta-keys.json": keyset,
+            "expected.json": _expected(
+                "unverified", "sig_mismatch", "Flipped signature byte; Ed25519 verify fails.",
+                "invalid",
+            ),
+        },
     )
 
     # Optional commitment mode signs SHA-256(JCS); the baseline verifier MUST fail it, never pass.
     commit_payload = _genesis_payload()
     commit_payload["agent_id"] = "agt_acta_commit"
-    digest = hashlib.sha256(jcs(commit_payload)).digest()
+    digest = hashlib.sha256(_jcs(commit_payload)).digest()
     commit = {
         "payload": commit_payload,
         "signature": {"alg": "EdDSA", "kid": _KID, "sig": _sk.sign(digest).hex()},
     }
     _write(
         "acta-05-commitment-mode-unsupported",
-        {"receipt.json": commit, "acta-keys.json": keyset, "expected.json": {"verdict": "FAIL"}},
+        {
+            "receipt.json": commit,
+            "acta-keys.json": keyset,
+            "expected.json": _expected(
+                "unverified",
+                "sig_mismatch",
+                "Commitment-mode receipt (signs SHA-256(JCS)) fails the baseline JCS verifier - honest, never a false pass.",
+                "invalid",
+            ),
+        },
+    )
+
+    # ACTA -03 §6.7: the chain link carries "sha256:" + the hex of the full signed
+    # predecessor. The preimage is unchanged from -02; only the form differs.
+    succ06_payload = _genesis_payload()
+    succ06_payload["agent_id"] = "agt_acta_006"
+    succ06_payload["previousReceiptHash"] = "sha256:" + _chain_hash(genesis)
+    _write(
+        "acta-06-chain-link-03-prefixed",
+        {
+            "receipt.json": _sign(succ06_payload),
+            "predecessor.json": genesis,
+            "acta-keys.json": keyset,
+            "expected.json": _expected(
+                "verified",
+                "",
+                "ACTA -03 §6.7 chain form: previousReceiptHash carries the 'sha256:' "
+                "prefix over SHA-256 of the JCS of the full signed predecessor. Both "
+                "receipts are Ed25519-signed by the corpus seed key; the adapter reads "
+                "the form from the carried value and verifies.",
+            ),
+        },
+    )
+
+    wrong = list("sha256:" + _chain_hash(genesis))
+    wrong[7] = "0" if wrong[7] != "0" else "1"
+    succ07_payload = _genesis_payload()
+    succ07_payload["agent_id"] = "agt_acta_006"
+    succ07_payload["previousReceiptHash"] = "".join(wrong)
+    _write(
+        "acta-07-chain-link-03-wrong-digest",
+        {
+            "receipt.json": _sign(succ07_payload),
+            "predecessor.json": genesis,
+            "acta-keys.json": keyset,
+            "expected.json": _expected(
+                "unverified",
+                "chain",
+                "The -03 prefixed form with one wrong hex nibble, re-signed so the "
+                "signature PASSes and the chain axis is what FAILs. A proven break, so "
+                "the class is invalid; the reason code is the corpus's 'chain' token "
+                "(aerf-04's), the acta family having no older broken-link vector.",
+                "invalid",
+            ),
+        },
     )
 
     manifest_path = _HERE / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
-    manifest = [m for m in manifest if not m["dir"].startswith("acta-")]
-    manifest += [
-        {"dir": "acta-01-genesis", "format": "acta", "outcome": "PASS", "reason_code": "",
-         "notes": "Valid ACTA genesis; Ed25519 over JCS(payload) verifies."},
-        {"dir": "acta-02-chain-link", "format": "acta", "outcome": "PASS", "reason_code": "",
-         "notes": "ACTA successor links via SHA-256 of the JCS of the full predecessor receipt."},
-        {"dir": "acta-03-tamper-sig", "format": "acta", "outcome": "FAIL", "reason_code": "sig_mismatch",
-         "notes": "Flipped signature byte; Ed25519 verify fails."},
-        {"dir": "acta-05-commitment-mode-unsupported", "format": "acta", "outcome": "FAIL",
-         "reason_code": "sig_mismatch",
-         "notes": "Commitment-mode receipt (signs SHA-256(JCS)) fails the baseline JCS verifier - honest, never a false pass."},
+    owned = [
+        _manifest_entry(
+            "acta-01-genesis", "verified", "",
+            "Valid ACTA genesis; Ed25519 over JCS(payload) verifies.",
+        ),
+        _manifest_entry(
+            "acta-02-chain-link", "verified", "",
+            "ACTA successor links via SHA-256 of the JCS of the full predecessor receipt.",
+        ),
+        _manifest_entry(
+            "acta-03-tamper-sig", "unverified", "sig_mismatch",
+            "Flipped signature byte; Ed25519 verify fails.", "invalid",
+        ),
+        _manifest_entry(
+            "acta-05-commitment-mode-unsupported", "unverified", "sig_mismatch",
+            "Commitment-mode receipt (signs SHA-256(JCS)) fails the baseline JCS verifier - honest, never a false pass.",
+            "invalid",
+        ),
+        _manifest_entry(
+            "acta-06-chain-link-03-prefixed", "verified", "",
+            "ACTA -03 §6.7 chain form: previousReceiptHash carries the 'sha256:' prefix "
+            "over SHA-256 of the JCS of the full signed predecessor; verifies in both "
+            "languages.",
+        ),
+        _manifest_entry(
+            "acta-07-chain-link-03-wrong-digest", "unverified", "chain",
+            "The -03 prefixed form with one wrong hex nibble, re-signed so the signature "
+            "PASSes and the chain axis FAILs. Proven break: invalid.",
+            "invalid",
+        ),
     ]
+    # Replace the owned entries in place, keeping every other family's position.
+    first = min(i for i, m in enumerate(manifest) if m["dir"] in _OWNED)
+    manifest = [m for m in manifest if m["dir"] not in _OWNED]
+    manifest[first:first] = owned
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
     print(f"wrote ACTA vectors; manifest now {len(manifest)} entries")
 

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -112,6 +112,21 @@
     "notes": "Commitment-mode receipt (signs SHA-256(JCS)) fails the baseline JCS verifier - honest, never a false pass."
   },
   {
+    "dir": "acta-06-chain-link-03-prefixed",
+    "format": "acta",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "ACTA -03 \u00a76.7 chain form: previousReceiptHash carries the 'sha256:' prefix over SHA-256 of the JCS of the full signed predecessor; verifies in both languages."
+  },
+  {
+    "dir": "acta-07-chain-link-03-wrong-digest",
+    "format": "acta",
+    "outcome": "unverified",
+    "failure_class": "invalid",
+    "reason_code": "chain",
+    "notes": "The -03 prefixed form with one wrong hex nibble, re-signed so the signature PASSes and the chain axis FAILs. Proven break: invalid."
+  },
+  {
     "dir": "acta-up-01-a2a-trusted-attestation",
     "format": "acta",
     "outcome": "verified",

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-verifier-conformance-vectors",
-  "corpus_version": 11,
+  "corpus_version": 12,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -58,6 +58,11 @@
       "version": 10,
       "files": 249,
       "digest": "2c8d871648474b3fc000d3afce7e3de8d840be12daeca9df9c1e2aa5d64d737b"
+    },
+    {
+      "version": 11,
+      "files": 249,
+      "digest": "bd51a3f9f0c606e9df151e9cc01c2fb6cfc96a869bc3b86f1625bd0698f4ceaa"
     }
   ],
   "files": [
@@ -135,6 +140,46 @@
       "path": "acta-05-commitment-mode-unsupported/receipt.json",
       "sha256": "ced1fe77d143f8077c0cb2f0c73c5d70034b2725c05e2c6cc24a751467badd08",
       "bytes": 534
+    },
+    {
+      "path": "acta-06-chain-link-03-prefixed/acta-keys.json",
+      "sha256": "4f3dafaf1e2db10e23a389c7d85035b1e09a4308509e2314b464228b258445b6",
+      "bytes": 179
+    },
+    {
+      "path": "acta-06-chain-link-03-prefixed/expected.json",
+      "sha256": "1e8a665bd67d401c4d1abca782a4c11fadfe45d423b5341b24d39c6515bf2245",
+      "bytes": 340
+    },
+    {
+      "path": "acta-06-chain-link-03-prefixed/predecessor.json",
+      "sha256": "3dc3b36962eb8b27efc56d53b2b87fe75b88781c00111b660aad4808d8f4706d",
+      "bytes": 531
+    },
+    {
+      "path": "acta-06-chain-link-03-prefixed/receipt.json",
+      "sha256": "1bbc26dd4a89513f25215798e0c66b7bc5cbe24765938a0b2ee1d6c64990c8f9",
+      "bytes": 633
+    },
+    {
+      "path": "acta-07-chain-link-03-wrong-digest/acta-keys.json",
+      "sha256": "4f3dafaf1e2db10e23a389c7d85035b1e09a4308509e2314b464228b258445b6",
+      "bytes": 179
+    },
+    {
+      "path": "acta-07-chain-link-03-wrong-digest/expected.json",
+      "sha256": "70d1e7d14ea1e9ccb857962464c03da9da9903a6875c3779df581d0d3b93844c",
+      "bytes": 389
+    },
+    {
+      "path": "acta-07-chain-link-03-wrong-digest/predecessor.json",
+      "sha256": "3dc3b36962eb8b27efc56d53b2b87fe75b88781c00111b660aad4808d8f4706d",
+      "bytes": 531
+    },
+    {
+      "path": "acta-07-chain-link-03-wrong-digest/receipt.json",
+      "sha256": "eab852c676053326f792b23822587856f094f5a3593fef1749c3a7b77e96d204",
+      "bytes": 633
     },
     {
       "path": "acta-up-01-a2a-trusted-attestation/acta-keys.json",
@@ -1138,8 +1183,8 @@
     },
     {
       "path": "gen_acta_vectors.py",
-      "sha256": "5b0185e9cfe4a27899adbefb8c08b97bbd428dc7ac9e4dd19a25af1a1df9e4fc",
-      "bytes": 4733
+      "sha256": "831fec25de5d0e352f75876fe91db5625c596294028695a5caeffda1828a6e54",
+      "bytes": 9809
     },
     {
       "path": "gen_key_binding_vectors.py",
@@ -1163,8 +1208,8 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "9485cae038de3e70bd5b1ca5133efc5ec3483433cc1c1af1b07edb245b0b2c57",
-      "bytes": 25926
+      "sha256": "eeb632ee4d783299167ff9ba50797a5b81d0911473a11a15b8fc762a7d61cc09",
+      "bytes": 26547
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
@@ -1198,8 +1243,8 @@
     },
     {
       "path": "requirement-map.json",
-      "sha256": "61c00432d8cfaa850ecddbff4b3766b6ca12fe87a17230ab543349f16af769a6",
-      "bytes": 40054
+      "sha256": "6529aac4927681646054c9717525548de4f1fd8c7f0ce8ac136565753743743d",
+      "bytes": 40556
     },
     {
       "path": "w3c-vc-01-didweb-happy-path/did_map.json",
@@ -1337,5 +1382,5 @@
       ]
     }
   },
-  "digest": "bd51a3f9f0c606e9df151e9cc01c2fb6cfc96a869bc3b86f1625bd0698f4ceaa"
+  "digest": "da40f506f477b438087358a1f30c34043cb864d299a47aeef6a54fb878f5ab7f"
 }

--- a/verifier/conformance-vectors/requirement-map.json
+++ b/verifier/conformance-vectors/requirement-map.json
@@ -635,6 +635,16 @@
       "exercises_profile_requirements": false,
       "note": "interoperability fixture for another specification; it is not evidence about this profile's normative requirements"
     },
+    "acta-06-chain-link-03-prefixed": {
+      "format": "acta",
+      "exercises_profile_requirements": false,
+      "note": "interoperability fixture for another specification; it is not evidence about this profile's normative requirements"
+    },
+    "acta-07-chain-link-03-wrong-digest": {
+      "format": "acta",
+      "exercises_profile_requirements": false,
+      "note": "interoperability fixture for another specification; it is not evidence about this profile's normative requirements"
+    },
     "acta-up-01-a2a-trusted-attestation": {
       "format": "acta",
       "exercises_profile_requirements": false,
@@ -1182,7 +1192,7 @@
   "unmapped_note": "These are normative requirements no vector in this corpus exercises. They are published because an unmapped requirement stays unmapped however many vectors exist, so growing the corpus does not remove one from this list; writing a vector that reaches it does.",
   "counts": {
     "asqav_native_vectors": 26,
-    "interop_fixtures": 50,
+    "interop_fixtures": 52,
     "requirements": 13,
     "requirements_covered": 12,
     "requirements_unmapped": 1

--- a/verifier/first-bad-edge-cases.json
+++ b/verifier/first-bad-edge-cases.json
@@ -76,6 +76,8 @@
     "asqav-25-payload-digest-rederives": null,
     "asqav-26-payload-digest-mismatch": "payload_digest",
     "asqav-23-anchor-status-pending": null,
-    "asqav-24-anchor-block-hash-prod": null
+    "asqav-24-anchor-block-hash-prod": null,
+    "acta-06-chain-link-03-prefixed": null,
+    "acta-07-chain-link-03-wrong-digest": "chain"
   }
 }


### PR DESCRIPTION
## What

Both ACTA adapters (`python/.../oracle/adapters/acta.py`,
`typescript/.../adapters/acta.ts`) verify the chain link in the form the
receipt carries: a `previousReceiptHash` starting with `sha256:` recomputes
as `"sha256:" + hex`, any other value recomputes as bare hex, and the core
comparison is untouched. An unknown prefix (`sha512:`) is compared as
carried and fails the chain axis; unit tests in both languages pin the two
forms and the unknown-prefix failure.

ACTA -03 §6.7: the link is the string "sha256:" followed by the lowercase
hex of SHA-256(JCS(receipt)) over the entire signed predecessor. The
preimage matches the -02 behaviour the adapters already had; only the form
changed. The adapter module texts name both forms and cite -03 §6.7.

## Vectors

- `acta-06-chain-link-03-prefixed` — genesis + successor with the prefixed
  link, both Ed25519-signed by the corpus seed. Outcome verified (PY + TS).
- `acta-07-chain-link-03-wrong-digest` — the same successor, one hex nibble
  wrong, re-signed so the signature PASSes and the chain axis FAILs.
  Outcome unverified/invalid, reason code `chain` (the corpus's existing
  broken-link token, aerf-04's; the acta family had none).
- `acta-02-chain-link` (bare hex) still passes unchanged in both languages.

`gen_acta_vectors.py` mints them and rewrites the numbered acta manifest
entries in place; the acta-up-* entries pass through. The generator was
also repaired to the current layout: it imported a moved module
(`oracle.canonical`) and wrote a superseded expected.json shape.

## Proof

- Mutation: reverting the Python adapter to bare-hex recompute turns
  `test_runner_main_reports_all_green`, `test_corpus_runs_and_every_vector_matches`,
  `test_every_vector_reports_its_pinned_first_bad_edge` and the new Python
  unit test RED on acta-06; restoring turns all four green.
- `python/tests/test_corpus_lock.py test_corpus_integrity.py test_oracle.py
  test_requirement_map.py test_acta_chain_form.py`: 202 passed.
- `bash verifier/check_corpus_lock.sh`: exit 0 over 243 verifier pins; the
  lock digest constant moved with the freeze.
- `npm test`: 71 files / 1152 tests passed; `npm run lint` (tsc) clean.
- Baselines on origin/main from the same checkout: the four corpus suites
  200 passed, npm 1150 passed, full python suite 3165 passed / 2 skipped.

Note on base: branched from origin/main per the task; the rebase onto the
post-T-002/T-005 main is the LEAD's call (count pins and the lock digest
then move again mechanically).
