### PR TITLE
docs: state the three plans and their real limits in every README

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,11 +379,13 @@ Both SDKs ship to different registries on independent cadences, driven by prefix
 
 ## Plans
 
-Asqav has two plans: Free and Enterprise.
+Asqav has three plans: Free, Pro and Enterprise.
 
-Free covers 25,000 signatures/month, 10 agents, 10 policies, 3 team members, and 30-day log retention. Most features are included: OpenTimestamps anchoring, audit export, framework integrations, content scanning, OpenTelemetry export, the Replay API, approvals, governance query and attestation, and 2 compliance reports/month.
+Free ($0, no credit card) covers 25,000 signatures/month (1,000/day), 10 agents, 10 policies, 3 team members, and 30-day log retention. Most features are included: OpenTimestamps anchoring, audit export, framework integrations, content scanning, OpenTelemetry export, the Replay API, approvals, governance query and attestation, and 2 compliance reports/month.
 
-Enterprise adds RFC 3161 timestamps, SSO/SAML, managed and bring-your-own KMS, SD-JWT selective disclosure, IP allowlists, multi-party quorum signing, quarantine and incident management, a self-hosted signer, and dedicated support. See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
+Pro ($99/month, or $79/month billed annually) covers 250,000 signatures/month (10,000/day) with usage-based overage, 50 agents, 100 policies, 10 team members, 1-year log retention and 25 compliance reports/month, and adds RFC 3161 timestamps.
+
+Enterprise adds SSO/SAML, managed and bring-your-own KMS, SD-JWT selective disclosure, IP allowlists, multi-party quorum signing, quarantine and incident management, a self-hosted signer, custom volumes and retention (five years by default), and dedicated support. See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
 
 ## Discovery
 

--- a/python/README.md
+++ b/python/README.md
@@ -256,7 +256,7 @@ See <https://www.asqav.com/docs/threat-framework-mapping>.
 - `required` must be in `[1, len(witnesses)]`.
 - `witnesses` must be a non-empty subset of the two shipped witnesses: `rfc3161` and `opentimestamps`.
 - `rekor` is rejected. It is not a shipped witness.
-- `rfc3161` confirmation is available on the Enterprise tier only. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.
+- `rfc3161` confirmation is available on the Pro and Enterprise tiers. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.
 
 ```python
 sig = agent.sign(

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -250,7 +250,7 @@ See <https://www.asqav.com/docs/threat-framework-mapping>.
 - `required` must be an integer in `[1, witnesses.length]`.
 - `witnesses` must be a non-empty subset of the two shipped witnesses: `rfc3161` and `opentimestamps`.
 - `rekor` is rejected. It is not a shipped witness.
-- `rfc3161` confirmation is available on the Enterprise tier only. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.
+- `rfc3161` confirmation is available on the Pro and Enterprise tiers. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.
 
 ```typescript
 const sig = await agent.sign({


### PR DESCRIPTION
The plan facts now match the platform's tier table and the pricing page: Free 25,000 signatures/month (1,000/day), Pro 250,000/month (10,000/day) at $99/month or $79/month billed annually with timestamp-authority tokens, Enterprise custom. The root README said two plans; the packaged Python and TypeScript READMEs (the ones PyPI and npm show) placed the timestamp-authority token on Enterprise only, and Pro carries it. The published readmes update with the next release.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4