### PR TITLE
fix: bind TypeScript agents to their connection

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -39,6 +39,16 @@ console.log(sig.verificationUrl);      // anyone can open this
 One install, one `govern`, one `sign`. `init({ apiKey })` + `Agent.create({ name })` remain
 available when you want control over `algorithm`, `capabilities` and other agent options.
 
+Each Agent keeps the API key and base URL selected when its creation or retrieval starts.
+Its signing mode and a copy of the supplied salt stay with it too. A later `init` or `govern`
+configures future Agents; it does not retarget an existing Agent, even during an awaited operation.
+To rotate a key, call `init` with the new configuration and obtain a new Agent with `Agent.get(id)`.
+Hooks and detector registrations continue to apply to existing Agents when they sign.
+
+Module helpers such as `request` and `verifySignature` use the current default configuration.
+Integrations that create an Agent lazily through the static API also use the default at that time;
+storing configuration in another object does not give that object an isolated SDK connection.
+
 ## Verify it without an account
 
 This is the point of the whole thing — the receipt stands on its own:

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -288,20 +288,20 @@ const HASH_ONLY_METADATA_WHITELIST = new Set<string>([
 ]);
 
 interface Config {
-  apiKey: string | null;
-  baseUrl: string;
-  mode: Mode;
-  orgSalt: Uint8Array | null;
+  readonly apiKey: string | null;
+  readonly baseUrl: string;
+  readonly mode: Mode;
+  readonly orgSalt: Uint8Array | null;
 }
 
-const config: Config = {
+let config: Config = Object.freeze({
   apiKey: null,
   // Seed the base URL from ASQAV_API_URL, matching the Python half's module-level
   // _api_base, so keyless verify() honors the env without an init() call.
   baseUrl: process.env.ASQAV_API_URL ?? DEFAULT_BASE_URL,
   mode: "full-payload",
   orgSalt: null,
-};
+});
 
 // === Errors ===
 
@@ -906,18 +906,18 @@ export function init(options: InitOptions = {}): void {
         "to init(). A saved key is read from ~/.asqav/credentials. Get yours at asqav.com",
     );
   }
-  config.apiKey = apiKey;
-  config.baseUrl = options.baseUrl ?? config.baseUrl ?? DEFAULT_BASE_URL;
-  config.mode = resolveMode(
-    config.baseUrl,
+  const baseUrl = options.baseUrl ?? config.baseUrl ?? DEFAULT_BASE_URL;
+  const mode = resolveMode(
+    baseUrl,
     process.env.ASQAV_MODE ?? null,
     options.mode ?? "auto",
   );
-  config.orgSalt = options.orgSalt ?? null;
+  const orgSalt = options.orgSalt == null ? null : new Uint8Array(options.orgSalt);
+  config = Object.freeze({ apiKey, baseUrl, mode, orgSalt });
 }
 
-function ensureInitialized(): void {
-  if (!config.apiKey) {
+function ensureInitialized(connection: Config): void {
+  if (!connection.apiKey) {
     throw new AuthenticationError("Call init() first. Get your API key at asqav.com");
   }
 }
@@ -979,11 +979,20 @@ export async function request<T = unknown>(
   path: string,
   body?: unknown,
 ): Promise<T> {
-  ensureInitialized();
+  return requestWithConnection<T>(config, method, path, body);
+}
 
-  const url = config.baseUrl.replace(/\/+$/, "") + (path.startsWith("/") ? path : `/${path}`);
+async function requestWithConnection<T>(
+  connection: Config,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  ensureInitialized(connection);
+
+  const url = connection.baseUrl.replace(/\/+$/, "") + (path.startsWith("/") ? path : `/${path}`);
   const headers: Record<string, string> = {
-    "X-API-Key": config.apiKey as string,
+    "X-API-Key": connection.apiKey as string,
     "Content-Type": "application/json",
     Accept: "application/json",
     ...userAgentHeaders(),
@@ -1796,11 +1805,11 @@ interface BuildSignBodyArgs {
   userIntent?: UserIntent;
 }
 
-async function buildSignBody(args: BuildSignBodyArgs): Promise<Record<string, unknown>> {
-  if (config.mode === "hash-only") {
+async function buildSignBody(connection: Config, args: BuildSignBodyArgs): Promise<Record<string, unknown>> {
+  if (connection.mode === "hash-only") {
     const canonical = canonicalizeAction(args.actionType, args.context);
     const payloadSize = canonical.byteLength;
-    const salt = config.orgSalt ?? undefined;
+    const salt = connection.orgSalt ?? undefined;
     const hex = salt
       ? createHmac("sha256", Buffer.from(salt)).update(canonical).digest("hex")
       : createHash("sha256").update(canonical).digest("hex");
@@ -1883,7 +1892,31 @@ interface AgentData {
   created_at: string | number;
 }
 
+
+function preflightExplanation(
+  cleared: boolean, checksComplete: boolean, agentActive: boolean,
+  policyAllowed: boolean, reasons: string[],
+): string {
+  let explanation: string;
+  if (cleared) {
+    explanation = "Allowed: agent is active and action is permitted by policy";
+  } else if (!checksComplete) {
+    explanation = `Blocked: could not verify (${reasons.join("; ")})`;
+  } else if (!agentActive && reasons.includes("agent is revoked")) {
+    explanation = "Blocked: agent has been revoked";
+  } else if (!agentActive && reasons.some((r) => r.startsWith("agent is suspended"))) {
+    const suspendReason = reasons.find((r) => r.startsWith("agent is suspended")) ?? "";
+    explanation = `Blocked: ${suspendReason}`;
+  } else if (!policyAllowed) {
+    explanation = "Blocked: action not permitted by current policy rules";
+  } else {
+    explanation = reasons.length ? `Blocked: ${reasons.join("; ")}` : "Blocked";
+  }
+  return explanation;
+}
+
 export class Agent {
+  readonly #connection: Config;
   readonly agentId: string;
   readonly name: string;
   readonly publicKey: string;
@@ -1893,7 +1926,8 @@ export class Agent {
   readonly createdAt: string | number;
   private sessionId: string | null = null;
 
-  private constructor(data: AgentData) {
+  private constructor(data: AgentData, connection: Config) {
+    this.#connection = connection;
     this.agentId = requireField<string>(data, "agent_id");
     this.name = requireField<string>(data, "name");
     this.publicKey = requireField<string>(data, "public_key");
@@ -1905,10 +1939,11 @@ export class Agent {
 
   /** Internal: rebuild an Agent from a server payload. */
   static attach(data: AgentData): Agent {
-    return new Agent(data);
+    return new Agent(data, config);
   }
 
   static async create(options: AgentCreateOptions): Promise<Agent> {
+    const connection = config;
     const algorithm = options.algorithm ?? "ml-dsa-65";
     // Cloud accepts ml-dsa-{44,65,87}; ed25519/es256 are local-signing only.
     if (!isSupportedAlgorithm(algorithm)) {
@@ -1916,20 +1951,22 @@ export class Agent {
         `unsupported_algorithm: '${algorithm}'. Use one of: ${SUPPORTED_ALGORITHMS.join(", ")}`,
       );
     }
-    const data = await request<AgentData>("POST", "/agents/create", {
+    const data = await requestWithConnection<AgentData>(connection, "POST", "/agents/create", {
       name: options.name,
       algorithm,
       capabilities: options.capabilities ?? [],
     });
-    return new Agent(data);
+    return new Agent(data, connection);
   }
 
   static async get(agentId: string): Promise<Agent> {
-    const data = await request<AgentData>("GET", `/agents/${agentId}`);
-    return new Agent(data);
+    const connection = config;
+    const data = await requestWithConnection<AgentData>(connection, "GET", `/agents/${agentId}`);
+    return new Agent(data, connection);
   }
 
   async sign(options: SignOptions): Promise<SignatureResponse> {
+    const connection = this.#connection;
     const initialContext = surfaceKwargsIntoContext(options);
     const afterHookContext = _dispatchBefore(options.actionType, initialContext);
     const complianceMode = options.complianceMode !== false;
@@ -1964,7 +2001,7 @@ export class Agent {
       finalContext,
     );
 
-    const body = await buildSignBody({
+    const body = await buildSignBody(connection, {
       actionType: options.actionType,
       context: finalContext,
       sessionId: this.sessionId,
@@ -1974,7 +2011,8 @@ export class Agent {
     applyOptionalWireFields(body, options);
     applyComplianceFields(body, options, complianceMode, actionRef);
 
-    const data = await request<SignWireResponse>(
+    const data = await requestWithConnection<SignWireResponse>(
+      connection,
       "POST",
       `/agents/${this.agentId}/sign`,
       body,
@@ -1985,7 +2023,7 @@ export class Agent {
   }
 
   async countersign(signatureId: string): Promise<SignatureResponse> {
-    const data = await request<{
+    const data = await requestWithConnection<{
       signature: string;
       signature_id: string;
       action_id: string;
@@ -1998,7 +2036,7 @@ export class Agent {
       co_signatures?: Array<{ agent_id: string; signature: string; signed_at: string }>;
       countersign_url?: string;
       user_intent_verified?: boolean;
-    }>("POST", `/agents/${this.agentId}/countersign/${signatureId}`, {});
+    }>(this.#connection, "POST", `/agents/${this.agentId}/countersign/${signatureId}`, {});
 
     return {
       signature: requireField<string>(data, "signature"),
@@ -2020,12 +2058,12 @@ export class Agent {
   }
 
   async startSession(): Promise<SessionResponse> {
-    const data = await request<{
+    const data = await requestWithConnection<{
       session_id: string;
       agent_id: string;
       status: string;
       started_at: string;
-    }>("POST", "/sessions/", { agent_id: this.agentId });
+    }>(this.#connection, "POST", "/sessions/", { agent_id: this.agentId });
     this.sessionId = data.session_id;
     return {
       sessionId: data.session_id,
@@ -2040,12 +2078,12 @@ export class Agent {
       throw new AsqavError("No active session");
     }
     const sessionId = this.sessionId;
-    const data = await request<{
+    const data = await requestWithConnection<{
       agent_id: string;
       status: string;
       started_at: string;
       ended_at?: string;
-    }>("PATCH", `/sessions/${sessionId}`, { status: options.status ?? "completed" });
+    }>(this.#connection, "PATCH", `/sessions/${sessionId}`, { status: options.status ?? "completed" });
     this.sessionId = null;
     return {
       sessionId,
@@ -2057,7 +2095,7 @@ export class Agent {
   }
 
   async revoke(options: { reason?: string } = {}): Promise<void> {
-    await request("POST", `/agents/${this.agentId}/revoke`, {
+    await requestWithConnection(this.#connection, "POST", `/agents/${this.agentId}/revoke`, {
       reason: options.reason ?? "manual",
     });
   }
@@ -2073,7 +2111,8 @@ export class Agent {
     const reasons: string[] = [];
 
     try {
-      const status = await request<{ revoked?: boolean; suspended?: boolean; suspended_reason?: string }>(
+      const status = await requestWithConnection<{ revoked?: boolean; suspended?: boolean; suspended_reason?: string }>(
+        this.#connection,
         "GET",
         `/agents/${this.agentId}/status`,
       );
@@ -2100,12 +2139,12 @@ export class Agent {
     }
 
     try {
-      const policies = await request<Array<{
+      const policies = await requestWithConnection<Array<{
         is_active?: boolean;
         action_pattern?: string;
         action?: string;
         name?: string;
-      }>>("GET", "/policies");
+      }>>(this.#connection, "GET", "/policies");
       if (!Array.isArray(policies)) {
         // A non-list response is anomalous, so fail closed instead of
         // silently clearing on an empty iteration.
@@ -2129,21 +2168,7 @@ export class Agent {
     }
 
     const cleared = agentActive && policyAllowed && checksComplete;
-    let explanation: string;
-    if (cleared) {
-      explanation = "Allowed: agent is active and action is permitted by policy";
-    } else if (!checksComplete) {
-      explanation = `Blocked: could not verify (${reasons.join("; ")})`;
-    } else if (!agentActive && reasons.includes("agent is revoked")) {
-      explanation = "Blocked: agent has been revoked";
-    } else if (!agentActive && reasons.some((r) => r.startsWith("agent is suspended"))) {
-      const suspendReason = reasons.find((r) => r.startsWith("agent is suspended")) ?? "";
-      explanation = `Blocked: ${suspendReason}`;
-    } else if (!policyAllowed) {
-      explanation = "Blocked: action not permitted by current policy rules";
-    } else {
-      explanation = reasons.length ? `Blocked: ${reasons.join("; ")}` : "Blocked";
-    }
+    const explanation = preflightExplanation(cleared, checksComplete, agentActive, policyAllowed, reasons);
 
     return { cleared, agentActive, policyAllowed, reasons, explanation, checksComplete };
   }
@@ -2485,16 +2510,17 @@ export function verifyReceiptOffline(
 
 /** @internal - reset module state. Used in tests. */
 export function _resetForTests(): void {
-  config.apiKey = null;
-  config.baseUrl = process.env.ASQAV_API_URL ?? DEFAULT_BASE_URL;
-  config.mode = "full-payload";
-  config.orgSalt = null;
+  config = Object.freeze({
+    apiKey: null,
+    baseUrl: process.env.ASQAV_API_URL ?? DEFAULT_BASE_URL,
+    mode: "full-payload",
+    orgSalt: null,
+  });
 }
 
 /** @internal - inspect or override mode in tests. */
 export function _setModeForTests(mode: Mode, orgSalt?: Uint8Array | null): void {
-  config.mode = mode;
-  config.orgSalt = orgSalt ?? null;
+  config = Object.freeze({ ...config, mode, orgSalt: orgSalt == null ? null : new Uint8Array(orgSalt) });
 }
 
 /** @internal - read current mode in tests. */

--- a/typescript/tests/clientHashMode.test.ts
+++ b/typescript/tests/clientHashMode.test.ts
@@ -267,23 +267,23 @@ describe("Agent.sign body shape across modes", () => {
   });
 
   it("hash-only with org salt produces a different hash than without", async () => {
-    const agent = await makeAgent();
-
     _setModeForTests("hash-only");
+    const plainAgent = await makeAgent();
     let fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
-    await agent.sign({ actionType: "api:call", context: { k: 3 } });
+    await plainAgent.sign({ actionType: "api:call", context: { k: 3 } });
     const plain = JSON.parse(
       (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
     ).hash;
     fetchSpy.mockRestore();
 
     _setModeForTests("hash-only", new Uint8Array(32).fill(1));
+    const saltedAgent = await makeAgent();
     fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
-    await agent.sign({ actionType: "api:call", context: { k: 3 } });
+    await saltedAgent.sign({ actionType: "api:call", context: { k: 3 } });
     const salted = JSON.parse(
       (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
     ).hash;
@@ -294,23 +294,23 @@ describe("Agent.sign body shape across modes", () => {
   });
 
   it("hash-only labels a keyed digest hmac-sha256, not sha256", async () => {
-    const agent = await makeAgent();
-
     _setModeForTests("hash-only");
+    const plainAgent = await makeAgent();
     let fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
-    await agent.sign({ actionType: "api:call", context: { k: 3 } });
+    await plainAgent.sign({ actionType: "api:call", context: { k: 3 } });
     const plainBody = JSON.parse(
       (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
     );
     fetchSpy.mockRestore();
 
     _setModeForTests("hash-only", new Uint8Array(32).fill(1));
+    const saltedAgent = await makeAgent();
     fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(mockJsonResponse(SIGN_RESPONSE));
-    await agent.sign({ actionType: "api:call", context: { k: 3 } });
+    await saltedAgent.sign({ actionType: "api:call", context: { k: 3 } });
     const saltedBody = JSON.parse(
       (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
     );

--- a/typescript/tests/connectionIsolation.test.ts
+++ b/typescript/tests/connectionIsolation.test.ts
@@ -1,0 +1,293 @@
+import { createHash, createHmac } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  Agent, AuthenticationError, DetectorBlockedError, _resetForTests, clearDetectors,
+  clearHooks, govern, init, registerBefore, registerDetector, request,
+  type InitOptions,
+} from "../src/index.js";
+import { canonicalizeAction } from "../src/canonicalize.js";
+
+const tenants = {
+  A: { apiKey: "fixture-key-A-not-a-credential", baseUrl: "https://tenant-a.invalid/api/v1" },
+  B: { apiKey: "fixture-key-B-not-a-credential", baseUrl: "https://tenant-b.invalid/api/v1" },
+};
+type Tenant = keyof typeof tenants;
+type Call = { tenant: Tenant; path: string; body: Record<string, unknown> };
+const calls: Call[] = [];
+const payload = (tenant: Tenant) => ({
+  agent_id: `agt_${tenant}`, name: "fixture", public_key: "fixture-public-key",
+  key_id: "fixture-key-id", algorithm: "ml-dsa-65", capabilities: [], created_at: "2026-09-08",
+});
+const signResponse = {
+  signature: "fixture-signature", signature_id: "sig_fixture", action_id: "act_fixture",
+  timestamp: "2026-09-08", verification_url: "https://fixture.invalid/receipt",
+};
+let intercept: ((call: Call) => Promise<void>) | undefined;
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+function configure(tenant: Tenant, extra: Partial<InitOptions> = {}) {
+  init({ ...tenants[tenant], mode: "full-payload", ...extra });
+}
+
+beforeEach(() => {
+  vi.stubEnv("ASQAV_MODE", "");
+  _resetForTests();
+  clearHooks();
+  clearDetectors();
+  calls.length = 0;
+  intercept = undefined;
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, options) => {
+    const url = new URL(String(input));
+    const tenant = url.hostname === "tenant-a.invalid" ? "A" : "B";
+    expect(url.origin).toBe(new URL(tenants[tenant].baseUrl).origin);
+    expect(new Headers(options?.headers).get("x-api-key")).toBe(tenants[tenant].apiKey);
+    const call: Call = { tenant, path: url.pathname, body: JSON.parse(String(options?.body ?? "{}")) };
+    calls.push(call);
+    await intercept?.(call);
+    if (url.pathname.endsWith("/policies")) return Response.json([]);
+    if (url.pathname.endsWith("/status")) return Response.json({ revoked: false });
+    return Response.json({ ...payload(tenant), ...signResponse,
+      session_id: `ses_${tenant}`, status: "active", started_at: "2026-09-08" });
+  });
+});
+
+afterEach(() => {
+  clearHooks();
+  clearDetectors();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  _resetForTests();
+});
+
+describe("Agent connection lifetime", () => {
+  it.each(["create", "get", "attach", "govern-create", "govern-get"] as const)(
+    "%s retains A while later defaults select B", async (factory) => {
+      configure("A");
+      const agent = factory === "create" ? await Agent.create({ name: "fixture" })
+        : factory === "get" ? await Agent.get("agt_A")
+        : factory === "attach" ? Agent.attach(payload("A"))
+        : await govern({ ...tenants.A, ...(factory === "govern-get" ? { agentId: "agt_A" } : {}) });
+      await govern({ ...tenants.B, agentName: "fixture" });
+      calls.length = 0;
+      await agent.sign({ actionType: "api:call" });
+      await agent.countersign("sig_fixture");
+      await agent.startSession();
+      await agent.endSession();
+      await agent.revoke();
+      expect((await agent.preflight("api:call")).cleared).toBe(true);
+      expect(calls).toHaveLength(7);
+      expect(calls.every((call) => call.tenant === "A")).toBe(true);
+      expect(calls.map((call) => call.path)).toEqual([
+        "/api/v1/agents/agt_A/sign", "/api/v1/agents/agt_A/countersign/sig_fixture",
+        "/api/v1/sessions/", "/api/v1/sessions/ses_A", "/api/v1/agents/agt_A/revoke",
+        "/api/v1/agents/agt_A/status", "/api/v1/policies",
+      ]);
+      await request("GET", "/policies");
+      expect(calls.at(-1)?.tenant).toBe("B");
+      const future = await Agent.get("agt_B");
+      await future.sign({ actionType: "api:call" });
+      expect(calls.at(-1)?.tenant).toBe("B");
+    },
+  );
+
+  it.each(["A", "B"] as const)("captures %s before create/get responses resolve", async (first) => {
+    const second = first === "A" ? "B" : "A";
+    for (const operation of ["create", "get"] as const) {
+      const entered = deferred();
+      const release = deferred();
+      configure(first);
+      intercept = async (call) => {
+        if (call.tenant === first && !call.path.endsWith("/sign")) {
+          entered.resolve();
+          await release.promise;
+        }
+      };
+      const pending = operation === "create" ? Agent.create({ name: "fixture" }) : Agent.get(`agt_${first}`);
+      await entered.promise;
+      const other = await govern({ ...tenants[second], agentName: "fixture" });
+      await other.sign({ actionType: "api:call" });
+      release.resolve();
+      const original = await pending;
+      await original.sign({ actionType: "api:call" });
+      expect(calls.slice(-4).map((call) => call.tenant)).toEqual([first, second, second, first]);
+    }
+  });
+
+  it("uses its original connection for the second preflight read", async () => {
+    configure("A");
+    const agent = Agent.attach(payload("A"));
+    const entered = deferred();
+    const release = deferred();
+    intercept = async (call) => {
+      if (call.path.endsWith("/status")) { entered.resolve(); await release.promise; }
+    };
+    const pending = agent.preflight("api:call");
+    await entered.promise;
+    configure("B");
+    release.resolve();
+    expect((await pending).checksComplete).toBe(true);
+    expect(calls.map((call) => call.tenant)).toEqual(["A", "A"]);
+  });
+
+  it("does not bind an uninitialized attached Agent during a later init", async () => {
+    const agent = Agent.attach(payload("A"));
+    configure("B");
+    await expect(agent.sign({ actionType: "api:call" })).rejects.toBeInstanceOf(AuthenticationError);
+    await expect(agent.countersign("sig_fixture")).rejects.toBeInstanceOf(AuthenticationError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("publishes no partial default when initialization fails", async () => {
+    configure("A", { mode: "hash-only", orgSalt: new Uint8Array([1, 2, 3]) });
+    expect(() => configure("B", { mode: "invalid" as InitOptions["mode"] })).toThrow("mode must");
+    const agent = await Agent.get("agt_A");
+    await agent.sign({ actionType: "api:call" });
+    expect(calls.map((call) => call.tenant)).toEqual(["A", "A"]);
+    const canonical = canonicalizeAction("api:call", {});
+    expect(calls.at(-1)?.body.hash).toBe(`sha256:${createHmac("sha256", new Uint8Array([1, 2, 3])).update(canonical).digest("hex")}`);
+  });
+
+  it.each([false, true])("owns salt bytes even when input is a Buffer: %s", async (buffer) => {
+    const salt = buffer ? Buffer.alloc(32, 7) : new Uint8Array(32).fill(7);
+    configure("A", { mode: "hash-only", orgSalt: salt });
+    salt.fill(9);
+    const agent = Agent.attach(payload("A"));
+    configure("B");
+    await agent.sign({ actionType: "api:call", context: { private: "fixture" } });
+    const canonical = canonicalizeAction("api:call", { private: "fixture" });
+    expect(calls[0].body.hash).toBe(`sha256:${createHmac("sha256", Buffer.alloc(32, 7)).update(canonical).digest("hex")}`);
+    expect(Object.getOwnPropertyNames(agent).sort()).toEqual([
+      "agentId", "algorithm", "capabilities", "createdAt", "keyId", "name", "publicKey", "sessionId",
+    ]);
+    expect(Object.getOwnPropertySymbols(agent)).toEqual([]);
+    const serialized = JSON.stringify(agent);
+    for (const secret of [tenants.A.apiKey, tenants.A.baseUrl, "orgSalt", "hash-only"]) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+});
+
+describe.each(["hash-only", "full-payload"] as const)("bound %s signing", (mode) => {
+  it.each(["hook", "schema", "detector"] as const)("keeps mode and salt across %s reinitialization", async (boundary) => {
+    const salt = new Uint8Array(32).fill(5);
+    configure("A", { mode, orgSalt: salt });
+    const agent = Agent.attach(payload("A"));
+    const context: Record<string, unknown> = { private: "fixture", _model_name: "fixture-model" };
+    const entered = deferred();
+    const release = deferred();
+    const switchDefault = () => configure("B", { mode: mode === "hash-only" ? "full-payload" : "hash-only" });
+    if (boundary === "hook") registerBefore("*", () => { switchDefault(); });
+    const verdict = { allow: true, confidence: 1, labels: [], detector: "fixture", reason: "fixture" };
+    if (boundary === "detector") registerDetector({ name: "fixture", inspect: async () => {
+      entered.resolve(); await release.promise; return verdict;
+    } });
+    const pending = agent.sign({
+      actionType: "api:call", context, policyDecision: "permit",
+      contextSchema: boundary === "schema" ? switchDefault : undefined,
+    });
+    if (boundary === "detector") {
+      await entered.promise; switchDefault(); release.resolve();
+    }
+    await pending;
+    expect(calls[0].tenant).toBe("A");
+    const body = calls[0].body;
+    const signedContext = boundary === "detector" ? { ...context, _detectors: [verdict] } : context;
+    expect(body.policy_decision).toBe("permit");
+    expect(body.action_ref).toMatch(/^sha256:[0-9a-f]{64}$/);
+    if (mode === "hash-only") {
+      const canonical = canonicalizeAction("api:call", signedContext);
+      expect(body.hash).toBe(`sha256:${createHmac("sha256", salt).update(canonical).digest("hex")}`);
+      expect(body.hash_algo).toBe("hmac-sha256");
+      expect(body.payload_size).toBe(canonical.byteLength);
+      expect(body.metadata).toEqual({ agent_id: "agt_A", action_type: "api:call", model_name: "fixture-model" });
+      expect(body).not.toHaveProperty("context");
+    } else {
+      expect(body.context).toEqual(signedContext);
+      expect(body).not.toHaveProperty("hash");
+    }
+    clearHooks(); clearDetectors();
+    await Agent.attach(payload("B")).sign({ actionType: "api:call", context });
+    expect(calls.at(-1)?.tenant).toBe("B");
+    expect(calls.at(-1)?.body).toHaveProperty(mode === "hash-only" ? "context" : "hash");
+  });
+});
+
+it.each(["deny", "throw"] as const)("preserves late detector %s blocking before HTTP", async (failure) => {
+  configure("A");
+  const agent = Agent.attach(payload("A"));
+  registerDetector({ name: "fixture", inspect: () => {
+    configure("B");
+    if (failure === "throw") throw new Error("fixture detector failure");
+    return { allow: false, confidence: 1, labels: ["fixture-deny"], detector: "fixture", reason: "fixture" };
+  } });
+  await expect(agent.sign({ actionType: "api:call" })).rejects.toBeInstanceOf(DetectorBlockedError);
+  expect(calls).toHaveLength(0);
+  clearDetectors();
+  await agent.sign({ actionType: "api:call" });
+  expect(calls[0].tenant).toBe("A");
+});
+
+it("retains unsalted hashing when a later default supplies a salt", async () => {
+  configure("A", { mode: "hash-only" });
+  const agent = Agent.attach(payload("A"));
+  configure("B", { mode: "hash-only", orgSalt: new Uint8Array([1]) });
+  await agent.sign({ actionType: "api:call" });
+  expect(calls[0].body.hash_algo).toBe("sha256");
+  expect(calls[0].body.hash).toBe(`sha256:${createHash("sha256").update(canonicalizeAction("api:call", {})).digest("hex")}`);
+});
+
+it.each([undefined, "fixture suspension"])("preserves suspended-agent preflight: %s", async (reason) => {
+  configure("A");
+  const agent = Agent.attach(payload("A"));
+  configure("B");
+  vi.mocked(fetch).mockImplementation(async (input, options) => {
+    expect(new Headers(options?.headers).get("x-api-key")).toBe(tenants.A.apiKey);
+    expect(String(input)).toMatch(/^https:\/\/tenant-a\.invalid\//);
+    return String(input).endsWith("/status")
+      ? Response.json({ suspended: true, suspended_reason: reason }) : Response.json([]);
+  });
+  const result = await agent.preflight("api:call");
+  expect(result).toMatchObject({ cleared: false, agentActive: false, checksComplete: true });
+  expect(result.explanation).toBe(`Blocked: agent is suspended${reason ? ` (${reason})` : ""}`);
+});
+
+it.each(["network", "rate-limit", "retry-success"])("retains bound retry transport: %s", async (failure) => {
+  configure("A");
+  const agent = Agent.attach(payload("A"));
+  vi.useFakeTimers();
+  let attempts = 0;
+  vi.mocked(fetch).mockImplementation(async (input, options) => {
+    expect(String(input)).toMatch(/^https:\/\/tenant-a\.invalid\//);
+    expect(new Headers(options?.headers).get("x-api-key")).toBe(tenants.A.apiKey);
+    expect(JSON.parse(String(options?.body)).context).toEqual({ private: "fixture" });
+    configure("B", { mode: "hash-only" });
+    attempts++;
+    if (failure === "network") throw new Error("fixture network failure");
+    if (failure === "rate-limit") return Response.json({}, { status: 429 });
+    return Response.json(attempts < 3 ? {} : signResponse, { status: attempts < 3 ? 503 : 200 });
+  });
+  const pending = agent.sign({ actionType: "api:call", context: { private: "fixture" } });
+  const checked = failure === "retry-success" ? expect(pending).resolves.toMatchObject({ signatureId: "sig_fixture" })
+    : expect(pending).rejects.toThrow(failure === "network" ? "Network error: fixture network failure" : "Rate limit exceeded");
+  await vi.runAllTimersAsync();
+  await checked;
+  expect(attempts).toBe(3);
+});
+
+it("preserves non-JSON error details and empty successful responses", async () => {
+  configure("A");
+  const agent = Agent.attach(payload("A"));
+  configure("B");
+  vi.mocked(fetch).mockResolvedValueOnce(new Response("fixture refused", { status: 400 }));
+  await expect(agent.revoke()).rejects.toThrow();
+  vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+  await expect(agent.revoke()).resolves.toBeUndefined();
+  vi.mocked(fetch).mockResolvedValueOnce(new Response("not-json", { status: 200 }));
+  await expect(request("GET", "/fixture")).resolves.toBeUndefined();
+});


### PR DESCRIPTION
An Agent retains the connection selected when creation or retrieval starts. Reinitializing the SDK for another account configures future Agents; pending operations keep their selected destination and signing mode. The supplied salt is copied, and failed initialization leaves the default configuration intact. The README explains key rotation through a newly obtained Agent.

Validation: 1,192 tests pass with the locked runner, plus the native coverage run. All 18 changed TypeScript functions are measured, with maximum CRAP 21; six guard mutations fail their assertions. Independent package reviews exercise both module formats and public entrypoints. LEAD replay passes all 27 focused cases and a retry interrupted by default reinitialization.

THREAT_MODEL
- Attack surface: shared SDK defaults can mix account credentials or signing configuration across asynchronous Agent operations.
- Guard: capture an immutable connection before asynchronous work and use it for every Agent request, including both preflight reads.
- Negative proof: held responses, callback reinitialization and mutable salt controls detect connection crossings; the published package fails the held-create control.
- Trust boundary: module helpers and static Agent creation still select the active default. Integrations that construct Agents lazily need an explicit client; package publication and adapter adoption are separate work.
