### PR TITLE
Forward invocation references through Asqav signing

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -125,6 +125,7 @@ sig = agent.sign(
     risk_class="high",                 # low | medium | high | unknown
     issuer_id="legal:Acme GmbH",       # LEI, EIN, CIK or W3C DID
     iteration_id="task-2026-Q2-4821",  # logical task, distinct from session
+    invocation_ref="toolu_abc123",  # one tool invocation; no uniqueness, de-dup, or exactly-once
 )
 ```
 

--- a/python/src/asqav/cli_hook.py
+++ b/python/src/asqav/cli_hook.py
@@ -171,10 +171,13 @@ def _map_event(
     Field map (snake_case keys confirmed against code.claude.com/docs/en/hooks):
     action_type=tool:<tool_name>; context={tool_input}; session_id and trace_id
     from session_id. result_digest is added only when binding a tool result.
+    invocation_ref forwards a nonempty string tool_use_id verbatim, else is
+    omitted (never synthesized, never falls back to session_id: the trace).
     """
     tool_name = event.get("tool_name", "unknown")
     tool_input = event.get("tool_input", {})
     session_id = event.get("session_id", "") or ""
+    tool_use_id = event.get("tool_use_id")
 
     action_type = f"tool:{tool_name}"
     context = {"tool_input": tool_input}
@@ -185,6 +188,8 @@ def _map_event(
         "capture_topology": capture_topology,
         "trace_id": session_id or None,
     }
+    if isinstance(tool_use_id, str) and tool_use_id != "":
+        compliance_fields["invocation_ref"] = tool_use_id
     if bind_result:
         compliance_fields["result_digest"] = _result_digest(event.get("tool_response"))
     return action_type, context, session_id, compliance_fields

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -2021,6 +2021,9 @@ class Agent:
         finding_ref: str | None = None,
         approval_ref: str | None = None,
         risk_snapshot: "RiskSnapshot | dict[str, Any] | None" = None,
+        # Invocation pointer, producer-asserted and unfenced: names one
+        # invocation only, promises nothing about uniqueness or exactly-once.
+        invocation_ref: str | None = None,
         # Code-authorship receipt extension fields. Valid only on
         # receipt_type=protectmcp:lifecycle:code_authorship (fenced below).
         repo_ref: str | None = None,
@@ -2345,6 +2348,8 @@ class Agent:
                 ("finding_ref", finding_ref),
                 ("approval_ref", approval_ref),
                 ("risk_snapshot", risk_snapshot),
+                # Unfenced invocation pointer (see signature comment).
+                ("invocation_ref", invocation_ref),
                 # Code-authorship extension fields (fenced to the receipt type).
                 ("repo_ref", repo_ref),
                 ("commit_sha", commit_sha),

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -24,7 +24,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
 FINGERPRINT_LOCK_DIGEST = "e5a3b808981265b808487b12d9ce029013bbab34fcea2f079bbcff8b893e1c7b"
-VERIFIER_LOCK_DIGEST = "bb3e2e68cbb6914aa323f1e23e653c7d4606826bd0399dc0d191b7cd273d7d2b"
+VERIFIER_LOCK_DIGEST = "813d051f865ea2b05d96e1ee23ed98eaa8bb4d7f240551dda981ebbd595ea4b0"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_hook_invocation_ref.py
+++ b/python/tests/test_hook_invocation_ref.py
@@ -1,0 +1,172 @@
+"""The hook forwards `tool_use_id` as `invocation_ref` on both hook paths.
+
+A pre-action decision receipt and a post-action observation receipt for the
+same tool call carry the SAME value, so a reader can SEE duplicate emissions.
+Absent or non-string inputs omit the field entirely: nothing is synthesised
+and there is no fallback to `session_id` (the trace, not the invocation).
+Visibility only: no de-duplication, no rejection keyed on this field.
+
+The `_map_event` kwargs below mirror the real `hook_pretool` / `hook_posttool`
+call sites exactly; the CLI controls beneath invoke the real entry points so
+the entrypoint semantics cannot drift behind these unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from asqav import cli_hook  # noqa: E402
+from asqav.cli import app  # noqa: E402
+from asqav.client import Agent  # noqa: E402
+
+# Exact kwargs of the hook_pretool call site (FAIL-CLOSED gate).
+_PRE_FIELDS = dict(
+    receipt_type="protectmcp:decision",
+    capture_topology="in_process_sdk",
+    bind_result=False,
+    policy_decision="permit",
+)
+# Exact kwargs of the hook_posttool call site without --bind-result (audit).
+_POST_FIELDS = dict(
+    receipt_type="protectmcp:observation",
+    capture_topology="passive_telemetry",
+    bind_result=False,
+    policy_decision=None,
+)
+
+_runner = CliRunner()
+
+
+def _pre_event(tool_use_id: Any = "toolu_abc123") -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "session_id": "sess_1",
+        "tool_name": "Write",
+        "tool_input": {"file_path": "/tmp/f"},
+    }
+    if tool_use_id is not ...:
+        event["tool_use_id"] = tool_use_id
+    return event
+
+
+def _post_event(tool_use_id: Any = "toolu_abc123") -> dict[str, Any]:
+    event = _pre_event(tool_use_id)
+    event["tool_response"] = {"success": True}
+    return event
+
+
+def _dry_run(subcommand: str, event: dict, extra_args: list[str] | None = None) -> dict:
+    args = ["hook", subcommand, "--dry-run"] + (extra_args or [])
+    result = _runner.invoke(app, args, input=json.dumps(event))
+    assert result.exit_code == 0, result.output
+    return json.loads(result.stdout)
+
+
+def test_pre_receipt_carries_tool_use_id_verbatim() -> None:
+    _, _, _, fields = cli_hook._map_event(_pre_event(), **_PRE_FIELDS)
+    assert fields["invocation_ref"] == "toolu_abc123"
+
+
+def test_post_receipt_carries_tool_use_id_verbatim() -> None:
+    _, _, _, fields = cli_hook._map_event(_post_event(), **_POST_FIELDS)
+    assert fields["invocation_ref"] == "toolu_abc123"
+
+
+def test_pre_and_post_share_one_invocation_ref() -> None:
+    _, _, _, pre = cli_hook._map_event(_pre_event(), **_PRE_FIELDS)
+    _, _, _, post = cli_hook._map_event(_post_event(), **_POST_FIELDS)
+    assert pre["invocation_ref"] == post["invocation_ref"] == "toolu_abc123"
+
+
+def test_absent_tool_use_id_omits_the_key() -> None:
+    _, _, _, fields = cli_hook._map_event(_pre_event(...), **_PRE_FIELDS)
+    assert "invocation_ref" not in fields
+    assert fields["trace_id"] == "sess_1"
+
+
+def test_non_string_tool_use_id_omits_the_key() -> None:
+    for bad in (123, ["toolu_x"], {"id": "toolu_x"}, True):
+        _, _, _, fields = cli_hook._map_event(_pre_event(bad), **_PRE_FIELDS)
+        assert "invocation_ref" not in fields, bad
+
+
+def test_empty_tool_use_id_omits_the_key() -> None:
+    _, _, _, fields = cli_hook._map_event(_pre_event(""), **_PRE_FIELDS)
+    assert "invocation_ref" not in fields
+
+
+def test_cli_pretool_dry_run_forwards_the_reference() -> None:
+    body = _dry_run("pretool", _pre_event())
+    assert body["invocation_ref"] == "toolu_abc123"
+    assert body["receipt_type"] == "protectmcp:decision"
+
+
+def test_cli_posttool_dry_run_forwards_the_reference() -> None:
+    body = _dry_run("posttool", _post_event())
+    assert body["invocation_ref"] == "toolu_abc123"
+    assert body["receipt_type"] == "protectmcp:observation"
+
+
+def test_cli_posttool_bind_result_forwards_the_reference() -> None:
+    body = _dry_run("posttool", _post_event(), ["--bind-result"])
+    assert body["invocation_ref"] == "toolu_abc123"
+    assert body["receipt_type"] == "protectmcp:observation:result_bound"
+    assert "result_digest" in body
+
+
+def test_cli_pretool_dry_run_omits_a_missing_reference() -> None:
+    body = _dry_run("pretool", _pre_event(...))
+    assert "invocation_ref" not in body
+
+
+def _agent() -> Agent:
+    return Agent(
+        agent_id="agent_hook",
+        name="hook-agent",
+        public_key="pk_test",
+        key_id="key_hook",
+        algorithm="ML-DSA-65",
+        capabilities=["tool:*"],
+        created_at=1700000000.0,
+    )
+
+
+def _ok_response() -> dict:
+    return {
+        "signature": "sig_b64",
+        "signature_id": "sig_abc",
+        "action_id": "act_abc",
+        "timestamp": 1700000000.0,
+        "verification_url": "https://example.invalid/verify/sig_abc",
+    }
+
+
+def test_sign_projects_invocation_ref_to_wire() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("tool:Write", context={"tool_input": {}}, invocation_ref="toolu_abc123")
+    assert captured["body"]["invocation_ref"] == "toolu_abc123"
+
+
+def test_sign_omits_invocation_ref_when_unset() -> None:
+    captured: dict = {}
+
+    def fake_post(path: str, body: dict) -> dict:
+        captured["body"] = body
+        return _ok_response()
+
+    with patch("asqav.client._post", side_effect=fake_post):
+        _agent().sign("tool:Write", context={"tool_input": {}})
+    assert "invocation_ref" not in captured["body"]

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -240,7 +240,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 79
+    assert len(results) == 81
     # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -589,6 +589,10 @@ export interface SignOptions {
    * numeric without `snapshotSource` is rejected so it is never read as an Asqav score. */
   riskSnapshot?: RiskSnapshot;
 
+  /** Invocation pointer (`invocation_ref`), producer-asserted and unfenced:
+   * names one invocation only, promises nothing about uniqueness or exactly-once. */
+  invocationRef?: string;
+
   /** Code-authorship receipt: opaque repository pointer, REQUIRED on
    * `protectmcp:lifecycle:code_authorship`. Recorded, never resolved by Asqav. */
   repoRef?: string;
@@ -1672,6 +1676,8 @@ const IETF_OPTIONAL_FIELD_MAP: ReadonlyArray<{
   { wire: "finding_ref", read: (o) => o.findingRef },
   { wire: "approval_ref", read: (o) => o.approvalRef },
   { wire: "risk_snapshot", read: (o) => riskSnapshotToWire(o.riskSnapshot) },
+  // Unfenced invocation pointer (see SignOptions comment).
+  { wire: "invocation_ref", read: (o) => o.invocationRef },
   // Code-authorship receipt extension fields (fenced to the receipt type).
   { wire: "repo_ref", read: (o) => o.repoRef },
   { wire: "commit_sha", read: (o) => o.commitSha },

--- a/typescript/tests/invocationRef.test.ts
+++ b/typescript/tests/invocationRef.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `invocationRef` is forwarded as `invocation_ref`, unfenced.
+ * Producer-asserted like `findingRef` / `approvalRef`, valid on any receipt
+ * type: pre-action decisions and post-action observations alike.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Agent, _resetForTests, init } from "../src/index.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fakeAgent(): Agent {
+  return Agent.attach({
+    agent_id: "agt_hook",
+    name: "hook",
+    public_key: "pk",
+    key_id: "kid",
+    algorithm: "ml-dsa-65",
+    capabilities: [],
+    created_at: "2026-05-25T00:00:00Z",
+  });
+}
+
+function okBody(): Record<string, unknown> {
+  return {
+    signature: "sig",
+    signature_id: "sig_test",
+    action_id: "act_test",
+    timestamp: "2026-06-01T19:00:00Z",
+    verification_url: "https://verify",
+  };
+}
+
+function readBody(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown> {
+  const init = spy.mock.calls[0][1] as RequestInit;
+  return JSON.parse((init?.body as string) ?? "{}");
+}
+
+beforeEach(() => {
+  _resetForTests();
+  init({ apiKey: "asq_test_key", baseUrl: "https://api.example.com/api/v1" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("invocation_ref forwarding", () => {
+  it("forwards invocationRef as invocation_ref on a non-risk receipt", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "tool:Write",
+      context: { tool_input: {} },
+      complianceMode: true,
+      receiptType: "protectmcp:decision",
+      invocationRef: "toolu_abc123",
+    });
+    expect(readBody(spy).invocation_ref).toBe("toolu_abc123");
+  });
+
+  it("omits invocation_ref when unset", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse(okBody()));
+    await fakeAgent().sign({
+      actionType: "tool:Write",
+      context: { tool_input: {} },
+      complianceMode: true,
+      receiptType: "protectmcp:decision",
+    });
+    expect("invocation_ref" in readBody(spy)).toBe(false);
+  });
+});

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -28,7 +28,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 79 corpus vectors", () => {
+  it("matches every manifest outcome across all 81 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -45,9 +45,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(79);
+    expect(results.length).toBe(81);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(79);
+    expect(passed).toBe(81);
   });
 
   it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {

--- a/verifier/conformance-vectors/asqav-35-invocation-ref-binds-pre-post/expected.json
+++ b/verifier/conformance-vectors/asqav-35-invocation-ref-binds-pre-post/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "A pre-action receipt and its post-action receipt carry the same invocation_ref, so a reader binds them to one tool invocation without trusting timestamps. Both receipts are correctly signed and the chain link rederives. The shared member is pure correlation: it changes no verdict."
+}

--- a/verifier/conformance-vectors/asqav-35-invocation-ref-binds-pre-post/jwks.json
+++ b/verifier/conformance-vectors/asqav-35-invocation-ref-binds-pre-post/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-invocation-ref-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "c7H95VWMRO5bt+vmKn2xgQPAkd/5FSIzfvxzjNx5UUA="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-35-invocation-ref-binds-pre-post/predecessor.json
+++ b/verifier/conformance-vectors/asqav-35-invocation-ref-binds-pre-post/predecessor.json
@@ -1,0 +1,27 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "v": 1,
+    "issued_at": "2026-09-07T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_invocation_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "mode": "payload",
+    "tool_name": "demo.action",
+    "hook_event": "PreToolUse",
+    "invocation_ref": "toolu_vec_shared"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-invocation-ref-vec-key",
+    "sig": "kQPYfMDIAv0o31r9AA/vN49nJt/U3mpdRnuJ9ySbvY9ZnJ9ZI+IS27Rw4l2dWJnVESae6AHEadFZXDRiTsHqCQ=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-35-invocation-ref-binds-pre-post/receipt.json
+++ b/verifier/conformance-vectors/asqav-35-invocation-ref-binds-pre-post/receipt.json
@@ -1,0 +1,27 @@
+{
+  "payload": {
+    "type": "protectmcp:observation",
+    "v": 1,
+    "issued_at": "2026-09-07T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_invocation_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "abab46c5f7d3549e37cedccc69ff3789f6eec5b08483805a4e3b08863fa91464",
+    "decision": "observation",
+    "mode": "payload",
+    "tool_name": "demo.action",
+    "hook_event": "PostToolUse",
+    "invocation_ref": "toolu_vec_shared"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-invocation-ref-vec-key",
+    "sig": "yBS+OtnG3JwX2Rm6dkr7JeudABtruEKecZbN78fh3BhMLI+40YcB4sIYD6FHxqR9ZMQ+DRDB+rRqtI6J36toAw=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-36-invocation-ref-duplicate-emission/expected.json
+++ b/verifier/conformance-vectors/asqav-36-invocation-ref-duplicate-emission/expected.json
@@ -1,0 +1,6 @@
+{
+  "format": "asqav-native",
+  "outcome": "verified",
+  "reason_code": "",
+  "notes": "Two pre-action receipts carry the same invocation_ref: the duplicate-emission shape a harness produces when it fires the hook twice for one invocation. Both receipts verify, because invocation_ref exists so a reader can SEE the duplicate, never to reject it. A verifier that refuses this pair is wrong, not strict."
+}

--- a/verifier/conformance-vectors/asqav-36-invocation-ref-duplicate-emission/jwks.json
+++ b/verifier/conformance-vectors/asqav-36-invocation-ref-duplicate-emission/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "asqav-invocation-ref-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "c7H95VWMRO5bt+vmKn2xgQPAkd/5FSIzfvxzjNx5UUA="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-36-invocation-ref-duplicate-emission/predecessor.json
+++ b/verifier/conformance-vectors/asqav-36-invocation-ref-duplicate-emission/predecessor.json
@@ -1,0 +1,27 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "v": 1,
+    "issued_at": "2026-09-07T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_invocation_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "mode": "payload",
+    "tool_name": "demo.action",
+    "hook_event": "PreToolUse",
+    "invocation_ref": "toolu_vec_shared"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-invocation-ref-vec-key",
+    "sig": "kQPYfMDIAv0o31r9AA/vN49nJt/U3mpdRnuJ9ySbvY9ZnJ9ZI+IS27Rw4l2dWJnVESae6AHEadFZXDRiTsHqCQ=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/asqav-36-invocation-ref-duplicate-emission/receipt.json
+++ b/verifier/conformance-vectors/asqav-36-invocation-ref-duplicate-emission/receipt.json
@@ -1,0 +1,27 @@
+{
+  "payload": {
+    "type": "protectmcp:decision",
+    "v": 1,
+    "issued_at": "2026-09-07T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_invocation_001",
+    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "payload_digest": {
+      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size": 0
+    },
+    "policy_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "previousReceiptHash": "abab46c5f7d3549e37cedccc69ff3789f6eec5b08483805a4e3b08863fa91464",
+    "decision": "allow",
+    "mode": "payload",
+    "tool_name": "demo.action",
+    "hook_event": "PreToolUse",
+    "invocation_ref": "toolu_vec_shared"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "asqav-invocation-ref-vec-key",
+    "sig": "4BI2GtO/AgjUiV8oppU+WZqAIGZPnH1oiUcYE5Lersv6wwetIki20zUWmB4E1tjN6eCBQjLVK7NZWDafzQduCQ=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/gen_invocation_ref_vectors.py
+++ b/verifier/conformance-vectors/gen_invocation_ref_vectors.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the invocation_ref visibility conformance vectors.
+
+`invocation_ref` carries a hook event's `tool_use_id` into the signed payload
+so a pre-action receipt and its post-action receipt bind to ONE invocation. A
+duplicate emission (two pre-action receipts, one ref) is representable and
+verifies: the member exists so a reader can SEE duplicates, never to reject
+them. No de-duplication, uniqueness check, or rejection is keyed on it.
+
+  asqav-35-invocation-ref-binds-pre-post  pre + post sharing one ref; verifies
+  asqav-36-invocation-ref-duplicate-emission  two pres sharing one ref; verifies
+
+The signing key is derived from a published phrase so anyone can re-derive it;
+nothing here depends on a secret the corpus does not ship.
+
+Usage: python verifier/conformance-vectors/gen_invocation_ref_vectors.py
+Re-freeze the corpus lock afterwards: python verifier/freeze_corpus_lock.py
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+_HERE = Path(__file__).resolve().parent
+
+#: Nothing-up-my-sleeve seed phrase; the key is SHA-256 of these ASCII bytes
+SEED_PHRASE = b"asqav conformance corpus v1 invocation-ref visibility seed"
+KID = "asqav-invocation-ref-vec-key"
+ISSUER = "Asqav Ltd"
+_ZERO_DIGEST = hashlib.sha256(b"").hexdigest()
+
+#: The prefixed rendering of payload_digest.hash.
+ACTION_REF = f"sha256:{_ZERO_DIGEST}"
+
+#: The shared invocation both vectors revolve around (fixed: minting is deterministic).
+INVOCATION_REF = "toolu_vec_shared"
+
+
+def _jcs(obj: object) -> bytes:
+    """Canonical JSON bytes, matching the oracle's asqav_jcs."""
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+
+
+def _signing_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(SEED_PHRASE).digest())
+
+
+def _sign(payload: dict, sk: Ed25519PrivateKey) -> dict:
+    """The three-key envelope: signature is over the canonical payload bytes."""
+    return {
+        "payload": payload,
+        "signature": {
+            "alg": "Ed25519",
+            "kid": KID,
+            "sig": base64.b64encode(sk.sign(_jcs(payload))).decode(),
+        },
+        "anchors": [],
+    }
+
+
+def _chain_hash(payload: dict) -> str:
+    """The successor's previousReceiptHash: SHA-256 of the predecessor payload."""
+    return hashlib.sha256(_jcs(payload)).hexdigest()
+
+
+def _payload(previous: str, hook_event: str, receipt_type: str, decision: str) -> dict:
+    # Real posttool emits observation, pretool emits decision. The decision
+    # member stays present on both: required, and "observation" claims nothing.
+    return {
+        "type": receipt_type,
+        "v": 1,
+        "issued_at": "2026-09-07T12:00:00+00:00",
+        "issuer_id": ISSUER,
+        "agent_id": "agt_invocation_001",
+        "action_ref": ACTION_REF,
+        "payload_digest": {"hash": _ZERO_DIGEST, "size": 0},
+        "policy_digest": f"sha256:{_ZERO_DIGEST}",
+        "previousReceiptHash": previous,
+        "decision": decision,
+        "mode": "payload",
+        "tool_name": "demo.action",
+        "hook_event": hook_event,
+        "invocation_ref": INVOCATION_REF,
+    }
+
+
+def _jwks() -> dict:
+    pub = _signing_key().public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return {
+        "keys": [
+            {
+                "kid": KID,
+                "issuer_id": ISSUER,
+                "alg": "Ed25519",
+                "status": "active",
+                "public_key": base64.b64encode(pub).decode(),
+            }
+        ]
+    }
+
+
+def _write(name: str, files: dict[str, object]) -> None:
+    out = _HERE / name
+    out.mkdir(parents=True, exist_ok=True)
+    for fname, obj in files.items():
+        (out / fname).write_text(json.dumps(obj, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {name}")
+
+
+def main() -> int:
+    sk = _signing_key()
+
+    pre = _payload("0" * 64, "PreToolUse", "protectmcp:decision", "allow")
+    post = _payload(
+        _chain_hash(pre), "PostToolUse", "protectmcp:observation", "observation"
+    )
+    _write(
+        "asqav-35-invocation-ref-binds-pre-post",
+        {
+            "predecessor.json": _sign(pre, sk),
+            "receipt.json": _sign(post, sk),
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "verified",
+                "reason_code": "",
+                "notes": (
+                    "A pre-action receipt and its post-action receipt carry the "
+                    "same invocation_ref, so a reader binds them to one tool "
+                    "invocation without trusting timestamps. Both receipts are "
+                    "correctly signed and the chain link rederives. The shared "
+                    "member is pure correlation: it changes no verdict."
+                ),
+            },
+        },
+    )
+
+    first = _payload("0" * 64, "PreToolUse", "protectmcp:decision", "allow")
+    second = _payload(
+        _chain_hash(first), "PreToolUse", "protectmcp:decision", "allow"
+    )
+    _write(
+        "asqav-36-invocation-ref-duplicate-emission",
+        {
+            "predecessor.json": _sign(first, sk),
+            "receipt.json": _sign(second, sk),
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "verified",
+                "reason_code": "",
+                "notes": (
+                    "Two pre-action receipts carry the same invocation_ref: the "
+                    "duplicate-emission shape a harness produces when it fires "
+                    "the hook twice for one invocation. Both receipts verify, "
+                    "because invocation_ref exists so a reader can SEE the "
+                    "duplicate, never to reject it. A verifier that refuses "
+                    "this pair is wrong, not strict."
+                ),
+            },
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -591,5 +591,19 @@
     "failure_class": "unverifiable",
     "reason_code": "malformed_member",
     "notes": "asqav-17's receipt with the anchors member present as a JSON null: a third spelling of no anchors found in the wild, and a malformed one - the structure axis FAILs, naming the member and the shape, and the verdict reads unverified/unverifiable rather than reading null as absent. Nothing cryptographic was disproved, so the class is unverifiable, not invalid (same family as duplicate_member: the receipt's own bytes are malformed)."
+  },
+  {
+    "dir": "asqav-35-invocation-ref-binds-pre-post",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "A pre-action receipt and its post-action receipt carry the same invocation_ref, so a reader binds them to one tool invocation without trusting timestamps. Both receipts are correctly signed and the chain link rederives. The shared member is pure correlation: it changes no verdict."
+  },
+  {
+    "dir": "asqav-36-invocation-ref-duplicate-emission",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "Two pre-action receipts carry the same invocation_ref: the duplicate-emission shape a harness produces when it fires the hook twice for one invocation. Both receipts verify, because invocation_ref exists so a reader can SEE the duplicate, never to reject it. A verifier that refuses this pair is wrong, not strict."
   }
 ]

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-verifier-conformance-vectors",
-  "corpus_version": 20,
+  "corpus_version": 21,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -103,6 +103,11 @@
       "version": 19,
       "files": 269,
       "digest": "9a7dd7b2b9884ca0d959e85d6941413c77ca0ace6da10cb5a95bc6f1fa0629d8"
+    },
+    {
+      "version": 20,
+      "files": 270,
+      "digest": "bb3e2e68cbb6914aa323f1e23e653c7d4606826bd0399dc0d191b7cd273d7d2b"
     }
   ],
   "files": [
@@ -1222,6 +1227,46 @@
       "bytes": 880
     },
     {
+      "path": "asqav-35-invocation-ref-binds-pre-post/expected.json",
+      "sha256": "55afa16c0f9d18b3069d59ff2f4b77e63a190b6a21fa2db81f4ec24ff4e978d9",
+      "bytes": 373
+    },
+    {
+      "path": "asqav-35-invocation-ref-binds-pre-post/jwks.json",
+      "sha256": "a00b3fe84d8c84f58ff8a012b448b302b3e85b57f280e6f2a269285122cfd717",
+      "bytes": 226
+    },
+    {
+      "path": "asqav-35-invocation-ref-binds-pre-post/predecessor.json",
+      "sha256": "b2b7b0dadc9e3ef08a418367773fa37f3afc5f8e79f8f637686ce76d8873322d",
+      "bytes": 956
+    },
+    {
+      "path": "asqav-35-invocation-ref-binds-pre-post/receipt.json",
+      "sha256": "e7e4e261851ed167ffd5bf06300e45451be2090d04929a8337fb944aba5cc44c",
+      "bytes": 966
+    },
+    {
+      "path": "asqav-36-invocation-ref-duplicate-emission/expected.json",
+      "sha256": "570f043a77764ad116d7d2a39b77a678acb9d10e42724e92fe42b48b66c1d729",
+      "bytes": 406
+    },
+    {
+      "path": "asqav-36-invocation-ref-duplicate-emission/jwks.json",
+      "sha256": "a00b3fe84d8c84f58ff8a012b448b302b3e85b57f280e6f2a269285122cfd717",
+      "bytes": 226
+    },
+    {
+      "path": "asqav-36-invocation-ref-duplicate-emission/predecessor.json",
+      "sha256": "b2b7b0dadc9e3ef08a418367773fa37f3afc5f8e79f8f637686ce76d8873322d",
+      "bytes": 956
+    },
+    {
+      "path": "asqav-36-invocation-ref-duplicate-emission/receipt.json",
+      "sha256": "d8256169056afc141ed47b15d0a4558e731e511710814f96e1c6509c137310d8",
+      "bytes": 956
+    },
+    {
       "path": "authproof-01-genesis-real-sdk/expected.json",
       "sha256": "5599a2e6341d4194186cd5c43be8c271c2dd40d8a382f1be536d89488e6378a8",
       "bytes": 274
@@ -1287,6 +1332,11 @@
       "bytes": 9809
     },
     {
+      "path": "gen_invocation_ref_vectors.py",
+      "sha256": "ab18b63d5a336d652ba0b638052a67a1b72298e52a7473b784705e71cea35c6f",
+      "bytes": 6265
+    },
+    {
       "path": "gen_key_binding_vectors.py",
       "sha256": "7cb9d35fb67819347f1da3505532b42e2d429ea77554f71f5a07c99405d7e7f8",
       "bytes": 6984
@@ -1313,8 +1363,8 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "bfa5054bf2102a9ae53e04548daa3e098f3cae119921aca8703e42844c4a86d2",
-      "bytes": 27614
+      "sha256": "7d0cf18a4e47eebb024f2360efbe50b5c5b5fcc5042459d0ab578d8489a30d9c",
+      "bytes": 28529
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
@@ -1348,8 +1398,8 @@
     },
     {
       "path": "requirement-map.json",
-      "sha256": "3d7263a4acf0e75bc805d7d5ccae3bdc9dc0677edd8f9e234eb0e2e164eb40bb",
-      "bytes": 51695
+      "sha256": "ca69d390ef205b735586a8b68a8bc7b8c637cf572278aa8ee40a49841389c357",
+      "bytes": 54753
     },
     {
       "path": "w3c-vc-01-didweb-happy-path/did_map.json",
@@ -1487,5 +1537,5 @@
       ]
     }
   },
-  "digest": "bb3e2e68cbb6914aa323f1e23e653c7d4606826bd0399dc0d191b7cd273d7d2b"
+  "digest": "813d051f865ea2b05d96e1ee23ed98eaa8bb4d7f240551dda981ebbd595ea4b0"
 }

--- a/verifier/conformance-vectors/requirement-map.json
+++ b/verifier/conformance-vectors/requirement-map.json
@@ -385,6 +385,36 @@
     },
     "asqav-28-anchors-null-malformed": {
       "structure": "FAIL"
+    },
+    "asqav-35-invocation-ref-binds-pre-post": {
+      "structure": "PASS",
+      "nonce": "PASS",
+      "issuer_key": "PASS",
+      "issuer_bind": "PASS",
+      "key_status": "PASS",
+      "signature": "PASS",
+      "key_binding": "PASS",
+      "counterparty": "PASS",
+      "payload_digest": "PASS",
+      "chain": "PASS",
+      "anchors": "SKIPPED",
+      "skew": "PASS",
+      "expiry": "PASS"
+    },
+    "asqav-36-invocation-ref-duplicate-emission": {
+      "structure": "PASS",
+      "nonce": "PASS",
+      "issuer_key": "PASS",
+      "issuer_bind": "PASS",
+      "key_status": "PASS",
+      "signature": "PASS",
+      "key_binding": "PASS",
+      "counterparty": "PASS",
+      "payload_digest": "PASS",
+      "chain": "PASS",
+      "anchors": "SKIPPED",
+      "skew": "PASS",
+      "expiry": "PASS"
     }
   },
   "requirements": {
@@ -1039,6 +1069,48 @@
         "REQ-SIGNATURE",
         "REQ-SKEW"
       ]
+    },
+    "asqav-35-invocation-ref-binds-pre-post": {
+      "declared_outcome": "verified",
+      "observed_verdict": "unverified",
+      "exercises": [
+        "REQ-CHAIN",
+        "REQ-COUNTERPARTY",
+        "REQ-EXPIRY",
+        "REQ-ISSUER-BIND",
+        "REQ-KEY-RESOLUTION",
+        "REQ-KEY-STATUS",
+        "REQ-KEY-THUMBPRINT",
+        "REQ-NONCE",
+        "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
+        "REQ-SKEW",
+        "REQ-STRUCTURE"
+      ],
+      "not_exercised": [
+        "REQ-ANCHOR"
+      ]
+    },
+    "asqav-36-invocation-ref-duplicate-emission": {
+      "declared_outcome": "verified",
+      "observed_verdict": "unverified",
+      "exercises": [
+        "REQ-CHAIN",
+        "REQ-COUNTERPARTY",
+        "REQ-EXPIRY",
+        "REQ-ISSUER-BIND",
+        "REQ-KEY-RESOLUTION",
+        "REQ-KEY-STATUS",
+        "REQ-KEY-THUMBPRINT",
+        "REQ-NONCE",
+        "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
+        "REQ-SKEW",
+        "REQ-STRUCTURE"
+      ],
+      "not_exercised": [
+        "REQ-ANCHOR"
+      ]
     }
   },
   "interop_fixtures": {
@@ -1329,7 +1401,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-KEY-RESOLUTION": [
       "asqav-01-genesis-permit",
@@ -1356,7 +1430,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-ISSUER-BIND": [
       "asqav-01-genesis-permit",
@@ -1383,7 +1459,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-KEY-STATUS": [
       "asqav-01-genesis-permit",
@@ -1410,7 +1488,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-KEY-THUMBPRINT": [
       "asqav-01-genesis-permit",
@@ -1437,7 +1517,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-CHAIN": [
       "asqav-01-genesis-permit",
@@ -1464,7 +1546,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-ANCHOR": [
       "asqav-24-anchor-block-hash-prod"
@@ -1494,7 +1578,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-EXPIRY": [
       "asqav-01-genesis-permit",
@@ -1521,7 +1607,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-NONCE": [
       "asqav-01-genesis-permit",
@@ -1548,7 +1636,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-PAYLOAD-DIGEST": [
       "asqav-01-genesis-permit",
@@ -1575,7 +1665,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-COUNTERPARTY": [
       "asqav-01-genesis-permit",
@@ -1602,7 +1694,9 @@
       "asqav-24-anchor-block-hash-prod",
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
-      "asqav-27-anchors-absent"
+      "asqav-27-anchors-absent",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ],
     "REQ-STRUCTURE": [
       "asqav-01-genesis-permit",
@@ -1630,14 +1724,16 @@
       "asqav-25-payload-digest-rederives",
       "asqav-26-payload-digest-mismatch",
       "asqav-27-anchors-absent",
-      "asqav-28-anchors-null-malformed"
+      "asqav-28-anchors-null-malformed",
+      "asqav-35-invocation-ref-binds-pre-post",
+      "asqav-36-invocation-ref-duplicate-emission"
     ]
   },
   "unmapped_requirements": [],
   "unmapped_detail": {},
   "unmapped_note": "These are normative requirements no vector in this corpus exercises. They are published because an unmapped requirement stays unmapped however many vectors exist, so growing the corpus does not remove one from this list; writing a vector that reaches it does.",
   "counts": {
-    "asqav_native_vectors": 28,
+    "asqav_native_vectors": 30,
     "interop_fixtures": 52,
     "requirements": 13,
     "requirements_covered": 13,

--- a/verifier/first-bad-edge-cases.json
+++ b/verifier/first-bad-edge-cases.json
@@ -79,6 +79,8 @@
     "asqav-24-anchor-block-hash-prod": null,
     "asqav-27-anchors-absent": null,
     "asqav-28-anchors-null-malformed": "structure",
+    "asqav-35-invocation-ref-binds-pre-post": null,
+    "asqav-36-invocation-ref-duplicate-emission": null,
     "acta-06-chain-link-03-prefixed": null,
     "acta-07-chain-link-03-wrong-digest": "chain"
   }


### PR DESCRIPTION
Python hooks carry tool invocation IDs into receipts, and both SDK sign APIs accept the optional pointer. Signed corpus cases cover pre/post linking and valid duplicate emissions.

Validation: affected Python/TypeScript tests, signed-vector reproduction, independent corpus-lock checks and changed-function CRAP below 30.

THREAT_MODEL

- Surface: callers choose an optional invocation identifier.
- Guard: existing signing and verification bind the field to the receipt.
- Tests: absent/non-string hook IDs, signed pre/post pairs and valid duplicate emissions.
- Boundary: correlation is a producer assertion; the field does not enforce effect uniqueness.
