### PR TITLE
feat(verifier): verify Ed25519 and ES256 signatures, not only ML-DSA-65

### DIFF
--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -1795,10 +1795,60 @@ def check_key_status(status, issued_at: str, revoked_at=None, has_trusted_anchor
     return "FAIL", f"signing key status {status!r}; receipt cannot be trusted"
 
 
-    # ML-DSA-65 verify. Returns (result, note); result in PASS/FAIL/SKIPPED.
+    # ML-DSA-65 / Ed25519 / ES256 verify. Returns (result, note); result in PASS/FAIL/SKIPPED.
 def verify_signature(pk: bytes, msg: bytes, sig: bytes, alg: object):
-    if (alg if isinstance(alg, str) else "").upper() != "ML-DSA-65":
-        return "SKIPPED", f"unsupported alg {alg!r} (this tool checks ML-DSA-65)"
+    token = (alg if isinstance(alg, str) else "").upper()
+    if token in ("ED25519", "ES256"):
+        display = "Ed25519" if token == "ED25519" else "ES256"
+        # Lazy import: cryptography is an optional dep and must never load at
+        # module level (the standalone surface pins that).
+        try:
+            from cryptography.exceptions import InvalidSignature
+            from cryptography.hazmat.primitives import hashes
+            from cryptography.hazmat.primitives.asymmetric.ec import (
+                ECDSA,
+                SECP256R1,
+                EllipticCurvePublicKey,
+            )
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+            from cryptography.hazmat.primitives.asymmetric.utils import (
+                encode_dss_signature,
+            )
+        except ImportError:
+            return "SKIPPED", f"run 'pip install cryptography' for the {display} check"
+        # The same key and signature forms the oracle verifies: a raw 32-byte
+        # Ed25519 key; a 65-byte uncompressed P-256 point and the 64-byte raw
+        # r||s signature (converted to DER for the library).
+        if token == "ED25519":
+            try:
+                key = Ed25519PublicKey.from_public_bytes(pk)
+            except Exception as exc:  # malformed key bytes
+                return "FAIL", f"bad Ed25519 public key: {exc}"
+            try:
+                key.verify(sig, msg)
+                return "PASS", "signature valid"
+            except InvalidSignature:
+                return "FAIL", "signature mismatch"
+            except Exception as exc:  # malformed signature bytes
+                return "FAIL", f"verify error: {exc}"
+        try:
+            key = EllipticCurvePublicKey.from_encoded_point(SECP256R1(), pk)
+        except Exception as exc:  # malformed point bytes
+            return "FAIL", f"bad P-256 public key: {exc}"
+        if len(sig) != 64:
+            return "FAIL", f"ES256 signature must be 64-byte raw r||s, got {len(sig)}"
+        der = encode_dss_signature(
+            int.from_bytes(sig[:32], "big"), int.from_bytes(sig[32:], "big")
+        )
+        try:
+            key.verify(der, msg, ECDSA(hashes.SHA256()))
+            return "PASS", "signature valid"
+        except InvalidSignature:
+            return "FAIL", "signature mismatch"
+        except Exception as exc:  # malformed signature bytes
+            return "FAIL", f"verify error: {exc}"
+    if token != "ML-DSA-65":
+        return "SKIPPED", f"unsupported alg {alg!r} (this tool checks ML-DSA-65, Ed25519, ES256)"
     try:
         from dilithium_py.ml_dsa import ML_DSA_65
     except ImportError:

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -24,7 +24,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
 FINGERPRINT_LOCK_DIGEST = "1ef6d34d3f9515f2442218e8bf1e1370dd3b0cf1cb1dd143e121b0ff8384732f"
-VERIFIER_LOCK_DIGEST = "bf948b76adda5d7a69de3f7d234218181e744f7cd7963f1a3036ef7dca983f6f"
+VERIFIER_LOCK_DIGEST = "a62640b54b9fb18e4266e735bdf4dce8308909024e02074d0c887b0be833a318"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_full_verifier_ed25519_es256.py
+++ b/python/tests/test_full_verifier_ed25519_es256.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""The full verifier verifies Ed25519 and ES256 signatures, not only ML-DSA-65.
+
+The profile's mandatory-to-implement algorithm is Ed25519, and the platform's
+self-hosted signer emits Ed25519 and ES256; the single-file verifier used to
+SKIP every non-ML-DSA-65 algorithm, so no Ed25519 vector's signature axis ever
+ran through it. The dispatch now verifies both via the optional ``cryptography``
+dependency, with the oracle's key and signature forms (raw 32-byte Ed25519 key;
+65-byte uncompressed P-256 point and 64-byte raw r||s signature).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from asqav.verifier import verify_receipt as v
+
+_VECTORS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+
+def _vector(name: str):
+    d = _VECTORS / name
+    return json.loads((d / "receipt.json").read_text()), json.loads((d / "jwks.json").read_text())
+
+
+def _predecessor_payload(name: str):
+    p = _VECTORS / name / "predecessor.json"
+    if not p.exists():
+        return None
+    doc = json.loads(p.read_text())
+    return doc["payload"] if isinstance(doc.get("payload"), dict) else doc
+
+
+def _axis(result: dict, name: str) -> dict:
+    return next(a for a in result["axes"] if a["name"] == name)
+
+
+def _es256_material(payload: dict):
+    """A P-256 key, the canonical payload signed, and the JWKS entry for it."""
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric.ec import (
+        ECDSA,
+        SECP256R1,
+        generate_private_key,
+    )
+    from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    sk = generate_private_key(SECP256R1())
+    point = sk.public_key().public_bytes(Encoding.X962, PublicFormat.UncompressedPoint)
+    msg = v.canonical_json(payload)
+    r, s = decode_dss_signature(sk.sign(msg, ECDSA(hashes.SHA256())))
+    raw_sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    jwks_entry = {
+        "kid": "k1",
+        "issuer_id": payload["issuer_id"],
+        "alg": "ES256",
+        "status": "active",
+        "public_key": base64.b64encode(point).decode(),
+    }
+    return point, msg, raw_sig, jwks_entry
+
+
+def test_ed25519_vector_signature_passes_and_the_fold_stays_fail_closed() -> None:
+    """asqav-17: the signature axis PASSes; the verdict stays unverified on the
+    anchors SKIP (the anchor-less receipt cannot complete that axis offline)."""
+    receipt, jwks = _vector("asqav-17-seq-contiguous")
+    result = v.run_structured(
+        receipt, jwks, predecessor_payload=_predecessor_payload("asqav-17-seq-contiguous")
+    )
+    signature = _axis(result, "signature")
+    assert signature["result"] == "PASS", signature
+    anchors = _axis(result, "anchors")
+    assert anchors["result"] == "SKIPPED"
+    assert anchors["note"] == "no anchors on this receipt"
+    assert result["verdict"] == "unverified"
+    assert result["failure_class"] == "unverifiable"
+
+
+def test_tampered_ed25519_vector_signature_fails() -> None:
+    """asqav-04 (decision flipped after signing): FAIL, and the fold says invalid."""
+    receipt, jwks = _vector("asqav-04-tamper-sig")
+    result = v.run_structured(receipt, jwks)
+    signature = _axis(result, "signature")
+    assert signature["result"] == "FAIL", signature
+    assert signature["note"] == "signature mismatch"
+    assert result["verdict"] == "unverified"
+    assert result["failure_class"] == "invalid"
+
+
+def test_es256_verifies_directly_and_through_run_structured() -> None:
+    """A P-256 signature verifies; a flipped byte and a 63-byte form fail."""
+    pytest.importorskip("cryptography")
+    receipt, _jwks = _vector("asqav-01-genesis-permit")
+    payload = receipt["payload"]
+    point, msg, raw_sig, jwks_entry = _es256_material(payload)
+
+    assert v.verify_signature(point, msg, raw_sig, "ES256") == ("PASS", "signature valid")
+    bad = bytearray(raw_sig)
+    bad[10] ^= 0x01
+    assert v.verify_signature(point, msg, bytes(bad), "ES256")[0] == "FAIL"
+    short = v.verify_signature(point, msg, raw_sig[:63], "ES256")
+    assert short[0] == "FAIL" and "64-byte" in short[1] and "63" in short[1]
+
+    envelope = {
+        "payload": payload,
+        "signature": {"alg": "ES256", "kid": "k1", "sig": base64.b64encode(raw_sig).decode()},
+        "anchors": [],
+    }
+    result = v.run_structured(envelope, {"keys": [jwks_entry]})
+    signature = _axis(result, "signature")
+    assert signature["result"] == "PASS", signature
+
+
+def test_ml_dsa_65_path_unchanged() -> None:
+    """asqav-06's signature still verifies through the dilithium-py path."""
+    pytest.importorskip("dilithium_py.ml_dsa")
+    receipt, jwks = _vector("asqav-06-mldsa65-payload-prod")
+    result = v.run_structured(receipt, jwks)
+    signature = _axis(result, "signature")
+    assert signature["result"] == "PASS", signature
+
+
+def test_unknown_alg_still_skips_naming_it() -> None:
+    result, note = v.verify_signature(b"\x00", b"\x00", b"\x00", "Ed448")
+    assert result == "SKIPPED"
+    assert "Ed448" in note
+
+
+def test_missing_cryptography_skips_instead_of_crashing(monkeypatch) -> None:
+    """No `cryptography` installed: Ed25519/ES256 report SKIPPED with the install hint."""
+    # Every cached submodule must read as absent: a None parent alone lets
+    # already-cached children through the from-import.
+    for name in list(sys.modules):
+        if name == "cryptography" or name.startswith("cryptography."):
+            monkeypatch.setitem(sys.modules, name, None)
+    for alg in ("Ed25519", "ES256"):
+        result, note = v.verify_signature(b"\x00" * 32, b"\x00", b"\x00" * 64, alg)
+        assert result == "SKIPPED", (alg, note)
+        assert "pip install cryptography" in note

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -232,9 +232,9 @@ def test_agent_id_fallback_never_trusts_a_non_verifying_key() -> None:
         "anchors": [],
     }
     code = v.run(envelope, jwks, None)
-    # The standalone surface only checks ML-DSA-65, so the Ed25519 signature axis
-    # SKIPs and the verdict is unverified/unverifiable (exit 2), never verified.
-    assert code == 2
+    # The Ed25519 signature axis now runs: signed by a different key it FAILs,
+    # so the verdict is unverified/invalid (exit 1), never verified.
+    assert code == 1
 
 
 # === agent_id fallback must bind the resolved key to the claimed issuer ===

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-verifier-conformance-vectors",
-  "corpus_version": 13,
+  "corpus_version": 14,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -68,6 +68,11 @@
       "version": 12,
       "files": 257,
       "digest": "da40f506f477b438087358a1f30c34043cb864d299a47aeef6a54fb878f5ab7f"
+    },
+    {
+      "version": 13,
+      "files": 257,
+      "digest": "bf948b76adda5d7a69de3f7d234218181e744f7cd7963f1a3036ef7dca983f6f"
     }
   ],
   "files": [
@@ -1248,8 +1253,8 @@
     },
     {
       "path": "requirement-map.json",
-      "sha256": "e48a893ba19010b94aa63fe2c2a22b36b2cf04b6405b983fb0484f81fd2d9d2b",
-      "bytes": 50159
+      "sha256": "ac66aeeb3335c732db2b01d9439d645c15df8d3ec7b1b9f6bef5145da48b1d8a",
+      "bytes": 50760
     },
     {
       "path": "w3c-vc-01-didweb-happy-path/did_map.json",
@@ -1387,5 +1392,5 @@
       ]
     }
   },
-  "digest": "bf948b76adda5d7a69de3f7d234218181e744f7cd7963f1a3036ef7dca983f6f"
+  "digest": "a62640b54b9fb18e4266e735bdf4dce8308909024e02074d0c887b0be833a318"
 }

--- a/verifier/conformance-vectors/requirement-map.json
+++ b/verifier/conformance-vectors/requirement-map.json
@@ -8,7 +8,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -23,7 +23,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -38,7 +38,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -53,7 +53,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "FAIL",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -86,7 +86,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "FAIL",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -101,7 +101,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -116,7 +116,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "FAIL",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -134,7 +134,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "FAIL",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -164,7 +164,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "FAIL",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -179,7 +179,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -194,7 +194,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -209,7 +209,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -224,7 +224,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -239,7 +239,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -254,7 +254,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -269,7 +269,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -314,7 +314,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -344,7 +344,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "PASS",
@@ -359,7 +359,7 @@
       "issuer_key": "PASS",
       "issuer_bind": "PASS",
       "key_status": "PASS",
-      "signature": "SKIPPED",
+      "signature": "PASS",
       "key_binding": "PASS",
       "counterparty": "PASS",
       "payload_digest": "FAIL",
@@ -450,12 +450,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-02-genesis-deny": {
@@ -471,12 +471,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-03-chain-link": {
@@ -492,12 +492,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-04-tamper-sig": {
@@ -513,12 +513,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-05-hash-mode-prod": {
@@ -575,12 +575,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-08-v2-signer-canary": {
@@ -596,12 +596,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-09-v2-signer-tampered": {
@@ -617,12 +617,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-10-hash-mode-multikey": {
@@ -658,12 +658,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-12-time-edge-expiry": {
@@ -700,12 +700,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-14-omitted-action-chain": {
@@ -721,12 +721,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-15-unsigned-gap": {
@@ -742,12 +742,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-16-chain-emission-blocked": {
@@ -763,12 +763,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-17-seq-contiguous": {
@@ -784,12 +784,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-18-seq-gap": {
@@ -805,12 +805,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-19-seq-non-monotonic": {
@@ -826,12 +826,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-20-seq-absent": {
@@ -847,12 +847,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-21-key-thumbprint-binds": {
@@ -910,12 +910,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-24-anchor-block-hash-prod": {
@@ -952,12 +952,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     },
     "asqav-26-payload-digest-mismatch": {
@@ -973,12 +973,12 @@
         "REQ-KEY-THUMBPRINT",
         "REQ-NONCE",
         "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
         "REQ-SKEW",
         "REQ-STRUCTURE"
       ],
       "not_exercised": [
-        "REQ-ANCHOR",
-        "REQ-SIGNATURE"
+        "REQ-ANCHOR"
       ]
     }
   },
@@ -1246,11 +1246,30 @@
   },
   "coverage": {
     "REQ-SIGNATURE": [
+      "asqav-01-genesis-permit",
+      "asqav-02-genesis-deny",
+      "asqav-03-chain-link",
+      "asqav-04-tamper-sig",
       "asqav-06-mldsa65-payload-prod",
+      "asqav-07-revoked-key",
+      "asqav-08-v2-signer-canary",
+      "asqav-09-v2-signer-tampered",
+      "asqav-11-dup-member-toplevel",
       "asqav-12-time-edge-expiry",
+      "asqav-13-dup-member-nested",
+      "asqav-14-omitted-action-chain",
+      "asqav-15-unsigned-gap",
+      "asqav-16-chain-emission-blocked",
+      "asqav-17-seq-contiguous",
+      "asqav-18-seq-gap",
+      "asqav-19-seq-non-monotonic",
+      "asqav-20-seq-absent",
       "asqav-21-key-thumbprint-binds",
       "asqav-22-key-substituted",
-      "asqav-24-anchor-block-hash-prod"
+      "asqav-23-anchor-status-pending",
+      "asqav-24-anchor-block-hash-prod",
+      "asqav-25-payload-digest-rederives",
+      "asqav-26-payload-digest-mismatch"
     ],
     "REQ-KEY-RESOLUTION": [
       "asqav-01-genesis-permit",


### PR DESCRIPTION
## What

The single-file verifier's `verify_signature` now verifies **Ed25519** and
**ES256**, not only ML-DSA-65 — the profile's mandatory-to-implement algorithm
and the platform's self-hosted signer algorithms. Ed25519 takes the raw
32-byte key; ES256 takes the 65-byte uncompressed P-256 point and the 64-byte
raw r||s signature (converted to DER for the library). Both go through the
optional `cryptography` dependency, imported inside the function the way the
timestamp-token check already does, so the standalone artifact's import
surface (stdlib + optional crypto deps, pinned by test_standalone_verifier_surface)
is unchanged and no `asqav.*` import appears in the file.

The ML-DSA-65 path is byte-for-byte unchanged; SKIPPED remains for a genuinely
unknown algorithm (the note names it and now lists all three checked
algorithms) or a missing optional dependency (proven by blocking the import in
a test).

## Fallout, pinned

- Every Ed25519 corpus vector's signature axis now runs: asqav-01..03, 17..20,
  25, 26 PASS; the deliberately tampered ones (asqav-04, -09, -11, -13) FAIL.
  Anchor-less vectors keep `observed_verdict: unverified` — the anchors axis
  SKIPs offline and the fail-closed fold blocks on that; the new test asserts
  BOTH facts so the fold stays pinned.
- The regenerated requirement map lists REQ-SIGNATURE exercised by all 24
  asqav-native vectors (was 5). The corpus lock re-froze;
  `VERIFIER_LOCK_DIGEST` moves with it, `FINGERPRINT_LOCK_DIGEST` untouched.
- One existing pin moves to the stronger outcome:
  `test_agent_id_fallback_never_trusts_a_non_verifying_key` asserted exit 2
  (axis skipped, unverifiable); with the axis running, a wrong-key Ed25519
  receipt FAILs the signature, so the assertion is now exit 1 (invalid). That
  is the diff's only change to that file.

## Verification

- New `test_full_verifier_ed25519_es256.py`: 6 passed on the branch; on
  origin/main 4 of 6 fail with the old `SKIPPED / unsupported alg` note (the
  bug), 2 pass (the unchanged-path pins).
- `pytest python/tests -q`: 3185 passed, 2 skipped; baseline on the base
  commit: 3179 passed, 2 skipped (+6 is the new file).
- `test_standalone_verifier_surface.py` + `test_exit_artifact_cli.py` green —
  the import allowlist, the lazy-import pin, and the bare-directory subprocess
  with the asqav package refused all hold.
- `ruff check python/src`: clean.

Criterion 716; feeds 574.
