### PR TITLE
fix(verifier): report a null anchors member as malformed at the structure axis

### DIFF
--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -198,6 +198,26 @@ def _axis(axis: str, result: str, note: str) -> AxisResult:
     return AxisResult(axis, result, note, axis_failure_class(axis, result, note))
 
 
+#: Structure-axis note for the malformed third spelling of "no anchors": the member
+#: absent and the member present as an empty array are the conformant spellings; a
+#: JSON null is found in the wild and is malformed, reported unverifiable rather
+#: than read as either. Verbatim in all three engines; a wording drift fails the
+#: cross-language anchor-shape tests.
+_ANCHORS_NULL_NOTE = (
+    "anchors is null: malformed; absent or [] is the conformant spelling of no anchors"
+)
+
+
+    # The structure axis: the adapter schema, plus the one envelope-member shape rule
+    # the schema cannot see - anchors sits beside the signed payload, so no adapter
+    # schema reads it. Caught here, on the document as parsed.
+def _structure_axis(ad: FormatAdapter, doc: dict) -> AxisResult:
+    res, note = ad.schema(doc)
+    if res == crypto.PASS and "anchors" in doc and doc["anchors"] is None:
+        return _axis("structure", crypto.FAIL, _ANCHORS_NULL_NOTE)
+    return _axis("structure", res, note)
+
+
 def _signature_axis(ad: FormatAdapter, doc: dict, key_provider: Any) -> AxisResult:
     sm = ad.extract_signature(doc)
     pk, note = ad.resolve_key(doc, key_provider)
@@ -317,7 +337,7 @@ def verify(
         )
 
     axes = [
-        _axis("structure", *ad.schema(doc)),
+        _structure_axis(ad, doc),
         _signature_axis(ad, doc, key_provider),
         _chain_axis(ad, doc, adapters, predecessor),
         _seq_axis(ad, doc, adapters, predecessor),

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -1287,8 +1287,11 @@ def evaluate_anchors(envelope: dict, *, trusted_tsa_keys=None, bitcoin_headers=N
     declared ``status: pending``/``failed`` never count as trusted anchors.
     """
     anchors = envelope.get("anchors")
-    # Absent/null is a legitimate no-anchors receipt (SKIPPED); a present
-    # non-list value ({} / "" / 0) is malformed and FAILs, never laundered to [].
+    # Absent is a legitimate no-anchors receipt (SKIPPED); a present non-list
+    # value ({} / "" / 0) is malformed and FAILs, never laundered to []. A wire
+    # "anchors": null reaches here only from a direct caller: run_structured FAILs
+    # it at the structure gate, and normalise_envelope projects absent and null to
+    # the same None, so this layer cannot tell the two spellings apart.
     if anchors is None:
         return AnchorEvaluation("SKIPPED", "no anchors on this receipt", [])
     if not isinstance(anchors, list):
@@ -2570,6 +2573,16 @@ def _struct_axis(name: str, result: str, note: str) -> dict:
     }
 
 
+#: Structure-axis note for the malformed third spelling of "no anchors": the member
+#: absent and the member present as an empty array are the conformant spellings; a
+#: JSON null is found in the wild and is malformed, reported unverifiable rather
+#: than read as either. Verbatim in all three engines; a wording drift fails the
+#: cross-language anchor-shape tests.
+_ANCHORS_NULL_NOTE = (
+    "anchors is null: malformed; absent or [] is the conformant spelling of no anchors"
+)
+
+
 def run_structured(
     envelope: dict,
     jwks: dict,
@@ -2604,6 +2617,22 @@ def run_structured(
                 f"expected a JSON object receipt, got {type(envelope).__name__}",
             )
         ]
+        return {
+            "not_checked": not_checked_declaration(),
+            "coverage": coverage_declaration(axes),
+            "verdict": VERDICT_UNVERIFIED,
+            "failure_class": FAILURE_UNVERIFIABLE,
+            "axes": axes,
+            "canonical_sha256": None,
+            "kid": None,
+            "alg": None,
+        }
+    # A wire "anchors": null is the malformed third spelling of "no anchors"
+    # (absent and [] are the conformant two). The gate reads the raw envelope:
+    # normalise_envelope projects absent and null to the same None, so after it
+    # the two spellings are indistinguishable.
+    if "anchors" in envelope and envelope["anchors"] is None:
+        axes = [_struct_axis("structure", "FAIL", _ANCHORS_NULL_NOTE)]
         return {
             "not_checked": not_checked_declaration(),
             "coverage": coverage_declaration(axes),

--- a/python/tests/test_anchor_shapes.py
+++ b/python/tests/test_anchor_shapes.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""The three anchors wire shapes: absent, empty array, and null.
+
+The profile states it once: the member ABSENT and the member present as an
+EMPTY ARRAY are both conformant and mean the same thing (no anchor presented);
+a JSON null is a third shape found in the wild, is MALFORMED, and must be
+reported unverifiable rather than read as either. None of the three changes
+any digest: anchors sits outside the signed bytes, so asqav-17's Ed25519
+signature stays valid under all three spellings, and the two corpus twins
+(asqav-27 absent, asqav-28 null) pin the outcomes end to end.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from asqav.verifier import verify_receipt as v
+from asqav.verifier.oracle import ADAPTERS
+from asqav.verifier.oracle.core import verify as oracle_verify
+
+_VECTORS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+#: The one sentence all three engines report for the malformed shape, pinned
+#: verbatim so a wording drift in any engine fails here and in the TS half.
+ANCHORS_NULL_NOTE = (
+    "anchors is null: malformed; absent or [] is the conformant spelling of no anchors"
+)
+
+
+def _vector(name: str):
+    d = _VECTORS / name
+    receipt = json.loads((d / "receipt.json").read_text())
+    jwks = json.loads((d / "jwks.json").read_text())
+    pred_doc = json.loads((d / "predecessor.json").read_text())
+    pred = pred_doc["payload"] if isinstance(pred_doc.get("payload"), dict) else pred_doc
+    return receipt, jwks, pred
+
+
+def _mask_skew(note: str) -> str:
+    # The skew note embeds live wall-clock seconds; everything else is deterministic.
+    return re.sub(r"-?\d+s\b", "<n>s", note)
+
+
+def _structured_shape(result: dict) -> list:
+    return [
+        (a["name"], a["result"], _mask_skew(a["note"]), a["failure_class"])
+        for a in result["axes"]
+    ]
+
+
+def _oracle_shape(result) -> list:
+    return [
+        (a.axis, a.result, _mask_skew(a.note), a.failure_class) for a in result.axes
+    ]
+
+
+def test_run_structured_absent_and_empty_array_are_one_fact() -> None:
+    """asqav-27 (member absent) and asqav-17 (member present as []) must be
+    indistinguishable in every axis result, the verdict, and the canonical bytes."""
+    receipt17, jwks, pred = _vector("asqav-17-seq-contiguous")
+    receipt27, _, _ = _vector("asqav-27-anchors-absent")
+    out17 = v.run_structured(receipt17, jwks, pred)
+    out27 = v.run_structured(receipt27, jwks, pred)
+    assert _structured_shape(out27) == _structured_shape(out17)
+    assert out27["verdict"] == out17["verdict"]
+    assert out27["failure_class"] == out17["failure_class"]
+    assert out27["canonical_sha256"] == out17["canonical_sha256"]
+
+
+def test_run_structured_null_anchors_is_malformed_not_no_anchors() -> None:
+    """asqav-28 (``"anchors": null``): the structure axis FAILs, naming the member
+    and the shape; the verdict reads unverified/unverifiable; the anchors axis is
+    never reached, so null is not reported as "no anchors on this receipt"."""
+    receipt, jwks, pred = _vector("asqav-28-anchors-null-malformed")
+    out = v.run_structured(receipt, jwks, pred)
+    structure = next(a for a in out["axes"] if a["name"] == "structure")
+    assert structure["result"] == "FAIL", structure
+    assert structure["note"] == ANCHORS_NULL_NOTE
+    assert structure["failure_class"] == "unverifiable"
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "unverifiable"
+    # The malformed member stops evaluation at the structure gate.
+    assert out["coverage"]["stopped_at"] == "structure"
+    assert "anchors" not in {a["name"] for a in out["axes"]}
+    assert all(a["note"] != "no anchors on this receipt" for a in out["axes"])
+
+
+def test_oracle_absent_and_empty_array_are_one_fact() -> None:
+    """The oracle's axis results for asqav-27 equal asqav-17's, verdict included."""
+    receipt17, jwks, pred = _vector("asqav-17-seq-contiguous")
+    receipt27, _, _ = _vector("asqav-27-anchors-absent")
+    res17 = oracle_verify(receipt17, ADAPTERS, key_provider=jwks, predecessor=pred)
+    res27 = oracle_verify(receipt27, ADAPTERS, key_provider=jwks, predecessor=pred)
+    assert _oracle_shape(res27) == _oracle_shape(res17)
+    assert res27.verdict == res17.verdict == "verified"
+    assert res27.failure_class == res17.failure_class
+    assert res27.first_failing_edge == res17.first_failing_edge
+
+
+def test_oracle_null_anchors_is_malformed_not_no_anchors() -> None:
+    """The oracle FAILs asqav-28 at the structure axis: unverified, unverifiable,
+    first failing edge structure - never a silent read of null as no anchors."""
+    receipt, jwks, pred = _vector("asqav-28-anchors-null-malformed")
+    res = oracle_verify(receipt, ADAPTERS, key_provider=jwks, predecessor=pred)
+    structure = res.axis("structure")
+    assert structure is not None
+    assert structure.result == "FAIL", structure.note
+    assert structure.note == ANCHORS_NULL_NOTE
+    assert res.verdict == "unverified"
+    assert res.failure_class == "unverifiable"
+    assert res.first_failing_edge == "structure"
+    assert all(a.note != "no anchors on this receipt" for a in res.axes)

--- a/python/tests/test_corpus_integrity.py
+++ b/python/tests/test_corpus_integrity.py
@@ -377,18 +377,25 @@ def test_no_derived_member_escapes_a_pin() -> None:
 
 
 class TestTheCorpusSpellsNoAnchorsOneWay:
-    """The corpus carried two spellings of the same fact: null and an empty array.
+    """The corpus states no-anchors one way: the member absent or an empty array.
 
-    The verifier maps absent, null and empty to the identical SKIPPED result, so this
-    never changed a verdict, but a corpus that states one fact two ways invites a
-    reader to infer a distinction that is not there.
+    Absent and [] are the two conformant spellings of the same fact and the
+    engines treat them identically; a JSON null is a third, malformed spelling
+    that the structure axis FAILs. asqav-28-anchors-null-malformed exists to pin
+    that malformed shape, so it is the one vector the rule below names - every
+    other asqav vector stays under it.
     """
+
+    #: The one vector that pins the malformed null shape; any other null is drift.
+    _MALFORMED_ANCHORS_VECTORS = frozenset({"asqav-28-anchors-null-malformed"})
 
     def test_no_asqav_vector_uses_null_for_no_anchors(self) -> None:
         """One spelling, pinned, so the corpus cannot drift back to carrying both."""
         offenders = []
         for vector_dir in sorted(_VECTOR_ROOT.glob("asqav-*")):
             if not vector_dir.is_dir():
+                continue
+            if vector_dir.name in self._MALFORMED_ANCHORS_VECTORS:
                 continue
             receipt = json.loads((vector_dir / "receipt.json").read_text())
             if "anchors" in receipt and receipt["anchors"] is None:
@@ -399,6 +406,9 @@ class TestTheCorpusSpellsNoAnchorsOneWay:
         """A non-list anchors value is malformed: the verifier FAILs it, never laundered."""
         for vector_dir in sorted(_VECTOR_ROOT.glob("asqav-*")):
             if not vector_dir.is_dir():
+                continue
+            if vector_dir.name in self._MALFORMED_ANCHORS_VECTORS:
+                # asqav-28 pins exactly the malformed shape this test forbids.
                 continue
             receipt = json.loads((vector_dir / "receipt.json").read_text())
             if "anchors" in receipt:

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -24,7 +24,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
 FINGERPRINT_LOCK_DIGEST = "1ef6d34d3f9515f2442218e8bf1e1370dd3b0cf1cb1dd143e121b0ff8384732f"
-VERIFIER_LOCK_DIGEST = "40e4fd334f5fe8bc835498f95a8b29659f65f14a23dc233c9e967aabe6b556d3"
+VERIFIER_LOCK_DIGEST = "828e46f9a786321389d7621b1734dc9ea5eaebd6c15f4edda8dd7dc5223b337f"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -240,7 +240,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 77
+    assert len(results) == 79
     # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -121,6 +121,29 @@ function axis(axis: string, result: VerifyState, note: string): AxisResult {
 }
 
 /**
+ * Structure-axis note for the malformed third spelling of "no anchors": the member
+ * absent and the member present as an empty array are the conformant spellings; a
+ * JSON null is found in the wild and is malformed, reported unverifiable rather than
+ * read as either. Verbatim in all three engines; a wording drift fails the
+ * cross-language anchor-shape tests.
+ */
+const ANCHORS_NULL_NOTE =
+  "anchors is null: malformed; absent or [] is the conformant spelling of no anchors";
+
+/**
+ * The structure axis: the adapter schema, plus the one envelope-member shape rule the
+ * schema cannot see - anchors sits beside the signed payload, so no adapter schema
+ * reads it. Caught here, on the document as parsed.
+ */
+function structureAxis(ad: FormatAdapter, doc: Record<string, unknown>): AxisResult {
+  const [res, note] = ad.schema(doc);
+  if (res === PASS && "anchors" in doc && doc.anchors === null) {
+    return axis("structure", FAIL, ANCHORS_NULL_NOTE);
+  }
+  return axis("structure", res, note);
+}
+
+/**
  * Fixed leading axis order every adapter walks, before its format-specific extras.
  * Pinned so a reorder fails a gate instead of quietly renaming which edge is "first".
  */
@@ -316,9 +339,8 @@ export function verify(
     return { fmt: ad.name, axes, verdict, failureClass, signer: null, firstFailingEdge: firstFailingEdge(axes), notChecked: notCheckedDeclaration(), coverage: coverageDeclaration(axes) };
   }
 
-  const [structResult, structNote] = ad.schema(doc);
   const axes: AxisResult[] = [
-    axis("structure", structResult, structNote),
+    structureAxis(ad, doc),
     signatureAxis(ad, doc, keyProvider),
     chainAxis(ad, doc, adapters, predecessor),
     seqAxis(ad, doc, adapters, predecessor),

--- a/typescript/tests/verifier-anchor-shapes.test.ts
+++ b/typescript/tests/verifier-anchor-shapes.test.ts
@@ -1,0 +1,63 @@
+// The three anchors wire shapes through verify(): the member absent and the member
+// present as an empty array are one conformant fact; a JSON null is a malformed third
+// shape and FAILs the structure axis, reported unverified/unverifiable. Mirrors
+// python/tests/test_anchor_shapes.py; the corpus twins are asqav-27 and asqav-28.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { verify, type VerifyResult } from "../src/verifier/core.js";
+import { ADAPTERS } from "../src/verifier/index.js";
+
+const VECTORS = resolve(__dirname, "..", "..", "verifier", "conformance-vectors");
+
+// The one sentence every engine reports for the malformed shape, pinned verbatim
+// so a wording drift in either language fails here and in the Python half.
+const ANCHORS_NULL_NOTE =
+  "anchors is null: malformed; absent or [] is the conformant spelling of no anchors";
+
+function vector(name: string) {
+  const dir = resolve(VECTORS, name);
+  const receipt = JSON.parse(readFileSync(resolve(dir, "receipt.json"), "utf-8"));
+  const jwks = JSON.parse(readFileSync(resolve(dir, "jwks.json"), "utf-8"));
+  const predDoc = JSON.parse(readFileSync(resolve(dir, "predecessor.json"), "utf-8"));
+  const predecessor =
+    predDoc && typeof predDoc === "object" && predDoc.payload ? predDoc.payload : predDoc;
+  return { receipt, jwks, predecessor };
+}
+
+// The skew note embeds live wall-clock seconds; everything else is deterministic.
+const maskSkew = (note: string): string => note.replace(/-?\d+s\b/g, "<n>s");
+
+function shape(r: VerifyResult): unknown[][] {
+  return r.axes.map((a) => [a.axis, a.result, maskSkew(a.note), a.failureClass]);
+}
+
+describe("anchors wire shapes", () => {
+  it("absent and [] are indistinguishable in every axis result", () => {
+    const a17 = vector("asqav-17-seq-contiguous");
+    const a27 = vector("asqav-27-anchors-absent");
+    const r17 = verify(a17.receipt, ADAPTERS, a17.jwks, a17.predecessor);
+    const r27 = verify(a27.receipt, ADAPTERS, a27.jwks, a27.predecessor);
+    expect(shape(r27)).toEqual(shape(r17));
+    expect(r27.verdict).toBe(r17.verdict);
+    expect(r27.verdict).toBe("verified");
+    expect(r27.failureClass).toBe(r17.failureClass);
+    expect(r27.firstFailingEdge).toBe(r17.firstFailingEdge);
+  });
+
+  it("a JSON null anchors member fails the structure axis, unverifiable", () => {
+    const a28 = vector("asqav-28-anchors-null-malformed");
+    const r = verify(a28.receipt, ADAPTERS, a28.jwks, a28.predecessor);
+    const structure = r.axes.find((a) => a.axis === "structure")!;
+    expect(structure.result).toBe("FAIL");
+    expect(structure.note).toBe(ANCHORS_NULL_NOTE);
+    expect(structure.failureClass).toBe("unverifiable");
+    expect(r.verdict).toBe("unverified");
+    expect(r.failureClass).toBe("unverifiable");
+    expect(r.firstFailingEdge).toBe("structure");
+    // The null never reads as "no anchors": no axis claims the skip.
+    expect(r.axes.some((a) => a.note === "no anchors on this receipt")).toBe(false);
+  });
+});

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -28,7 +28,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 77 corpus vectors", () => {
+  it("matches every manifest outcome across all 79 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -45,9 +45,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(77);
+    expect(results.length).toBe(79);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(77);
+    expect(passed).toBe(79);
   });
 
   it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {

--- a/verifier/conformance-vectors/asqav-27-anchors-absent/expected.json
+++ b/verifier/conformance-vectors/asqav-27-anchors-absent/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "asqav-17's receipt with the anchors member absent entirely: absent and an empty array are the two conformant spellings of no anchors, so the outcome and every axis result must equal asqav-17's. The signature covers the payload only, so removing the envelope-level member keeps it valid."
+}

--- a/verifier/conformance-vectors/asqav-27-anchors-absent/jwks.json
+++ b/verifier/conformance-vectors/asqav-27-anchors-absent/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-seq-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "zTmSVd5DfaAncDhLL0aDCTlGaJ+PMX1l7QZLSdSKRb0="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-27-anchors-absent/predecessor.json
+++ b/verifier/conformance-vectors/asqav-27-anchors-absent/predecessor.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_1",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 7
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "lpBJ9g+ug5LJiH4YpwfinVegV1YGXkk4QFTCl6yrTAU+8Xo1zLgHmsKgVYRvRJeyiEn/tN0HAQuaxTqdSYJOCg=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-27-anchors-absent/receipt.json
+++ b/verifier/conformance-vectors/asqav-27-anchors-absent/receipt.json
@@ -1,0 +1,23 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_2",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "11c3ddff7c593e0168bbe6ba5f682c9d503972f233cf655b7ab1633c9ddaa659",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 8
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "ySZavYGbR3/4OvSa6yFcCo4yHpmgW6YYC7/+L7wLQ/QbXAX+IPoVdTLRPPwUuUJNZhvdL97xmwwYzsNimMB5CA=="
+  }
+}

--- a/verifier/conformance-vectors/asqav-28-anchors-null-malformed/expected.json
+++ b/verifier/conformance-vectors/asqav-28-anchors-null-malformed/expected.json
@@ -1,0 +1,7 @@
+{
+  "format": "asqav-native",
+  "outcome": "unverified",
+  "failure_class": "unverifiable",
+  "reason_code": "malformed_member",
+  "notes": "asqav-17's receipt with the anchors member present as a JSON null: a third spelling of no anchors found in the wild, and a malformed one - the structure axis FAILs, naming the member and the shape, and the verdict reads unverified/unverifiable rather than reading null as absent. Nothing cryptographic was disproved, so the class is unverifiable, not invalid (same family as duplicate_member: the receipt's own bytes are malformed)."
+}

--- a/verifier/conformance-vectors/asqav-28-anchors-null-malformed/jwks.json
+++ b/verifier/conformance-vectors/asqav-28-anchors-null-malformed/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-seq-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "zTmSVd5DfaAncDhLL0aDCTlGaJ+PMX1l7QZLSdSKRb0="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-28-anchors-null-malformed/predecessor.json
+++ b/verifier/conformance-vectors/asqav-28-anchors-null-malformed/predecessor.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_1",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 7
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "lpBJ9g+ug5LJiH4YpwfinVegV1YGXkk4QFTCl6yrTAU+8Xo1zLgHmsKgVYRvRJeyiEn/tN0HAQuaxTqdSYJOCg=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-28-anchors-null-malformed/receipt.json
+++ b/verifier/conformance-vectors/asqav-28-anchors-null-malformed/receipt.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "issued_at": "2026-08-30T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_seq_001",
+    "action_ref": "act_2",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "11c3ddff7c593e0168bbe6ba5f682c9d503972f233cf655b7ab1633c9ddaa659",
+    "decision": "allow",
+    "tool_name": "demo.action",
+    "seq": 8
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-seq-vec-key",
+    "sig": "ySZavYGbR3/4OvSa6yFcCo4yHpmgW6YYC7/+L7wLQ/QbXAX+IPoVdTLRPPwUuUJNZhvdL97xmwwYzsNimMB5CA=="
+  },
+  "anchors": null
+}

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -576,5 +576,20 @@
     "outcome": "verified",
     "reason_code": "",
     "notes": "Production receipt (ML-DSA-65, hash-mode, seq 63 with its seq-62 predecessor) whose opentimestamps entry carries status anchored and anchor_block_hash - the real Bitcoin block hash at which the commitment upgraded (height 965451). Signature, key thumbprint and chain verify offline; the anchors axis SKIPs for want of TSA key material and Bitcoin headers, which the corpus does not ship."
+  },
+  {
+    "dir": "asqav-27-anchors-absent",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "asqav-17's receipt with the anchors member absent entirely: absent and an empty array are the two conformant spellings of no anchors, so the outcome and every axis result must equal asqav-17's. The signature covers the payload only, so removing the envelope-level member keeps it valid."
+  },
+  {
+    "dir": "asqav-28-anchors-null-malformed",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "failure_class": "unverifiable",
+    "reason_code": "malformed_member",
+    "notes": "asqav-17's receipt with the anchors member present as a JSON null: a third spelling of no anchors found in the wild, and a malformed one - the structure axis FAILs, naming the member and the shape, and the verdict reads unverified/unverifiable rather than reading null as absent. Nothing cryptographic was disproved, so the class is unverifiable, not invalid (same family as duplicate_member: the receipt's own bytes are malformed)."
   }
 ]

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-verifier-conformance-vectors",
-  "corpus_version": 15,
+  "corpus_version": 16,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -78,6 +78,11 @@
       "version": 14,
       "files": 257,
       "digest": "a62640b54b9fb18e4266e735bdf4dce8308909024e02074d0c887b0be833a318"
+    },
+    {
+      "version": 15,
+      "files": 260,
+      "digest": "40e4fd334f5fe8bc835498f95a8b29659f65f14a23dc233c9e967aabe6b556d3"
     }
   ],
   "files": [
@@ -1152,6 +1157,46 @@
       "bytes": 855
     },
     {
+      "path": "asqav-27-anchors-absent/expected.json",
+      "sha256": "8ff396cb533c06e37f75df4817d8a4726741ce58b38324630ebc693329ad9c44",
+      "bytes": 378
+    },
+    {
+      "path": "asqav-27-anchors-absent/jwks.json",
+      "sha256": "79868ab758a20f67ec0e9b670760c8cde54b62a55754336d0f1b8379f4c42c4b",
+      "bytes": 215
+    },
+    {
+      "path": "asqav-27-anchors-absent/predecessor.json",
+      "sha256": "1da61225a7cee5d09079eff486a29bef02c36f5be5e9de30ef496e8012e71909",
+      "bytes": 777
+    },
+    {
+      "path": "asqav-27-anchors-absent/receipt.json",
+      "sha256": "1bb255db1bea9ad49d5383641ab379a450679130f13e0ee71efd64e4019492fc",
+      "bytes": 760
+    },
+    {
+      "path": "asqav-28-anchors-null-malformed/expected.json",
+      "sha256": "31a89695259911a0ecee5fd3311160fd2cda415820df353abaee752de17f8b03",
+      "bytes": 577
+    },
+    {
+      "path": "asqav-28-anchors-null-malformed/jwks.json",
+      "sha256": "79868ab758a20f67ec0e9b670760c8cde54b62a55754336d0f1b8379f4c42c4b",
+      "bytes": 215
+    },
+    {
+      "path": "asqav-28-anchors-null-malformed/predecessor.json",
+      "sha256": "1da61225a7cee5d09079eff486a29bef02c36f5be5e9de30ef496e8012e71909",
+      "bytes": 777
+    },
+    {
+      "path": "asqav-28-anchors-null-malformed/receipt.json",
+      "sha256": "aa8e941d002a964f5ba679ca6e752fa2fa9c8b6e3ef50f549e20f32e25da52e3",
+      "bytes": 779
+    },
+    {
       "path": "authproof-01-genesis-real-sdk/expected.json",
       "sha256": "5599a2e6341d4194186cd5c43be8c271c2dd40d8a382f1be536d89488e6378a8",
       "bytes": 274
@@ -1238,8 +1283,8 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "eeb632ee4d783299167ff9ba50797a5b81d0911473a11a15b8fc762a7d61cc09",
-      "bytes": 26547
+      "sha256": "bfa5054bf2102a9ae53e04548daa3e098f3cae119921aca8703e42844c4a86d2",
+      "bytes": 27614
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
@@ -1273,8 +1318,8 @@
     },
     {
       "path": "requirement-map.json",
-      "sha256": "b92620530426bc2fdbc7992a9b5875c79febc1e4fb9660b351dd4ed84c6ff0ba",
-      "bytes": 49773
+      "sha256": "3d7263a4acf0e75bc805d7d5ccae3bdc9dc0677edd8f9e234eb0e2e164eb40bb",
+      "bytes": 51695
     },
     {
       "path": "w3c-vc-01-didweb-happy-path/did_map.json",
@@ -1412,5 +1457,5 @@
       ]
     }
   },
-  "digest": "40e4fd334f5fe8bc835498f95a8b29659f65f14a23dc233c9e967aabe6b556d3"
+  "digest": "828e46f9a786321389d7621b1734dc9ea5eaebd6c15f4edda8dd7dc5223b337f"
 }

--- a/verifier/conformance-vectors/requirement-map.json
+++ b/verifier/conformance-vectors/requirement-map.json
@@ -367,6 +367,24 @@
       "anchors": "SKIPPED",
       "skew": "PASS",
       "expiry": "PASS"
+    },
+    "asqav-27-anchors-absent": {
+      "structure": "PASS",
+      "nonce": "PASS",
+      "issuer_key": "PASS",
+      "issuer_bind": "PASS",
+      "key_status": "PASS",
+      "signature": "PASS",
+      "key_binding": "PASS",
+      "counterparty": "PASS",
+      "payload_digest": "PASS",
+      "chain": "PASS",
+      "anchors": "SKIPPED",
+      "skew": "PASS",
+      "expiry": "PASS"
+    },
+    "asqav-28-anchors-null-malformed": {
+      "structure": "FAIL"
     }
   },
   "requirements": {
@@ -979,6 +997,48 @@
       "not_exercised": [
         "REQ-ANCHOR"
       ]
+    },
+    "asqav-27-anchors-absent": {
+      "declared_outcome": "verified",
+      "observed_verdict": "unverified",
+      "exercises": [
+        "REQ-CHAIN",
+        "REQ-COUNTERPARTY",
+        "REQ-EXPIRY",
+        "REQ-ISSUER-BIND",
+        "REQ-KEY-RESOLUTION",
+        "REQ-KEY-STATUS",
+        "REQ-KEY-THUMBPRINT",
+        "REQ-NONCE",
+        "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
+        "REQ-SKEW",
+        "REQ-STRUCTURE"
+      ],
+      "not_exercised": [
+        "REQ-ANCHOR"
+      ]
+    },
+    "asqav-28-anchors-null-malformed": {
+      "declared_outcome": "unverified",
+      "observed_verdict": "unverified",
+      "exercises": [
+        "REQ-STRUCTURE"
+      ],
+      "not_exercised": [
+        "REQ-ANCHOR",
+        "REQ-CHAIN",
+        "REQ-COUNTERPARTY",
+        "REQ-EXPIRY",
+        "REQ-ISSUER-BIND",
+        "REQ-KEY-RESOLUTION",
+        "REQ-KEY-STATUS",
+        "REQ-KEY-THUMBPRINT",
+        "REQ-NONCE",
+        "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
+        "REQ-SKEW"
+      ]
     }
   },
   "interop_fixtures": {
@@ -1268,7 +1328,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-KEY-RESOLUTION": [
       "asqav-01-genesis-permit",
@@ -1294,7 +1355,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-ISSUER-BIND": [
       "asqav-01-genesis-permit",
@@ -1320,7 +1382,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-KEY-STATUS": [
       "asqav-01-genesis-permit",
@@ -1346,7 +1409,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-KEY-THUMBPRINT": [
       "asqav-01-genesis-permit",
@@ -1372,7 +1436,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-CHAIN": [
       "asqav-01-genesis-permit",
@@ -1398,7 +1463,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-ANCHOR": [
       "asqav-24-anchor-block-hash-prod"
@@ -1427,7 +1493,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-EXPIRY": [
       "asqav-01-genesis-permit",
@@ -1453,7 +1520,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-NONCE": [
       "asqav-01-genesis-permit",
@@ -1479,7 +1547,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-PAYLOAD-DIGEST": [
       "asqav-01-genesis-permit",
@@ -1505,7 +1574,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-COUNTERPARTY": [
       "asqav-01-genesis-permit",
@@ -1531,7 +1601,8 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent"
     ],
     "REQ-STRUCTURE": [
       "asqav-01-genesis-permit",
@@ -1557,14 +1628,16 @@
       "asqav-23-anchor-status-pending",
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
-      "asqav-26-payload-digest-mismatch"
+      "asqav-26-payload-digest-mismatch",
+      "asqav-27-anchors-absent",
+      "asqav-28-anchors-null-malformed"
     ]
   },
   "unmapped_requirements": [],
   "unmapped_detail": {},
   "unmapped_note": "These are normative requirements no vector in this corpus exercises. They are published because an unmapped requirement stays unmapped however many vectors exist, so growing the corpus does not remove one from this list; writing a vector that reaches it does.",
   "counts": {
-    "asqav_native_vectors": 26,
+    "asqav_native_vectors": 28,
     "interop_fixtures": 52,
     "requirements": 13,
     "requirements_covered": 13,

--- a/verifier/first-bad-edge-cases.json
+++ b/verifier/first-bad-edge-cases.json
@@ -77,6 +77,8 @@
     "asqav-26-payload-digest-mismatch": "payload_digest",
     "asqav-23-anchor-status-pending": null,
     "asqav-24-anchor-block-hash-prod": null,
+    "asqav-27-anchors-absent": null,
+    "asqav-28-anchors-null-malformed": "structure",
     "acta-06-chain-link-03-prefixed": null,
     "acta-07-chain-link-03-wrong-digest": "chain"
   }


### PR DESCRIPTION
## Why

The profile states the anchors wire shapes once: the member ABSENT and the member present as an EMPTY ARRAY are both conformant and mean the same thing (no anchor presented); a JSON `null` is a third shape found in the wild, is MALFORMED, and must be reported unverifiable rather than read as either. Measured on the default branch, every engine read `null` as "no anchors": the oracle graded such a receipt verified, and run_structured SKIPs the anchors axis with "no anchors on this receipt".

## What changed

- The structure axis of the oracle, of `run_structured` and of the TypeScript core FAILs a null anchors member, naming the member and the shape: `anchors is null: malformed; absent or [] is the conformant spelling of no anchors`. The verdict reads unverified with failure_class unverifiable — a malformed member is not a cryptographic disproof, so the class is never invalid.
- Absent and `[]` stay byte-for-byte identical in every axis result (pinned by new tests in both languages).
- The corpus gains one vector per wire shape: `asqav-27-anchors-absent` (conformant twin of asqav-17 with the member removed; the signature covers the payload only, so it stays valid) and `asqav-28-anchors-null-malformed` (expected unverified/unverifiable, reason_code `malformed_member`, the duplicate_member family).
- `TestTheCorpusSpellsNoAnchorsOneWay` keeps its rule for every vector and names asqav-28 as the one vector pinning the malformed shape.
- Corpus lock re-frozen (`VERIFIER_LOCK_DIGEST` moved), requirement map regenerated (asqav-28 exercises REQ-STRUCTURE via the structure FAIL), first-bad-edge table and both count pins moved 77 -> 79.

## Proof

- RED before the engine change: the oracle graded asqav-28 verified against its expected.json, and run_structured reported the null as SKIPPED "no anchors on this receipt" (both pasted in the task evidence).
- The one-way rule still bites any other vector: a temporary null in asqav-05 reddens it naming asqav-05; restored green.
- Full suites: python 3203 passed / 2 skipped (baseline 3199 / 2), TypeScript 1165 passed (baseline 1163), `ruff check python/src` clean, `verifier/check_corpus_lock.sh` green.