### PR TITLE
feat(verifier): a machine-readable registry of outside recomputations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/python/tests/test_independent_runs.py
+++ b/python/tests/test_independent_runs.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""The independent-runs registry is honest: every entry pins real history.
+
+``verifier/independent-runs.json`` records outside recomputations of the corpus.
+An entry that names a commit this repository never had, or a vector the corpus
+did not carry at that commit, is not evidence - it is marketing. These tests
+refuse both, so the file stays an append-only log of runs that actually
+happened against bytes that actually existed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = REPO_ROOT / "verifier" / "independent-runs.json"
+
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+#: Every run entry carries these members with these types.
+_REQUIRED_MEMBERS = {
+    "id": str,
+    "date": str,
+    "runner": dict,
+    "asqav_sdk_commit": str,
+    "corpus": str,
+    "vectors": list,
+    "algorithms": list,
+    "uses_asqav_code": bool,
+    "independent_checks": list,
+    "result": str,
+    "not_proved": list,
+    "non_claims_text": str,
+}
+_RUNNER_MEMBERS = {
+    "repository": str,
+    "evidence": str,
+    "merge_commit": str,
+    "head_commit": str,
+}
+
+
+def _document() -> dict:
+    return json.loads(REGISTRY.read_text())
+
+
+def _runs() -> list[dict]:
+    return _document()["runs"]
+
+
+def _entry_ids() -> list[str]:
+    return [entry["id"] for entry in _runs()]
+
+
+def _git(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True
+    )
+
+
+def test_document_shape_is_the_published_one() -> None:
+    doc = _document()
+    assert doc["version"] == 1
+    assert isinstance(doc["purpose"], str) and doc["purpose"]
+    assert isinstance(doc["rules"], list) and all(isinstance(r, str) for r in doc["rules"])
+    assert isinstance(doc["runs"], list) and doc["runs"], "the registry has no entries"
+
+
+@pytest.mark.parametrize("entry", _runs(), ids=_entry_ids())
+def test_entry_members_have_the_required_types(entry: dict) -> None:
+    missing = sorted(set(_REQUIRED_MEMBERS) - set(entry))
+    assert not missing, f"{entry.get('id')}: missing members {missing}"
+    for member, kind in _REQUIRED_MEMBERS.items():
+        assert isinstance(entry[member], kind), (
+            f"{entry['id']}: {member} must be {kind.__name__}, "
+            f"got {type(entry[member]).__name__}"
+        )
+    for member, kind in _RUNNER_MEMBERS.items():
+        assert isinstance(entry["runner"].get(member), kind), (
+            f"{entry['id']}: runner.{member} must be {kind.__name__}"
+        )
+    assert all(isinstance(v, str) for v in entry["vectors"])
+    assert all(isinstance(c, str) for c in entry["independent_checks"])
+    assert all(isinstance(n, str) for n in entry["not_proved"])
+
+
+@pytest.mark.parametrize("entry", _runs(), ids=_entry_ids())
+def test_pinned_commit_is_40_hex_and_exists_in_this_repository(entry: dict) -> None:
+    sha = entry["asqav_sdk_commit"]
+    assert _COMMIT_RE.match(sha), (
+        f"{entry['id']}: asqav_sdk_commit {sha!r} is not 40 lowercase hex"
+    )
+    probe = _git("cat-file", "-e", f"{sha}^{{commit}}")
+    assert probe.returncode == 0, (
+        f"{entry['id']}: pinned commit {sha} does not exist in this repository"
+    )
+
+
+@pytest.mark.parametrize("entry", _runs(), ids=_entry_ids())
+def test_vectors_exist_in_the_corpus_at_the_pinned_commit(entry: dict) -> None:
+    sha = entry["asqav_sdk_commit"]
+    corpus = entry["corpus"]
+    listing = _git("ls-tree", "--name-only", "-d", sha, f"{corpus}/")
+    assert listing.returncode == 0, (
+        f"{entry['id']}: git ls-tree failed for {corpus} at {sha}: {listing.stderr}"
+    )
+    present = {line.rsplit("/", 1)[-1] for line in listing.stdout.splitlines()}
+    for vector in entry["vectors"]:
+        assert vector in present, (
+            f"{entry['id']}: vector {vector!r} is not a directory under {corpus} "
+            f"at pinned commit {sha}"
+        )
+
+
+@pytest.mark.parametrize("entry", _runs(), ids=_entry_ids())
+def test_date_is_iso_and_the_code_flag_is_a_bool(entry: dict) -> None:
+    try:
+        date.fromisoformat(entry["date"])
+    except ValueError:
+        pytest.fail(f"{entry['id']}: date {entry['date']!r} is not an ISO date")
+    # bool must not slip in as 0/1: isinstance(True, int) is True, so check exact.
+    assert type(entry["uses_asqav_code"]) is bool
+
+
+def test_entry_ids_are_unique() -> None:
+    ids = _entry_ids()
+    assert len(ids) == len(set(ids)), f"duplicate entry ids: {sorted(ids)}"

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -139,6 +139,16 @@ vector through this verifier and reading the axes off the result: an axis the
 verifier skipped is not coverage, whatever a vector'"'"'s notes say. A test fails if
 the committed map drifts from the corpus.
 
+## Outside recomputations
+
+`independent-runs.json` records recomputations of this corpus run by third
+parties from the published text alone, one entry per run. The file is
+append-only: an entry is never edited or removed. An entry is the runner's own
+claim, with the runner's own non-claims — it is not an Asqav endorsement, and
+the file's purpose line says so. A test keeps the list honest: it refuses an
+entry whose pinned asqav-sdk commit is not in this repository's history or
+whose vector names are not directories in the corpus at that commit.
+
 ## The same axes from TypeScript
 
 This file is Python. The TypeScript SDK reaches the same axes through

--- a/verifier/independent-runs.json
+++ b/verifier/independent-runs.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "purpose": "Outside recomputations of this corpus, one entry per run, append-only. An entry records what a third party reproduced from the published text alone, at which commit, and what it does not claim. No entry is a claim by Asqav.",
+  "rules": ["append only; never edit or remove an entry", "asqav_sdk_commit must exist in this repository's history", "every vector name must exist in the corpus at that commit"],
+  "runs": [
+    {
+      "id": "2026-09-04-t-trace-pr38",
+      "date": "2026-09-04",
+      "runner": {"repository": "https://github.com/safal207/T-Trace", "evidence": "https://github.com/safal207/T-Trace/pull/38", "merge_commit": "3126937608ab5c8164ace103f3cfb08e2ad852b6", "head_commit": "6150ffb89bd802b683ee883c641d92958f0734d5"},
+      "asqav_sdk_commit": "17c814f9e2e51f005faa707d44adec0316534da8",
+      "corpus": "verifier/conformance-vectors",
+      "vectors": ["asqav-14-omitted-action-chain", "asqav-15-unsigned-gap", "asqav-16-chain-emission-blocked"],
+      "algorithms": ["Ed25519"],
+      "uses_asqav_code": false,
+      "independent_checks": ["Ed25519 signature over the canonical predecessor payload", "Ed25519 signature over the canonical receipt payload", "SHA-256 previousReceiptHash linkage", "presence and shape of the vector-specific observability marker"],
+      "result": "3/3 agree: local_outcome equals expected_outcome (verified) on every vector",
+      "not_proved": ["global capture completeness", "deployment-level non-bypassability", "policy evaluation of unsigned actions", "absence of effects outside the receipt path", "endorsement by the upstream author"],
+      "non_claims_text": "This is bounded interoperability and claim-ceiling evidence. It does not prove global capture completeness, deployment-level non-bypassability, policy evaluation of unsigned actions, absence of effects outside the receipt path, or endorsement by Asqav."
+    }
+  ]
+}


### PR DESCRIPTION
## What

`verifier/independent-runs.json` — a machine-readable, append-only registry of
outside recomputations of the corpus. The first entry records the T-Trace run
(pull request 38, merged 2026-09-04): a third party reproduced
`previousReceiptHash` byte for byte on asqav-14/15/16 at the pinned commit
`17c814f9`, Ed25519 only, with no Asqav code, 3/3 agree — with its claim
boundary carried verbatim, both the machine-readable arrays and the PR
paragraph.

An entry is the runner's own claim and non-claims, not an Asqav endorsement;
the file's purpose line and the README paragraph both say so.

## How it stays honest

`python/tests/test_independent_runs.py` refuses an entry whose pinned
`asqav_sdk_commit` is not in this repository's history (`git cat-file -e
<sha>^{commit}`) or whose vector names are not directories in the corpus at
that commit (`git ls-tree`). The `python` CI job now checks out with
`fetch-depth: 0` so the probe can see history — the only CI change.

Neither corpus lock moves; the file lives beside the lock-pinned trees, not
inside them.

## Verification

- Registry parses and every fact was copied from source (`gh api
  repos/safal207/T-Trace/pulls/38`, the committed report at the merge commit,
  the PR body).
- Gate proofs: mutating one vector name → red test naming the vector; mutating
  the pinned commit to 40 zeros → red test naming the commit; restored, green.
- `bash verifier/check_corpus_lock.sh` → exit 0, both locks unmoved.
- `pytest python/tests -q` → 3179 passed, 2 skipped (baseline origin/main:
  3173 passed, 2 skipped; the +6 is the new test file).

Rubric axis 2.4.
