### PR TITLE
docs: shorter, concrete READMEs; pricing lives on the pricing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,13 +379,12 @@ Both SDKs ship to different registries on independent cadences, driven by prefix
 
 ## Plans
 
-Asqav has three plans: Free, Pro and Enterprise.
+Asqav has three plans: Free, Pro and Enterprise. Free needs no credit card, Pro is a paid
+monthly or annual subscription, and Enterprise is custom and volume-priced.
 
-Free ($0, no credit card) covers 25,000 signatures/month (1,000/day), 10 agents, 10 policies, 3 team members, and 30-day log retention. Most features are included: OpenTimestamps anchoring, audit export, framework integrations, content scanning, OpenTelemetry export, the Replay API, approvals, governance query and attestation, and 2 compliance reports/month.
-
-Pro ($99/month, or $79/month billed annually) covers 250,000 signatures/month (10,000/day) with usage-based overage, 50 agents, 100 policies, 10 team members, 1-year log retention and 25 compliance reports/month, and adds RFC 3161 timestamps.
-
-Enterprise adds SSO/SAML, managed and bring-your-own KMS, SD-JWT selective disclosure, IP allowlists, multi-party quorum signing, quarantine and incident management, a self-hosted signer, custom volumes and retention (five years by default), and dedicated support. See [asqav.com/pricing](https://asqav.com/pricing.html) for the full breakdown.
+Quotas, prices and the per-plan feature list live on one page so they cannot drift out of
+step with each other: see [asqav.com/pricing](https://asqav.com/pricing.html). Where a
+specific capability is plan-gated, the section describing that capability says so.
 
 ## Discovery
 

--- a/README.md
+++ b/README.md
@@ -1,381 +1,128 @@
-<p align="center">
-  <a href="https://asqav.com">
-    <img src="https://asqav.com/logo-text-white.png" alt="Asqav" width="200">
-  </a>
-</p>
-<p align="center">
-  The evidence layer for AI agents. Audit trails, approvals, policy gates, and compliance reports for every action.
-</p>
-<p align="center">
-  <a href="https://pypi.org/project/asqav/"><img src="https://img.shields.io/pypi/v/asqav?style=flat-square&logo=pypi&logoColor=white&label=pypi" alt="PyPI version"></a>
-  <a href="https://www.npmjs.com/package/@asqav/sdk"><img src="https://img.shields.io/npm/v/%40asqav%2Fsdk?style=flat-square&logo=npm&logoColor=white&label=npm" alt="npm version"></a>
-  <a href="https://github.com/jagmarques/asqav-sdk/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/jagmarques/asqav-sdk/ci.yml?style=flat-square&logo=github&logoColor=white" alt="CI"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Elastic%202.0-blue.svg?style=flat-square" alt="License: Elastic 2.0"></a>
-  <a href="https://github.com/jagmarques/asqav-sdk"><img src="https://img.shields.io/github/stars/jagmarques/asqav-sdk?style=social" alt="GitHub stars"></a>
-</p>
-<p align="center">
-  <a href="https://asqav.com">Website</a> |
-  <a href="https://asqav.com/docs">Docs</a> |
-  <a href="https://asqav.com/docs/sdk">SDK Guide</a> |
-  <a href="https://www.asqav.com/docs">Compliance</a>
-</p>
+# Asqav SDK — Python + TypeScript
 
-# Asqav SDK - Python + TypeScript
+[![GitHub stars](https://img.shields.io/github/stars/jagmarques/asqav-sdk?style=social)](https://github.com/jagmarques/asqav-sdk)
+[![PyPI](https://img.shields.io/pypi/v/asqav)](https://pypi.org/project/asqav/)
+[![npm](https://img.shields.io/npm/v/@asqav/sdk)](https://www.npmjs.com/package/@asqav/sdk)
 
-The official client SDKs for [Asqav](https://asqav.com), the evidence layer for AI agents. Sign every action with ML-DSA-65 (FIPS 204), enforce policies before execution, and produce regulator-ready audit trails.
+Client SDKs for [asqav.com](https://asqav.com), the evidence layer for AI agents.
 
-This repository ships two SDKs from a single monorepo:
+Every agent action gets a signed, hash-chained **compliance receipt**: ML-DSA-65 (FIPS 204,
+post-quantum), timestamped against independent witnesses, and verifiable by anyone —
+auditor, counterparty, regulator — **without an Asqav account and without trusting us**.
 
-- `python/` - the original Python SDK, published to PyPI as [`asqav`](https://pypi.org/project/asqav/)
-- `typescript/` - the TypeScript SDK, published to npm as [`@asqav/sdk`](https://www.npmjs.com/package/@asqav/sdk)
-
-Both wrap the same Asqav API. Pick the one that matches your stack.
+Zero native dependencies in either SDK. Cryptography runs server-side.
 
 ## Install
 
-Python:
-
 ```bash
-pip install asqav
+pip install asqav            # Python 3.10+
+npm install @asqav/sdk       # Node 20+
 ```
 
-TypeScript / Node.js:
-
-```bash
-npm install @asqav/sdk
-```
-
-Both packages have zero native dependencies. All ML-DSA cryptography runs server-side.
-
-## 30-second example
-
-Python:
+## Sign an action
 
 ```python
 import asqav
 
 agent = asqav.govern(api_key="sk_...", agent_name="my-agent")
-sig = agent.sign("api:call", {"model": "gpt-4"})
-
-print(sig.signature_id, sig.verification_url)
+sig = agent.sign("api:openai:chat", {"model": "gpt-4o"})
+print(sig.verification_url)
 ```
-
-TypeScript:
 
 ```ts
 import { govern } from "@asqav/sdk";
 
-const agent = await govern({ apiKey: "sk_...", agentName: "my-agent" });
-const sig = await agent.sign({
-  actionType: "api:call",
-  context: { model: "gpt-4" },
-});
-
-console.log(sig.signatureId, sig.verificationUrl);
+const agent = await govern({ apiKey: process.env.ASQAV_API_KEY, agentName: "my-agent" });
+const sig = await agent.sign({ actionType: "api:openai:chat", context: { model: "gpt-4o" } });
+console.log(sig.verificationUrl);
 ```
 
-Each signed action returns a receipt like:
+## Verify one, with no account
 
-```json
-{
-  "signature_id": "sig_a1b2c3",
-  "agent_id": "agt_x7y8z9",
-  "action": "api:call",
-  "algorithm": "ML-DSA-65",
-  "timestamp": "2026-04-27T18:30:00Z",
-  "chain_hash": "b94d27b9934d3e08...",
-  "verification_url": "https://asqav.com/verify/sig_a1b2c3"
-}
-```
-
-The agent now has a cryptographic identity, a signed audit trail, and a verifiable action record.
-
-## 10-minute quickstart
-
-The fastest path from zero to a signed action.
-
-### Install
-
-```bash
-# Python
-pip install asqav
-
-# TypeScript / Node.js
-npm install @asqav/sdk
-```
-
-### Get an API key
-
-Sign up at [asqav.com](https://asqav.com) and copy your `sk_...` key.
-
-### Call govern() - one line to init + create
-
-Python:
+Receipts are portable. Anyone holding a `signature_id` can verify it without an API key.
+`verify()` returns the public verdict and recomputes `chain_hash` locally, as the SHA-256
+over the RFC 8785 canonical payload, so the chain link is reproducible on your machine.
 
 ```python
 import asqav
 
-# govern() calls init() + Agent.create() for you
-agent = asqav.govern(api_key="sk_...", agent_name="my-agent")
-```
-
-TypeScript:
-
-```ts
-import { govern } from "@asqav/sdk";
-
-// govern() calls init() + Agent.create() for you
-const agent = await govern({ apiKey: "sk_...", agentName: "my-agent" });
-```
-
-### Sign an action
-
-Python:
-
-```python
-sig = agent.sign("api:call", {"model": "gpt-4", "tokens": 512})
-print(sig.signature_id, sig.verification_url)
-```
-
-TypeScript:
-
-```ts
-const sig = await agent.sign({
-  actionType: "api:call",
-  context: { model: "gpt-4", tokens: 512 },
-});
-console.log(sig.signatureId, sig.verificationUrl);
-```
-
-### Verify
-
-Paste the `verification_url` in a browser, or call the API directly:
-
-```bash
-curl https://api.asqav.com/api/v1/verify/<signature_id>
-```
-
-That's it. See `python/examples/quickstart.py` and `typescript/examples/quickstart.ts` for
-runnable versions.
-
----
-
-## Data handling modes
-
-The SDK auto-detects whether you're pointing at the Asqav cloud or a self-hosted deployment, and selects the safer default for each:
-
-- **Cloud (`*.asqav.com`)**: hash-only by default. The SDK builds a fingerprint of your action context, computes a SHA-256 hash locally, and sends only the hash plus a small metadata bag of action_type, agent_id, session_id, model_name, and tool_name. Raw prompts and tool arguments stay on your side.
-- **Self-hosted**: full-payload by default. The server can run policy checks, PII redaction, and richer audit. Recommended when you control the deployment.
-
-Override anytime:
-
-```python
-# Python
-asqav.init(api_key="...", base_url="https://api.asqav.com", mode="hash-only")
+result = asqav.verify("sig_example_regulator_cold_verify_2026")
+print(result["verified"])     # False -- deliberately, see below
+print(result["chain_hash"])
 ```
 
 ```ts
-// TypeScript
-await init({ apiKey: "...", baseUrl: "https://api.asqav.com", mode: "hash-only" });
+import { verify } from "@asqav/sdk";
+
+const result = await verify("sig_example_regulator_cold_verify_2026");
+console.log(result.verified, result.chainHash);
 ```
 
-The fingerprint format is RFC 8785-style sorted JSON with no whitespace, hashed with SHA-256. See `docs/fingerprint-spec.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
+That id is a **shape example**: its signature bytes are placeholders and its `kid` resolves to
+no key, so the verifier reports `verified: false` rather than waving it through. Swap in a
+`signature_id` of your own for a receipt that passes. A verifier that says no when the
+evidence is absent is the only kind worth having.
 
-For self-hosted and split-trust deployments, bring-your-own KMS, SCITT and COSE receipt export, and air-gapped mode, see [asqav.com/docs](https://asqav.com/docs).
+For a fully offline, zero-trust check that reproduces the signature itself, use
+`asqav.verify_receipt_offline(receipt, jwks)` in Python, `verifyReceiptOffline()` in
+TypeScript, or the standalone `python -m asqav.verifier.verify_receipt --offline`. The
+algorithm is per-receipt from `signature.alg`: ML-DSA-65 for cloud-issued receipts,
+Ed25519/ES256 for locally signed ones.
 
-## Standards
+## Per-language guides
 
-Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/), an Independent Submission that profiles [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) for EU AI Act Articles 12 and 26, and DORA Article 17 bindings.
+The package READMEs are the reference for each language — quick start, CLI, data-handling
+modes, framework integrations, offline verification, and what a receipt does not prove:
 
-## Coding agents
-
-Autonomous coding agents open and merge their own pull requests, and a git author string is mutable. The `protectmcp:lifecycle:code_authorship` receipt binds a change to the agent that authored it: the repository, the commit and base SHA, a digest of the diff, the change class, and a producer-asserted `authored_by` block, signed with ML-DSA-65 and chained per agent. Asqav records that the change existed, was key-authored, and was chained at a point in time. It does not clone the repository, re-run the diff, or judge whether the code is correct. A ready-to-use GitHub Action lives in [`github-action/`](github-action/) and can also emit the receipt as an in-toto attestation. See the [code-authorship receipts docs](https://asqav.com/docs/code-authorship-receipts).
-
-## Why governance
-
-Without governance, there is no record of what agents did, any agent can do anything, one person approves everything by hand, compliance reports are written manually, and the reasoning is lost once the run ends. Asqav changes each of those:
-
-* Every action is signed; the algorithm is per-receipt in `signature.alg` — ML-DSA-65 (FIPS 204) for cloud-issued receipts, Ed25519/ES256 for locally signed ones.
-* Policies block dangerous actions before they run.
-* Critical actions can require multi-party authorization.
-* EU AI Act and DORA reports are generated automatically.
-* The prompt, trace, and output are signed and replayable.
-
-## Per-language docs
-
-The root README only covers the cross-language story. For language-specific guides - decorators, async clients, framework integrations, CLI commands, local mode, batched signing, three-phase signing, scope tokens, replay, attestations, and more - see:
-
-- Python: [`python/README.md`](python/README.md)
-- TypeScript: [`typescript/README.md`](typescript/README.md)
-
-The full reference lives at [asqav.com/docs](https://asqav.com/docs).
-
-### What's in each SDK
-
-Both SDKs cover the same core surface: agent identity, signed actions, batched signing, policy enforcement, scope tokens, replay, attestations, three-phase signing, and the `user_intent` envelope on `agent.sign(...)`, signed with Ed25519, ECDSA P-256, or WebAuthn.
-
-The Python SDK additionally ships:
-
-- The `asqav` CLI: `quickstart`, `demo`, `verify`, `doctor`, `agents`, `sync`, `hook`, plus `replay`, `preflight`, `approve`, `budget` with `check` and `record`, and `compliance` with `frameworks` and `export`. See [asqav.com/docs/cli](https://asqav.com/docs/cli).
-- The `asqav hook` CLI signs Claude Code harness hook events for audit and gating. See [`hooks/README.md`](hooks/README.md).
-- A pytest plugin, enabled with `pytest --asqav`, that signs every test result and emits a Merkle-rooted compliance bundle on session finish. See [asqav.com/docs/pytest-plugin](https://asqav.com/docs/pytest-plugin).
-- Native callbacks for LangChain, CrewAI, LiteLLM, Haystack, OpenAI Agents SDK, LlamaIndex, smolagents, DSPy, PydanticAI, Letta, Strands, and Instructor through the Hooks API.
-- A LiteLLM cloud-signing logger (`asqav.extras.litellm.AsqavSigningLogger`) that signs each LLM call via the asqav cloud for third-party-verifiable receipts — the cloud upgrade to LiteLLM's built-in local audit ledger. See [`docs/integrations-litellm.md`](docs/integrations-litellm.md).
-- Cookbooks for Streamlit dashboards and Dify workflows under `python/examples/`.
-- Local-mode offline signing with deferred sync.
-
-The TypeScript SDK focuses on the core API and `Agent` surface for Node 20+ runtimes. It additionally ships:
-
-- The `user_intent` envelope on `agent.sign(...)`.
-- A Vercel AI SDK adapter at `@asqav/sdk/extras/vercel-ai` that plugs into `experimental_telemetry: { tracer }` and signs every span the AI SDK opens.
-- A LangChain.js callback handler `AsqavCallbackHandler` at `@asqav/sdk/extras/langchain` that signs each chain step.
-- A Mastra hook `AsqavMastraHook` at `@asqav/sdk/extras/mastra` that signs each step the Mastra agent emits.
-- An OpenAI Agents JS adapter `AsqavOpenAIAgentsAdapter` at `@asqav/sdk/extras/openai-agents` that signs tool calls on the agent runner.
-
-If a feature exists in one SDK but not the other, the language README will mark it explicitly.
+- **[python/README.md](python/README.md)** — also rendered on [PyPI](https://pypi.org/project/asqav/)
+- **[typescript/README.md](typescript/README.md)** — also rendered on [npm](https://www.npmjs.com/package/@asqav/sdk)
 
 ## Repository layout
 
 ```
 asqav-sdk/
   python/           Python SDK (pip install asqav)
-    src/
-    tests/
-    pyproject.toml
-    README.md
   typescript/       TypeScript SDK (npm install @asqav/sdk)
-    src/
-    tests/
-    package.json
-    README.md
-  conformance/      Cross-language conformance fixtures both SDKs run against
+  conformance/      Cross-language fixtures both SDKs run against
+  verifier/         Neutral multi-format verifier + its conformance corpus
   .github/workflows/
     ci.yml          Path-filtered CI for both languages
     publish.yml     Tag-based publish (py-v* to PyPI, ts-v* to npm)
-  CHANGELOG.md
-  README.md         (this file)
 ```
 
 The two SDKs are versioned and released independently.
 
-## Verifying a receipt
-
-Receipts are portable. Anyone with a `signature_id` can verify one without an API key. `verify()` returns the public verdict and recomputes the receipt's `chain_hash` on your machine (the SHA-256 over the RFC 8785 canonical payload), so the chain link is reproducible locally.
-
-Python:
-
-```python
-import asqav
-
-# The public fixture below needs no API key. Swap in your own signature_id.
-result = asqav.verify("sig_example_regulator_cold_verify_2026")
-assert result["verified"]
-print(result["agent_id"], result["chain_hash"])
-```
-
-TypeScript:
-
-```ts
-import { verify } from "@asqav/sdk";
-
-const result = await verify("sig_example_regulator_cold_verify_2026");
-console.assert(result.verified);
-console.log(result.agentId, result.chainHash);
-```
-
-From the command line, install the optional CLI extra (`pip install "asqav[cli]"`) and run:
-
-```bash
-asqav verify sig_example_regulator_cold_verify_2026
-```
-
-Or open the receipt's `verification_url` in a browser. For a fully offline, zero-trust check that reproduces the receipt's signature itself (the algorithm is per-receipt from `signature.alg`: ML-DSA-65 for cloud-issued receipts, Ed25519/ES256 for locally signed), use `asqav.verify_receipt_offline(receipt, jwks)` in Python or `verifyReceiptOffline()` in TypeScript, or run the standalone `python -m asqav.verifier.verify_receipt --offline`. Every hash rederives from the RFC 8785 canonical payload, so auditors do not need to trust Asqav's servers.
-
-## Verified by Asqav badge
-
-Drop this badge into a README, doc, or status page to link a signed record to its public verifier. Swap `<record_id>` for a real `signature_id`.
-
-Markdown:
-
-```markdown
-[![Verified by Asqav](https://www.asqav.com/badge.svg)](https://www.asqav.com/verify/<record_id>)
-```
-
-HTML:
-
-```html
-<a href="https://www.asqav.com/verify/<record_id>" rel="noopener" target="_blank">
-  <img src="https://www.asqav.com/badge.svg" alt="Verified by Asqav" height="20" loading="lazy">
-</a>
-```
-
-Anyone who clicks it lands on the public verifier and can check the signature independently.
-
-## Counterparty acknowledgment
-
-When two agents hand off a workflow, where A signs an action and B acts on it, the SDK lets B emit a `protectmcp:acknowledgment` receipt that cryptographically binds B's bytes to A's. The bundle carries A's full envelope, B's acknowledgment, and a SHA-256 binding the verifier recomputes offline. A tampered intermediary cannot mutate the bytes without breaking the equality, so a regulator can verify the handoff with one digest comparison.
-
-Python:
-
-```python
-from asqav import compute_counterparty_binding, verify_counterparty_binding
-
-binding = compute_counterparty_binding(originating_envelope)
-b_payload["counterparty_binding"] = binding.to_wire()
-# ... B signs b_payload normally ...
-
-outcome = verify_counterparty_binding(b_envelope, originating_envelope)
-assert outcome.valid, outcome.label
-```
-
-TypeScript:
-
-```ts
-import { computeCounterpartyBinding, verifyCounterpartyBinding } from "@asqav/sdk";
-
-const binding = computeCounterpartyBinding(originatingEnvelope);
-bPayload.counterparty_binding = binding;
-// ... B signs bPayload normally ...
-
-const outcome = verifyCounterpartyBinding(bEnvelope, originatingEnvelope);
-if (!outcome.valid) throw new Error(outcome.label);
-```
-
-The cloud `/verify` endpoint reports the same outcome on the verification response under `counterparty_binding_verified`, and `/audit-pack/export` pulls the originating receipt into the bundle automatically when an acknowledgment in the export window references one outside it.
-
 ## Conformance
 
-The `conformance/` directory contains shared test fixtures both SDKs run against. Adding a feature means adding a fixture there first, then making both SDKs pass it. CI reruns both matrices whenever `conformance/` changes, even if neither `python/` nor `typescript/` was touched, so cross-language drift is caught at PR time.
+`conformance/` holds shared fixtures both SDKs run against. Adding a feature means adding a
+fixture first, then making both SDKs pass it. CI reruns both matrices whenever `conformance/`
+changes even if neither language directory was touched, so cross-language drift is caught at
+PR time. The TypeScript verifier is held to verdict parity with the Python oracle by that
+same corpus.
 
 ## CI
 
-CI runs on every push to `main` and every pull request. It tests only the language whose source changed: pytest on Python 3.10, 3.11, and 3.12, and npm test on Node 20 and 22. A change to `conformance/` runs both. The aggregator job `ci-ok` is the single required status check for branch protection.
+Every push to `main` and every pull request. Only the language whose source changed is
+tested: pytest on Python 3.10/3.11/3.12, npm test on Node 20/22; a `conformance/` change runs
+both. The aggregator job `ci-ok` is the single required status check.
 
-### Run governance checks in your own CI
-
-`asqav doctor` validates configuration and connectivity in any environment with `ASQAV_API_KEY` set, returning non-zero on failure so it gates PRs cleanly. Pair it with `asqav.compliance.export_bundle` to package signed receipts from your test runs into a self-contained, Merkle-rooted artifact for auditors. See [`docs/github-actions.md`](docs/github-actions.md) for a copy-paste workflow.
+`asqav doctor` validates configuration and connectivity in any environment with
+`ASQAV_API_KEY` set and returns non-zero on failure, so it gates your own PRs cleanly. See
+[docs/github-actions.md](docs/github-actions.md) for a copy-paste workflow.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide. The short version:
+See [CONTRIBUTING.md](CONTRIBUTING.md). The short version:
 
-1. Fork the repo and create a feature branch.
-2. Run the relevant test suite locally.
+1. Fork and branch.
+2. Run the relevant suite:
    - Python: `cd python && pip install -e ".[all,dev]" && pytest tests -v`
    - TypeScript: `cd typescript && npm ci && npm test`
-3. Open a pull request against `main`. CI must go green for the PR to land.
+3. Open a PR against `main`. CI must be green to land. Direct pushes to `main` are blocked.
 
-Direct pushes to `main` are blocked. Every change lands through a PR.
-
-### Releases
-
-Both SDKs ship to different registries on independent cadences, driven by prefixed git tags: `py-v*` publishes the Python half to PyPI, `ts-v*` publishes the TypeScript half to npm. Bump the version in the relevant manifest, update [`CHANGELOG.md`](CHANGELOG.md), then tag and push. The `publish.yml` workflow inspects the tag prefix and runs only the matching publish job. Python uses PyPI's OIDC trusted publisher. TypeScript publishes via the `NPM_TOKEN` repo secret.
-
-## Ecosystem
-
-* [`asqav` (PyPI)](https://pypi.org/project/asqav/): the Python SDK.
-* [`@asqav/sdk` (npm)](https://www.npmjs.com/package/@asqav/sdk): the TypeScript SDK.
-* [asqav-compliance](https://github.com/jagmarques/asqav-compliance): CI/CD compliance scanner.
+**Releases** are driven by prefixed tags: `py-v*` publishes to PyPI via OIDC, `ts-v*`
+publishes to npm via the `NPM_TOKEN` secret. Bump the manifest, update
+[CHANGELOG.md](CHANGELOG.md), then tag and push.
 
 ## Plans
 
@@ -386,36 +133,25 @@ Quotas, prices and the per-plan feature list live on one page so they cannot dri
 step with each other: see [asqav.com/pricing](https://asqav.com/pricing.html). Where a
 specific capability is plan-gated, the section describing that capability says so.
 
-## Discovery
+## Standards
 
-Machine-readable service descriptor at [`https://asqav.com/.well-known/governance.json`](https://asqav.com/.well-known/governance.json) for external tools that want to auto-discover Asqav's endpoints, algorithms, capabilities, and integrations.
+Profiled in the IETF Internet-Draft
+[`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/),
+an Independent Submission profiling
+[`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/).
+Aligns with NIST FIPS 204 (ML-DSA), RFC 8785 (JCS) and NSA CSI U/OO/6030316-26.
+
+## Ecosystem
+
+- [`asqav` on PyPI](https://pypi.org/project/asqav/) — the Python SDK
+- [`@asqav/sdk` on npm](https://www.npmjs.com/package/@asqav/sdk) — the TypeScript SDK
+- [asqav-compliance](https://github.com/jagmarques/asqav-compliance) — CI/CD compliance scanner
 
 ## Links
 
-- Docs: <https://asqav.com/docs>
-- Repo: <https://github.com/jagmarques/asqav-sdk>
-- Blog: <https://dev.to/jagmarques>
-- Dashboard: <https://asqav.com/dashboard>
+[Docs](https://asqav.com/docs) · [SDK guide](https://asqav.com/docs/sdk) ·
+[Discovery descriptor](https://asqav.com/.well-known/governance.json)
 
 ## License
 
-Starting with the releases that come after 0.8.0, the asqav SDK is licensed under
-the [Elastic License 2.0](LICENSE) (ELv2). ELv2 allows free use, modification, and
-distribution but restricts offering the SDK as a hosted or managed service.
-
-Version 0.8.0 and all versions published before it remain under the MIT license
-irrevocably.
-
-Two parts of this repo carry an Apache-2.0 exception to that default:
-
-- The conformance test vectors in `conformance/`. See
-  [conformance/LICENSE](conformance/LICENSE).
-- The standalone offline verifier,
-  [`python/src/asqav/verifier/verify_receipt.py`](python/src/asqav/verifier/verify_receipt.py),
-  which carries an `SPDX-License-Identifier: Apache-2.0` header. It ships inside the
-  exit artifact, so a customer keeps a permanently free, dependency-light tool for
-  checking their receipts offline after Asqav is gone.
-
----
-
-If Asqav helps you, consider giving the repo a star. It helps others find the project.
+Elastic License 2.0. Get an API key at [asqav.com](https://asqav.com).

--- a/python/README.md
+++ b/python/README.md
@@ -58,18 +58,21 @@ to no key, so the verifier returns `verified: false` instead of waving it throug
 `signature_id` of your own for a receipt that passes. A verifier that says no when the
 evidence is absent is the only kind worth having.
 
-From the shell:
+From the shell (the `cli` extra provides the `asqav` command):
 
 ```bash
-pip install "asqav[verify]"
+pip install "asqav[cli]"
 asqav verify <your_signature_id>
 ```
 
-The verifier re-derives the signature, the chain link, the payload digest and the anchors
-from the RFC 8785 canonical bytes, and reports a verdict per axis. It never asks Asqav to
-vouch for anything.
+Offline or air-gapped, snapshot the keys once and verify with no network at all. This
+re-derives the signature itself, so it needs the `verify` extra
+(`dilithium-py` for ML-DSA-65, `cryptography` for the Ed25519 and ES256 axes — without it
+those signatures report INCOMPLETE rather than verifying):
 
-Offline or air-gapped, snapshot the keys once and verify with no network at all:
+```bash
+pip install "asqav[verify]"
+```
 
 ```python
 import asqav, json

--- a/python/README.md
+++ b/python/README.md
@@ -2,7 +2,13 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/jagmarques/asqav-sdk?style=social)](https://github.com/jagmarques/asqav-sdk)
 
-Python SDK for [asqav.com](https://asqav.com), the evidence layer for AI agents. Sign every agent action with ML-DSA-65 (FIPS 204), enforce policies before execution, and produce regulator-ready audit trails. All cryptography runs server-side, and the package has zero native dependencies.
+Python SDK for [asqav.com](https://asqav.com), the evidence layer for AI agents.
+
+Every agent action gets a signed, hash-chained **compliance receipt**: ML-DSA-65 (FIPS 204,
+post-quantum), timestamped against independent witnesses, and verifiable by anyone —
+auditor, counterparty, regulator — **without an Asqav account and without trusting us**.
+
+Zero native dependencies. Cryptography runs server-side.
 
 ## Install
 
@@ -12,533 +18,182 @@ pip install asqav
 
 ## Quick start
 
-Get an API key at [asqav.com](https://asqav.com). The fastest path is the CLI:
-
 ```bash
 pip install "asqav[cli]"
 asqav login        # validates your key, saves it to ~/.asqav/credentials
-asqav init         # prints a ready-to-paste snippet for your project
 ```
-
-`asqav login` saves your key so the SDK and CLI resolve it automatically (no `ASQAV_API_KEY` needed). Then sign your first agent action:
 
 ```python
 import asqav
 
-# govern() is a one-call setup: init() + Agent.create() in one line
+# govern() = init() + Agent.create() in one call
 agent = asqav.govern(api_key="sk_...", agent_name="my-agent")
 
 sig = agent.sign("api:openai:chat", {"model": "gpt-4o"})
 
 print(sig.action_ref)             # "sha256:..." over the JCS-canonical action
-print(sig.previous_receipt_hash)  # 64 hex; "0"*64 on the first record per agent
-print(sig.verification_url)
+print(sig.previous_receipt_hash)  # 64 hex; "0"*64 on this agent's first receipt
+print(sig.verification_url)       # anyone can open this
 ```
 
-That's it. One install, one govern call, one sign call. The receipt lands on the Asqav cloud under [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 (FIPS 204) signature, chain hash, retained `policy_digest`, fail-closed anchoring, and a public verification URL.
+One install, one `govern`, one `sign`. `asqav.init()` + `asqav.Agent.create()` remain
+available when you want control over `algorithm`, `capabilities` and other agent options.
 
-Prefer the lower-level building blocks? `asqav.init(api_key=...)` followed by `asqav.Agent.create("my-agent")` still works and gives more control over `algorithm`, `capabilities`, and other agent options.
+## Verify it without an account
 
-### No account? Offline path
+This is the point of the whole thing — the receipt stands on its own:
 
-If you need to record actions without a network call or an API key, use `local_sign`. Actions queue to disk and can be synced later:
+Run this right now, with no key and no signup:
+
+```python
+import asqav
+
+result = asqav.verify("sig_example_regulator_cold_verify_2026")
+print(result["verified"])     # False -- and that is the point, see below
+print(result["chain_hash"])   # recomputed on your machine from the canonical bytes
+```
+
+That id is a **shape example**: its signature bytes are placeholders and its `kid` resolves
+to no key, so the verifier returns `verified: false` instead of waving it through. Swap in a
+`signature_id` of your own for a receipt that passes. A verifier that says no when the
+evidence is absent is the only kind worth having.
+
+From the shell:
+
+```bash
+pip install "asqav[verify]"
+asqav verify <your_signature_id>
+```
+
+The verifier re-derives the signature, the chain link, the payload digest and the anchors
+from the RFC 8785 canonical bytes, and reports a verdict per axis. It never asks Asqav to
+vouch for anything.
+
+Offline or air-gapped, snapshot the keys once and verify with no network at all:
+
+```python
+import asqav, json
+
+jwks = asqav.fetch_jwks()                     # online, once
+json.dump(jwks, open("jwks.json", "w"))
+
+receipt = json.load(open("receipt.json"))     # offline from here
+result  = asqav.verify_receipt_offline(receipt, json.load(open("jwks.json")))
+assert result["verdict"] == "PASS", result["axes"]
+```
+
+Pass `predecessor=prev_receipt` to check the hash-chain link too.
+Guide: [offline and air-gapped verification](https://asqav.com/docs/offline-air-gapped-verification).
+
+## No account? Queue locally
 
 ```python
 from asqav.local import local_sign, LocalQueue
 
-item_id = local_sign("my-agent", "api:openai:chat", {"model": "gpt-4o"})
-# Writes a pending JSON item to ~/.asqav/queue/
+local_sign("my-agent", "api:openai:chat", {"model": "gpt-4o"})  # -> ~/.asqav/queue/
 
-# When back online, init with your key then sync:
 import asqav
-asqav.init(api_key="sk_...")   # or set ASQAV_API_KEY in the environment
-result = LocalQueue().sync()   # uploads queued items, returns {"synced": N, "failed": M}
+asqav.init(api_key="sk_...")
+LocalQueue().sync()            # {"synced": N, "failed": M}
 ```
-
-Pass `compliance_mode=False` on any `agent.sign(...)` call if you want a non-Compliance receipt.
-
-## CLI
-
-The package ships an `asqav` CLI mirroring the Python API. Start with `asqav login` (or set `ASQAV_API_KEY`) and run:
-
-```bash
-asqav login                                  # save your key to ~/.asqav/credentials
-asqav whoami                                 # show the active key source + validate it
-asqav init                                   # print a ready-to-paste snippet
-asqav verify <signature_id> [--output json]   # IETF axes when present
-asqav sign --agent-id ID --action-type T --action-json action.json \
-           --compliance-mode --receipt-type protectmcp:decision \
-           --risk-class high --issuer-id legal:Acme
-asqav agents list / create / revoke
-asqav sessions list / end <session_id>
-asqav replay <agent_id> <session_id>
-asqav replay-verify <agent_id> <session_id> [--strict]     # IETF chain
-asqav preflight <agent_id> <action_type>
-asqav budget check / record
-asqav approve <session_id> <entity_id>
-asqav compliance frameworks / export
-asqav audit-pack export --start ISO --end ISO --output-file bundle.json
-asqav audit-pack policy <sha256:hex>
-asqav payloads erase <signature_id>                        # P4 right-to-erasure
-asqav org set-compliance-strict <org_id> --enable|--disable
-asqav keys generate --algorithm ed25519|es256 [--out priv.pem]
-asqav migrate run v3-20|v3-21|v3-22                        # X-Maintenance-Key required
-asqav policies / webhooks list / create / delete
-```
-
-Every command listed here works on the free tier. The Asqav cloud is the source of truth for what your key may do.
 
 ## Data handling modes
 
-The SDK auto-detects whether you're pointing at the Asqav cloud or a self-hosted deployment and selects the safer default for each:
+The SDK picks the safer default for where you point it:
 
-- **Cloud (`*.asqav.com`)**: hash-only by default. The SDK builds a fingerprint of your action context, computes a SHA-256 hash locally, and sends only the hash plus a small metadata bag of `action_type`, `agent_id`, `session_id`, `model_name`, and `tool_name`. Raw prompts and tool arguments stay on your side.
-- **Self-hosted**: full-payload by default. The server can run policy checks, PII redaction, and richer audit. Recommended when you control the deployment.
-
-Override anytime:
+- **Cloud (`*.asqav.com`)** — hash-only. A SHA-256 fingerprint is computed locally and only
+  the hash plus `action_type`, `agent_id`, `session_id`, `model_name`, `tool_name` is sent.
+  Prompts and tool arguments never leave your side.
+- **Self-hosted** — full payload, so the server can run policy checks and richer audit.
 
 ```python
 asqav.init(api_key="...", base_url="https://api.asqav.com", mode="hash-only")
 ```
 
-The fingerprint format is sorted JSON with no whitespace per JCS, hashed with SHA-256. See `docs/fingerprint-spec.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
+## High-value actions
 
-## Advanced / high-value actions
-
-Once you have the basics working, you can pass compliance envelope fields for regulated or high-risk actions. The full parameter set is useful for things like large financial transfers, healthcare decisions, or anything that needs an auditor-facing trail.
+For regulated or high-risk actions, pass envelope fields that an auditor will look for:
 
 ```python
 sig = agent.sign(
     "payment.wire_transfer",
     {"amount_eur": 850000, "beneficiary_iban": "DE89370400440532013000"},
     receipt_type="protectmcp:decision",
-    risk_class="high",
-    issuer_id="legal:Acme GmbH",
-    iteration_id="task-2026-Q2-4821",
+    risk_class="high",                 # low | medium | high | unknown
+    issuer_id="legal:Acme GmbH",       # LEI, EIN, CIK or W3C DID
+    iteration_id="task-2026-Q2-4821",  # logical task, distinct from session
 )
 ```
 
-The envelope extensions most callers reach for:
-
-- `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:lifecycle:configuration_change`, `protectmcp:acknowledgment`, `protectmcp:observation`, or `protectmcp:observation:result_bound`, which is an observation receipt that binds tool output via `result_digest`.
-- `risk_class` - controlled vocabulary: `low | medium | high | unknown`.
-- `iteration_id` - logical task id, distinct from session.
-- `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
-- `incident_class` - DORA / NYDFS / CIRCIA token, or an array of tokens.
-- `issuer_id` - LEI per ISO 17442, EIN, CIK, or a W3C DID for non-LEI deployers.
-
-## Compliance receipts: the IETF profile
-
-Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): cloud-issued receipts carry an ML-DSA-65 signature (locally signed receipts carry Ed25519/ES256 — the algorithm is per-receipt in `signature.alg`), JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `compliance_mode=False` if you want the older shape.
-
-### Observation receipts and passive_telemetry
-
-Two `receipt_type` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action. `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block, such as a SIEM forwarder, a browser extension in observe-only mode, or a NetFlow-style proxy with no enforcement hook.
-
-Set `capture_topology='passive_telemetry'` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `capture_topology='passive_telemetry'` receipt MUST use `receipt_type='protectmcp:observation'`. Any other receipt_type paired with `passive_telemetry`, namely `:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, or `:acknowledgment`, raises `ValueError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation[:result_bound], not :<offending> (rule 8)` message before the HTTP roundtrip. The guard lives as `false_attestation_guard` in `python/src/asqav/client.py`.
-
-```python
-sig = agent.sign(
-    "mcp:tool_call",
-    {"server": "filesystem", "tool": "read"},
-    receipt_type="protectmcp:observation",
-    capture_topology="passive_telemetry",
-    issuer_id="legal:Acme GmbH",
-)
-```
-
-`capture_topology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `mcp_proxy`, and `github_sha_pull`. A client-supplied `capture_topology` is advisory: the server stamps the authoritative value from the ingress route, and for code-authorship that authoritative value is `github_sha_pull`, set only after the server re-fetches the commit and recomputes the diff. Only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
-
-### Configuration change receipts, rule 9
-
-A `receipt_type='protectmcp:lifecycle:configuration_change'` receipt declares the agent's runtime configuration was mutated. The SDK pre-flights the Asqav cloud's rule 9 cross-field gate for NSA CSI U/OO/6030316-26 alignment: the receipt MUST carry `config_manifest_digest`. Omitting it raises `ValueError` with the verbatim `configuration_change_missing_config_manifest_digest: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (sha256:<64 hex>).` message before the HTTP roundtrip.
-
-```python
-sig = agent.sign(
-    "mcp:config_update",
-    {"server": "filesystem", "delta": "tool_added"},
-    receipt_type="protectmcp:lifecycle:configuration_change",
-    policy_decision="none",
-    config_manifest_digest="sha256:<hex of manifest>",
-    cve_inventory_digest="sha256:<hex of cve snapshot>",
-)
-```
-
-### Expiry precedence, rule 10
-
-The legacy `valid_seconds`, where the server computes `valid_until = signed_at + valid_seconds`, and the caller-supplied horizon `expires_at` are mutually exclusive. Pass exactly one of the two: `valid_seconds=3600` for "expire one hour after signing", or `expires_at="2026-06-01T00:00:00Z"` for an explicit horizon. Passing both raises `ValueError` with the verbatim `expiry_collision_guard: pass either valid_seconds or expires_at, not both (rule 10)` message before the HTTP roundtrip. Passing neither falls back to the server-side default of `valid_seconds=86400`.
-
-### Digest format, rule 11
-
-Every caller-supplied self-describing digest field, namely `config_manifest_digest`, `cve_inventory_digest`, `executable_hash`, and `sbom_digest`, MUST match the regex `^sha256:[a-f0-9]{64}$`. `tool_fingerprint` is the exception: it uses the cloud wire form of 32 bare lowercase hex chars, SHA-256[:32], matching `^[0-9a-f]{32}$` with no `sha256:` prefix. Anything else raises `ValueError` with the verbatim `tool_fingerprint_not_32_hex_chars: must be 32 lowercase hex chars (SHA-256[:32]).` guard. The two URL pointer fields `slsa_provenance_pointer` and `supply_chain_pointer` MUST start with `http://` or `https://`. Anything else raises `ValueError` with a verbatim guard message before the HTTP roundtrip. To avoid wire drift, use the SDK's deterministic helpers, each byte-deterministic under JCS:
-
-```python
-from asqav.client import (
-    _compute_tool_fingerprint,
-    _compute_config_manifest_digest,
-    _compute_cve_inventory_digest,
-)
-
-fp = _compute_tool_fingerprint("search", {"args": {"q": "string"}})
-cfg = _compute_config_manifest_digest({"server": "filesystem", "tools": ["read"]})
-cve = _compute_cve_inventory_digest([{"id": "CVE-2026-0001", "severity": "high"}])
-```
-
-## NSA-aligned receipt fields
-
-Six wire fields on `agent.sign(...)` carry the NSA CSI U/OO/6030316-26 alignment for MCP server lifecycle and tool output binding:
-
-- `result_digest` - `sha256:<hex>` of the tool output, binds the receipt to a specific result. See <https://www.asqav.com/docs/result-digest>.
-- `expires_at` - explicit ISO-8601 or POSIX validity horizon. Converted client-side to `valid_seconds` and sent as a duration, since the cloud owns absolute time-binding. Mutually exclusive with `valid_seconds`. See <https://www.asqav.com/docs/time-bound-receipts>.
-- `nonce` - 12 random bytes auto-generated when omitted, carried as an opaque per-call token. The cloud rejects a re-used value: a nonce already held by a live signature for the same agent in the same organisation is refused with HTTP 409, so the field does bound replay for as long as the earlier receipt is inside its validity window. A record whose `valid_until` has passed frees its token, and one signed with no expiry keeps it. Pair it with `valid_seconds` or `expires_at` to bound the window itself, which the verifier enforces by returning `signature_expired`.
-- `tool_fingerprint` - 32 bare lowercase hex chars, SHA-256[:32], over `{tool_name, schema}`, auto-derived when `tool_name` + `tool_schema` are present. See <https://www.asqav.com/docs/tool-fingerprint>.
-- `config_manifest_digest` - `sha256:<hex>` of the agent's runtime configuration snapshot. Required on configuration_change receipts. See <https://www.asqav.com/docs/configuration-change-receipts>.
-- `cve_inventory_digest` - `sha256:<hex>` over the CVE snapshot at sign time. See <https://www.asqav.com/docs/cve-inventory>.
-
-The `protectmcp:observation:result_bound` `receipt_type` variant carries `result_digest` and lets observation receipts bind to a specific tool result without claiming the policy gated the call.
-
-### Build-provenance 4-tuple
-
-Four optional wire fields bind build-side provenance into the signed receipt:
-
-- `executable_hash` - `sha256:<hex>` of the executable that invoked the action.
-- `sbom_digest` - `sha256:<hex>` of the canonical CycloneDX or SPDX SBOM document.
-- `slsa_provenance_pointer` - https URL to the SLSA attestation envelope.
-- `supply_chain_pointer` - https URL to the in-toto, Sigstore, or Rekor entry.
-
-```python
-sig = agent.sign(
-    "build:provenance",
-    {"image": "asqav/cloud:0.5.1"},
-    compliance_mode=True,
-    executable_hash="sha256:<hex of executable>",
-    sbom_digest="sha256:<hex of SBOM>",
-    slsa_provenance_pointer="https://attestations.example.com/slsa/build-1.intoto.jsonl",
-    supply_chain_pointer="https://rekor.sigstore.dev/api/v1/log/entries/abc",
-)
-```
-
-See <https://www.asqav.com/docs/executable-hash-and-sbom-provenance>.
-
-## Optional threat-framework mappings
-
-Seven optional wire fields let a caller pin the receipt to industry threat-and-control taxonomies. Each list is caller-supplied and Asqav-preserved verbatim. The cloud sets `framework_mappings_self_declared=true` on the receipt whenever any of the six list fields is populated, so verifiers can tell self-declared classifications apart from cloud-verified ones.
-
-- `mitre_techniques` - list of MITRE ATT&CK technique ids, for example `["T1059", "T1078"]`.
-- `mitre_atlas` - list of MITRE ATLAS ids for AI-system threats, for example `["AML.T0051"]`.
-- `owasp_llm_top10` - list of OWASP Top 10 for LLM ids, for example `["LLM01", "LLM02"]`.
-- `nist_ai_rmf` - list of NIST AI RMF function ids, for example `["GOVERN-1.1", "MEASURE-2.7"]`.
-- `iso_42001` - list of ISO/IEC 42001 control ids, for example `["A.6.2.6"]`.
-- `eu_ai_act_articles` - list of EU AI Act article ids, for example `["Article-12", "Article-15"]`.
-- `rfc3161_timestamp` - caller-supplied base64-encoded RFC 3161 TimeStampResp in DER.
-
-```python
-sig = agent.sign(
-    "api:call",
-    {"user": "..."},
-    compliance_mode=True,
-    mitre_techniques=["T1059", "T1078"],
-    owasp_llm_top10=["LLM01"],
-    nist_ai_rmf=["GOVERN-1.1", "MEASURE-2.7"],
-    eu_ai_act_articles=["Article-12"],
-)
-```
-
-Each list must be a non-empty list of strings, each entry up to 128 characters. Empty lists, non-string entries, or oversize entries raise `ValueError` with the verbatim guard messages `<field>_must_be_non_empty_list` or `<field>_entry_invalid` and skip the HTTP roundtrip. The `rfc3161_timestamp` must be valid base64 or raises `rfc3161_timestamp_not_base64`.
-
-See <https://www.asqav.com/docs/threat-framework-mapping>.
-
-## Optional witness policy
-
-`witness_policy` lets a caller declare an N-of-M durable-anchoring quorum on the receipt. The receipt reaches `witness_quorum_met` only when `required` witnesses hold a real inclusion proof.
-
-- Shape: `{"required": int, "witnesses": [<subset of "rfc3161", "opentimestamps">]}`.
-- `required` must be in `[1, len(witnesses)]`.
-- `witnesses` must be a non-empty subset of the two shipped witnesses: `rfc3161` and `opentimestamps`.
-- `rekor` is rejected. It is not a shipped witness.
-- `rfc3161` confirmation is available on the Pro and Enterprise tiers. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.
-
-```python
-sig = agent.sign(
-    "deploy:release",
-    {"build": "..."},
-    compliance_mode=True,
-    witness_policy={"required": 1, "witnesses": ["rfc3161", "opentimestamps"]},
-)
-```
-
-Bad input raises `ValueError` with a verbatim guard message before the HTTP roundtrip: `witness_policy_unknown_witness` for an entry like `rekor`, `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, or `witness_policy_duplicate_witness`. Omit the field for today's behaviour.
-
-### Audit Pack export
-
-The cloud signs a Compliance Audit Pack over a window of receipts. The SDK wraps the endpoint:
-
-```python
-pack = asqav.fetch_audit_pack(start="2026-05-01T00:00Z", end="2026-06-01T00:00Z")
-print(pack["bundle_digest"])              # sha256:<hex>
-print(pack["bundle_signature"])           # base64 ML-DSA-65 sig over the bundle
-print(pack["regime_mapping"])             # {regime_token: [record_id, ...]}
-print(pack["algorithm_registry_version"]) # registry version pinned at issuance
-```
-
-`asqav.export_bundle(signatures, framework="dora")` is the offline alternative for air-gapped flows: it computes a Merkle root over an in-memory list of receipts without calling the cloud. Use `fetch_audit_pack` whenever the cloud is reachable, since only the cloud signature gives the auditor a tamper-evident manifest.
-
-Local-side sanity checks, covering presence of REQUIRED fields, namespace, the 300s skew bound, and predecessor rederivation, are available as `asqav.verify_compliance_receipt(envelope, predecessor_envelope=...)`. The cloud is the authoritative verifier. This helper is a convenience.
-
-`asqav.SUPPORTED_ALGORITHMS` is the set `asqav.generate_local_keypair(...)` can mint locally: `{ed25519, es256}`. It does not list the cloud agent-signing algorithms. `Agent.create(...)` sends its `algorithm` to the Asqav cloud, which accepts `ml-dsa-44`, `ml-dsa-65` (default), and `ml-dsa-87`. `ed25519` and `es256` are for local keypair generation only, so passing either to `Agent.create(...)` returns a 400 from the cloud.
-
-## Offline / air-gapped verification
-
-Receipts can be verified without calling the Asqav API once you have a JWKS snapshot.
-Full guide: [`docs/offline-verification.md`](../docs/offline-verification.md).
-
-Install the `verify` extra, which adds `dilithium-py` (ML-DSA-65) and `cryptography`
-(Ed25519, ES256):
+## CLI
 
 ```bash
-pip install "asqav[verify]"
+asqav whoami                       # active key source, validated
+asqav init                         # print a ready-to-paste snippet
+asqav verify <signature_id>        # verify a receipt (no key needed)
+asqav sign --agent-id ID --action-type T --action-json action.json
+asqav agents list | create | revoke
+asqav replay-verify <agent_id> <session_id> [--strict]
+asqav audit-pack export --start ISO --end ISO --output-file bundle.json
+asqav payloads erase <signature_id>          # right-to-erasure
 ```
 
-Snapshot the JWKS while you have network access, then verify offline:
+Full command reference: [asqav.com/docs/cli](https://asqav.com/docs/cli).
 
-```python
-import asqav, json
+## Framework integrations
 
-# online: snapshot the keys
-jwks = asqav.fetch_jwks()
-json.dump(jwks, open("jwks.json", "w"))
+Native callbacks under `asqav.extras.*` for **LangChain**, **CrewAI**, **LiteLLM**,
+**OpenAI Agents** and others, plus a pytest plugin. Adapters install behind documented
+extras (`asqav[langchain]`, `asqav[litellm]`, `asqav[openai-agents]`).
+See [integrations](https://asqav.com/docs/integrations) and
+[pytest plugin](https://asqav.com/docs/pytest-plugin).
 
-# offline: verify any receipt
-receipt = json.load(open("receipt.json"))
-jwks    = json.load(open("jwks.json"))
-result  = asqav.verify_receipt_offline(receipt, jwks)
-assert result["verdict"] == "PASS", result["axes"]
-```
+## What a receipt does not prove
 
-Supply a predecessor receipt to check the hash-chain link:
+Stated plainly, because an auditor will ask:
 
-```python
-result = asqav.verify_receipt_offline(receipt, jwks, predecessor=prev_receipt)
-```
+- **Not that the action ran, or ran once.** A receipt records a decision and the bytes that
+  passed through, never the effect. A retry produces a second receipt.
+- **Not that the policy was correct.** `policy_digest` proves which policy artefact existed,
+  not that it was the right one.
+- **Not that the environment was intact.** No field here carries a remote attestation result.
+- **Tamper-evident, not tamper-proof.** Modification is detectable, not prevented.
 
-## Integrations
+The full list is in the IETF profile under "What a Compliance Receipt Does Not Prove".
 
-The SDK ships native callbacks and adapters for common agent frameworks under `asqav.extras.*`:
+## Reference
 
-- **LangChain** - `from asqav.extras.langchain import AsqavCallbackHandler`, pass to a chain's `callbacks=[handler]`. Signs each chain, tool, and LLM lifecycle event.
-- **CrewAI** - `from asqav.extras.crewai import AsqavCrewHook, AsqavGuardrailProvider`, attach the hook to the Crew so every task and agent step signs through Asqav.
-- **LiteLLM** - `from asqav.extras.litellm import AsqavGuardrail`, register on `litellm.callbacks`. Signs every completion across providers.
-- **OpenAI Agents SDK** - `from asqav.extras.openai_agents import AsqavGuardrail, AsqavTracingProcessor`, attaches to the runner and signs tool calls plus tracer spans.
-- **LlamaIndex**, **Haystack**, **smolagents**, **DSPy**, **Letta**, **Strands**, **Instructor** - same pattern via `asqav.extras.<framework>`, each exposing one `AsqavAdapter` subclass.
-- **pytest** - run `pytest --asqav --asqav-agent=test-runner` with `ASQAV_API_KEY` set. Each test result signs and a Merkle-rooted compliance bundle emits on session finish.
-
-Cookbooks for FastAPI middleware, AutoGen, and reasoning-trace capture live under `python/examples/`. See <https://asqav.com/docs/integrations> for the per-framework guide.
-
-## Errors
-
-All raised exceptions extend `AsqavError`. `AuthenticationError` for 401, `RateLimitError` for 429, and `APIError` carrying `status_code` are exported for fine-grained handling:
-
-```python
-from asqav import AsqavError, AuthenticationError, RateLimitError, APIError
-
-try:
-    agent.sign("api:call", {"model": "gpt-4"})
-except AuthenticationError:
-    # rotate ASQAV_API_KEY
-    raise
-except RateLimitError as exc:
-    # exc.retry_after holds the cooldown in seconds
-    raise
-except APIError as exc:
-    # exc.status_code holds the HTTP status
-    raise
-```
-
-`ValueError` is raised before the HTTP roundtrip for the verbatim rule 8 / 9 / 10 / 11 guards listed above. Catch `ValueError` separately so guard violations surface as developer errors, not API errors.
-
-## Structured receipts (optional schema)
-
-Pass a `context_schema` to `Agent.sign()` to validate and normalise the
-`context` dict before it is signed. This keeps every receipt in your audit
-trail in a consistent, queryable shape.
-
-```python
-import asqav
-from asqav import AsqavValidationError
-
-PAYMENT_SCHEMA = {
-    "user_id":  {"type": "string", "required": True},
-    "amount":   {"type": "number", "required": True},
-    "currency": {"type": "string", "required": True},
-}
-
-asqav.init(api_key="sk_...")
-agent = asqav.Agent.create("my-agent")
-
-# Valid context: keys are sorted before signing (consistent hash order).
-sig = agent.sign(
-    "payment:initiate",
-    {"user_id": "u1", "currency": "EUR", "amount": 49.95},
-    context_schema=PAYMENT_SCHEMA,
-)
-
-# Missing required field: raises AsqavValidationError BEFORE the network call.
-try:
-    agent.sign(
-        "payment:initiate",
-        {"amount": 100},          # user_id missing, currency missing
-        context_schema=PAYMENT_SCHEMA,
-    )
-except AsqavValidationError as exc:
-    print(exc)            # context_schema_error: field 'user_id' is required but missing
-    print(exc.docs_url)   # https://asqav.com/docs/structured-receipts
-```
-
-Field descriptor keys:
-- `type` (required) - one of `"string"`, `"number"`, `"boolean"`, `"object"`, `"array"`.
-- `required` (optional, default `False`) - whether the field must be present.
-
-`"number"` rejects `bool` values; `"array"` rejects plain dicts.
-No schema means today's exact behaviour (zero behaviour change).
-
-You can also pass a callable for full JSON Schema validation (no new
-mandatory dependencies needed in the core package):
-
-```python
-def my_validator(ctx: dict) -> None:
-    import jsonschema
-    jsonschema.validate(ctx, MY_FULL_SCHEMA)
-
-agent.sign("action", context, context_schema=my_validator)
-```
-
-See `examples/schema_receipts_example.py` for a runnable demo.
-
-## Bind your agent's declared configuration into the receipt
-
-A signed action is more useful when the receipt also proves *which declared
-configuration* the agent was running when it acted. You can bind that today
-with the sign context, no extra API surface:
-
-1. Hash whatever declares the agent: an agent manifest, an `AGENTS.md`, a
-   container image digest, or an SBOM. Any bytes on disk work.
-2. Put the digest in the `context` under your own keys (for example
-   `config_digest` plus `config_kind`).
-3. Optionally pin those keys with a `context_schema` so a receipt that claims a
-   config always carries both fields.
-
-```python
-import hashlib
-from pathlib import Path
-
-import asqav
-
-def config_digest(path: Path) -> str:
-    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
-
-CONFIG_BINDING_SCHEMA = {
-    "config_digest": {"type": "string", "required": True},
-    "config_kind":   {"type": "string", "required": True},
-}
-
-asqav.init(api_key="sk_...")
-agent = asqav.Agent.create("my-agent")
-
-digest = config_digest(Path("AGENTS.md"))
-
-sig = agent.sign(
-    "payment:refund",
-    {
-        "amount": 49.95,
-        "currency": "EUR",
-        "config_digest": digest,        # sha256:<hex> of your declaration
-        "config_kind": "agents-md",     # name the artifact you hashed
-    },
-    context_schema=CONFIG_BINDING_SCHEMA,
-)
-print(sig.verification_url)             # digest is inside the signed receipt
-```
-
-The digest is part of the signed body, so anyone can fetch the receipt at the
-public verify endpoint and confirm the action ran under that exact declaration.
-The key names and the artifact kind are yours to choose, which keeps the pattern
-generic across any declaration format.
-
-For a couple of common cases there are dedicated wire fields instead of context
-keys (`config_manifest_digest` for a runtime config snapshot, `sbom_digest` for
-an SBOM). The context recipe above is the general form for any other declaration
-you want to bind.
-
-See `examples/bind_config_digest.py` for a runnable demo.
-
-## Pluggable detectors (bring-your-own DLP/policy)
-
-asqav owns the enforce + signed-proof spine; detection is pluggable. Register a
-detector and it runs inside every `Agent.sign()`, after the context is normalised
-and before the network call. Its verdict is recorded in the signed receipt (under
-`_detectors`), so the audit trail proves which detector saw the action and why. A
-deny raises `DetectorBlockedError` and no signature is created.
-
-```python
-import asqav
-from asqav import DetectorBlockedError, DetectorResult, register_detector
-
-class SsnDetector:
-    name = "ssn-regex"
-    def inspect(self, action_type: str, context: dict) -> DetectorResult:
-        if "123-45-6789" in str(context):
-            return DetectorResult(allow=False, labels=["US_SSN"], reason="SSN in context")
-        return DetectorResult(allow=True)
-
-asqav.init(api_key="sk_...")
-agent = asqav.Agent.create("my-agent")
-register_detector(SsnDetector())            # fail_open defaults to False
-
-try:
-    agent.sign("email:send", {"body": "ssn 123-45-6789"})
-except DetectorBlockedError as exc:
-    print(exc.detector_name, exc.result.labels)   # ssn-regex ['US_SSN']
-```
-
-- **Fail-closed by default**: if `inspect()` raises, sign blocks. Opt out per
-  detector with `register_detector(d, fail_open=True)`.
-- **Additive**: with no detector registered, the signed body is byte-identical
-  to today (zero behaviour change).
-- **Reference detectors** ship in `asqav.extras` behind optional extras:
-  `PresidioDetector` (PII, `pip install asqav[presidio]`) and `OpaDetector`
-  (Open Policy Agent policy-as-code, no extra deps). Any classifier or policy
-  engine can feed the signed preflight decision this way.
-
-See `examples/detector_plugin_example.py` for a runnable demo.
+| Topic | Docs |
+|---|---|
+| Threat-framework mappings (MITRE, OWASP, NIST AI RMF, ISO 42001, EU AI Act) | [threat-framework-mapping](https://asqav.com/docs/threat-framework-mapping) |
+| NSA CSI U/OO/6030316-26 receipt fields | [nsa-mcp-csi-alignment](https://asqav.com/docs/nsa-mcp-csi-alignment) |
+| Build provenance (`executable_hash`, `sbom_digest`, SLSA) | [executable-hash-and-sbom-provenance](https://asqav.com/docs/executable-hash-and-sbom-provenance) |
+| Witness policy and multi-witness anchoring | [multi-witness-anchoring](https://asqav.com/docs/multi-witness-anchoring) |
+| Binding tool output (`result_digest`) | [result-digest](https://asqav.com/docs/result-digest) |
+| Configuration-change receipts | [configuration-change-receipts](https://asqav.com/docs/configuration-change-receipts) |
+| Code-authorship receipts | [code-authorship-receipts](https://asqav.com/docs/code-authorship-receipts) |
+| Structured receipts (optional schema) | [structured-receipts](https://asqav.com/docs/structured-receipts) |
+| Bring-your-own DLP / policy detectors | [scanning](https://asqav.com/docs/scanning) |
+| Audit Pack export | [compliance](https://asqav.com/docs/compliance) |
+| Independent verification protocol | [independent-verification](https://asqav.com/docs/independent-verification) |
 
 ## Requirements
 
-Python 3.10 or newer. Uses `httpx` for the API client. Zero native dependencies. ML-DSA cryptography runs server-side.
+Python 3.10+. Uses `httpx`. Zero native dependencies.
 
 ## Standards
 
-Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/), an Independent Submission that profiles [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) for EU AI Act Articles 12 and 26, and DORA Article 17 bindings. The SDK aligns with NIST FIPS 204 (ML-DSA), JCS canonicalization, and the NSA Cybersecurity Information Sheet U/OO/6030316-26 on MCP server lifecycle telemetry.
+Profiled in the IETF Internet-Draft
+[`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/),
+an Independent Submission profiling
+[`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/).
+Aligns with NIST FIPS 204 (ML-DSA), RFC 8785 (JCS) and NSA CSI U/OO/6030316-26.
 
-## Roadmap
+## Links
 
-What ships on Asqav today. Each item is available on `main`:
-
-- Hash-only mode for cloud - default for `*.asqav.com`.
-- Self-hosted signer with split-trust - compose file in the Asqav backend repo.
-- Bring-your-own KMS for AWS KMS or GCP KMS - Enterprise tier.
-- Customer-owned storage - self-hosted, with the relay payload allowlist enforced in code.
-- SCITT / COSE_Sign1 receipt export - public `GET /api/v1/signatures/{id}/cose` returns `application/cose`.
-- Air-gapped / on-prem mode - offline license + zero-egress. See the backend repo `docs/airgapped-mode.md`.
-
-See <https://asqav.com/docs> for the live feature set.
-
-## Documentation
-
-- Repository: <https://github.com/jagmarques/asqav-sdk>
-- Full docs: <https://asqav.com/docs>
-- SDK guide: <https://asqav.com/docs/sdk>
-- IETF profile: <https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/>
-- Discovery descriptor: <https://asqav.com/.well-known/governance.json>
+[Docs](https://asqav.com/docs) · [SDK guide](https://asqav.com/docs/sdk) ·
+[Repository](https://github.com/jagmarques/asqav-sdk) ·
+[Discovery descriptor](https://asqav.com/.well-known/governance.json)
 
 ## License
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -2,7 +2,13 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/jagmarques/asqav-sdk?style=social)](https://github.com/jagmarques/asqav-sdk)
 
-TypeScript SDK for [asqav.com](https://asqav.com), the evidence layer for AI agents. Sign every agent action with ML-DSA-65 (FIPS 204), enforce policies before execution, and produce regulator-ready audit trails. All cryptography runs server-side, and the package has zero native dependencies.
+TypeScript SDK for [asqav.com](https://asqav.com), the evidence layer for AI agents.
+
+Every agent action gets a signed, hash-chained **compliance receipt**: ML-DSA-65 (FIPS 204,
+post-quantum), timestamped against independent witnesses, and verifiable by anyone —
+auditor, counterparty, regulator — **without an Asqav account and without trusting us**.
+
+Zero native dependencies. Cryptography runs server-side.
 
 ## Install
 
@@ -12,548 +18,196 @@ npm install @asqav/sdk
 
 ## Quick start
 
-Get an API key at [asqav.com](https://asqav.com). The fastest path is the CLI:
-
 ```bash
 npm install -g @asqav/sdk
 asqav login        # validates your key, saves it to ~/.asqav/credentials
-asqav init         # prints a ready-to-paste snippet for your project
 ```
-
-`asqav login` saves your key so the SDK and CLI resolve it automatically (no `ASQAV_API_KEY` needed). Then sign your first agent action:
 
 ```ts
 import { govern } from "@asqav/sdk";
 
-// govern() is a one-call setup: init() + Agent.create() in one line
+// govern() = init() + Agent.create() in one call
 const agent = await govern({ apiKey: process.env.ASQAV_API_KEY, agentName: "my-agent" });
 
 const sig = await agent.sign({ actionType: "api:openai:chat", context: { model: "gpt-4o" } });
 
-console.log(sig.actionRef);             // "sha256:..." over the JCS-canonical action
-console.log(sig.previousReceiptHash);   // 64 hex; "0".repeat(64) on the first record per agent
-console.log(sig.verificationUrl);
+console.log(sig.actionRef);            // "sha256:..." over the JCS-canonical action
+console.log(sig.previousReceiptHash);  // 64 hex; "0".repeat(64) on this agent's first receipt
+console.log(sig.verificationUrl);      // anyone can open this
 ```
 
-That's it. One install, one govern call, one sign call. The receipt lands on the Asqav cloud under [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): ML-DSA-65 (FIPS 204) signature, chain hash, retained `policy_digest`, fail-closed anchoring, and a public verification URL.
+One install, one `govern`, one `sign`. `init({ apiKey })` + `Agent.create({ name })` remain
+available when you want control over `algorithm`, `capabilities` and other agent options.
 
-Prefer the lower-level building blocks? `init({ apiKey })` followed by `Agent.create({ name })` still works and gives more control over `algorithm`, `capabilities`, and other agent options.
+## Verify it without an account
 
-### No account? Offline path
+This is the point of the whole thing — the receipt stands on its own:
 
-TypeScript does not ship a `local_sign` queue equivalent. For offline/air-gapped scenarios use the Python SDK's `local_sign` helper, or set `mode: "hash-only"` to minimize what leaves the process while still reaching the cloud:
+Run this right now, with no key and no signup:
 
 ```ts
-await init({ apiKey: "...", baseUrl: "https://api.asqav.com", mode: "hash-only" });
+import { verify } from "@asqav/sdk";
+
+const result = await verify("sig_example_regulator_cold_verify_2026");
+console.log(result.verified);    // false -- and that is the point, see below
+console.log(result.chainHash);   // recomputed on your machine from the canonical bytes
 ```
 
-Pass `complianceMode: false` on any `agent.sign(...)` call if you want a non-Compliance receipt.
+That id is a **shape example**: its signature bytes are placeholders and its `kid` resolves
+to no key, so the verifier returns `verified: false` instead of waving it through. Swap in a
+`signature_id` of your own for a receipt that passes. A verifier that says no when the
+evidence is absent is the only kind worth having.
 
-## CLI
-
-The package ships an `asqav` binary mirroring the Python CLI surface. Start with `asqav login` (or set `ASQAV_API_KEY`) and run:
+From the shell:
 
 ```bash
-asqav login                                   # save your key to ~/.asqav/credentials
-asqav whoami                                  # show the active key source + validate it
-asqav init                                    # print a ready-to-paste snippet
-asqav verify <signature_id> [--output json]   # IETF axes when present
-asqav sign --agent-id ID --action-type T --action-json action.json \
-           --receipt-type protectmcp:decision \
-           --risk-class high --issuer-id legal:Acme
-           # add --no-compliance-mode to opt out of the IETF profile (default is on)
-asqav agents list / create / revoke
-asqav sessions list / end <session_id>
-asqav replay <agent_id> <session_id> [--json]
-asqav replay-verify <agent_id> <session_id> [--strict]     # IETF chain
-asqav preflight <agent_id> <action_type> [--json]
-asqav budget check / record
-asqav approve <session_id> <entity_id>
-asqav compliance frameworks / export
-asqav audit-pack export --start ISO --end ISO --output-file bundle.json
-asqav audit-pack policy <sha256:hex>
-asqav payloads erase <signature_id> --yes                  # P4 right-to-erasure
-asqav org set-compliance-strict <org_id> --enable|--disable
-asqav keys generate --algorithm ed25519|es256 [--out priv.bin]
-asqav migrate run v3-20|v3-21|v3-22                        # X-Maintenance-Key required
+asqav verify <your_signature_id>
 ```
 
-Every command listed here works on the free tier. The Asqav cloud is the source of truth for what your key may do.
+The verifier re-derives the signature, the chain link, the payload digest and the anchors
+from the RFC 8785 canonical bytes, and reports a verdict per axis. It never asks Asqav to
+vouch for anything.
+
+Offline or air-gapped, snapshot the keys once and verify with no network at all:
+
+```ts
+import { fetchJwks, verifyReceiptOffline } from "@asqav/sdk";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const jwks = await fetchJwks();                        // online, once
+writeFileSync("jwks.json", JSON.stringify(jwks));
+
+const receipt = JSON.parse(readFileSync("receipt.json", "utf8"));   // offline from here
+const result = await verifyReceiptOffline(receipt, JSON.parse(readFileSync("jwks.json", "utf8")));
+if (result.verdict === "unverified") throw new Error(JSON.stringify(result.axes));
+```
+
+`verdict` is `"verified" | "verified_keyed" | "unverified"`. `verified_keyed` is a pass over a
+keyed digest: internally consistent, but not third-party re-derivable. Pass
+`{ predecessor: prevReceipt }` to check the hash-chain link too.
+ML-DSA-65 verifies in-process via `@noble/post-quantum`; Ed25519 and ES256 via `node:crypto`.
+Guide: [offline and air-gapped verification](https://asqav.com/docs/offline-air-gapped-verification).
+
+## Neutral verifier
+
+A standalone verifier for agent receipts **across formats** ships as a subpath export:
+
+```ts
+import { verify, ADAPTERS } from "@asqav/sdk/verifier";
+
+const result = verify(receipt, ADAPTERS, keyProvider);
+```
+
+It checks the issuer signature over the canonical bytes, the chain link and structural
+presence for the asqav-native, AERF, ACTA, agent-receipts and Authproof formats. No account
+required. It is the port of the Python `asqav.verifier.oracle`, held to verdict parity by a
+shared conformance corpus.
 
 ## Data handling modes
 
-The SDK auto-detects whether you're pointing at the Asqav cloud or a self-hosted deployment and selects the safer default for each:
+The SDK picks the safer default for where you point it:
 
-- **Cloud (`*.asqav.com`)**: hash-only by default. The SDK builds a fingerprint of your action context, computes a SHA-256 hash locally, and sends only the hash plus a small metadata bag (`action_type`, `agent_id`, `session_id`, `model_name`, `tool_name`). Raw prompts and tool arguments stay on your side.
-- **Self-hosted**: full-payload by default. The server can run policy checks, PII redaction, and richer audit. Recommended when you control the deployment.
-
-Override anytime:
+- **Cloud (`*.asqav.com`)** — hash-only. A SHA-256 fingerprint is computed locally and only
+  the hash plus `actionType`, `agentId`, `sessionId`, `modelName`, `toolName` is sent.
+  Prompts and tool arguments never leave your process.
+- **Self-hosted** — full payload, so the server can run policy checks and richer audit.
 
 ```ts
 await init({ apiKey: "...", baseUrl: "https://api.asqav.com", mode: "hash-only" });
 ```
 
-The fingerprint format is sorted JSON with no whitespace per JCS, hashed with SHA-256. See `docs/fingerprint-spec.md` and `conformance/vectors.json` for the spec and cross-language test vectors.
+There is no local offline queue in TypeScript; use the Python SDK's `local_sign` for that.
 
-## Advanced / high-value actions
+## High-value actions
 
-Once you have the basics working, you can pass compliance envelope fields for regulated or high-risk actions. The full parameter set is useful for things like large financial transfers, healthcare decisions, or anything that needs an auditor-facing trail.
+For regulated or high-risk actions, pass envelope fields that an auditor will look for:
 
 ```ts
 const sig = await agent.sign({
   actionType: "payment.wire_transfer",
   context: { amountEur: 850000, beneficiaryIban: "DE89370400440532013000" },
   receiptType: "protectmcp:decision",
-  riskClass: "high",
-  issuerId: "legal:Acme GmbH",
-  iterationId: "task-2026-Q2-4821",
+  riskClass: "high",                 // low | medium | high | unknown
+  issuerId: "legal:Acme GmbH",       // LEI, EIN, CIK or W3C DID
+  iterationId: "task-2026-Q2-4821",  // logical task, distinct from session
 });
 ```
 
-The envelope extensions most callers reach for, camelCase on the SDK and snake_case on the JSON wire:
+## CLI
 
-- `receiptType` -> `receipt_type` - `protectmcp:decision`, `protectmcp:restraint`, `protectmcp:lifecycle`, `protectmcp:lifecycle:configuration_change`, `protectmcp:acknowledgment`, `protectmcp:observation`, or `protectmcp:observation:result_bound`, which is an observation receipt that binds tool output via `resultDigest`.
-- `riskClass` -> `risk_class` - controlled vocabulary: `low | medium | high | unknown`.
-- `iterationId` -> `iteration_id` - logical task id, distinct from session.
-- `sandboxState` -> `sandbox_state` - `enabled | disabled | unavailable` for high-risk gating.
-- `incidentClass` -> `incident_class` - DORA / NYDFS / CIRCIA token, or an array of tokens.
-- `issuerId` -> `issuer_id` - LEI per ISO 17442, EIN, CIK, or a W3C DID for non-LEI deployers.
-
-## Compliance receipts: the IETF profile
-
-Compliance Receipts are the SDK default. Each `agent.sign(...)` call produces a receipt that conforms to [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/): cloud-issued receipts carry an ML-DSA-65 signature (locally signed receipts carry Ed25519/ES256 — the algorithm is per-receipt in `signature.alg`), JCS canonicalization, retained `policy_digest`, hash-chained `previous_receipt_hash`, OpenTimestamps anchoring. Opt out with `complianceMode: false` if you want the older shape.
-
-### Observation receipts and passive_telemetry
-
-Two `receiptType` values cover the gating axis: `protectmcp:decision` records that a policy ran and gated the action. `protectmcp:observation` records that a passive monitor saw the event without gating it. Pick `observation` when the producer never had the option to block, such as a SIEM forwarder, a browser extension in observe-only mode, or a NetFlow-style proxy with no enforcement hook.
-
-Set `captureTopology: "passive_telemetry"` to declare the producer is observing after the fact. The SDK client-side check pre-flights the Asqav cloud's full rule 8 gate: a `captureTopology: "passive_telemetry"` receipt MUST use `receiptType: "protectmcp:observation"`. Any other receiptType paired with `passive_telemetry`, namely `:decision`, `:restraint`, `:lifecycle`, `:lifecycle:configuration_change`, or `:acknowledgment`, throws `AsqavError` with the verbatim `false_attestation_guard: capture_topology=passive_telemetry receipts must use receipt_type=protectmcp:observation[:result_bound], not :<offending> (rule 8)` message before the HTTP roundtrip. The guard lives as `false_attestation_guard` in `typescript/src/index.ts`.
-
-```ts
-const sig = await agent.sign({
-  actionType: "mcp:tool_call",
-  context: { server: "filesystem", tool: "read" },
-  receiptType: "protectmcp:observation",
-  captureTopology: "passive_telemetry",
-  issuerId: "legal:Acme GmbH",
-});
+```bash
+asqav whoami                       # active key source, validated
+asqav init                         # print a ready-to-paste snippet
+asqav verify <signature_id>        # verify a receipt (no key needed)
+asqav sign --agent-id ID --action-type T --action-json action.json
+asqav agents list | create | revoke
+asqav replay-verify <agent_id> <session_id> [--strict]
+asqav audit-pack export --start ISO --end ISO --output-file bundle.json
+asqav payloads erase <signature_id>          # right-to-erasure
 ```
 
-`captureTopology` is stamped on the audit-pack manifest entry but never on the signed payload. The other accepted topologies are `in_process_sdk`, `network_proxy`, `browser_extension`, `mcp_proxy`, and `github_sha_pull`. A client-supplied `captureTopology` is advisory: the server stamps the authoritative value from the ingress route, and for code-authorship that authoritative value is `github_sha_pull`, set only after the server re-fetches the commit and recomputes the diff. Only `passive_telemetry` triggers the false-attestation guard. The full topology semantics live in the cloud's `docs/capture-topology.md`, and the wire vocabulary is published live at `https://api.asqav.com/.well-known/governance.json` for discovery.
-
-### Configuration change receipts, rule 9
-
-A `receiptType: "protectmcp:lifecycle:configuration_change"` receipt declares the agent's runtime configuration was mutated. The SDK pre-flights the Asqav cloud's rule 9 cross-field gate for NSA CSI U/OO/6030316-26 alignment: the receipt MUST carry `configManifestDigest`. Omitting it throws `AsqavError` with the verbatim `configuration_change_missing_config_manifest_digest: receipt_type=protectmcp:lifecycle:configuration_change requires config_manifest_digest (sha256:<64 hex>).` message before the HTTP roundtrip.
-
-```ts
-const sig = await agent.sign({
-  actionType: "mcp:config_update",
-  context: { server: "filesystem", delta: "tool_added" },
-  receiptType: "protectmcp:lifecycle:configuration_change",
-  policyDecision: "none",
-  configManifestDigest: "sha256:<hex of manifest>",
-  cveInventoryDigest: "sha256:<hex of cve snapshot>",
-});
-```
-
-### Expiry precedence, rule 10
-
-The legacy `validSeconds`, where the server computes `valid_until = signed_at + valid_seconds`, and the caller-supplied horizon `expiresAt` are mutually exclusive. Pass exactly one of the two: `validSeconds: 3600` for "expire one hour after signing", or `expiresAt: "2026-06-01T00:00:00Z"` for an explicit horizon. Passing both throws `AsqavError` with the verbatim `expiry_collision_guard: pass either valid_seconds or expires_at, not both (rule 10)` message before the HTTP roundtrip. Passing neither falls back to the server-side default of `valid_seconds=86400`.
-
-### Digest format, rule 11
-
-Every caller-supplied self-describing digest field, namely `configManifestDigest`, `cveInventoryDigest`, `executableHash`, and `sbomDigest`, MUST match the regex `^sha256:[a-f0-9]{64}$`. `toolFingerprint` is the exception: it uses the cloud wire form of 32 bare lowercase hex chars, SHA-256[:32], matching `^[0-9a-f]{32}$` with no `sha256:` prefix. Anything else throws `AsqavError` with the verbatim `tool_fingerprint_not_32_hex_chars: must be 32 lowercase hex chars (SHA-256[:32]).` message before the HTTP roundtrip. To avoid wire drift, use the SDK's deterministic helpers, each byte-deterministic under JCS:
-
-```ts
-import {
-  computeToolFingerprint,
-  computeConfigManifestDigest,
-  computeCveInventoryDigest,
-} from "@asqav/sdk";
-
-const fp = computeToolFingerprint("search", { args: { q: "string" } });
-const cfg = computeConfigManifestDigest({ server: "filesystem", tools: ["read"] });
-const cve = computeCveInventoryDigest([{ id: "CVE-2026-0001", severity: "high" }]);
-```
-
-## NSA-aligned receipt fields
-
-Six wire fields on `agent.sign(...)` carry the NSA CSI U/OO/6030316-26 alignment for MCP server lifecycle and tool output binding:
-
-- `resultDigest` - `sha256:<hex>` of the tool output, binds the receipt to a specific result. See <https://www.asqav.com/docs/result-digest>.
-- `expiresAt` - explicit ISO-8601 or POSIX validity horizon. Converted client-side to `validSeconds` and sent as a duration, since the cloud owns absolute time-binding. Mutually exclusive with `validSeconds`. See <https://www.asqav.com/docs/time-bound-receipts>.
-- `nonce` - 12 random bytes auto-generated when omitted, carried as an opaque per-call token. The cloud rejects a re-used value: a nonce already held by a live signature for the same agent in the same organisation is refused with HTTP 409, so the field does bound replay for as long as the earlier receipt is inside its validity window. A record whose `valid_until` has passed frees its token, and one signed with no expiry keeps it. Pair it with `validSeconds` or `expiresAt` to bound the window itself, which the verifier enforces by returning `signature_expired`.
-- `toolFingerprint` - 32 bare lowercase hex chars, SHA-256[:32], over `{tool_name, schema}`, auto-derived when `toolName` + `toolSchema` are present. See <https://www.asqav.com/docs/tool-fingerprint>.
-- `configManifestDigest` - `sha256:<hex>` of the agent's runtime configuration snapshot. Required on configuration_change receipts. See <https://www.asqav.com/docs/configuration-change-receipts>.
-- `cveInventoryDigest` - `sha256:<hex>` over the CVE snapshot at sign time. See <https://www.asqav.com/docs/cve-inventory>.
-
-The `protectmcp:observation:result_bound` `receiptType` variant carries `resultDigest` and lets observation receipts bind to a specific tool result without claiming the policy gated the call.
-
-### Build-provenance 4-tuple
-
-Four optional wire fields bind build-side provenance into the signed receipt, subsuming standalone SBOM or SLSA verifiers in a single envelope. All four are independent and may be set together or individually:
-
-- `executableHash` - `sha256:<hex>` of the executable that invoked the action. MUST match `sha256:<64-hex>`.
-- `sbomDigest` - `sha256:<hex>` of the canonical CycloneDX or SPDX SBOM document.
-- `slsaProvenancePointer` - https URL to the SLSA attestation envelope for the executing build.
-- `supplyChainPointer` - https URL to the in-toto, Sigstore, or Rekor entry covering the build.
-
-```ts
-import { Agent } from "@asqav/sdk";
-
-const agent = await Agent.create({ apiKey: process.env.ASQAV_API_KEY! });
-const receipt = await agent.sign({
-  actionType: "tool.invoke",
-  toolName: "exec_query",
-  executableHash: "sha256:" + "a".repeat(64),
-  sbomDigest: "sha256:" + "b".repeat(64),
-  slsaProvenancePointer: "https://example.com/slsa/build-123.json",
-  supplyChainPointer: "https://rekor.sigstore.dev/api/v1/log/entries/abc",
-});
-```
-
-See <https://www.asqav.com/docs/executable-hash-and-sbom-provenance> for the field semantics and a worked policy example.
-
-## Optional threat-framework mappings
-
-Seven optional wire fields let a caller pin the receipt to industry threat-and-control taxonomies. Each list is caller-supplied and Asqav-preserved verbatim. The cloud sets `framework_mappings_self_declared=true` on the receipt whenever any of the six list fields is populated, so verifiers can tell self-declared classifications apart from cloud-verified ones.
-
-- `mitreTechniques` - list of MITRE ATT&CK technique ids, for example `["T1059", "T1078"]`.
-- `mitreAtlas` - list of MITRE ATLAS ids for AI-system threats, for example `["AML.T0051"]`.
-- `owaspLlmTop10` - list of OWASP Top 10 for LLM ids, for example `["LLM01", "LLM02"]`.
-- `nistAiRmf` - list of NIST AI RMF function ids, for example `["GOVERN-1.1", "MEASURE-2.7"]`.
-- `iso42001` - list of ISO/IEC 42001 control ids, for example `["A.6.2.6"]`.
-- `euAiActArticles` - list of EU AI Act article ids, for example `["Article-12", "Article-15"]`.
-- `rfc3161Timestamp` - caller-supplied base64-encoded RFC 3161 TimeStampResp in DER.
-
-```ts
-const receipt = await agent.sign({
-  actionType: "api:call",
-  context: { user: "..." },
-  complianceMode: true,
-  mitreTechniques: ["T1059", "T1078"],
-  owaspLlmTop10: ["LLM01"],
-  nistAiRmf: ["GOVERN-1.1", "MEASURE-2.7"],
-  euAiActArticles: ["Article-12"],
-});
-```
-
-Each list must be a non-empty array of strings, each entry up to 128 characters. Empty arrays, non-string entries, or oversize entries throw `AsqavError` with the verbatim guard messages `<field>_must_be_non_empty_list` or `<field>_entry_invalid` and skip the HTTP roundtrip. The `rfc3161Timestamp` must be valid base64 or throws `rfc3161_timestamp_not_base64`. Camel-case props project onto snake_case wire keys via the SDK's `IETF_OPTIONAL_FIELD_MAP`.
-
-See <https://www.asqav.com/docs/threat-framework-mapping>.
-
-## Optional witness policy
-
-`witnessPolicy` lets a caller declare an N-of-M durable-anchoring quorum on the receipt. The receipt reaches `witness_quorum_met` only when `required` witnesses hold a real inclusion proof. It projects onto the snake_case `witness_policy` wire key via the SDK's `IETF_OPTIONAL_FIELD_MAP`.
-
-- Shape: `{ required: number, witnesses: Array<"rfc3161" | "opentimestamps"> }`.
-- `required` must be an integer in `[1, witnesses.length]`.
-- `witnesses` must be a non-empty subset of the two shipped witnesses: `rfc3161` and `opentimestamps`.
-- `rekor` is rejected. It is not a shipped witness.
-- `rfc3161` confirmation is available on the Pro and Enterprise tiers. On the Free tier, `opentimestamps` is the witness that produces an inclusion proof; a policy requiring only `rfc3161` will not reach `witness_quorum_met` on Free.
-
-```typescript
-const sig = await agent.sign({
-  actionType: "deploy:release",
-  context: { build: "..." },
-  complianceMode: true,
-  witnessPolicy: { required: 1, witnesses: ["rfc3161", "opentimestamps"] },
-});
-```
-
-Bad input throws `AsqavError` with a verbatim guard message before the HTTP roundtrip: `witness_policy_unknown_witness` for an entry like `rekor`, `witness_policy_required_out_of_range`, `witness_policy_witnesses_must_be_non_empty_list`, `witness_policy_required_must_be_int`, or `witness_policy_duplicate_witness`. Omit the field for today's behaviour.
-
-### Audit Pack export
-
-The SDK exposes the public audit-trail endpoint as `exportAuditJson` for filtered windows of receipts:
-
-```ts
-import { exportAuditJson } from "@asqav/sdk";
-
-const bundle = await exportAuditJson({
-  startDate: "2026-05-01T00:00Z",
-  endDate: "2026-06-01T00:00Z",
-  agentId: "agt_abc",
-});
-console.log(bundle.records.length, bundle.bundleDigest);
-```
-
-For offline chain verification, `verifyChain(records)` walks an ordered list of signed envelopes for one agent and re-derives each `previous_receipt_hash`. The first record's seed is `"0".repeat(64)`. The cloud is the authoritative verifier. This helper is a convenience.
-
-Algorithm agility is exposed via `SUPPORTED_ALGORITHMS`, the five-element client-side validation set (`ml-dsa-44`, `ml-dsa-65`, `ml-dsa-87`, `ed25519`, `es256`) - unlike the Python SDK's `SUPPORTED_ALGORITHMS`, which lists only the two local-keygen algorithms. `Agent.create(...)` sends the algorithm to the Asqav cloud, which accepts `ml-dsa-44`, `ml-dsa-65` (default), and `ml-dsa-87`. `ed25519` and `es256` are for local keypair generation only (`generateKeypair("ed25519")`); passing them to `Agent.create(...)` returns a 400 from the cloud. ES256 signatures emit in IEEE-P1363 raw r||s form so they match the cloud verifier byte-for-byte.
-
-## Offline / air-gapped verification
-
-Receipts can be verified without calling the Asqav API once you have a JWKS snapshot.
-Full guide: [`docs/offline-verification.md`](../docs/offline-verification.md).
-
-`@noble/post-quantum` ships as a runtime dependency and covers ML-DSA-65 in-process.
-Ed25519 and ES256 run via Node's built-in `crypto` module.
-
-Snapshot the JWKS while you have network access, then verify offline:
-
-```ts
-import { fetchJwks, verifyReceiptOffline } from "@asqav/sdk";
-import { readFileSync, writeFileSync } from "node:fs";
-
-// online: snapshot the keys
-const jwks = await fetchJwks();
-writeFileSync("jwks.json", JSON.stringify(jwks));
-
-// offline: verify any receipt
-const receipt = JSON.parse(readFileSync("receipt.json", "utf8"));
-const jwksSnap = JSON.parse(readFileSync("jwks.json", "utf8"));
-const result = await verifyReceiptOffline(receipt, jwksSnap);
-// verdict is "verified" | "verified_keyed" | "unverified"; "verified_keyed" means a
-// keyed digest (internally consistent, not third-party re-derivable) and is also a pass
-if (result.verdict === "unverified") throw new Error(JSON.stringify(result.axes));
-```
-
-Supply a predecessor receipt to check the hash-chain link:
-
-```ts
-const result = await verifyReceiptOffline(receipt, jwksSnap, { predecessor: prevReceipt });
-```
-
-## Integrations
-
-The SDK ships native callbacks and adapters for common agent frameworks:
-
-- **Vercel AI SDK** - import `createAsqavExporter` from `@asqav/sdk/extras/vercel-ai`, pass to `experimental_telemetry: { tracer }`. Every span becomes a signed Asqav action, whether text generation, a tool call, or an embedding.
-- **LangChain.js** - import `AsqavCallbackHandler` from `@asqav/sdk/extras/langchain`, construct via `await AsqavCallbackHandler.create({ agent })` then pass to `callbacks: [handler]`. Requires `@langchain/core` as a peer dep.
-- **Mastra** - import `AsqavMastraHook` from `@asqav/sdk/extras/mastra`, attach via `await new AsqavMastraHook({ agent }).attach(mastraAgent)`. Requires `@mastra/core` as a peer dep.
-- **OpenAI Agents JS** - import `AsqavOpenAIAgentsAdapter` from `@asqav/sdk/extras/openai-agents`, wrap individual tools via `new AsqavOpenAIAgentsAdapter({ agent }).wrapTool(tool)`. Each invocation signs `tool:start` / `tool:end` / `tool:error`. Requires `@openai/agents` as a peer dep.
-- **CrewAI**, **LiteLLM**, **LlamaIndex**, **Haystack** - same pattern via the Hooks API. The Python SDK has the richer ecosystem, see <https://asqav.com/docs/integrations> for parity status.
-
-Span names are mapped to Asqav action types: `ai.generateText` -> `ai:completion`, `ai.streamText` -> `ai:completion_stream`, `ai.toolCall` -> `ai:tool_call`, errors -> `ai:error`. Signing is fire-and-forget and never blocks generation. Failures log a warning instead of throwing.
-
-## Errors
-
-All thrown errors extend `AsqavError`. `AuthenticationError` for 401, `RateLimitError` for 429, and `APIError` carrying `statusCode` are exported for fine-grained handling:
-
-```ts
-import { AsqavError, AuthenticationError, RateLimitError, APIError } from "@asqav/sdk";
-
-try {
-  await agent.sign({ actionType: "api:call", context: { model: "gpt-4" } });
-} catch (err) {
-  if (err instanceof AuthenticationError) throw err;     // rotate ASQAV_API_KEY
-  if (err instanceof RateLimitError) throw err;          // err.retryAfter holds the cooldown
-  if (err instanceof APIError) throw err;                // err.statusCode holds the HTTP status
-  throw err;
-}
-```
-
-`TypeError` is thrown before the HTTP roundtrip for the verbatim rule 8 / 9 / 10 / 11 guards listed above. Catch `TypeError` separately so guard violations surface as developer errors, not API errors.
-
-## Neutral verifier
-
-A standalone offline verifier for agent receipts across formats ships as a subpath export:
-
-```ts
-import { verify, ADAPTERS } from "@asqav/sdk/verifier";
-
-const result = verify(receipt, ADAPTERS, keyProvider);
-// result.verdict is "verified", "verified_keyed", or "unverified"; "verified_keyed"
-// means a keyed digest (internally consistent, not third-party re-derivable)
-```
-
-It verifies the issuer signature over the canonical bytes, the hash-chain link, and structural presence across the asqav-native, AERF, ACTA, agent-receipts, and Authproof formats. It never attests the behaviour of the recorded action, and no account is required. Ed25519 and ES256 verify in-process via `node:crypto`, and ML-DSA-65 verifies in-process via `@noble/post-quantum`, byte-compatible with the Python verifier. This is the TypeScript port of the Python `asqav.verifier.oracle`, held to verdict parity by a shared conformance corpus.
-
-## Structured receipts (optional schema)
-
-Pass a `contextSchema` to `agent.sign()` to validate and normalise the
-`context` object before it is signed. This keeps every receipt in your audit
-trail in a consistent, queryable shape.
-
-```typescript
-import { Agent, ValidationError, type ContextSchema, init } from "@asqav/sdk";
-
-const PAYMENT_SCHEMA: ContextSchema = {
-  userId:   { type: "string",  required: true },
-  amount:   { type: "number",  required: true },
-  currency: { type: "string",  required: true },
-};
-
-init({ apiKey: "sk_..." });
-const agent = await Agent.create({ name: "my-agent" });
-
-// Valid context: keys are sorted before signing (consistent hash order).
-const sig = await agent.sign({
-  actionType: "payment:initiate",
-  context: { userId: "u1", currency: "EUR", amount: 49.95 },
-  contextSchema: PAYMENT_SCHEMA,
-});
-
-// Missing required field: throws ValidationError BEFORE the network call.
-try {
-  await agent.sign({
-    actionType: "payment:initiate",
-    context: { amount: 100 },       // userId missing, currency missing
-    contextSchema: PAYMENT_SCHEMA,
-  });
-} catch (err) {
-  if (err instanceof ValidationError) {
-    console.error(err.message);   // context_schema_error: field 'userId' is required but missing
-    console.error(err.docsUrl);   // https://asqav.com/docs/structured-receipts
-  }
-}
-```
-
-Field descriptor keys:
-- `type` (required) - one of `"string"`, `"number"`, `"boolean"`, `"object"`, `"array"`.
-- `required` (optional, default `false`) - whether the field must be present.
-
-`"number"` rejects `boolean` values; `"array"` rejects plain objects.
-No schema means today's exact behaviour (zero behaviour change).
-
-You can also pass a callable for full JSON Schema (no new mandatory
-dependencies in the core package):
-
-```typescript
-import Ajv from "ajv";
-const ajv = new Ajv();
-const validate = ajv.compile(MY_FULL_SCHEMA);
-
-await agent.sign({
-  actionType: "action",
-  context: { ... },
-  contextSchema: (ctx) => {
-    if (!validate(ctx)) throw new Error(ajv.errorsText(validate.errors));
-  },
-});
-```
-
-See `examples/schema-receipts.ts` for a runnable demo.
-
-## Bind your agent's declared configuration into the receipt
-
-A signed action is more useful when the receipt also proves *which declared
-configuration* the agent was running when it acted. You can bind that today
-with the sign context, no extra API surface:
-
-1. Hash whatever declares the agent: an agent manifest, an `AGENTS.md`, a
-   container image digest, or an SBOM. Any bytes on disk work.
-2. Put the digest in the `context` under your own keys (for example
-   `config_digest` plus `config_kind`).
-3. Optionally pin those keys with a `contextSchema` so a receipt that claims a
-   config always carries both fields.
-
-```typescript
-import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
-import { Agent, init } from "@asqav/sdk";
-
-function configDigest(path: string): string {
-  return "sha256:" + createHash("sha256").update(readFileSync(path)).digest("hex");
-}
-
-const CONFIG_BINDING_SCHEMA = {
-  config_digest: { type: "string", required: true },
-  config_kind:   { type: "string", required: true },
-} as const;
-
-init({ apiKey: "sk_..." });
-const agent = await Agent.create({ name: "my-agent" });
-
-const digest = configDigest("AGENTS.md");
-
-const sig = await agent.sign({
-  actionType: "payment:refund",
-  context: {
-    amount: 49.95,
-    currency: "EUR",
-    config_digest: digest,        // sha256:<hex> of your declaration
-    config_kind: "agents-md",     // name the artifact you hashed
-  },
-  contextSchema: CONFIG_BINDING_SCHEMA,
-});
-console.log(sig.verificationUrl); // digest is inside the signed receipt
-```
-
-The digest is part of the signed body, so anyone can fetch the receipt at the
-public verify endpoint and confirm the action ran under that exact declaration.
-The key names and the artifact kind are yours to choose, which keeps the pattern
-generic across any declaration format.
-
-For a couple of common cases there are dedicated wire fields instead of context
-keys (`config_manifest_digest` for a runtime config snapshot, `sbom_digest` for
-an SBOM). The context recipe above is the general form for any other declaration
-you want to bind.
-
-See `examples/bind-config-digest.mjs` for a runnable demo.
-
-## Pluggable detectors (bring-your-own DLP/policy)
-
-asqav owns the enforce + signed-proof spine; detection is pluggable. Register a
-detector and it runs inside every `agent.sign()`, after the context is normalised
-and before the network call. Its verdict is recorded in the signed receipt (under
-`_detectors`), so the audit trail proves which detector saw the action and why. A
-deny throws `DetectorBlockedError` and no signature is created.
-
-```typescript
-import { Agent, DetectorBlockedError, init, registerDetector } from "@asqav/sdk";
-
-const ssnDetector = {
-  name: "ssn-regex",
-  inspect(_actionType: string, context: Record<string, unknown>) {
-    if (/\b\d{3}-\d{2}-\d{4}\b/.test(JSON.stringify(context))) {
-      return { allow: false, confidence: 1, labels: ["US_SSN"], detector: "", reason: "SSN" };
-    }
-    return { allow: true, confidence: 1, labels: [], detector: "", reason: "" };
-  },
-};
-
-init({ apiKey: "sk_..." });
-const agent = await Agent.create({ name: "my-agent" });
-registerDetector(ssnDetector);            // failOpen defaults to false
-
-try {
-  await agent.sign({ actionType: "email:send", context: { body: "ssn 123-45-6789" } });
-} catch (err) {
-  if (err instanceof DetectorBlockedError) console.error(err.detectorName, err.result.labels);
-}
-```
-
-- **Fail-closed by default**: if `inspect()` throws, sign blocks. Opt out per
-  detector with `registerDetector(d, { failOpen: true })`.
-- **Additive**: with no detector registered, the signed body is byte-identical
-  to today (zero behaviour change).
-- **Reference detectors** ship in `@asqav/sdk/extras`: `PresidioDetector` (PII,
-  via the Presidio REST analyzer) and `OpaDetector` (Open Policy Agent
-  policy-as-code). Any classifier or policy engine can feed the signed preflight
-  decision this way.
-
-See `examples/detector-plugin.ts` for a runnable demo.
+Full command reference: [asqav.com/docs/cli](https://asqav.com/docs/cli).
+
+## Framework integrations
+
+Native adapters under `@asqav/sdk/extras/*`:
+
+- **Vercel AI SDK** — `createAsqavExporter`, passed to `experimental_telemetry`. Every span
+  becomes a signed action.
+- **LangChain.js** — `AsqavCallbackHandler`, passed to `callbacks: [handler]`.
+- **Mastra** — `AsqavMastraHook`, attached to a Mastra agent.
+- **OpenAI Agents JS** — `AsqavOpenAIAgentsAdapter`, wrapping a tool.
+
+Each needs its framework as a peer dependency. CrewAI, LiteLLM, LlamaIndex and Haystack
+follow the same Hooks API; the Python SDK has the richer ecosystem. Parity status:
+[integrations](https://asqav.com/docs/integrations).
+
+## What a receipt does not prove
+
+Stated plainly, because an auditor will ask:
+
+- **Not that the action ran, or ran once.** A receipt records a decision and the bytes that
+  passed through, never the effect. A retry produces a second receipt.
+- **Not that the policy was correct.** `policy_digest` proves which policy artefact existed,
+  not that it was the right one.
+- **Not that the environment was intact.** No field here carries a remote attestation result.
+- **Tamper-evident, not tamper-proof.** Modification is detectable, not prevented.
+
+The full list is in the IETF profile under "What a Compliance Receipt Does Not Prove".
+
+## Reference
+
+| Topic | Docs |
+|---|---|
+| Threat-framework mappings (MITRE, OWASP, NIST AI RMF, ISO 42001, EU AI Act) | [threat-framework-mapping](https://asqav.com/docs/threat-framework-mapping) |
+| NSA CSI U/OO/6030316-26 receipt fields | [nsa-mcp-csi-alignment](https://asqav.com/docs/nsa-mcp-csi-alignment) |
+| Build provenance (`executable_hash`, `sbom_digest`, SLSA) | [executable-hash-and-sbom-provenance](https://asqav.com/docs/executable-hash-and-sbom-provenance) |
+| Witness policy and multi-witness anchoring | [multi-witness-anchoring](https://asqav.com/docs/multi-witness-anchoring) |
+| Binding tool output (`result_digest`) | [result-digest](https://asqav.com/docs/result-digest) |
+| Configuration-change receipts | [configuration-change-receipts](https://asqav.com/docs/configuration-change-receipts) |
+| Code-authorship receipts | [code-authorship-receipts](https://asqav.com/docs/code-authorship-receipts) |
+| Structured receipts (optional schema) | [structured-receipts](https://asqav.com/docs/structured-receipts) |
+| Bring-your-own DLP / policy detectors | [scanning](https://asqav.com/docs/scanning) |
+| Audit Pack export | [compliance](https://asqav.com/docs/compliance) |
+| Independent verification protocol | [independent-verification](https://asqav.com/docs/independent-verification) |
 
 ## Requirements
 
-Node 20 or newer. Uses the built-in `fetch`. Zero native dependencies. ML-DSA cryptography runs server-side.
+Node 20+. Uses the built-in `fetch`. Zero native dependencies.
 
 ## Standards
 
-Asqav's compliance receipts are profiled in IETF Internet-Draft [`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/), an Independent Submission that profiles [`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) for EU AI Act Articles 12 and 26, and DORA Article 17 bindings. The SDK aligns with NIST FIPS 204 (ML-DSA), JCS canonicalization, and the NSA Cybersecurity Information Sheet U/OO/6030316-26 on MCP server lifecycle telemetry.
+Profiled in the IETF Internet-Draft
+[`draft-marques-asqav-compliance-receipts`](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/),
+an Independent Submission profiling
+[`draft-farley-acta-signed-receipts`](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/).
+Aligns with NIST FIPS 204 (ML-DSA), RFC 8785 (JCS) and NSA CSI U/OO/6030316-26.
 
-## Roadmap
+## Links
 
-What ships on Asqav today. Each item is available on `main`:
-
-- Hash-only mode for cloud - default for `*.asqav.com`.
-- Self-hosted signer with split-trust - compose file in the Asqav backend repo.
-- Bring-your-own KMS for AWS KMS or GCP KMS - Enterprise tier.
-- Customer-owned storage - self-hosted, with the relay payload allowlist enforced in code.
-- SCITT / COSE_Sign1 receipt export - public `GET /api/v1/signatures/{id}/cose` returns `application/cose`.
-- Air-gapped / on-prem mode - offline license + zero-egress. See the backend repo `docs/airgapped-mode.md`.
-
-See <https://asqav.com/docs> for the live feature set.
-
-## Documentation
-
-- Repository: <https://github.com/jagmarques/asqav-sdk>
-- Full docs: <https://asqav.com/docs>
-- SDK guide: <https://asqav.com/docs/sdk>
-- IETF profile: <https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/>
-- Discovery descriptor: <https://asqav.com/.well-known/governance.json>
+[Docs](https://asqav.com/docs) · [SDK guide](https://asqav.com/docs/sdk) ·
+[Repository](https://github.com/jagmarques/asqav-sdk) ·
+[Discovery descriptor](https://asqav.com/.well-known/governance.json)
 
 ## License
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -58,17 +58,15 @@ to no key, so the verifier returns `verified: false` instead of waving it throug
 `signature_id` of your own for a receipt that passes. A verifier that says no when the
 evidence is absent is the only kind worth having.
 
-From the shell:
+From the shell (`npm install -g @asqav/sdk` provides the `asqav` command):
 
 ```bash
 asqav verify <your_signature_id>
 ```
 
-The verifier re-derives the signature, the chain link, the payload digest and the anchors
-from the RFC 8785 canonical bytes, and reports a verdict per axis. It never asks Asqav to
-vouch for anything.
-
-Offline or air-gapped, snapshot the keys once and verify with no network at all:
+Offline or air-gapped, snapshot the keys once and verify with no network at all. This
+re-derives the signature itself from the RFC 8785 canonical bytes and reports a verdict per
+axis, so it never asks Asqav to vouch for anything:
 
 ```ts
 import { fetchJwks, verifyReceiptOffline } from "@asqav/sdk";


### PR DESCRIPTION
## Shorter and more concrete

| page | before | after |
|---|---|---|
| `python/README.md` (rendered on PyPI) | 545 lines | 200 |
| `typescript/README.md` (rendered on npm) | 560 lines | 214 |
| `README.md` (repo landing) | 422 lines | 157 |

All three now mirror each other section for section. Deep material moved to a reference table linking `asqav.com/docs`; **every one of the 16 links was checked to resolve**.

## Three live bugs fixed in passing

**1. The flagship example was broken.** The root README told readers to run:

```python
result = asqav.verify("sig_example_regulator_cold_verify_2026")
assert result["verified"]
```

Measured against prod, that returns `False`. The API's own `example_note` says why: *"the signature and anchor values here are fixed placeholders, not ML-DSA-65 output, and the kid resolves to no key."* So the headline snippet raised `AssertionError` for anyone who pasted it — on the page a skeptical auditor reads first. Both languages now print the real value and explain that a verifier reporting `false` on absent evidence is the point, then tell you to swap in your own id.

**2. Dead links on the registries.** Both package READMEs linked `../docs/offline-verification.md`, which resolves on GitHub and 404s on PyPI and npm, which render the file standalone. Replaced with the live docs URL.

**3. Pricing restated where it drifts.** The `## Plans` section carried quotas and prices. It now names the lineup and links to the page that owns the numbers.

## Verification

- the published Python snippet was executed verbatim and prints exactly what the README says
- `verify()`'s TypeScript return type checked against `typescript/src/index.ts:2265` before documenting `chainHash`
- the TS integration list checked against the source; no framework claimed that isn't shipped
- every referenced path (`verifier/`, `conformance/`, `CONTRIBUTING.md`, `docs/github-actions.md`, both workflows) exists
- `test_verify_public_dict.py` and `test_corpus_lock.py` green; no test reads a package README

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4