### PR TITLE
chore(release): 0.10.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Both language halves version together; tags are independent (`py-v*`, `ts-v*`).
 
 ## [Unreleased]
 
+## [0.10.10] - 2026-09-05
+
+### Changed
+
+- **The package pages are shorter and lead with what a reader can check themselves.**
+  `python/README.md` (rendered on PyPI) goes from 545 lines to 200 and
+  `typescript/README.md` (rendered on npm) from 560 to 214, mirroring each other
+  section for section. Reference material moves to a linked table pointing at
+  `asqav.com/docs`; every link was checked to resolve.
+
+### Fixed
+
+- **The documented verification example no longer fails when you run it.** The pages
+  told readers to assert `verified` on the public example id
+  `sig_example_regulator_cold_verify_2026`. That receipt is a shape example whose
+  signature bytes are placeholders and whose `kid` resolves to no key, so the API
+  reports `verified: false` by design and the snippet raised `AssertionError` for
+  anyone who pasted it. Both languages now print the real value and explain that a
+  verifier reporting `false` on absent evidence is the intended behaviour.
+- **The install line beside the `asqav verify` example names the extra that provides
+  the command.** It said `asqav[verify]`, which carries the offline crypto; the
+  command comes from `asqav[cli]`. Following the page left the reader without the
+  binary it then told them to run.
+- **Two links that resolved only on GitHub.** `../docs/offline-verification.md` is
+  dead on PyPI and npm, which render the README standalone; both now point at the
+  live docs page.
+
 ## [0.10.9] - 2026-09-05
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "asqav"
-version = "0.10.9"
+version = "0.10.10"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
 license = "LicenseRef-Elastic-License-2.0"

--- a/python/src/asqav/__init__.py
+++ b/python/src/asqav/__init__.py
@@ -192,7 +192,7 @@ from .verifier.oracle import ADAPTERS as _ADAPTERS
 from .verifier.oracle import verify as _oracle_verify
 from .verifier.verify_receipt import fetch_jwks
 
-__version__ = "0.10.9"
+__version__ = "0.10.10"
 __all__ = [
     # Initialization
     "init",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asqav/sdk",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "AI agent governance - audit trails, policy enforcement, ML-DSA cryptographic signatures",
   "keywords": [
     "ai",

--- a/typescript/src/userAgent.ts
+++ b/typescript/src/userAgent.ts
@@ -3,7 +3,7 @@
  * added under Node, since browsers forbid setting User-Agent on fetch.
  */
 
-export const SDK_VERSION = "0.10.9";
+export const SDK_VERSION = "0.10.10";
 
 export const USER_AGENT = `asqav-js/${SDK_VERSION} (+https://www.asqav.com)`;
 


### PR DESCRIPTION
Docs-only release. The rewritten package pages live on `main` but the registries keep serving the old ones until a publish, so this ships them.

Patch bump per the pre-1.0 policy: a small change moves the number one step.

## What reaches readers

- PyPI page: 545 lines to 200. npm page: 560 to 214.
- The documented verification example stops failing. It told readers to assert `verified` on a shape example whose signature bytes are placeholders, so it raised `AssertionError` for anyone who pasted it.
- The install line beside `asqav verify` now names `asqav[cli]`, which provides the command, rather than `asqav[verify]`, which provides the offline crypto.
- Two `../docs/` links that resolve on GitHub and 404 on both registries.

## Pre-publish checks

Both artifacts were built and inspected rather than assumed:

| check | result |
|---|---|
| wheel `Version` | `0.10.10` |
| wheel `Description-Content-Type` | `text/markdown` |
| wheel long_description | 203 lines, carries the new lead |
| broken `assert` present in wheel | no |
| dead relative link present in wheel | no |
| `npm pack` includes `README.md` | yes (55 files, `@asqav/sdk` 0.10.10) |

`twine check` reports `'2.5' is not a valid metadata version` on this machine. That is a local twine/hatchling mismatch, not a defect: the same error reproduces on `main`'s 0.10.9 build, and 0.10.9 published to PyPI without trouble. The publish path uses OIDC trusted publishing in Actions with its own toolchain.

Version pins moved together across all five files, so the consistency test holds.

https://claude.ai/code/session_015YqeLYJjunNx2ToSb3yeV4