### PR TITLE
fix: include scoped licenses in Python distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           filters: |
             python:
               - 'python/**'
+              - 'LICENSE'
               - 'conformance/**'
               # The shared case tables gate both verifiers, so editing one must run
               # the jobs that consume it or the gate could be weakened unseen.
@@ -88,6 +89,22 @@ jobs:
       - run: pip install -e "./python[all,dev]" pytest ruff
       - run: ruff check python/src
       - run: pytest python/tests -v --tb=short --continue-on-collection-errors
+
+  python-distributions:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: python -m pip install build
+      - run: cmp LICENSE python/LICENSE
+      # The default build creates a source archive, then builds its wheel.
+      - run: python -m build python --outdir python/dist
+      - run: python python/scripts/check_distribution_licenses.py python/dist/*.whl python/dist/*.tar.gz
+      - run: python python/scripts/test_distribution_licenses.py python/dist/*.whl python/dist/*.tar.gz
 
   typescript:
     needs: changes
@@ -164,16 +181,18 @@ jobs:
   ci-ok:
     # Single required status check for branch protection.
     # Passes when matrix jobs succeeded OR were skipped (no relevant changes).
-    needs: [python, typescript, verifier, actions]
+    needs: [python, python-distributions, typescript, verifier, actions]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - run: |
           echo "python=${{ needs.python.result }}"
+          echo "python-distributions=${{ needs.python-distributions.result }}"
           echo "typescript=${{ needs.typescript.result }}"
           echo "verifier=${{ needs.verifier.result }}"
           echo "actions=${{ needs.actions.result }}"
           [[ "${{ needs.python.result }}"     =~ ^(success|skipped)$ ]] || exit 1
+          [[ "${{ needs.python-distributions.result }}" =~ ^(success|skipped)$ ]] || exit 1
           [[ "${{ needs.typescript.result }}" =~ ^(success|skipped)$ ]] || exit 1
           [[ "${{ needs.verifier.result }}"   =~ ^(success|skipped)$ ]] || exit 1
           [[ "${{ needs.actions.result }}"    =~ ^(success|skipped)$ ]] || exit 1

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,95 @@
+Copyright (c) 2026 Asqav
+
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/python/NOTICE
+++ b/python/NOTICE
@@ -1,0 +1,13 @@
+Asqav Python distribution
+
+The SDK uses the Elastic License 2.0 terms in LICENSE.
+The file-level exception is asqav/verifier/verify_receipt.py
+(src/asqav/verifier/verify_receipt.py in the source distribution), whose
+header specifies the Apache License 2.0 and retains this notice:
+
+Copyright 2026 Asqav
+
+The Apache terms for that file are in licenses/Apache-2.0.txt. The broader
+verifier package and its oracle remain under the SDK's Elastic terms.
+The distribution's combined license expression describes these file scopes;
+it does not offer a choice of licenses for the SDK.

--- a/python/README.md
+++ b/python/README.md
@@ -200,4 +200,11 @@ Aligns with NIST FIPS 204 (ML-DSA), RFC 8785 (JCS) and NSA CSI U/OO/6030316-26.
 
 ## License
 
-Elastic License 2.0. Get an API key at [asqav.com](https://asqav.com).
+The SDK uses [Elastic License 2.0](LICENSE). The standalone
+`asqav/verifier/verify_receipt.py` file has an Apache-2.0 header;
+its terms are included in [licenses/Apache-2.0.txt](licenses/Apache-2.0.txt).
+The broader verifier package and oracle remain under Elastic terms.
+
+Wheels and source distributions include these terms and the file-scope
+[NOTICE](NOTICE). Their combined license expression describes the separate
+file scopes; it does not offer a choice of licenses for the SDK.

--- a/python/licenses/Apache-2.0.txt
+++ b/python/licenses/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -7,7 +7,8 @@ name = "asqav"
 version = "0.10.10"
 description = "AI agent governance - audit trails, policy enforcement, compliance"
 readme = "README.md"
-license = "LicenseRef-Elastic-License-2.0"
+license = "LicenseRef-Elastic-License-2.0 AND Apache-2.0"
+license-files = ["LICENSE", "NOTICE", "licenses/Apache-2.0.txt"]
 requires-python = ">=3.10"
 authors = [
     { name = "Asqav", email = "info@asqav.com" }
@@ -35,7 +36,6 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: Other/Proprietary License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/python/scripts/check_distribution_licenses.py
+++ b/python/scripts/check_distribution_licenses.py
@@ -1,0 +1,131 @@
+"""Check license contents and metadata in a built wheel and source archive."""
+
+import argparse
+import hashlib
+import lzma
+import sys
+import tarfile
+import zipfile
+import zlib
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+from typing import BinaryIO, cast
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPRESSION = "LicenseRef-Elastic-License-2.0 AND Apache-2.0"
+TERMS = {
+    "LICENSE": "ad5d7597acff2920f256e16d0a47b0547e67201b72f67a1813b1ce253e36a58c",
+    "licenses/Apache-2.0.txt": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+}
+LICENSE_FILES = ["LICENSE", "NOTICE", "licenses/Apache-2.0.txt"]
+VERIFIER = "asqav/verifier/verify_receipt.py"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def references(root: Path) -> dict[str, bytes]:
+    files = {name: (root / name).read_bytes() for name in LICENSE_FILES}
+    for name, expected in TERMS.items():
+        require(hashlib.sha256(files[name]).hexdigest() == expected, f"source terms drift: {name}")
+    files[VERIFIER] = (root / "src" / VERIFIER).read_bytes()
+    return files
+
+
+def archive_members(path: Path) -> dict[str, bytes]:
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as wheel_archive:
+            pairs = [
+                (name, wheel_archive.read(name))
+                for name in wheel_archive.namelist()
+                if not name.endswith("/")
+            ]
+    else:
+        require(path.name.endswith(".tar.gz"), "expected a wheel or .tar.gz source archive")
+        with tarfile.open(path, "r:gz") as source_archive:
+            pairs = [
+                (entry.name, cast(BinaryIO, source_archive.extractfile(entry)).read())
+                for entry in source_archive.getmembers()
+                if entry.isfile()
+            ]
+    require(len(pairs) == len({name for name, _ in pairs}), "duplicate archive member")
+    return dict(pairs)
+
+
+def check_metadata(raw: bytes) -> str:
+    metadata = BytesParser(policy=policy.default).parsebytes(raw)
+    require(metadata.get_all("Name") == ["asqav"], "unexpected package name")
+    versions = metadata.get_all("Version", [])
+    require(len(versions) == 1 and bool(versions[0]), "missing or duplicate package version")
+    formats = metadata.get_all("Metadata-Version", [])
+    require(len(formats) == 1, "missing or duplicate metadata version")
+    format_version = str(formats[0]).split(".")
+    require(
+        len(format_version) == 2 and all(part.isdigit() for part in format_version),
+        "invalid metadata version",
+    )
+    require(
+        tuple(map(int, format_version)) >= (2, 4), "license metadata requires version 2.4 or newer"
+    )
+    require(metadata.get_all("License-Expression") == [EXPRESSION], "license expression mismatch")
+    paths = metadata.get_all("License-File", [])
+    require(sorted(paths) == sorted(LICENSE_FILES), "missing, duplicate or unexpected License-File")
+    return str(versions[0])
+
+
+def check_archive(path: Path, expected: dict[str, bytes]) -> None:
+    members = archive_members(path)
+    wheel = path.suffix == ".whl"
+    suffix = "/METADATA" if wheel else "/PKG-INFO"
+    metadata_paths = [name for name in members if name.endswith(suffix)]
+    require(len(metadata_paths) == 1, "expected exactly one package metadata file")
+    metadata_path = metadata_paths[0]
+    version = check_metadata(members[metadata_path])
+    root = f"asqav-{version}.dist-info" if wheel else f"asqav-{version}"
+    require(metadata_path == root + suffix, "metadata archive path mismatch")
+    license_root = root + "/licenses/" if wheel else root + "/"
+    for name in LICENSE_FILES:
+        require(
+            members.get(license_root + name) == expected[name],
+            f"missing or changed license: {name}",
+        )
+    verifier_path = VERIFIER if wheel else root + "/src/" + VERIFIER
+    require(
+        members.get(verifier_path) == expected[VERIFIER], "standalone verifier or header changed"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path)
+    parser.add_argument("sdist", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        require(
+            args.wheel.suffix == ".whl" and args.sdist.name.endswith(".tar.gz"),
+            "supply one wheel followed by one .tar.gz source archive",
+        )
+        expected = references(ROOT)
+        check_archive(args.wheel, expected)
+        check_archive(args.sdist, expected)
+    except (
+        OSError,
+        ValueError,
+        EOFError,
+        RuntimeError,
+        tarfile.TarError,
+        zipfile.BadZipFile,
+        zlib.error,
+        lzma.LZMAError,
+    ) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    print("OK: wheel and source archive license files, metadata and verifier bytes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/scripts/test_distribution_licenses.py
+++ b/python/scripts/test_distribution_licenses.py
@@ -1,0 +1,217 @@
+"""Exercise license guards using actual built archives and altered copies."""
+
+import contextlib
+import io
+import struct
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+import check_distribution_licenses as checker
+
+
+class DistributionLicenses(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.archives = [Path(value).resolve() for value in sys.argv[1:]]
+        if len(cls.archives) != 2:
+            raise ValueError("tests require an actual built wheel and source archive")
+        cls.expected = checker.references(checker.ROOT)
+
+    def changed_archive(self, original, change):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        members = checker.archive_members(original)
+        change(members)
+        path = Path(directory.name) / original.name
+        if path.suffix == ".whl":
+            with zipfile.ZipFile(path, "w") as archive:
+                for name, value in members.items():
+                    archive.writestr(name, value)
+        else:
+            with tarfile.open(path, "w:gz") as archive:
+                for name, value in members.items():
+                    entry = tarfile.TarInfo(name)
+                    entry.size = len(value)
+                    archive.addfile(entry, io.BytesIO(value))
+        return path
+
+    def test_actual_built_pair(self):
+        for path in self.archives:
+            checker.check_archive(path, self.expected)
+        with contextlib.redirect_stdout(io.StringIO()) as output:
+            self.assertEqual(checker.main([str(path) for path in self.archives]), 0)
+        self.assertIn("OK:", output.getvalue())
+
+    def test_missing_or_changed_license_bytes(self):
+        for original in self.archives:
+            names = checker.archive_members(original)
+            for license_name in checker.LICENSE_FILES:
+                suffix = (
+                    "/licenses/" + license_name if original.suffix == ".whl" else "/" + license_name
+                )
+                member = next(name for name in names if name.endswith(suffix))
+                for remove in (True, False):
+                    with self.subTest(archive=original.name, member=member, remove=remove):
+
+                        def change(members):
+                            if remove:
+                                members.pop(member)
+                            else:
+                                members[member] += b"altered terms"
+
+                        broken = self.changed_archive(original, change)
+                        with self.assertRaisesRegex(ValueError, "missing or changed license"):
+                            checker.check_archive(broken, self.expected)
+
+    def test_metadata_guards(self):
+        for original in self.archives:
+            members = checker.archive_members(original)
+            name = next(key for key in members if key.endswith(("/METADATA", "/PKG-INFO")))
+            raw = members[name]
+            metadata_version = next(
+                line for line in raw.splitlines(True) if line.startswith(b"Metadata-Version:")
+            )
+            version = next(line for line in raw.splitlines(True) if line.startswith(b"Version:"))
+            cases = [
+                (b"License-File: LICENSE\n", b"", "License-File"),
+                (b"License-File: LICENSE\n", b"License-File: LICENSE\n" * 2, "License-File"),
+                (b"License-File: LICENSE\n", b"License-File: ../LICENSE\n", "License-File"),
+                (
+                    checker.EXPRESSION.encode(),
+                    b"Apache-2.0 OR LicenseRef-Elastic-License-2.0",
+                    "expression",
+                ),
+                (metadata_version, b"Metadata-Version: 2.3\n", "2.4 or newer"),
+                (metadata_version, b"Metadata-Version: wrong\n", "invalid metadata version"),
+                (metadata_version, metadata_version * 2, "duplicate metadata version"),
+                (b"Name: asqav\n", b"Name: another-package\n", "package name"),
+                (version, version * 2, "duplicate package version"),
+            ]
+            for before, after, error in cases:
+                with self.subTest(archive=original.name, error=error, after=after):
+                    self.assertIn(before, raw)
+                    broken = self.changed_archive(
+                        original, lambda data: data.update({name: raw.replace(before, after, 1)})
+                    )
+                    with self.assertRaisesRegex(ValueError, error):
+                        checker.check_archive(broken, self.expected)
+
+    def test_missing_metadata_and_wrong_path(self):
+        for original in self.archives:
+            members = checker.archive_members(original)
+            name = next(key for key in members if key.endswith(("/METADATA", "/PKG-INFO")))
+            broken = self.changed_archive(original, lambda data: data.pop(name))
+            with self.assertRaisesRegex(ValueError, "exactly one package metadata"):
+                checker.check_archive(broken, self.expected)
+            renamed = self.changed_archive(
+                original, lambda data: data.update({"wrong/" + name: data.pop(name)})
+            )
+            with self.assertRaisesRegex(ValueError, "metadata archive path mismatch"):
+                checker.check_archive(renamed, self.expected)
+
+    def test_standalone_verifier_bytes_and_header(self):
+        for original in self.archives:
+            name = next(
+                key for key in checker.archive_members(original) if key.endswith(checker.VERIFIER)
+            )
+            broken = self.changed_archive(
+                original, lambda data: data.update({name: b"# missing original header\n"})
+            )
+            with self.assertRaisesRegex(ValueError, "verifier or header changed"):
+                checker.check_archive(broken, self.expected)
+
+    def test_duplicate_archive_member(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "duplicate.tar.gz"
+        with tarfile.open(path, "w:gz") as archive:
+            for _ in range(2):
+                entry = tarfile.TarInfo("duplicate")
+                entry.size = 1
+                archive.addfile(entry, io.BytesIO(b"x"))
+        with self.assertRaisesRegex(ValueError, "duplicate archive member"):
+            checker.archive_members(path)
+
+    def test_source_terms_cannot_drift(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        root = Path(directory.name)
+        for name in checker.LICENSE_FILES:
+            target = root / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(self.expected[name])
+        verifier = root / "src" / checker.VERIFIER
+        verifier.parent.mkdir(parents=True)
+        verifier.write_bytes(self.expected[checker.VERIFIER])
+        for name in checker.TERMS:
+            with self.subTest(name=name):
+                (root / name).write_bytes(b"not the existing terms")
+                with self.assertRaisesRegex(ValueError, "source terms drift"):
+                    checker.references(root)
+                (root / name).write_bytes(self.expected[name])
+
+    def test_cli_refuses_incomplete_or_invalid_inputs(self):
+        with contextlib.redirect_stderr(io.StringIO()) as output:
+            self.assertEqual(checker.main([str(self.archives[1]), str(self.archives[0])]), 1)
+            self.assertEqual(checker.main(["missing.whl", str(self.archives[1])]), 1)
+        self.assertIn("FAIL:", output.getvalue())
+        with self.assertRaisesRegex(ValueError, "expected a wheel"):
+            checker.archive_members(Path("unsupported.zip"))
+
+    def test_damaged_archives_report_concise_cli_errors(self):
+        wheel, sdist = self.archives
+        wheel_bytes, source_bytes = wheel.read_bytes(), sdist.read_bytes()
+        damaged = {
+            "truncated.tar.gz": source_bytes[: len(source_bytes) // 2],
+            "deflate.tar.gz": source_bytes[:10] + b"\x07" + source_bytes[11:],
+            "truncated.whl": wheel_bytes[: len(wheel_bytes) // 2],
+        }
+        with zipfile.ZipFile(wheel) as archive:
+            first = archive.infolist()[0]
+            offset = first.header_offset + 30 + len(first.filename.encode()) + len(first.extra)
+            central = wheel_bytes.index(b"PK\x01\x02")
+            for name, local_field, central_field, value in (
+                ("unsupported", 8, 10, 99),
+                ("encrypted", 6, 8, first.flag_bits | 1),
+            ):
+                raw = bytearray(wheel_bytes)
+                struct.pack_into("<H", raw, first.header_offset + local_field, value)
+                struct.pack_into("<H", raw, central + central_field, value)
+                damaged[name + ".whl"] = bytes(raw)
+            raw = bytearray(wheel_bytes)
+            raw[offset] = 7
+            damaged["deflate.whl"] = bytes(raw)
+            stream = io.BytesIO()
+            with zipfile.ZipFile(stream, "w", compression=zipfile.ZIP_LZMA) as target:
+                for item in archive.infolist():
+                    target.writestr(item.filename, archive.read(item))
+        raw = bytearray(stream.getvalue())
+        name_size, extra_size = struct.unpack_from("<HH", raw, 26)
+        raw[30 + name_size + extra_size + 4] = 255
+        damaged["lzma.whl"] = bytes(raw)
+        with tempfile.TemporaryDirectory() as directory:
+            for name, data in damaged.items():
+                with self.subTest(name=name):
+                    path = Path(directory) / name
+                    path.write_bytes(data)
+                    arguments = [wheel, path] if name.endswith(".gz") else [path, sdist]
+                    result = subprocess.run(
+                        [sys.executable, "-B", str(Path(checker.__file__)), *map(str, arguments)],
+                        capture_output=True,
+                        text=True,
+                        timeout=15,
+                    )
+                    self.assertEqual(result.returncode, 1)
+                    self.assertEqual(result.stdout, "")
+                    self.assertTrue(result.stderr.startswith("FAIL: "), result.stderr)
+                    self.assertEqual(len(result.stderr.splitlines()), 1, result.stderr)
+                    self.assertNotIn("Traceback", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]], verbosity=2)


### PR DESCRIPTION
Include the SDK’s Elastic terms, the standalone verifier’s Apache terms and an explicit file-scope notice in Python wheels and source archives. Distribution metadata names both component licenses and includes their license-file paths. CI builds the wheel from its source archive and requires the packaging check in the aggregate status.

Validation: normal isolated builds at the minimum and resolved Hatchling versions, standalone source rebuilding and installed-package checks pass. The 71 runtime source files are unchanged. Nine archive tests, malformed-archive CLI cases and aggregate-failure controls pass; all six checker functions are measured with maximum CRAP 8. The complete diff is 694 lines, including 297 exact license-text lines.

THREAT_MODEL
- Attack surface: incomplete archives or incorrect metadata can omit terms or misstate their scope.
- Guard: compare exact license bytes and file paths, preserve the standalone verifier header and require the packaging result in CI.
- Negative proof: missing or changed terms, damaged archives, malformed metadata and a failed packaging job fail their checks.
- Trust boundary: this packages the existing file-level grants. It changes no runtime code, package version or publication workflow.
