### PR TITLE
build: vendor wire reference data

### DIFF
--- a/vendor/wire-vocabulary/LICENSE
+++ b/vendor/wire-vocabulary/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/wire-vocabulary/NOTICE
+++ b/vendor/wire-vocabulary/NOTICE
@@ -1,0 +1,25 @@
+NOTICE: Asqav Compliance Receipts Registries License
+
+The contents of this repository - the registry data files under registry/,
+their JSON Schemas, validate.py, and the registration documentation - are
+licensed under the Apache License, Version 2.0.
+
+These registries are the definitional surface of the Compliance Receipts
+profile. Every conformant verifier has to vendor them: an unregistered
+protectmcp namespace is a non-conformance, and a registered extension field
+carrying the wrong scope tag is a non-conformance, so a verifier that cannot
+lawfully embed these files cannot be built at all. A restrictively licensed
+registry would make the format one that only Asqav can implement, which is not
+a registry and not a standard. It is kept permissively licensed for the same
+reason the conformance vectors are: so that any implementation can
+independently verify receipt formats.
+
+Apache 2.0 rather than a data-only licence because this repository mixes data
+with code (the schemas and validate.py), and because Apache 2.0 carries an
+express patent grant, which a public wire-format registry should have and
+which CC0 explicitly withholds. It also matches the licence on the conformance
+vectors in the asqav-sdk repository, so the two artefacts a third-party
+verifier must vendor answer to one licence rather than two.
+
+The asqav-sdk implementation remains under the Elastic License 2.0. That is a
+product; this is a reference. Nothing here contains an implementation.

--- a/vendor/wire-vocabulary/README.md
+++ b/vendor/wire-vocabulary/README.md
@@ -1,0 +1,9 @@
+# Wire vocabulary reference
+
+This directory contains reference data from [asqav-registry](https://github.com/jagmarques/asqav-registry/tree/79f5d28fd132c97bc4a5eae02a2bafce72b145af), pinned at commit `79f5d28fd132c97bc4a5eae02a2bafce72b145af`.
+
+`vocabulary/wire.json` records wire vocabulary; `vocabulary/wire.schema.json` describes its data shape. `upstream.json` lists the four included upstream files and their SHA256 digests.
+
+This import supplies reference data only. Runtime integration requires the complete pinned tool snapshot and an offline integrity and output-drift check.
+
+The reference files retain their upstream [Apache License 2.0](LICENSE) and [NOTICE](NOTICE). The surrounding Asqav implementation remains under its repository license.

--- a/vendor/wire-vocabulary/upstream.json
+++ b/vendor/wire-vocabulary/upstream.json
@@ -1,0 +1,10 @@
+{
+  "repository": "jagmarques/asqav-registry",
+  "commit": "79f5d28fd132c97bc4a5eae02a2bafce72b145af",
+  "files": {
+    "LICENSE": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+    "NOTICE": "c5945b5627d32c54ec67b2f991c2501b655c419fbbb37029300be138b27f4624",
+    "vocabulary/wire.json": "d0b75824410c1e45f505ae67982b97c56b6da36b8a735920842eeeebd20c45da",
+    "vocabulary/wire.schema.json": "afebf3c43f215b200a07e4363ec65740232b62324aa0ae5f3ee402461ef9be12"
+  }
+}

--- a/vendor/wire-vocabulary/vocabulary/wire.json
+++ b/vendor/wire-vocabulary/vocabulary/wire.json
@@ -1,0 +1,358 @@
+{
+  "schema_version": 2,
+  "source_note": "Reference snapshot of public wire vocabulary; consumers apply their own validation policies.",
+  "receipt_types": [
+    "protectmcp:decision",
+    "protectmcp:restraint",
+    "protectmcp:lifecycle",
+    "protectmcp:lifecycle:configuration_change",
+    "protectmcp:lifecycle:risk_acceptance",
+    "protectmcp:lifecycle:code_authorship",
+    "protectmcp:acknowledgment",
+    "protectmcp:observation",
+    "protectmcp:observation:result_bound"
+  ],
+  "request_extra_types": [
+    "authoritative"
+  ],
+  "decisions": [
+    "allow",
+    "deny",
+    "rate_limit",
+    "observation"
+  ],
+  "policy_decisions": [
+    "permit",
+    "deny",
+    "rate_limit",
+    "none"
+  ],
+  "decision_map": [
+    [
+      "permit",
+      "allow"
+    ],
+    [
+      "allow",
+      "allow"
+    ],
+    [
+      "deny",
+      "deny"
+    ],
+    [
+      "rate_limit",
+      "rate_limit"
+    ],
+    [
+      "none",
+      "observation"
+    ]
+  ],
+  "capture_topologies": [
+    "in_process_sdk",
+    "network_proxy",
+    "browser_extension",
+    "mcp_proxy",
+    "passive_telemetry",
+    "github_sha_pull"
+  ],
+  "sandbox_states": [
+    "enabled",
+    "disabled",
+    "unavailable"
+  ],
+  "witnesses": [
+    "rfc3161",
+    "opentimestamps"
+  ],
+  "taxonomy_order": [
+    "mitre_techniques",
+    "mitre_atlas",
+    "owasp_llm_top10",
+    "nist_ai_rmf",
+    "iso_42001",
+    "eu_ai_act_articles"
+  ],
+  "fields": {
+    "mitre_techniques": {
+      "typescript_option": "mitreTechniques",
+      "list_entry_max_length": 128,
+      "metadata_ref": "mitre_techniques"
+    },
+    "mitre_atlas": {
+      "typescript_option": "mitreAtlas",
+      "list_entry_max_length": 128,
+      "metadata_ref": "mitre_atlas"
+    },
+    "owasp_llm_top10": {
+      "typescript_option": "owaspLlmTop10",
+      "list_entry_max_length": 128,
+      "metadata_ref": "owasp_llm_top10"
+    },
+    "nist_ai_rmf": {
+      "typescript_option": "nistAiRmf",
+      "list_entry_max_length": 128,
+      "metadata_ref": "nist_ai_rmf"
+    },
+    "iso_42001": {
+      "typescript_option": "iso42001",
+      "list_entry_max_length": 128,
+      "metadata_ref": "iso_42001"
+    },
+    "eu_ai_act_articles": {
+      "typescript_option": "euAiActArticles",
+      "list_entry_max_length": 128,
+      "metadata_ref": "eu_ai_act_articles"
+    }
+  },
+  "profiles": {
+    "receipt_profile": [
+      "receipt_types"
+    ],
+    "receipt_request": [
+      "receipt_types",
+      "request_extra_types"
+    ],
+    "sdk_incident": [
+      "dora_incident_classes",
+      "hipaa_incident_classes"
+    ]
+  },
+  "dora_incident_classes": [
+    "cybersecurity_related",
+    "process_failure",
+    "system_failure",
+    "external_event",
+    "payment_related",
+    "other"
+  ],
+  "hipaa_incident_classes": [
+    "hipaa_security_incident"
+  ],
+  "standard_risk_classes": [
+    "low",
+    "medium",
+    "high",
+    "unknown"
+  ],
+  "metadata_order": [
+    "result_digest",
+    "expires_at",
+    "nonce",
+    "tool_fingerprint",
+    "config_manifest_digest",
+    "cve_inventory_digest",
+    "executable_hash",
+    "sbom_digest",
+    "slsa_provenance_pointer",
+    "supply_chain_pointer",
+    "mitre_techniques",
+    "mitre_atlas",
+    "owasp_llm_top10",
+    "nist_ai_rmf",
+    "iso_42001",
+    "eu_ai_act_articles",
+    "rfc3161_timestamp",
+    "framework_mappings_self_declared",
+    "witness_policy",
+    "risk_class",
+    "incident_class",
+    "authorized_under_mandate",
+    "controls_evaluated",
+    "approver_id",
+    "initiator_id",
+    "acceptance_reason",
+    "accepted_at",
+    "supersedes",
+    "sarif_digest",
+    "finding_ref",
+    "approval_ref",
+    "invocation_ref",
+    "risk_snapshot",
+    "repo_ref",
+    "commit_sha",
+    "base_sha",
+    "change_digest",
+    "change_ref",
+    "change_approval_ref",
+    "change_class",
+    "authored_by",
+    "user_intent",
+    "user_intent_verified"
+  ],
+  "metadata": {
+    "result_digest": {
+      "form": "sha256:<64 hex>",
+      "description": "SHA-256 of canonical-JSON tool response bytes (sha256:<64 hex>). Binds output into the receipt; pairs with receipt_type=protectmcp:observation:result_bound."
+    },
+    "expires_at": {
+      "form": "RFC 3339 timestamp",
+      "description": "RFC 3339 receipt-expiry timestamp. Verifier returns validation_label='signature_expired' when current_time > expires_at."
+    },
+    "nonce": {
+      "form": "24 lowercase hex chars",
+      "description": "Server-issued per-receipt nonce (24 lowercase hex chars) minted by secrets.token_hex(12) on the sign route, bound into the signed bytes under compliance_mode. Pair it with expires_at for the enforced time bound."
+    },
+    "tool_fingerprint": {
+      "form": "32 lowercase hex chars",
+      "description": "SHA-256[:32] over tool_name|schema_canonical_json|module_path (32 lowercase hex). SDK-supplied at sign-time; surfaces naming collisions and registry-shadow drift."
+    },
+    "config_manifest_digest": {
+      "form": "sha256:<64 hex>",
+      "description": "SHA-256 of canonical-JSON MCP server manifest (sha256:<64 hex>). REQUIRED on receipt_type=protectmcp:lifecycle:configuration_change."
+    },
+    "cve_inventory_digest": {
+      "form": "sha256:<64 hex>",
+      "description": "SHA-256 over canonical-JSON CVE inventory at sign-time (sha256:<64 hex>). Enables known-at-sign-time vs disclosed-later audit."
+    },
+    "executable_hash": {
+      "form": "sha256:<64 hex>",
+      "description": "SHA-256 of the executable that invoked the action (sha256:<64 hex>). Binds build-side provenance; pairs with sbom_digest, slsa_provenance_pointer, supply_chain_pointer."
+    },
+    "sbom_digest": {
+      "form": "sha256:<64 hex>",
+      "description": "SHA-256 of the canonical CycloneDX or SPDX SBOM document covering the executing image (sha256:<64 hex>). Optional; bound into the signed receipt."
+    },
+    "slsa_provenance_pointer": {
+      "form": "https URL",
+      "description": "https URL to the SLSA attestation envelope for the executing build."
+    },
+    "supply_chain_pointer": {
+      "form": "https URL",
+      "description": "https URL to the in-toto, Sigstore, or Rekor entry covering the executing build."
+    },
+    "mitre_techniques": {
+      "form": "list of MITRE ATT&CK technique ids",
+      "description": "Caller-supplied list of MITRE ATT&CK technique ids (e.g. T1059, T1078). Self-declared; auto-flips framework_mappings_self_declared to True. Never Asqav-verified."
+    },
+    "mitre_atlas": {
+      "form": "list of MITRE ATLAS ids",
+      "description": "Caller-supplied list of MITRE ATLAS ids for AI-system threats (e.g. AML.T0051). Self-declared; auto-flips framework_mappings_self_declared to True. Never Asqav-verified."
+    },
+    "owasp_llm_top10": {
+      "form": "list of OWASP Top 10 for LLM ids",
+      "description": "Caller-supplied list of OWASP Top 10 for LLM ids (e.g. LLM01, LLM02). Self-declared; auto-flips framework_mappings_self_declared to True. Never Asqav-verified."
+    },
+    "nist_ai_rmf": {
+      "form": "list of NIST AI RMF function ids",
+      "description": "Caller-supplied list of NIST AI RMF function ids (GOVERN | MAP | MEASURE | MANAGE plus subcategories). Self-declared; auto-flips framework_mappings_self_declared to True."
+    },
+    "iso_42001": {
+      "form": "list of ISO/IEC 42001 control ids",
+      "description": "Caller-supplied list of ISO/IEC 42001 control ids (e.g. A.6.2.6). Self-declared; auto-flips framework_mappings_self_declared to True. Never Asqav-verified."
+    },
+    "eu_ai_act_articles": {
+      "form": "list of EU AI Act article ids",
+      "description": "Caller-supplied list of EU AI Act article ids (e.g. Article-12, Article-15, Article-50). Self-declared; auto-flips framework_mappings_self_declared to True. Never Asqav-verified."
+    },
+    "rfc3161_timestamp": {
+      "form": "base64 TimeStampResp",
+      "description": "Caller-supplied base64-encoded RFC 3161 TimeStampResp (DER) preserved on the receipt for offline TSA chain verification."
+    },
+    "framework_mappings_self_declared": {
+      "form": "boolean",
+      "description": "False-attestation guard. Server-set to True when any of mitre_techniques, mitre_atlas, owasp_llm_top10, nist_ai_rmf, iso_42001, or eu_ai_act_articles is populated; verification surface displays the caller-supplied label."
+    },
+    "witness_policy": {
+      "form": "{required: int, witnesses: [rfc3161, opentimestamps]}",
+      "description": "Caller-declared N-of-M durable-anchoring quorum {required: int, witnesses: [rfc3161, opentimestamps]}. required is in [1, len(witnesses)]; witnesses is a non-empty subset of the two shipped witnesses. rekor is rejected. The receipt reaches witness_quorum_met only when required witnesses hold a real inclusion proof."
+    },
+    "risk_class": {
+      "form": "low | medium | high | unknown",
+      "description": "Deployer risk classification of the Action. Controlled vocabulary: low | medium | high | unknown."
+    },
+    "incident_class": {
+      "form": "DORA ITS string or array of strings",
+      "description": "DORA ITS incident classification; string or array of strings for multi-regime classification (e.g. DORA + CIRCIA)."
+    },
+    "authorized_under_mandate": {
+      "form": "{mandate_id, issuer_id, scope_digest, verified}",
+      "description": "Server-built mandate attestation {mandate_id, issuer_id, scope_digest, verified}. verified=true is self-declared issuer authority, the same trust level as framework_mappings_self_declared, never Asqav-verified third-party authorization. scope_digest is verifiable by resolving mandate_id via GET /orgs/{org_id}/mandates/{mandate_id}."
+    },
+    "controls_evaluated": {
+      "form": "{emergency_halt, delegation_scope?, quorum?, mandate?, policy?, content_scan?, result}",
+      "description": "Server-built enumeration of the enforcement controls that genuinely fired on this sign (emergency_halt, delegation_scope, quorum, mandate, policy, content_scan) plus the allow result. Each key is present only when its control ran; an absent key means the control never ran, never that it passed silently. Never a request input; a caller-supplied controls_evaluated is dropped before signing."
+    },
+    "approver_id": {
+      "form": "string (bare kid or issuer_id)",
+      "description": "Producer-asserted identity that authored the risk acceptance (bare kid or issuer_id). FIELD ONLY: bound into the signed bytes; Asqav performs no authority check and no identity resolution, only the compliance_mode string-equality refusal against initiator_id (risk_acceptance_self_approval_guard)."
+    },
+    "initiator_id": {
+      "form": "string (bare kid or issuer_id)",
+      "description": "Producer-asserted identity that requested the acceptance. FIELD ONLY: bound into the signed bytes; under compliance_mode a risk_acceptance sign whose initiator_id string-equals approver_id is refused at sign time (risk_acceptance_self_approval_guard). No identity resolution."
+    },
+    "acceptance_reason": {
+      "form": "free-text string",
+      "description": "Free-text producer rationale for accepting the risk. Proves the reason existed and was key-authored at the signing time; never parsed or scored."
+    },
+    "accepted_at": {
+      "form": "RFC 3339 timestamp (producer-asserted)",
+      "description": "Producer-asserted authoring time of the acceptance (RFC 3339). Self-declared: the only Asqav-attested times are issued_at and anchors[]."
+    },
+    "supersedes": {
+      "form": "opaque receipt locator OR sha256:<64 hex>",
+      "description": "Producer-asserted pointer to the prior risk-acceptance receipt this one replaces (opaque locator or sha256:<64 hex>). Proves the supersession claim existed at T; Asqav never invalidates the prior receipt."
+    },
+    "sarif_digest": {
+      "form": "sha256:<64 hex> (shape-only existence proof)",
+      "description": "SHA-256 over the producer-declared canonical SARIF scan bytes (sha256:<64 hex>). Shape-only existence proof: Asqav never parses, fetches, re-runs, or validates the scan."
+    },
+    "finding_ref": {
+      "form": "opaque free-text pointer",
+      "description": "Producer-asserted opaque pointer to a finding/rule id inside the SARIF. Free-text; never resolved or validated by Asqav."
+    },
+    "approval_ref": {
+      "form": "opaque free-text correlation pointer",
+      "description": "Producer-asserted opaque correlation pointer to a HITL approval id or external ticket. Free-text; never resolved or validated by Asqav."
+    },
+    "invocation_ref": {
+      "form": "opaque string",
+      "description": "Producer-asserted opaque identifier for ONE tool invocation, carried so the pre-action and post-action receipts of the same invocation can be recognised as related. Free-text; never resolved or validated by Asqav."
+    },
+    "risk_snapshot": {
+      "form": "{snapshot_at, snapshot_source, epss?, cvss?, cvss_vector?, kev_listed?, cve_ids?}",
+      "description": "Point-in-time snapshot of THIRD-PARTY risk signals as read by the producer at snapshot_at from snapshot_source. Asqav does not fetch, compute, verify, or vouch for these values; the receipt proves only that the producer asserted them at T. Numerics are strings (floats rejected); snapshot_source is required whenever any numeric is present. A verifier MUST NOT read any value as an Asqav-derived or verified score."
+    },
+    "repo_ref": {
+      "form": "string (repository identifier or URL)",
+      "description": "Producer-asserted repository identifier or URL the change landed in. FIELD ONLY: bound into the signed bytes at T; Asqav never resolves, clones, or verifies the repository."
+    },
+    "commit_sha": {
+      "form": "string (resulting commit SHA)",
+      "description": "Producer-asserted resulting commit SHA. Proves the producer asserted this commit existed at T; Asqav never fetches the object or verifies that the SHA names real tree contents."
+    },
+    "base_sha": {
+      "form": "string (parent/base commit SHA)",
+      "description": "Producer-asserted parent/base commit SHA the change applied onto. FIELD ONLY: bound into the signed bytes; never resolved by Asqav."
+    },
+    "change_digest": {
+      "form": "sha256:<64 hex> (shape-only existence proof)",
+      "description": "SHA-256 over the producer-declared canonical diff/patch bytes (sha256:<64 hex>). Shape-only existence proof: Asqav does not fetch, re-diff, compute, verify, or vouch for the change; the receipt proves only that the producer asserted this digest at T."
+    },
+    "change_ref": {
+      "form": "PR/MR or change-request URL",
+      "description": "Producer-asserted PR/MR or change-request URL. Free-text reference; never resolved or validated by Asqav."
+    },
+    "change_approval_ref": {
+      "form": "opaque approval pointer",
+      "description": "Producer-asserted opaque pointer to a human or automated approval id. Free-text; never resolved or validated by Asqav."
+    },
+    "change_class": {
+      "form": "read | write | delete | execute | deploy",
+      "description": "Producer-asserted change classification. Controlled vocabulary: read | write | delete | execute | deploy."
+    },
+    "authored_by": {
+      "form": "{agent_id?, model_id?, model_version?, tool?, attestation_source?}",
+      "description": "Producer-asserted authorship context {agent_id?, model_id?, model_version?, tool?, attestation_source?}. Asqav does not fetch, compute, verify, or vouch for the model identity; a populated model_id or model_version requires attestation_source so the value is never read as an Asqav-verified attribution."
+    },
+    "user_intent": {
+      "form": "{signature, public_key, algorithm, signed_message, signed_at}",
+      "description": "Optional end-user signature over the Action, binding a human's authorization to the agent's signing request. Envelope {signature, public_key, algorithm, signed_message, signed_at}; algorithm is one of ed25519 | ecdsa-p256 | webauthn. Verified at sign time and reported in user_intent_verified."
+    },
+    "user_intent_verified": {
+      "form": "boolean (server-set)",
+      "description": "Server-set boolean recording whether the supplied user_intent envelope's signature verified against its public_key over signed_message. True only when an envelope was supplied and cryptographically verified; absent when no envelope was supplied."
+    }
+  }
+}

--- a/vendor/wire-vocabulary/vocabulary/wire.schema.json
+++ b/vendor/wire-vocabulary/vocabulary/wire.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Asqav wire vocabulary reference",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "source_note", "receipt_types", "request_extra_types",
+    "decisions", "policy_decisions", "decision_map", "capture_topologies",
+    "sandbox_states", "witnesses", "taxonomy_order", "fields", "profiles",
+    "metadata_order", "metadata", "standard_risk_classes",
+    "dora_incident_classes", "hipaa_incident_classes"
+  ],
+  "properties": {
+    "schema_version": {"type": "integer", "const": 2},
+    "source_note": {"$ref": "#/$defs/text"},
+    "receipt_types": {"$ref": "#/$defs/tokens"},
+    "request_extra_types": {"$ref": "#/$defs/tokens"},
+    "decisions": {"$ref": "#/$defs/tokens"},
+    "policy_decisions": {"$ref": "#/$defs/tokens"},
+    "capture_topologies": {"$ref": "#/$defs/tokens"},
+    "sandbox_states": {"$ref": "#/$defs/tokens"},
+    "witnesses": {"$ref": "#/$defs/tokens"},
+    "taxonomy_order": {"$ref": "#/$defs/tokens"},
+    "metadata_order": {"$ref": "#/$defs/tokens"},
+    "standard_risk_classes": {"$ref": "#/$defs/tokens"},
+    "dora_incident_classes": {"$ref": "#/$defs/tokens"},
+    "hipaa_incident_classes": {"$ref": "#/$defs/tokens"},
+    "metadata": {
+      "type": "object", "minProperties": 43, "maxProperties": 43,
+      "propertyNames": {"enum": [
+        "result_digest", "expires_at", "nonce", "tool_fingerprint",
+        "config_manifest_digest", "cve_inventory_digest", "executable_hash",
+        "sbom_digest", "slsa_provenance_pointer", "supply_chain_pointer",
+        "mitre_techniques", "mitre_atlas", "owasp_llm_top10", "nist_ai_rmf",
+        "iso_42001", "eu_ai_act_articles", "rfc3161_timestamp",
+        "framework_mappings_self_declared", "witness_policy", "risk_class",
+        "incident_class", "authorized_under_mandate", "controls_evaluated",
+        "approver_id", "initiator_id", "acceptance_reason", "accepted_at",
+        "supersedes", "sarif_digest", "finding_ref", "approval_ref", "invocation_ref",
+        "risk_snapshot", "repo_ref", "commit_sha", "base_sha", "change_digest",
+        "change_ref", "change_approval_ref", "change_class", "authored_by",
+        "user_intent", "user_intent_verified"
+      ]},
+      "additionalProperties": {"$ref": "#/$defs/metadata"}
+    },
+    "decision_map": {
+      "type": "array", "minItems": 1, "uniqueItems": true,
+      "items": {
+        "type": "array", "minItems": 2, "maxItems": 2,
+        "items": {"$ref": "#/$defs/token"}
+      }
+    },
+    "fields": {
+      "type": "object", "minProperties": 1,
+      "propertyNames": {"pattern": "^[a-z][a-z0-9_]*$", "not": {"pattern": "\\s"}},
+      "additionalProperties": {"$ref": "#/$defs/taxonomy"}
+    },
+    "profiles": {
+      "type": "object", "additionalProperties": false,
+      "required": ["receipt_profile", "receipt_request", "sdk_incident"],
+      "properties": {
+        "receipt_profile": {"$ref": "#/$defs/tokens"},
+        "receipt_request": {"$ref": "#/$defs/tokens"},
+        "sdk_incident": {"$ref": "#/$defs/tokens"}
+      }
+    }
+  },
+  "$defs": {
+    "text": {"type": "string", "minLength": 1, "pattern": "\\S"},
+    "token": {"type": "string", "pattern": "^[a-z][a-z0-9_:]*$", "not": {"pattern": "\\s"}},
+    "tokens": {
+      "type": "array", "minItems": 1, "uniqueItems": true,
+      "items": {"$ref": "#/$defs/token"}
+    },
+    "metadata": {
+      "type": "object", "additionalProperties": false,
+      "required": ["form", "description"],
+      "properties": {
+        "form": {"$ref": "#/$defs/text"},
+        "description": {"$ref": "#/$defs/text"}
+      }
+    },
+    "taxonomy": {
+      "type": "object", "additionalProperties": false,
+      "required": ["typescript_option", "metadata_ref", "list_entry_max_length"],
+      "properties": {
+        "typescript_option": {
+          "type": "string", "pattern": "^[a-z][a-zA-Z0-9]*$", "not": {"pattern": "\\s"}
+        },
+        "metadata_ref": {"$ref": "#/$defs/token"},
+        "list_entry_max_length": {"type": "integer", "minimum": 1}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Vendor the wire vocabulary data, its schema and Apache license notices from the immutable registry commit `79f5d28fd132c97bc4a5eae02a2bafce72b145af`. A four-file manifest records the exact source hashes, and the local README describes the reference scope.

Validation: normal HTTPS reads match immutable Git objects and both consumer copies byte for byte. The JSON and schema validate with jsonschema 4.26.0. Independent reviews check provenance, license scope and refusal of corrupted copies. The complete diff adds 699 non-generated lines, including 680 copied upstream lines.

THREAT_MODEL
- Attack surface: copied reference files can drift from their reviewed upstream source.
- Guard: review compares every included byte with the immutable source and exact path manifest.
- Negative proof: missing or extra paths, altered bytes, incorrect pins and symlinks fail the independent integrity checks.
- Trust boundary: this is a data-only import. It adds no consumer loader, generated runtime module or admission rule.
