### PR TITLE
chore(release): 0.10.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.9] - 2026-09-05
+
+### Added
+
+- **The full verifier verifies Ed25519 and ES256 signatures natively**, beside
+  ML-DSA-65, through the optional `cryptography` dependency it already declares;
+  the standalone file still imports nothing from the package. The published
+  requirement map lists the signature requirement as exercised by every
+  asqav-native vector rather than by the four post-quantum ones. (#477)
+- **Every result carries a `coverage` block in the shape the reviewer's public
+  tool emits** (`stopped_at`, `checks_not_evaluated[{id, reason, status}]`),
+  derived from the same table as `not_checked`, so the two tools' declarations
+  read side by side. Both languages. (#475)
+- **Per-vector anchor material.** A vector directory may ship `tsa_trust.pem`
+  and `bitcoin_headers.json`; the requirement-map builder passes them through.
+  asqav-24 ships both, so the anchoring requirement is exercised offline and
+  `unmapped_requirements` is empty. (#478)
+- **A machine-readable registry of outside recomputations**
+  (`verifier/independent-runs.json`), each pinned to a commit and the vectors it
+  re-derived, with a test that every pinned commit and vector exists. (#474)
+- **Vectors** for the anchor `status` and `anchor_block_hash` members (#468),
+  for receipts carrying both `context` and `payload_digest` (#465), and for the
+  counterparty binding's profile `payload_digest` shape (#473).
+- **A scheduled artifact probe** runs the published-package probe weekly, on
+  dispatch, and after every successful publish, uploading its output as a job
+  artifact. (#476)
+- The TypeScript verifier declares its non-coverage (`notChecked`) on every
+  result, in parity with Python. (#464)
+
+### Fixed
+
+- **The OpenTimestamps attestation parser reads the reference framing.** An
+  attestation is tag + varbytes(payload), with the block height a little-endian
+  (LEB128) varuint inside the payload. The production proof in asqav-24 lands in
+  block 965451 and parses to its last byte. (#478)
+- **The ACTA -03 chain-link form verifies alongside the -02 one.** (#469)
+- **Timestamp-authority tokens signed under the bare `rsaEncryption` algorithm
+  identifier verify.** (#470)
+- **The requirement-map builder hands the verifier the predecessor payload**, so
+  the chain axes in the published map reflect a real run. (#471)
+- A PEM file with several certificate blocks yields one trusted TSA key per
+  block. (#478)
+- The artifact probe reports PyPI simple-index lag as a sentence rather than a
+  traceback. (#466)
+
+### Changed
+
+- The TypeScript README states the verifier's shipped verdict vocabulary (#467);
+  every README states the three plans and their real limits (#472).
+
 ## [0.10.8] - 2026-09-04
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.8"
+version = "0.10.9"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -192,7 +192,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.8"
+__version__ = "0.10.9"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -3,7 +3,7 @@
  * added under Node, since browsers forbid setting User-Agent on fetch.
  */
 
-export const SDK_VERSION = "0.10.8";
+export const SDK_VERSION = "0.10.9";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
PATCH bump to 0.10.9 for the verifier work merged after 0.10.8: native Ed25519 and ES256 in the full verifier (#477), the coverage block in the reviewer's shape (#475), the OpenTimestamps framing fix with per-vector anchor material (#478), the registry of outside recomputations (#474), the artifact-probe workflow (#476), the rsaEncryption TSA fix (#470), the ACTA -03 chain-link form (#469), the requirement-map predecessor payload (#471), the new vectors (#465, #468, #473) and the README and probe fixes (#464, #466, #467, #472). The CHANGELOG entry lists them.

Rule-2.14 reproduction, done before this bump was pushed: the artifact probe ran against the locally built wheel and npm tarball of this exact content (26 asqav-native vectors through the installed verifier; every documented entry point resolves; exit 0). Both registries checked at 0.10.8 before bumping. The py- and ts- release tags follow the merge.