### PR TITLE
feat(verifier): every result carries a coverage block in the reviewer's shape

### DIFF
--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -1995,6 +1995,49 @@ def not_checked_declaration() -> list:
     return [dict(entry) for entry in NOT_CHECKED]
 
 
+#: The axis order run_structured reports on the normal path, structure first and
+#: expiry last. The coverage block measures "not reached" against this sequence.
+_FULL_AXIS_ORDER = (
+    "structure", "nonce", "issuer_key", "issuer_bind", "key_status", "signature",
+    "key_binding", "counterparty", "payload_digest", "chain", "anchors", "skew",
+    "expiry",
+)
+
+
+def coverage_declaration(axes: list) -> dict:
+    """The coverage block every result carries beside its non-coverage list.
+
+    The shape mirrors the reviewer's tool so the two read side by side:
+    stopped_at is None when evaluation ran the full axis sequence (the normal
+    path always ends at expiry); the early returns stop at the structure gate
+    (their axes name the failing input member), so it reads "structure" there.
+    checks_not_evaluated lists one not_implemented entry per NOT_CHECKED row,
+    then — on an early return — one not_reached entry per axis of the full
+    order after the stop point that the result does not carry.
+    """
+    entries = [
+        {
+            "id": row["check"],
+            "reason": "not_implemented",
+            "status": "not_implemented",
+            "requirement": row["requirement"],
+            "condition": row["condition"],
+        }
+        for row in NOT_CHECKED
+    ]
+    names = [a["name"] for a in axes]
+    if names and names[-1] == _FULL_AXIS_ORDER[-1]:
+        return {"stopped_at": None, "checks_not_evaluated": entries}
+    stopped_at = "structure"
+    after = _FULL_AXIS_ORDER[_FULL_AXIS_ORDER.index(stopped_at) + 1 :]
+    entries += [
+        {"id": name, "reason": "not_reached", "status": "implemented"}
+        for name in after
+        if name not in names
+    ]
+    return {"stopped_at": stopped_at, "checks_not_evaluated": entries}
+
+
 def check_payload_digest(payload: dict):
     """Recompute payload_digest from the context carried in the same receipt.
 
@@ -2485,17 +2528,19 @@ def run_structured(
     wire (ML-DSA-65 cloud-issued, Ed25519/ES256 local).
     """
     if not isinstance(envelope, dict):
+        axes = [
+            _struct_axis(
+                "input",
+                "FAIL",
+                f"expected a JSON object receipt, got {type(envelope).__name__}",
+            )
+        ]
         return {
             "not_checked": not_checked_declaration(),
+            "coverage": coverage_declaration(axes),
             "verdict": VERDICT_UNVERIFIED,
             "failure_class": FAILURE_UNVERIFIABLE,
-            "axes": [
-                _struct_axis(
-                    "input",
-                    "FAIL",
-                    f"expected a JSON object receipt, got {type(envelope).__name__}",
-                )
-            ],
+            "axes": axes,
             "canonical_sha256": None,
             "kid": None,
             "alg": None,
@@ -2503,19 +2548,21 @@ def run_structured(
     envelope = normalise_envelope(envelope)
     payload = envelope.get("payload", envelope)
     if not isinstance(payload, dict):
+        axes = [
+            _struct_axis(
+                "payload",
+                "FAIL",
+                "receipt payload not available from this surface "
+                f"(got {_describe_value(payload)} instead of an object). "
+                "Verify with a saved receipt instead.",
+            )
+        ]
         return {
             "not_checked": not_checked_declaration(),
+            "coverage": coverage_declaration(axes),
             "verdict": VERDICT_UNVERIFIED,
             "failure_class": FAILURE_UNVERIFIABLE,
-            "axes": [
-                _struct_axis(
-                    "payload",
-                    "FAIL",
-                    "receipt payload not available from this surface "
-                    f"(got {_describe_value(payload)} instead of an object). "
-                    "Verify with a saved receipt instead.",
-                )
-            ],
+            "axes": axes,
             "canonical_sha256": None,
             "kid": None,
             "alg": None,
@@ -2524,11 +2571,13 @@ def run_structured(
     if shape is None:
         shape = _scan_shape(predecessor_payload, max_depth=MAX_NESTING_DEPTH)
     if shape is not None:
+        axes = [_struct_axis("input", "FAIL", _SHAPE_MESSAGES[shape])]
         return {
             "not_checked": not_checked_declaration(),
+            "coverage": coverage_declaration(axes),
             "verdict": VERDICT_UNVERIFIED,
             "failure_class": FAILURE_UNVERIFIABLE,
-            "axes": [_struct_axis("input", "FAIL", _SHAPE_MESSAGES[shape])],
+            "axes": axes,
             "canonical_sha256": None,
             "kid": None,
             "alg": None,
@@ -2549,11 +2598,13 @@ def run_structured(
         msg = canonical_json(payload)
     except RecursionError:
         # Defense in depth; the shape gate above should already have caught this.
+        axes = [_struct_axis("input", "FAIL", _SHAPE_MESSAGES["too_deep"])]
         return {
             "not_checked": not_checked_declaration(),
+            "coverage": coverage_declaration(axes),
             "verdict": VERDICT_UNVERIFIED,
             "failure_class": FAILURE_UNVERIFIABLE,
-            "axes": [_struct_axis("input", "FAIL", _SHAPE_MESSAGES["too_deep"])],
+            "axes": axes,
             "canonical_sha256": None,
             "kid": None,
             "alg": None,
@@ -2654,6 +2705,7 @@ def run_structured(
 
     return {
         "not_checked": not_checked_declaration(),
+        "coverage": coverage_declaration(axes),
         "verdict": verdict,
         "failure_class": failure_class,
         "axes": axes,

--- a/python/tests/test_not_checked_declaration.py
+++ b/python/tests/test_not_checked_declaration.py
@@ -19,6 +19,7 @@ import pytest
 
 from asqav.verifier.verify_receipt import (
     NOT_CHECKED,
+    coverage_declaration,
     not_checked_declaration,
     run_structured,
 )
@@ -104,4 +105,87 @@ def test_every_return_path_of_run_structured_declares_it():
         keys = {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
         assert "not_checked" in keys, (
             f"run_structured returns at line {node.lineno} without not_checked"
+        )
+
+
+#: The twelve axes after the structure gate on the normal path, pinned verbatim so
+#: a reorder of the verifier's sequence fails here instead of editing the pin.
+_AXES_AFTER_STRUCTURE = (
+    "nonce", "issuer_key", "issuer_bind", "key_status", "signature", "key_binding",
+    "counterparty", "payload_digest", "chain", "anchors", "skew", "expiry",
+)
+
+
+def test_coverage_block_on_a_full_run():
+    """A receipt that runs the whole sequence reports stopped_at null and the table."""
+    receipt, jwks = _vector("asqav-01-genesis-permit")
+    result = run_structured(receipt, jwks)
+    # The pin is the live axis sequence itself: the coverage constant must track it.
+    assert [a["name"] for a in result["axes"]] == ["structure", *_AXES_AFTER_STRUCTURE]
+    cov = result["coverage"]
+    assert cov["stopped_at"] is None
+    entries = cov["checks_not_evaluated"]
+    assert [e["id"] for e in entries] == [e["check"] for e in NOT_CHECKED]
+    for entry in entries:
+        assert entry["reason"] == "not_implemented", entry
+        assert entry["status"] == "not_implemented", entry
+        assert list(entry)[:3] == ["id", "reason", "status"], entry
+        assert entry["requirement"] and "condition" in entry, entry
+
+
+def test_coverage_block_on_the_early_returns():
+    """The structure gate stops evaluation; the other axes read not_reached."""
+    for bad in ("not an envelope", {"payload": "not a dict"}):
+        result = run_structured(bad, {})
+        cov = result["coverage"]
+        assert cov["stopped_at"] == "structure", bad
+        entries = cov["checks_not_evaluated"]
+        not_impl = [e for e in entries if e["reason"] == "not_implemented"]
+        not_reached = [e for e in entries if e["reason"] == "not_reached"]
+        # not_implemented entries come first, in NOT_CHECKED table order.
+        assert [e["id"] for e in not_impl] == [e["check"] for e in NOT_CHECKED]
+        assert [e["id"] for e in not_reached] == list(_AXES_AFTER_STRUCTURE)
+        for entry in not_reached:
+            assert entry["status"] == "implemented", entry
+            assert list(entry) == ["id", "reason", "status"], entry
+
+
+def test_coverage_not_implemented_ids_match_the_table_in_order():
+    """Parity: the block's not_implemented ids ARE this language's table, in order."""
+    for axes in ([], [{"name": "expiry"}]):
+        entries = coverage_declaration(axes)["checks_not_evaluated"]
+        not_impl = [e["id"] for e in entries if e["reason"] == "not_implemented"]
+        assert not_impl == [e["check"] for e in NOT_CHECKED]
+
+
+def test_a_caller_cannot_narrow_the_coverage_block_of_later_results():
+    """Each result gets its own block; mutation does not reach the helper."""
+    first = run_structured("not an envelope", {})
+    first["coverage"]["checks_not_evaluated"].clear()
+    fresh = run_structured("not an envelope", {})["coverage"]
+    assert len(fresh["checks_not_evaluated"]) == len(NOT_CHECKED) + len(_AXES_AFTER_STRUCTURE)
+
+
+def test_every_return_path_of_run_structured_carries_coverage():
+    """The anti-regression gate for the coverage block, parsed from source.
+
+    Same construction as the not_checked gate above: a return path no test
+    reaches is exactly the one that would ship without the block.
+    """
+    source = pathlib.Path(
+        __import__("asqav.verifier.verify_receipt", fromlist=["_"]).__file__
+    ).read_text()
+    tree = ast.parse(source)
+    fn = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "run_structured"
+    )
+    returns = [n for n in ast.walk(fn) if isinstance(n, ast.Return)]
+    assert returns, "run_structured has no return statements; the gate is vacuous"
+    for node in returns:
+        assert isinstance(node.value, ast.Dict), "a non-dict return cannot carry coverage"
+        keys = {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
+        assert "coverage" in keys, (
+            f"run_structured returns at line {node.lineno} without coverage"
         )

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -5,7 +5,7 @@
 
 import type { FormatAdapter, KeyProvider } from "./adapter.js";
 import { FAIL, PASS, SKIPPED, verifySignature, type VerifyState } from "./crypto.js";
-import { notCheckedDeclaration, type NotCheckedEntry } from "./not-checked.js";
+import { notCheckedDeclaration, coverageDeclaration, type Coverage, type NotCheckedEntry } from "./not-checked.js";
 
 /**
  * Public verdict vocabulary (criteria 418/438). The per-axis PASS/FAIL/SKIPPED
@@ -58,6 +58,8 @@ export interface VerifyResult {
   firstFailingEdge: string | null;
   /** The checks this result does not claim, beside the claim it makes. */
   notChecked: NotCheckedEntry[];
+  /** The coverage block, mirrored from the reviewer's tool: snake_case keys are deliberate. */
+  coverage: Coverage;
 }
 
 /** Axes whose FAIL proves a cryptographic/policy binding failure (invalid). */
@@ -300,6 +302,7 @@ export function verify(
       signer: null,
       firstFailingEdge: firstFailingEdge(axes),
       notChecked: notCheckedDeclaration(),
+      coverage: coverageDeclaration(axes),
     };
   }
   // An over-nested receipt would crash the recursive JCS encoder. Cap it here and
@@ -310,7 +313,7 @@ export function verify(
   ) {
     const axes = [axis("structure", FAIL, TOO_DEEP_NOTE)];
     const [verdict, failureClass] = foldVerdict(axes, false);
-    return { fmt: ad.name, axes, verdict, failureClass, signer: null, firstFailingEdge: firstFailingEdge(axes), notChecked: notCheckedDeclaration() };
+    return { fmt: ad.name, axes, verdict, failureClass, signer: null, firstFailingEdge: firstFailingEdge(axes), notChecked: notCheckedDeclaration(), coverage: coverageDeclaration(axes) };
   }
 
   const [structResult, structNote] = ad.schema(doc);
@@ -329,5 +332,5 @@ export function verify(
   const [verdict, failureClass] = foldVerdict(axes, ad.keyedDigest(doc));
   const signerVal = ad.attestation(doc).signer;
   const signer = typeof signerVal === "string" ? signerVal : null;
-  return { fmt: ad.name, axes, verdict, failureClass, signer, firstFailingEdge: firstFailingEdge(axes), notChecked: notCheckedDeclaration() };
+  return { fmt: ad.name, axes, verdict, failureClass, signer, firstFailingEdge: firstFailingEdge(axes), notChecked: notCheckedDeclaration(), coverage: coverageDeclaration(axes) };
 }

--- a/typescript/src/verifier/index.ts
+++ b/typescript/src/verifier/index.ts
@@ -51,8 +51,8 @@ export {
   verify,
 } from "./core.js";
 export type { AxisResult, FailureClass, Verdict, VerifyResult } from "./core.js";
-export { NOT_CHECKED, notCheckedDeclaration } from "./not-checked.js";
-export type { NotCheckedEntry } from "./not-checked.js";
+export { AXIS_ORDER, coverageDeclaration, NOT_CHECKED, notCheckedDeclaration } from "./not-checked.js";
+export type { Coverage, CoverageEntry, NotCheckedEntry } from "./not-checked.js";
 // The axes the oracle leaves out by design, so a TypeScript caller runs what a
 // Python caller runs. normaliseEnvelope ships too: skip it and you digest other bytes.
 export {

--- a/typescript/src/verifier/not-checked.ts
+++ b/typescript/src/verifier/not-checked.ts
@@ -127,3 +127,75 @@ export const NOT_CHECKED: readonly NotCheckedEntry[] = [
 export function notCheckedDeclaration(): NotCheckedEntry[] {
   return NOT_CHECKED.map((entry) => ({ ...entry }));
 }
+
+/**
+ * The axis order verify() reports on the normal path for this profile's native
+ * format (the prefix, then the adapter's extras in order). The coverage block
+ * measures "not reached" against this sequence.
+ */
+export const AXIS_ORDER = [
+  "structure",
+  "signature",
+  "chain",
+  "seq",
+  "expiry",
+  "nonce",
+  "key_binding",
+  "counterparty",
+  "payload_digest",
+  "skew",
+  "key_status",
+  "issuer_bind",
+] as const;
+
+/** One entry of the coverage block: a check that did not run, with why. */
+export interface CoverageEntry {
+  /** The check (a NOT_CHECKED row's `check`, or an axis name). */
+  id: string;
+  /** not_implemented: declared and never evaluated; not_reached: evaluation stopped first. */
+  reason: "not_implemented" | "not_reached";
+  /** Whether the tool implements the check at all. */
+  status: "not_implemented" | "implemented";
+  /** The requirement family, on not_implemented entries. */
+  requirement?: string;
+  /** The caller input that would enable the check, on not_implemented entries. */
+  condition?: string | null;
+}
+
+/**
+ * The coverage block every result carries beside `notChecked`. A wire block
+ * mirrored from the reviewer's tool, so the keys stay snake_case deliberately.
+ */
+export interface Coverage {
+  /** null when the full axis sequence ran; else the axis evaluation stopped at. */
+  stopped_at: string | null;
+  /** not_implemented entries first (table order), then not_reached axes in axis order. */
+  checks_not_evaluated: CoverageEntry[];
+}
+
+/**
+ * Build the coverage declaration for one result's axes. The early returns in
+ * verify() stop at the structure gate, so stopped_at reads "structure" there;
+ * a run whose axes end at the last axis of AXIS_ORDER ran to the end.
+ */
+export function coverageDeclaration(axes: ReadonlyArray<{ axis: string }>): Coverage {
+  const entries: CoverageEntry[] = NOT_CHECKED.map((row) => ({
+    id: row.check,
+    reason: "not_implemented",
+    status: "not_implemented",
+    requirement: row.requirement,
+    condition: row.condition,
+  }));
+  const names = axes.map((a) => a.axis);
+  if (names.length > 0 && names[names.length - 1] === AXIS_ORDER[AXIS_ORDER.length - 1]) {
+    return { stopped_at: null, checks_not_evaluated: entries };
+  }
+  const stoppedAt = "structure";
+  const after = AXIS_ORDER.slice(AXIS_ORDER.indexOf(stoppedAt) + 1);
+  for (const name of after) {
+    if (!names.includes(name)) {
+      entries.push({ id: name, reason: "not_reached", status: "implemented" });
+    }
+  }
+  return { stopped_at: stoppedAt, checks_not_evaluated: entries };
+}

--- a/typescript/tests/verifier-not-checked.test.ts
+++ b/typescript/tests/verifier-not-checked.test.ts
@@ -10,7 +10,12 @@ import { describe, expect, it } from "vitest";
 
 import { verify } from "../src/verifier/core.js";
 import { ADAPTERS } from "../src/verifier/index.js";
-import { NOT_CHECKED, notCheckedDeclaration } from "../src/verifier/not-checked.js";
+import {
+  AXIS_ORDER,
+  NOT_CHECKED,
+  coverageDeclaration,
+  notCheckedDeclaration,
+} from "../src/verifier/not-checked.js";
 
 const VECTORS = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
 const REQUIRED_KEYS = ["check", "condition", "reason", "requirement"];
@@ -94,6 +99,105 @@ describe("notChecked declaration", () => {
         .filter(ts.isPropertyAssignment)
         .map((p) => (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name) ? p.name.text : ""));
       expect(names, `verify() returns at line ${line} without notChecked`).toContain("notChecked");
+    }
+  });
+});
+
+// The axes after the structure gate on the normal path, pinned verbatim so a
+// reorder of the verifier's sequence fails here instead of editing the pin.
+const AXES_AFTER_STRUCTURE = [
+  "signature",
+  "chain",
+  "seq",
+  "expiry",
+  "nonce",
+  "key_binding",
+  "counterparty",
+  "payload_digest",
+  "skew",
+  "key_status",
+  "issuer_bind",
+];
+
+describe("coverage declaration", () => {
+  it("rides a full run with stopped_at null and the not_implemented table", () => {
+    const [receipt, jwks] = loadVector("asqav-01-genesis-permit");
+    const result = verify(receipt, ADAPTERS, jwks);
+    // The pin is the live axis sequence itself: the coverage constant must track it.
+    expect(result.axes.map((a) => a.axis)).toEqual(["structure", ...AXES_AFTER_STRUCTURE]);
+    expect(result.coverage.stopped_at).toBeNull();
+    const entries = result.coverage.checks_not_evaluated;
+    expect(entries.map((e) => e.id)).toEqual(NOT_CHECKED.map((e) => e.check));
+    for (const entry of entries) {
+      expect(entry.reason).toBe("not_implemented");
+      expect(entry.status).toBe("not_implemented");
+      expect(Object.keys(entry).slice(0, 3)).toEqual(["id", "reason", "status"]);
+      expect(entry.requirement).toBeTruthy();
+      expect("condition" in entry).toBe(true);
+    }
+  });
+
+  it("marks the axes after a stop at the structure gate as not_reached", () => {
+    const result = verify("nope" as unknown as Record<string, unknown>, ADAPTERS, null);
+    expect(result.coverage.stopped_at).toBe("structure");
+    const entries = result.coverage.checks_not_evaluated;
+    const notImpl = entries.filter((e) => e.reason === "not_implemented");
+    const notReached = entries.filter((e) => e.reason === "not_reached");
+    // not_implemented entries come first, in NOT_CHECKED table order.
+    expect(notImpl.map((e) => e.id)).toEqual(NOT_CHECKED.map((e) => e.check));
+    expect(notReached.map((e) => e.id)).toEqual(AXES_AFTER_STRUCTURE);
+    for (const entry of notReached) {
+      expect(entry.status).toBe("implemented");
+      expect(Object.keys(entry)).toEqual(["id", "reason", "status"]);
+    }
+  });
+
+  it("keeps the not_implemented ids equal to this language's table, in order", () => {
+    for (const axes of [[], [{ axis: "issuer_bind" }]] as Array<Array<{ axis: string }>>) {
+      const entries = coverageDeclaration(axes).checks_not_evaluated;
+      expect(entries.filter((e) => e.reason === "not_implemented").map((e) => e.id)).toEqual(
+        NOT_CHECKED.map((e) => e.check),
+      );
+    }
+  });
+
+  it("cannot be narrowed by a caller mutating an earlier result's block", () => {
+    const first = verify({ hello: "world" }, ADAPTERS, null);
+    first.coverage.checks_not_evaluated.length = 0;
+    const fresh = verify({ hello: "world" }, ADAPTERS, null);
+    expect(fresh.coverage.checks_not_evaluated.length).toBe(
+      NOT_CHECKED.length + AXES_AFTER_STRUCTURE.length,
+    );
+  });
+
+  it("is on every return path of verify(), parsed from source", () => {
+    // Parsed rather than exercised: the path no test reaches would ship undeclared.
+    const source = readFileSync(resolve(__dirname, "..", "src", "verifier", "core.ts"), "utf-8");
+    const file = ts.createSourceFile("core.ts", source, ts.ScriptTarget.Latest, true);
+    let verifyBody: ts.Block | undefined;
+    ts.forEachChild(file, (node) => {
+      if (ts.isFunctionDeclaration(node) && node.name?.text === "verify" && node.body) {
+        verifyBody = node.body;
+      }
+    });
+    expect(verifyBody, "verify() not found; the gate is vacuous").toBeDefined();
+
+    const returns: ts.ReturnStatement[] = [];
+    const visit = (node: ts.Node): void => {
+      if (ts.isReturnStatement(node)) returns.push(node);
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(verifyBody as ts.Block, visit);
+    expect(returns.length, "verify() has no returns; the gate is vacuous").toBeGreaterThan(0);
+
+    for (const ret of returns) {
+      const expr = ret.expression;
+      const line = file.getLineAndCharacterOfPosition(ret.getStart()).line + 1;
+      expect(expr !== undefined && ts.isObjectLiteralExpression(expr), `line ${line}: not an object`).toBe(true);
+      const names = (expr as ts.ObjectLiteralExpression).properties
+        .filter(ts.isPropertyAssignment)
+        .map((p) => (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name) ? p.name.text : ""));
+      expect(names, `verify() returns at line ${line} without coverage`).toContain("coverage");
     }
   });
 });

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -117,14 +117,28 @@ travels with the claim instead of living in this file:
      "reason": "no X.509 chain walk from the RFC 3161 signing certificate to a public root; offline trust comes only from the TSA keys the caller pins",
      "condition": "--tsa-key pins the key this tool will trust; it does not build a path to it"},
     ...
-  ]
+  ],
+  "coverage": {
+    "stopped_at": null,
+    "checks_not_evaluated": [
+      {"id": "tsa_certificate_path", "reason": "not_implemented", "status": "not_implemented",
+       "requirement": "anchor trust",
+       "condition": "--tsa-key pins the key this tool will trust; it does not build a path to it"},
+      ...
+    ]
+  }
 }
 ```
 
 `condition` is `null` when the check is never performed at any invocation, and
 names the input that would enable it when the gap is one you can close. Read the
 current list from `asqav.verifier.verify_receipt.NOT_CHECKED`, or from any
-result. The headline gaps are the TSA certificate path and its revocation state,
+result. The `coverage` block carries the same boundary in the shape the
+reviewer's verifier publishes, so the two tools read side by side: `stopped_at`
+is `null` when the full axis sequence ran, and names the axis evaluation stopped
+at otherwise; `checks_not_evaluated` lists one `not_implemented` entry per
+declared gap, then any axes evaluation stopped short of as `not_reached`. The
+headline gaps are the TSA certificate path and its revocation state,
 `policy_digest` artefact resolution, aggregate-anchor inclusion proofs, and the
 caller-supplied framework taxonomies, which are carried under the signature but
 never evaluated. For those, use the hosted `/verify` endpoint or the full SDK.


### PR DESCRIPTION
## What

Every result from both verifiers now carries a `coverage` block beside
`not_checked`/`notChecked`, in the shape the reviewer's receipt-verify tool
publishes, so the two tools' coverage reads side by side:

```json
"coverage": {
  "stopped_at": null,
  "checks_not_evaluated": [
    { "id": "tsa_certificate_path", "reason": "not_implemented", "status": "not_implemented",
      "requirement": "anchor trust", "condition": "--tsa-key pins the key ..." }
  ]
}
```

- `stopped_at`: null when the full axis sequence ran; the early returns stop at
  the structure gate, so it reads `"structure"` there.
- `checks_not_evaluated`: one `not_implemented` entry per NOT_CHECKED row (with
  the row's requirement and condition carried as extra members), then, on an
  early return, one `not_reached`/`implemented` entry per axis of the full order
  after the stop point.
- `not_checked` is unchanged: same rows, same order.

## How

One helper per language — `coverage_declaration(axes)` in
`python/src/asqav/verifier/verify_receipt.py`, `coverageDeclaration(axes)` in
`typescript/src/verifier/not-checked.ts` — so no result site can drift. Each
language's full axis order is a module constant pinned against a live run in
that language's own suite (the two lists differ by design: the TypeScript port
runs no anchor cryptography and declares more). The TypeScript block keeps
snake_case wire keys deliberately, documented at the type.

An AST gate per language refuses a `run_structured`/`verify()` return that
drops the member — the same construction as the existing `not_checked` gate.

## Verification

- Python `pytest python/tests -q`: 3184 passed, 2 skipped (baseline origin/main:
  3179 passed, 2 skipped; +5 are the new tests).
- TypeScript `npm test`: 1163 passed, 72 files (baseline: 1158; +5 new).
- `ruff check python/src`: clean. `npm run build`: clean.
- Gate proofs per language: deleting `coverage` from one early-return site turns
  the AST gate red naming the site (line number); restored, green.
- Both CLIs' verifier output shows the block on asqav-01-genesis-permit.

Rubric axis 2.6.
