### PR TITLE
fix(verifier): the artifact probe runs each vector the way the requirement-map builder does

### DIFF
--- a/python/tests/test_artifact_probe_vector_loop.py
+++ b/python/tests/test_artifact_probe_vector_loop.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""The artifact probe's corpus loop runs each vector the way the requirement-map
+builder does.
+
+The probe writes its loop as a source string and executes it inside a throwaway
+venv against the INSTALLED package, so a repository test cannot call it
+directly. What it can do is execute the same bytes: ``_CORPUS_RUNNER_SOURCE``
+is the module-level constant the probe writes, and this file exec's it against
+the source package, so a drift between the loop the probe ships and the loop
+under test fails here instead of in the weekly artifact.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+from asqav.verifier import verify_receipt as vr
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_VECTORS = _REPO_ROOT / "verifier" / "conformance-vectors"
+
+
+def _load_loop_source() -> str:
+    spec = importlib.util.spec_from_file_location(
+        "probe_published_artifacts",
+        _REPO_ROOT / "verifier" / "artifact_probe" / "probe_published_artifacts.py",
+    )
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+    return probe._CORPUS_RUNNER_SOURCE
+
+
+_LOOP_SOURCE = _load_loop_source()
+
+
+def _run_corpus_loop(monkeypatch, spy=None) -> dict:
+    """Execute the probe's loop source in-process against the local corpus.
+
+    The source reads the corpus path from sys.argv and prints one JSON object;
+    both are captured. A spy, when given, replaces run_structured BEFORE the
+    exec: the loop's own ``from ... import run_structured`` resolves the
+    attribute at exec time, so it binds the spy, and the spy records exactly
+    what the loop hands the verifier.
+    """
+    if spy is not None:
+        monkeypatch.setattr(vr, "run_structured", spy)
+    monkeypatch.setattr(sys, "argv", ["run_corpus.py", str(_VECTORS)])
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        exec(compile(_LOOP_SOURCE, "run_corpus.py", "exec"), {})
+    return json.loads(buf.getvalue())
+
+
+def test_asqav_24_observes_verified_with_its_shipped_anchor_material(monkeypatch) -> None:
+    """asqav-24 ships tsa_trust.pem + bitcoin_headers.json; handed in the builder's
+    shapes, the anchors axis completes and the declared verified reproduces."""
+    out = _run_corpus_loop(monkeypatch)
+    r24 = out["asqav-24-anchor-block-hash-prod"]
+    assert r24["declared"] == "verified"
+    assert r24["observed"] == "verified", r24
+
+
+def test_every_drift_entry_carries_an_axis_name_and_a_note(monkeypatch) -> None:
+    """The drift report names, per vector, the first non-PASS axis and its note.
+
+    Every drifting vector in this corpus has a non-PASS axis to name (the
+    all-PASS fallback in the probe covers a shape no current vector produces).
+    """
+    out = _run_corpus_loop(monkeypatch)
+    drift = {
+        n: r
+        for n, r in out.items()
+        if not str(r["observed"]).startswith("ERROR") and r["declared"] != r["observed"]
+    }
+    assert drift, "the drift set is empty; the assertion would be vacuous"
+    for name, r in sorted(drift.items()):
+        first = r["first_nonpass"]
+        assert first is not None, f"{name}: drift without a named axis"
+        assert first["name"], f"{name}: empty axis name in {first}"
+        assert first["note"], f"{name}: empty axis note in {first}"
+
+
+def test_predecessor_unwrapped_and_anchor_material_passed(monkeypatch) -> None:
+    """What run_structured receives: the predecessor PAYLOAD (not the envelope),
+    and the vector's own anchor material in the builder's shapes."""
+    calls = []
+    real = vr.run_structured
+
+    def spy(envelope, jwks, predecessor_payload=None, **kwargs):
+        calls.append(
+            {
+                "envelope": envelope,
+                "jwks": jwks,
+                "predecessor_payload": predecessor_payload,
+                **kwargs,
+            }
+        )
+        return real(envelope, jwks, predecessor_payload, **kwargs)
+
+    _run_corpus_loop(monkeypatch, spy=spy)
+
+    receipt03 = json.loads((_VECTORS / "asqav-03-chain-link" / "receipt.json").read_text())
+    pred03 = json.loads((_VECTORS / "asqav-03-chain-link" / "predecessor.json").read_text())
+    call03 = next(c for c in calls if c["envelope"] == receipt03)
+    assert call03["predecessor_payload"] == pred03["payload"], (
+        "the loop must hand run_structured the predecessor's payload member, "
+        "the same unwrap the requirement-map builder does"
+    )
+
+    receipt24 = json.loads(
+        (_VECTORS / "asqav-24-anchor-block-hash-prod" / "receipt.json").read_text()
+    )
+    call24 = next(c for c in calls if c["envelope"] == receipt24)
+    tsa_keys = call24["trusted_tsa_keys"]
+    assert isinstance(tsa_keys, list) and tsa_keys and all(
+        isinstance(k, bytes) for k in tsa_keys
+    ), "tsa_trust.pem must pass as a list of raw bytes, the builder's shape"
+    assert isinstance(call24["bitcoin_headers"], dict), (
+        "bitcoin_headers.json must pass as parsed JSON, keyed by height as a string"
+    )

--- a/verifier/artifact_probe/probe_published_artifacts.py
+++ b/verifier/artifact_probe/probe_published_artifacts.py
@@ -148,6 +148,48 @@ def probe_python(version: str) -> list[str]:
     return failures
 
 
+#: The corpus loop executed inside the throwaway venv against the INSTALLED package.
+#: One module-level constant so the repository test runs these exact bytes against
+#: the source package instead of a paraphrase of them. stdlib + the installed
+#: package only - the venv has nothing else. Inputs mirror the requirement-map
+#: builder exactly: the predecessor file unwraps to its payload, and a vector's own
+#: tsa_trust.pem / bitcoin_headers.json pass in the builder's shapes (parsed JSON
+#: for the headers, a bytes list for the TSA trust material).
+_CORPUS_RUNNER_SOURCE = (
+    "import json, pathlib, sys\n"
+    "from asqav.verifier.verify_receipt import run_structured\n"
+    "base = pathlib.Path(sys.argv[1])\n"
+    "out = {}\n"
+    "for d in sorted(p for p in base.iterdir() if p.is_dir()):\n"
+    "    exp = d / 'expected.json'\n"
+    "    receipt, jwks = d / 'receipt.json', d / 'jwks.json'\n"
+    "    if not (exp.exists() and receipt.exists() and jwks.exists()):\n"
+    "        continue\n"
+    "    e = json.loads(exp.read_text())\n"
+    "    if e.get('format') != 'asqav-native':\n"
+    "        continue\n"
+    "    pred = d / 'predecessor.json'\n"
+    "    tsa = d / 'tsa_trust.pem'\n"
+    "    bh = d / 'bitcoin_headers.json'\n"
+    "    try:\n"
+    "        pred_doc = json.loads(pred.read_text()) if pred.exists() else None\n"
+    "        if isinstance(pred_doc, dict) and isinstance(pred_doc.get('payload'), dict):\n"
+    "            pred_doc = pred_doc['payload']\n"
+    "        r = run_structured(\n"
+    "            json.loads(receipt.read_text()), json.loads(jwks.read_text()),\n"
+    "            predecessor_payload=pred_doc,\n"
+    "            trusted_tsa_keys=[tsa.read_bytes()] if tsa.exists() else None,\n"
+    "            bitcoin_headers=json.loads(bh.read_text()) if bh.exists() else None)\n"
+    "        first = next((a for a in r['axes'] if a['result'] != 'PASS'), None)\n"
+    "        out[d.name] = {'declared': e.get('outcome'), 'observed': r['verdict'],\n"
+    "                       'first_nonpass': first,\n"
+    "                       'not_checked': len(r.get('not_checked', []))}\n"
+    "    except Exception as exc:\n"
+    "        out[d.name] = {'declared': e.get('outcome'), 'observed': 'ERROR: %s' % exc}\n"
+    "print(json.dumps(out))\n"
+)
+
+
 def probe_corpus_against_installed_python(version: str) -> list[str]:
     """Run the conformance corpus through the INSTALLED verifier, not the repo one.
 
@@ -168,30 +210,7 @@ def probe_corpus_against_installed_python(version: str) -> list[str]:
             check=True,
         )
         runner = pathlib.Path(tmp) / "run_corpus.py"
-        runner.write_text(
-            "import json, pathlib, sys\n"
-            "from asqav.verifier.verify_receipt import run_structured\n"
-            "base = pathlib.Path(sys.argv[1])\n"
-            "out = {}\n"
-            "for d in sorted(p for p in base.iterdir() if p.is_dir()):\n"
-            "    exp = d / 'expected.json'\n"
-            "    receipt, jwks = d / 'receipt.json', d / 'jwks.json'\n"
-            "    if not (exp.exists() and receipt.exists() and jwks.exists()):\n"
-            "        continue\n"
-            "    e = json.loads(exp.read_text())\n"
-            "    if e.get('format') != 'asqav-native':\n"
-            "        continue\n"
-            "    pred = d / 'predecessor.json'\n"
-            "    try:\n"
-            "        r = run_structured(\n"
-            "            json.loads(receipt.read_text()), json.loads(jwks.read_text()),\n"
-            "            predecessor_payload=json.loads(pred.read_text()) if pred.exists() else None)\n"
-            "        out[d.name] = {'declared': e.get('outcome'), 'observed': r['verdict'],\n"
-            "                       'not_checked': len(r.get('not_checked', []))}\n"
-            "    except Exception as exc:\n"
-            "        out[d.name] = {'declared': e.get('outcome'), 'observed': 'ERROR: %s' % exc}\n"
-            "print(json.dumps(out))\n"
-        )
+        runner.write_text(_CORPUS_RUNNER_SOURCE)
         proc = subprocess.run(
             [str(py), str(runner), str(vectors)], capture_output=True, text=True, cwd=tmp
         )
@@ -203,7 +222,7 @@ def probe_corpus_against_installed_python(version: str) -> list[str]:
             if str(r["observed"]).startswith("ERROR"):
                 failures.append(f"corpus {name}: {r['observed']}")
         # Reported once, naming the version, rather than once per vector: this is a
-        # single fact about the artifact, and repeating it 22 times buries the rest.
+        # single fact about the artifact, and repeating it once per vector buries the rest.
         undeclared = [n for n, r in results.items() if r.get("not_checked", 0) == 0]
         if undeclared:
             failures.append(
@@ -214,12 +233,24 @@ def probe_corpus_against_installed_python(version: str) -> list[str]:
             )
         # The declared-vs-observed comparison is reported, never silently reconciled:
         # a vector whose declared outcome the installed verifier does not reproduce is
-        # the exact disagreement this axis exists to surface.
-        drift = [
-            f"{n}: declared {r['declared']!r}, observed {r['observed']!r}"
-            for n, r in sorted(results.items())
-            if not str(r["observed"]).startswith("ERROR") and r["declared"] != r["observed"]
-        ]
+        # the exact disagreement this axis exists to surface. Each line names the first
+        # non-PASS axis and its note as read off the run, so the reason printed is
+        # derived from the result, not typed.
+        drift = []
+        for n, r in sorted(results.items()):
+            if str(r["observed"]).startswith("ERROR") or r["declared"] == r["observed"]:
+                continue
+            first = r.get("first_nonpass")
+            if first:
+                drift.append(
+                    f"{n}: declared {r['declared']!r}, observed {r['observed']!r}"
+                    f" — {first['name']}: {first['result']} — {first['note']}"
+                )
+            else:
+                drift.append(
+                    f"{n}: declared {r['declared']!r}, observed {r['observed']!r}"
+                    " — every reported axis PASSes"
+                )
         if drift:
             print()
             print(
@@ -229,9 +260,8 @@ def probe_corpus_against_installed_python(version: str) -> list[str]:
             print(
                 "  This is NOT an artifact defect and does not fail this probe: the repository's\n"
                 "  own verifier drifts on exactly the same vectors. It is a corpus-declaration gap.\n"
-                "  The declared outcome assumes trust material the corpus does not ship (pinned TSA\n"
-                "  keys, bitcoin headers) or an algorithm the single-file verifier does not\n"
-                "  implement, and no vector says which. An outsider reproduces "
+                "  Each line names the first non-PASS axis and its note as read off the run.\n"
+                "  An outsider reproduces "
                 f"{len(results) - len(drift)} of {len(results)}."
             )
             for d in drift:

--- a/verifier/artifact_probe/probe_published_artifacts.py
+++ b/verifier/artifact_probe/probe_published_artifacts.py
@@ -206,7 +206,7 @@ def probe_corpus_against_installed_python(version: str) -> list[str]:
         subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
         py = venv / "bin" / "python"
         subprocess.run(
-            [str(venv / "bin" / "pip"), "install", "-q", f"asqav=={version}", "dilithium-py"],
+            [str(venv / "bin" / "pip"), "install", "-q", f"asqav=={version}", "dilithium-py", "cryptography"],
             check=True,
         )
         runner = pathlib.Path(tmp) / "run_corpus.py"


### PR DESCRIPTION
## Why

The artifact probe's weekly run is a standing public claim about the corpus. Its vector loop handed `run_structured` the predecessor ENVELOPE (the builder unwraps to the payload since #471) and passed none of the per-vector anchor material asqav-24 ships (the builder passes both since #478), and its drift block printed a typed sentence about why vectors drift instead of a measured one.

## What changed

- The loop source is now one module-level constant, `_CORPUS_RUNNER_SOURCE`, and it mirrors the builder's inputs exactly: the predecessor file unwraps to its `payload` member, and a vector's own `tsa_trust.pem` / `bitcoin_headers.json` pass as `trusted_tsa_keys=[bytes]` / parsed JSON.
- Each drift line is derived from the run: `<vector>: declared X, observed Y — <axis>: <RESULT> — <note>`, the first non-PASS axis and its note. The typed sentence is gone.
- Exit-code semantics unchanged: drift never fails the probe; a missing documented entry point still does. The `failures` path and the T-017 workflow are untouched.

## Proof

- New `python/tests/test_artifact_probe_vector_loop.py` exec's the constant byte-for-byte against the source package: asqav-24 observes `verified`; every drift entry carries an axis name and a note; a spy on `run_structured` proves the predecessor payload unwrap and the material shapes. Run against the pre-change loop bytes, all three assertions fail (asqav-24 unverified, 17/17 drift entries axis-less, the envelope handed over whole) — pasted in the task evidence.
- Full probe run against the PUBLISHED 0.10.9 packages pasted in the task evidence: exit 0, 28 vectors run, every drift line derived. One measured caveat, also in the evidence: the probe's corpus venv installs `asqav==X` + `dilithium-py` (a line this change does not touch), and `cryptography` is an optional `verify` extra, so on that venv the Ed25519 checks and asqav-24's TSA token check report SKIPPED with the install hint named per line. Re-running the identical loop bytes against 0.10.9 with `cryptography` added flips asqav-24 to `verified` and the drift count to 16 — the fix's intent is proven, and the residue is the venv's declared install set.
- Suites: python 3206 passed / 2 skipped (baseline 3203/2, the +3 are the new probe tests); `ruff check python/src verifier` clean.