### PR TITLE
docs: specify standalone dependencies and trust inputs

### DIFF
--- a/docs/offline-verification.md
+++ b/docs/offline-verification.md
@@ -1,7 +1,9 @@
 # Offline / Air-Gapped Receipt Verification
 
-Asqav receipts can be verified entirely offline once you have a JWKS snapshot.
-No network call is made during verification; all crypto runs in-process.
+Verification can run offline using the complete signed receipt, a saved signer
+JWKS and the inputs required by each check. Anchor verification in the standalone
+tool also needs caller-selected TSA keys or Bitcoin block data, as described below.
+No network call is made during offline verification.
 
 ## Python
 
@@ -12,8 +14,9 @@ pip install "asqav[verify]"
 ```
 
 The `verify` extra adds `dilithium-py` (ML-DSA-65) and `cryptography` (Ed25519, ES256).
-Without it, the signature axis reports `SKIPPED` and the verdict is `unverified`
-(`failure_class=unverifiable`), never a false `verified`.
+Without the dependency required by the receipt's signature algorithm, that check
+reports `SKIPPED` and prevents a passing verdict. Dependencies installed separately
+also work. An independent demonstrated failure can still make the failure class `invalid`.
 
 ### 2. Snapshot the JWKS while online
 
@@ -49,8 +52,8 @@ result = asqav.verify_receipt_offline(receipt, jwks, predecessor=prev_receipt)
 
 | Verdict          | Meaning                                                    |
 |------------------|------------------------------------------------------------|
-| `verified`       | All axes checked and passed.                               |
-| `verified_keyed` | All axes passed, but the digest is keyed (e.g. HMAC-SHA256) and not third-party re-derivable. Never reported as plain `verified`. |
+| `verified`       | The verifier reports a pass for its evaluated checks; inspect the axes and documented limits.                               |
+| `verified_keyed` | Passing result, but the digest is keyed (e.g. HMAC-SHA256) and not third-party re-derivable. Never reported as plain `verified`. |
 | `unverified`     | Not verified; carries `failure_class` `invalid` or `unverifiable`. |
 
 Every `unverified` verdict names its `failure_class`, and the two are never collapsed:
@@ -64,30 +67,40 @@ Every `unverified` verdict names its `failure_class`, and the two are never coll
 
 ## Standalone single-file verifier (no asqav install)
 
-`python/src/asqav/verifier/verify_receipt.py` is a deliberately standalone
-artifact (criterion 421): one Apache-2.0 file whose import surface is the
-Python stdlib plus one optional dependency (`dilithium-py`, imported lazily
-inside the ML-DSA-65 check). It imports no asqav producer module, so it runs
-from a bare directory after a plain copy - the exit artifact ships exactly
-this file beside the archived receipts and JWKS:
+`python/src/asqav/verifier/verify_receipt.py` is one Apache-2.0 file that runs
+without the Asqav package. Its imports are the Python standard library and two
+optional dependencies, both loaded inside the checks that use them:
+
+- `dilithium-py` verifies ML-DSA-65 receipt and timestamp signatures.
+- `cryptography` verifies Ed25519/ES256 receipts, decodes TSA certificates and
+  keys, and verifies supported classical TSA signatures.
+
+Copy the file and install the dependencies before entering the offline environment:
 
 ```sh
 cp /path/to/asqav-sdk/python/src/asqav/verifier/verify_receipt.py ./
+python -m pip install dilithium-py cryptography
 python verify_receipt.py --receipt receipt.json --jwks jwks.json --offline
 ```
 
-`--offline` never reaches the network; the JWKS you archived is the only
-trust input. Without `dilithium-py` installed every other axis still runs and
-the signature axis reports SKIPPED and the verdict is `unverified` with
-`failure_class=unverifiable` - the tool never emits `verified` for a signature it
-did not check.
+`--offline` prevents network access. The JWKS identifies receipt-signing keys;
+applicable checks can need further inputs. `--predecessor FILE` supplies chain
+bytes, `--tsa-key FILE` supplies a caller-pinned TSA public key or certificate
+(PEM, DER or base64), and `--bitcoin-headers FILE` supplies a JSON map from block
+height to block data containing `merkle_root` and `time` for OpenTimestamps.
+Archive those inputs through a source you trust. The tool does not build a TSA
+certificate path to a public root or validate Bitcoin consensus and chain history.
 
-The import surface is pinned by `python/tests/test_standalone_verifier_surface.py`
-(AST scan: stdlib plus optional dilithium only, no `asqav` import, dilithium
-imported lazily) and by a subprocess run of the copied file that refuses any
-`asqav` import and any outbound socket in the child. For a toolchain that
-cannot install Python at all, `docs/openssl-jq-walkthrough.md` verifies the
-same published receipt with only `openssl`, `jq`, and `sha256sum`.
+An applicable check lacking its required dependency or trust input reports
+`SKIPPED` and prevents a passing verdict; another proven failure can still make
+the failure class `invalid`. Missing `dilithium-py` does not disable Ed25519 or
+ES256 verification when `cryptography` is installed. A signature pass alone does
+not establish that the receipt's anchors passed.
+
+`python/tests/test_standalone_verifier_surface.py` checks the import surface and
+lazy loading of both dependencies. It also executes a copied file with Asqav
+imports and outbound sockets refused. The OpenSSL alternative is documented in
+[the walkthrough](openssl-jq-walkthrough.md), including its algorithm requirements.
 
 ## TypeScript / Node
 
@@ -160,9 +173,9 @@ without a successful cryptographic check. The Python verifier therefore evaluate
 token itself: an RFC 3161 anchor PASSes only when its `messageImprint` commits
 `sha256(JCS(envelope minus anchors))` AND the TSA signature verifies against
 caller-pinned TSA key material (`trusted_tsa_keys`, or `--tsa-key` on the CLI);
-an OpenTimestamps anchor PASSes only when the proof commits the same digest and,
-when bitcoin headers are supplied (`bitcoin_headers` / `--bitcoin-headers`), its
-merkle path lands in the stated block. A token whose check runs and fails reports
+an OpenTimestamps anchor PASSes only when the proof commits the same digest and
+its merkle path matches caller-supplied block data (`bitcoin_headers` /
+`--bitcoin-headers`). Without usable supplied block data, placement is unverifiable; a supplied root that disagrees makes it invalid. A token whose check runs and fails reports
 FAIL (`invalid`); one the check cannot complete offline — junk token, no pinned TSA
 key, no header source, `status: pending`/`failed`, unknown type — reports SKIPPED
 (`unverifiable`), never PASS. The TypeScript shim carries no CMS/ots evaluation, so
@@ -208,9 +221,9 @@ changes to `revoked`. The verifier rejects signatures from revoked keys.
 
 | Algorithm | Status |
 |-----------|--------|
-| Ed25519 | Fully validated with real known-answer (tamper) vectors. |
-| ES256 | Fully validated with real known-answer (tamper) vectors. |
-| ML-DSA-65 | Fully proven. Known-answer conformance vector `asqav-06-mldsa65-payload-prod` was minted from a real api.asqav.com payload-mode receipt (2026-06-19, agent `agt_LBe47lJwgA0DfVom`, key `mxYqaLBR_T76ThNw0Kiekw`). Both Python (`test_verify_receipt_offline_mldsa65_real_cloud_kat`) and TypeScript test suites exercise the signature axis against this vector and assert `verified`; tamper tests assert `unverified`/`invalid`. |
+| Ed25519 | Signature checked against known-answer and tamper vectors. |
+| ES256 | Signature checked against known-answer and tamper vectors. |
+| ML-DSA-65 | Signature checked against known-answer conformance vector `asqav-06-mldsa65-payload-prod`, which was minted from a real api.asqav.com payload-mode receipt (2026-06-19, agent `agt_LBe47lJwgA0DfVom`, key `mxYqaLBR_T76ThNw0Kiekw`). Both Python (`test_verify_receipt_offline_mldsa65_real_cloud_kat`) and TypeScript test suites exercise the signature axis against this vector and assert `verified`; tamper tests assert `unverified`/`invalid`. |
 
 ## Canonical member order and the dialect cutover
 

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -18,12 +18,12 @@
 # exception to the Elastic-License-2.0 SDK) so it can ship in the exit artifact
 # as a permanently free, dependency-light tool a customer runs offline forever.
 
-"""Standalone Asqav receipt verifier - one dependency, mostly stdlib.
+"""Standalone Asqav receipt verifier - stdlib with optional cryptographic dependencies.
 
 Verify an Asqav Compliance Receipt yourself, without the Asqav SDK or liboqs.
 
 CHECKS (independently, on your machine):
-  - ML-DSA-65 (FIPS 204) signature over the receipt's canonical bytes
+  - ML-DSA-65 (FIPS 204), Ed25519 or ES256 receipt signature over canonical bytes
   - canonical-bytes integrity (JCS / RFC8785 reproduction, stdlib json)
   - hash-chain link to a predecessor receipt
   - expiry (the expires_at the signer committed to inside the signed bytes)
@@ -40,12 +40,12 @@ certificate-chain walk to a public root - offline trust comes only from the TSA
 keys you pin, never from the unsigned envelope; OpenTimestamps block placement
 without a caller-supplied header source; policy_digest artefact resolution.
 
-Only the signature checks need non-stdlib code:
-  pip install dilithium-py        (pure python; verify path uses stdlib SHAKE)
-  pip install cryptography        (pinned RSA/ECDSA/Ed25519 TSA certificates)
-Without either, the matching axis reports SKIPPED and the verdict is INCOMPLETE:
-this tool never emits a PASS on an unverified post-quantum signature, nor on
-anchor presence alone. dilithium-py is not constant-time, which is fine for a
+Optional dependencies are loaded inside the checks that require them:
+  pip install dilithium-py        (ML-DSA-65 receipt and timestamp signatures)
+  pip install cryptography        (Ed25519/ES256 receipts, TSA keys/certificates)
+A missing required dependency leaves that check SKIPPED and prevents a passing
+verdict; independent demonstrated failures still make the receipt invalid.
+The tool never passes a signature it did not check or an anchor on presence alone. dilithium-py is not constant-time, which is fine for a
 verify-only tool: it touches only public data (public key, signature, message),
 so there is no secret to leak through timing.
 

--- a/python/tests/test_standalone_verifier_surface.py
+++ b/python/tests/test_standalone_verifier_surface.py
@@ -1,7 +1,7 @@
 """The standalone verifier artifact carries zero asqav producer dependency (421).
 
-verify_receipt.py is the exit-artifact tool: one file, stdlib plus one optional
-signature dependency, no asqav producer module. The AST pins the import
+verify_receipt.py is the exit-artifact tool: one file, stdlib plus optional
+cryptographic dependencies, no asqav producer module. The AST pins the import
 surface, and a subprocess runs the copied file in a bare directory with the
 asqav package refused at import time, against the published ML-DSA-65 receipt.
 """

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -1,4 +1,4 @@
-# Verify an Asqav receipt yourself, one dependency
+# Verify an Asqav receipt yourself
 
 `verify_receipt.py` is a single readable file that verifies an Asqav
 Compliance Receipt on your own machine, without liboqs. It ships inside the
@@ -6,28 +6,25 @@ Compliance Receipt on your own machine, without liboqs. It ships inside the
 gives you the module and you can still copy that one file into an audit
 environment and read every line.
 
-It does the check that actually matters for third-party trust: it verifies the
-post-quantum **ML-DSA-65 (FIPS 204)** signature over the receipt's canonical
-bytes, resolves the issuer's public key from Asqav's public
-`/.well-known/jwks.json` (so you never take our word for which key signed),
-re-walks the SHA-256 hash chain, and reports the anchor binding and timestamp
-skew. Everything except the signature math is Python standard library.
+The tool verifies supported receipt signatures, resolves their keys from a
+JWKS, checks chain links and evaluates anchor proofs with caller-supplied trust
+material. Read each axis and the `not_checked` fields to see the result's limits.
 
 ## Install
 
-Standard library covers structure, canonical bytes, the hash chain, the anchor
-binding, and the skew check with zero installs. The single dependency is the
-post-quantum signature verify:
+The standard library handles structure, canonical bytes, chain links and proof
+parsing. Install the optional cryptographic dependencies for the checks you need:
 
 ```bash
-pip install dilithium-py
+python -m pip install dilithium-py cryptography
 ```
 
-`dilithium-py` is a pure-python FIPS 204 implementation; its verify path uses
-only stdlib SHAKE, so nothing compiles. If you skip it, every other check still
-runs and the signature axis reports `SKIPPED`; the overall verdict is then
-`unverified` with `failure_class=unverifiable`. The tool never reports
-`verified` unless the signature was actually verified.
+`dilithium-py` verifies ML-DSA-65 receipt and timestamp signatures.
+`cryptography` verifies Ed25519/ES256 receipt signatures, decodes TSA keys and
+certificates, and verifies supported classical TSA signatures. Both are imported
+lazily. Missing a dependency required by an applicable check leaves that axis
+`SKIPPED` and prevents a passing verdict. Other checks still run, and a proven
+failure can make the overall failure class `invalid`.
 
 ## Verify a live receipt
 
@@ -55,7 +52,7 @@ cryptographic path runs on an Audit Pack entry, as the next section shows.
 
 ## Verify fully offline
 
-Offline verification needs the signed bytes, and only the Audit Pack export carries them:
+Offline verification needs the complete signed bytes. An Audit Pack export can carry them:
 the hosted `/api/v1/verify/<id>` JSON is a display projection that omits the identifier
 members of the signed payload (`agent_id`, `org_id`, `issuer_id` and the digests), so a
 receipt saved from it can never reproduce the signature. Ask the receipt holder for an
@@ -71,8 +68,8 @@ python -m asqav.verifier.verify_receipt --receipt receipt.json --jwks jwks.json 
 The export carries more top-level members than the signer anchored; the verifier keeps
 only `payload`, `signature` and `anchors`, and every anchor is checked against
 `sha256(JCS({payload, signature}))`, the two-key object the signer committed. The
-standalone tool checks ML-DSA-65 signatures only; a receipt signed with another level
-reports the signature axis as SKIPPED with `unsupported alg`.
+standalone tool supports ML-DSA-65, Ed25519 and ES256 receipt signatures. Other
+algorithm identifiers report the signature axis as SKIPPED with `unsupported alg`.
 
 To check the hash-chain link, also save the predecessor receipt and pass it:
 
@@ -85,7 +82,7 @@ python -m asqav.verifier.verify_receipt --receipt receipt.json --jwks jwks.json 
 
 | Axis | Checked | How |
 |---|---|---|
-| signature | ML-DSA-65 over canonical bytes | `dilithium-py` against the jwks public key |
+| signature | ML-DSA-65, Ed25519 or ES256 over canonical bytes | `dilithium-py` or `cryptography` against the JWKS public key |
 | canonical bytes | JCS reproduction | stdlib `json` (sorted keys, no whitespace, UTF-8) |
 | issuer_key | key resolution by `kid` | matched against `/.well-known/jwks.json` |
 | chain | SHA-256 link to predecessor | stdlib `hashlib` |
@@ -104,8 +101,8 @@ A vector directory may carry the material those inputs need:
 `tsa_trust.pem` (PEM certificates the offline verifier trusts for that
 vector's timestamp-authority token) and `bitcoin_headers.json` (block headers
 keyed by height, each with `hash`, `merkle_root` and `time`). Both are public
-material — the certificates are embedded in the token itself, the headers are
-Bitcoin public data; `conformance-vectors/asqav-24-anchor-block-hash-prod`
+material. Being public or embedded in a token does not establish trust: the caller
+selects TSA keys and Bitcoin block data through a trusted source; `conformance-vectors/asqav-24-anchor-block-hash-prod`
 ships them, and `ANCHOR-MATERIAL.md` there records the two independent header
 sources. A vector without them keeps its anchors axis SKIPPED by design, and
 the requirement map says so.
@@ -151,7 +148,7 @@ declared gap, then any axes evaluation stopped short of as `not_reached`. The
 headline gaps are the TSA certificate path and its revocation state,
 `policy_digest` artefact resolution, aggregate-anchor inclusion proofs, and the
 caller-supplied framework taxonomies, which are carried under the signature but
-never evaluated. For those, use the hosted `/verify` endpoint or the full SDK.
+never evaluated. Assess those requirements separately; another verification entry point does not by itself establish that they were checked.
 
 ## Which requirements the corpus exercises
 
@@ -160,7 +157,7 @@ normative requirements it exercises, and publishes the requirements **no** vecto
 exercises alongside it. Both halves are generated by
 `verifier/build_requirement_map.py`, which derives coverage by running each
 vector through this verifier and reading the axes off the result: an axis the
-verifier skipped is not coverage, whatever a vector'"'"'s notes say. A test fails if
+verifier skipped is not coverage, whatever a vector's notes say. A test fails if
 the committed map drifts from the corpus.
 
 ## Outside recomputations


### PR DESCRIPTION
The offline instructions name the dependencies required for each signature algorithm and distinguish signer keys from timestamp and Bitcoin trust inputs. The verifier README and module descriptions use the same contract; unsupported blanket verification claims are narrowed.

This changes prose and docstrings only. Executable AST matches the main source. Eleven existing copied-file CLI and import-surface tests pass. An independent offline probe checks Ed25519/ES256 with and without their required dependency, signature tampering, and OpenTimestamps results for absent, matching and mismatching block data. Source/Devil and public review accepted the final text.

THREAT_MODEL
- Surface: offline verification instructions and interpretation of trust material.
- Existing guard: lazy cryptographic dependencies, explicit TSA pins and supplied Bitcoin block data govern applicable checks.
- Added test: a local documentation probe exercises real signatures and a committed OTS proof; existing copied-file tests run with producer imports and network access refused.
- Boundary: pinned material does not establish a public certificate path or Bitcoin consensus; no executable verifier change or package release is included.
