### PR TITLE
fix: refuse out-of-range integers across both SDK surfaces

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -81,11 +81,12 @@ tests that named it built their expected value by calling the function under tes
 
 If your implementation produces a different `canonical` or `sha256` for one of the provided inputs, open an issue at https://github.com/jagmarques/asqav-sdk/issues with your implementation, language, and JCS library name.
 
-## Corpus freeze at v1 (criterion 420)
+## Rolling corpus lock (criterion 420)
 
-This corpus is frozen at version 1. `manifest.lock.json` pins every corpus
-file by SHA-256 and byte length, and carries the digest of the lock itself;
-any drift fails CI.
+This corpus carries a rolling lock. `manifest.lock.json` records the current
+`corpus_version` with its completed-cut history, pins every corpus file by
+SHA-256 and byte length, and carries the digest of the lock itself; any
+drift fails CI.
 
 - Lock digest: pinned in the lock's own `digest` field and reproduced in the
   repo as the `FINGERPRINT_LOCK_DIGEST` constant in

--- a/conformance/manifest.lock.json
+++ b/conformance/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-fingerprint-corpus",
-  "corpus_version": 7,
+  "corpus_version": 10,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -36,6 +36,21 @@
       "version": 6,
       "files": 3,
       "digest": "1857cd565c62e99146389a70ef135378d9ed2eed3fdc123d5ab839d6fc568094"
+    },
+    {
+      "version": 7,
+      "files": 4,
+      "digest": "e5a3b808981265b808487b12d9ce029013bbab34fcea2f079bbcff8b893e1c7b"
+    },
+    {
+      "version": 8,
+      "files": 4,
+      "digest": "88e8ec15c6c95628ee7b02cc9ca0faba3f0903d1c0f0316cfdfbce37cc7fc5c6"
+    },
+    {
+      "version": 9,
+      "files": 4,
+      "digest": "2d828921b77606e48162da16ce191e8f396257790816cdc87717f647ac8af6df"
     }
   ],
   "files": [
@@ -51,13 +66,13 @@
     },
     {
       "path": "README.md",
-      "sha256": "3970a3ec91039a5b034dc074ac7bd147d3f893237a8c66c3b7cdca463448d4db",
-      "bytes": 7358
+      "sha256": "863f3546f676b610ed2ac816c6b15af0c794644f29d2692622ee5b35603b87f2",
+      "bytes": 7427
     },
     {
       "path": "vectors.json",
-      "sha256": "7beebf7661c02b1e70045aa956ba49836c968edd9b24ecd4ebfb893cca7c6341",
-      "bytes": 37923
+      "sha256": "c473ac3ed8414ba27ee0fdb1b2162eb3a275232c3c8ff19dc9cb8812ace97559",
+      "bytes": 39157
     }
   ],
   "signing": {
@@ -75,5 +90,5 @@
     },
     "known_answer_message_note": "the 32-byte SHA-256 digest of the canonical bytes of vector 'minimal_read': the hash is what ML-DSA-65 signs"
   },
-  "digest": "e5a3b808981265b808487b12d9ce029013bbab34fcea2f079bbcff8b893e1c7b"
+  "digest": "ad2c44c61cf2191cfe628b0628aa4e3ce560dba33be9e83bc584b57606ffdfbc"
 }

--- a/conformance/vectors.json
+++ b/conformance/vectors.json
@@ -537,11 +537,11 @@
       "description": "A digest-covered integer with no exact IEEE-754 double. Python's json.loads keeps 9007199254740993 exactly and JavaScript's JSON.parse rounds it to 9007199254740992, neither raising, so the same document would canonicalize to two different byte strings and carry two different SHA-256 digests. A conformant implementation MUST refuse this document as a parse failure reported unverifiable, and MUST NOT round, truncate or re-serialize the value. The document is given as input_text, not as a parsed input, because a refused document has no canonical form and because a corpus file carrying the bare literal would itself be refused by the rule it describes.",
       "input_text": "{\"n\":9007199254740993}",
       "expected_verify": false,
-      "reason": "9007199254740993 is outside the canonical integer range +/-2**53. The check MUST read the source digits, not the parsed value: Number(\"9007199254740993\") is already 9007199254740992, so a magnitude test on the parsed number accepts the exact case the rule exists to refuse.",
+      "reason": "9007199254740993 has no exact IEEE-754 double, so the generic source-digit guard refuses it before parsing loses precision. The narrowed profile bound +/-(2**53 - 1) would also refuse the parsed rounded value 9007199254740992 on magnitude, but a magnitude test on parsed digits cannot recover the lost original, so the source-digit check stays mandatory. 992 itself round-trips exactly (see the boundary-rejected twin); 993 is refused because the two languages disagree on the digits.",
       "expected": {
         "refused_at": "parse",
-        "bound": "+/-2**53",
-        "max_canonical_integer": 9007199254740992,
+        "bound": "+/-(2**53 - 1)",
+        "max_canonical_integer": 9007199254740991,
         "positive_twin": "asqav-25-number-above-safe-range-as-string"
       }
     },
@@ -561,17 +561,28 @@
     },
     {
       "name": "asqav-25-number-at-safe-range-boundary",
-      "description": "2**53 = 9007199254740992 is exactly representable as an IEEE-754 double and every reader emits the same digits for it, so it is INSIDE the canonical range and MUST be accepted. The bound is deliberately one above JavaScript's Number.isSafeInteger, which is 2**53 - 1: the upstream interop vector number_2_to_53 pins this value as canonical, so a verifier using isSafeInteger as its bound fails upstream conformance.",
+      "description": "2**53 - 1 = 9007199254740991 is the largest integer inside the Asqav profile safe interval: n and n+1 are still distinguishable there, and every reader emits the same digits, so it MUST be accepted. 2**53 is excluded not because it fails to round-trip (it round-trips exactly) but because the safe-integer property fails there.",
       "input": {
-        "n": 9007199254740992
+        "n": 9007199254740991
       },
       "expected_verify": true,
-      "reason": "The largest integer both implementations canonicalize identically.",
+      "reason": "The largest integer inside the Asqav profile safe interval +/-(2**53 - 1).",
       "expected": {
         "negative_twin": "asqav-25-number-above-safe-range-rejected"
       },
-      "canonical": "{\"n\":9007199254740992}",
-      "sha256": "66c87d9cb3014e05a11baa97df62282d89d425f22ee15816577c84534e2ef1bb"
+      "canonical": "{\"n\":9007199254740991}",
+      "sha256": "e1da48c6a6089f06ecb4e0a2259e658e3786b2420f52baccdf929ec6460d7b41"
+    },
+    {
+      "name": "asqav-25-number-above-safe-range-boundary-rejected",
+      "description": "2**53 = 9007199254740992 is exactly representable and every reader emits the same digits for it, yet it sits outside the closed Asqav profile interval of draft Section 4, which ends at 2**53 - 1. A conformant profile implementation MUST refuse this document as a parse failure reported unverifiable. The document is given as input_text, not as a parsed input, because a refused document has no canonical form.",
+      "input_text": "{\"n\":9007199254740992}",
+      "expected_verify": false,
+      "reason": "9007199254740992 round-trips identically in both languages but lies outside the profile safe interval +/-(2**53 - 1): at 2**53 the safe-integer property (n and n+1 distinguishable) already fails. This is a different rejection from asqav-25-number-above-safe-range-rejected (9007199254740993), which is refused because the two languages disagree on the digits.",
+      "expected": {
+        "refused_at": "parse",
+        "positive_twin": "asqav-25-number-at-safe-range-boundary"
+      }
     }
   ]
 }

--- a/python/src/asqav/_jcs.py
+++ b/python/src/asqav/_jcs.py
@@ -44,28 +44,32 @@ def _utf16_ordered(obj: Any) -> Any:
 
 
     # Return canonical JCS bytes for ``obj``, byte-identical to the cloud.
-#: Largest integer magnitude both SDKs canonicalise identically: 2**53 is exactly
-#: representable and both emit the same digits for it, while 2**53 + 1 has no exact
-#: double and JavaScript rounds it. One ABOVE JavaScript's Number.isSafeInteger bound,
-#: deliberately: the upstream interop vector `number_2_to_53` pins 2**53 as canonical.
-#: The bound also excludes every integer at or above 1e21, where JavaScript's toString
-#: switches to exponential notation and Python's str does not.
-MAX_CANONICAL_INTEGER = 2**53
+#: Asqav profile bound: draft Section 4 ends the safe interval at 2**53 - 1.
+#: Exactly representable 2**53 is refused here; generic JCS keeps accepting it.
+MAX_PROFILE_INTEGER = 2**53 - 1
 
 
 class UnsafeIntegerError(ValueError):
     """An integer outside the safe range reached the canonicaliser."""
 
 
-    # Refuse an int with no exact double, at every depth, before any bytes are produced.
+    # Refuse an int or integer-valued float outside the profile range, at every
+    # depth, before any bytes are produced.
 def _reject_unsafe_integers(obj: Any) -> None:
     if isinstance(obj, bool):
         return
     if isinstance(obj, int):
-        if not -MAX_CANONICAL_INTEGER <= obj <= MAX_CANONICAL_INTEGER:
+        if not -MAX_PROFILE_INTEGER <= obj <= MAX_PROFILE_INTEGER:
             raise UnsafeIntegerError(
-                f"integer outside the canonical integer range +/-2**53: {obj}; serialise it "
-                "as a JSON string or an integer-rational pair"
+                f"integer outside the Asqav profile range +/-(2**53 - 1): {obj}; "
+                "serialise it as a JSON string or an integer-rational pair"
+            )
+        return
+    if isinstance(obj, float) and obj.is_integer():
+        if not -MAX_PROFILE_INTEGER <= obj <= MAX_PROFILE_INTEGER:
+            raise UnsafeIntegerError(
+                f"number outside the Asqav profile range +/-(2**53 - 1): {obj!r}; "
+                "serialise it as a JSON string or an integer-rational pair"
             )
         return
     if isinstance(obj, dict):

--- a/python/src/asqav/strict_json.py
+++ b/python/src/asqav/strict_json.py
@@ -25,10 +25,14 @@ from typing import Any
 __all__ = [
     "DuplicateMemberError",
     "UnsafeIntegerError",
+    "ProfileIntegerError",
     "MAX_CANONICAL_INTEGER",
+    "MAX_PROFILE_INTEGER",
     "reject_duplicate_members",
     "reject_unsafe_integer",
     "loads",
+    "loads_profile",
+    "assert_profile_integers",
 ]
 
 #: Largest integer magnitude both SDKs canonicalise identically: 2**53 is exactly
@@ -39,6 +43,10 @@ __all__ = [
 #: switches to exponential notation and Python's str does not.
 MAX_CANONICAL_INTEGER = 2**53
 
+#: Largest integer magnitude the Asqav profile admits: draft Section 4 ends the
+#: safe interval at 2**53 - 1, one below the shared generic bound above.
+MAX_PROFILE_INTEGER = 2**53 - 1
+
 
 class DuplicateMemberError(ValueError):
     """A JSON object repeated a member name; last-wins ingest is never allowed."""
@@ -46,6 +54,10 @@ class DuplicateMemberError(ValueError):
 
 class UnsafeIntegerError(ValueError):
     """An integer outside the safe range; the two SDKs would canonicalise it differently."""
+
+
+class ProfileIntegerError(ValueError):
+    """An integer the Asqav profile refuses; exactly representable yet out of range."""
 
 
     # object_pairs_hook: reject a repeated member name, else build the object.
@@ -80,3 +92,37 @@ def loads(text: str | bytes, **kwargs: Any) -> Any:
         parse_int=reject_unsafe_integer,
         **kwargs,
     )
+
+
+    # Refuse any parsed int or integer-valued float outside the profile interval.
+def assert_profile_integers(obj: Any) -> None:
+    stack: list[tuple[Any, str]] = [(obj, "$")]
+    while stack:
+        node, path = stack.pop()
+        if isinstance(node, bool):
+            continue
+        if isinstance(node, int):
+            if not -MAX_PROFILE_INTEGER <= node <= MAX_PROFILE_INTEGER:
+                raise ProfileIntegerError(
+                    f"integer outside the Asqav profile range +/-(2**53 - 1): "
+                    f"{node} at {path}; serialise it as a JSON string"
+                )
+            continue
+        if isinstance(node, float) and node.is_integer():
+            if not -MAX_PROFILE_INTEGER <= node <= MAX_PROFILE_INTEGER:
+                raise ProfileIntegerError(
+                    f"number outside the Asqav profile range +/-(2**53 - 1): "
+                    f"{node!r} at {path}; serialise it as a JSON string"
+                )
+            continue
+        if isinstance(node, dict):
+            stack.extend((v, f"{path}.{k}") for k, v in node.items())
+        elif isinstance(node, (list, tuple)):
+            stack.extend((v, f"{path}[{i}]") for i, v in enumerate(node))
+
+
+    # Strict ingest plus the narrower Asqav profile range; shared loads unchanged.
+def loads_profile(text: str | bytes, **kwargs: Any) -> Any:
+    obj = loads(text, **kwargs)
+    assert_profile_integers(obj)
+    return obj

--- a/python/src/asqav/verifier/oracle/adapter.py
+++ b/python/src/asqav/verifier/oracle/adapter.py
@@ -129,3 +129,9 @@ class FormatAdapter(ABC):
         ``verified_keyed``, never plain ``verified``. Default is False.
         """
         return False
+
+    def profile_precheck(
+        self, doc: dict, predecessor: Any = None, predecessor_fmt: str | None = None
+    ) -> str | None:
+        """Refusal note or None; default no-op, the core reports a note early."""
+        return None

--- a/python/src/asqav/verifier/oracle/adapters/asqav_native.py
+++ b/python/src/asqav/verifier/oracle/adapters/asqav_native.py
@@ -93,6 +93,23 @@ def _payload(doc: dict) -> dict:
     return payload if isinstance(payload, dict) else env
 
 
+    # The flat object the cloud's hash-mode path signs, before canonicalisation.
+def _flat_signed_fields(doc: dict) -> dict:
+    return {
+        "v": 1,
+        "mode": "hash",
+        "hash": doc.get("hash"),
+        "hash_algo": doc.get("hash_algo") or "sha256",
+        "metadata": doc.get("metadata") or {},
+        "server_timestamp": doc.get("server_timestamp"),
+        "action_id": doc.get("action_id"),
+        "agent_id": doc.get("agent_id"),
+        "org_id": doc.get("org_id"),
+        "policy_digest": doc.get("policy_digest"),
+        "policy_decision": doc.get("policy_decision"),
+    }
+
+
     # Decode signature material; b'' on any malformed input so verify FAILs, never crashes.
 def _safe_b64(value: Any) -> bytes:
     if not isinstance(value, str):
@@ -187,20 +204,7 @@ class AsqavNativeAdapter(FormatAdapter):
         Mirrors ``agents.py::_build_signing_message`` hash-mode branch field-for-field;
         ``asqav_jcs`` sorts the keys, so insertion order is cosmetic but kept aligned.
         """
-        flat = {
-            "v": 1,
-            "mode": "hash",
-            "hash": doc.get("hash"),
-            "hash_algo": doc.get("hash_algo") or "sha256",
-            "metadata": doc.get("metadata") or {},
-            "server_timestamp": doc.get("server_timestamp"),
-            "action_id": doc.get("action_id"),
-            "agent_id": doc.get("agent_id"),
-            "org_id": doc.get("org_id"),
-            "policy_digest": doc.get("policy_digest"),
-            "policy_decision": doc.get("policy_decision"),
-        }
-        return asqav_jcs(flat)
+        return asqav_jcs(_flat_signed_fields(doc))
 
     def chain_step(self, doc: dict) -> ChainStep:
         if _is_hash_mode(doc):
@@ -312,3 +316,25 @@ class AsqavNativeAdapter(FormatAdapter):
         plain verified. Read from the signed field set only.
         """
         return _is_hash_mode(doc) and doc.get("hash_algo") == "hmac-sha256"
+
+    def profile_precheck(
+        self, doc: dict, predecessor: Any = None, predecessor_fmt: str | None = None
+    ) -> str | None:
+        """Refuse current-profile digest inputs outside the range, else None."""
+        if _is_hash_mode(doc):
+            if not _vr.is_current_profile_version(doc.get("v")):
+                return None
+            return _vr.profile_range_note(_flat_signed_fields(doc))
+        signed = _payload(doc)
+        if not _vr.is_current_profile_version(signed.get("v")):
+            return None
+        note = _vr.profile_range_note(signed)
+        if note is not None:
+            return note
+        if (
+            isinstance(predecessor, dict)
+            and predecessor_fmt == self.name
+            and signed.get("previousReceiptHash") != _vr.FIRST_RECEIPT_SEED
+        ):
+            return _vr.profile_range_note(_payload(predecessor))
+        return None

--- a/python/src/asqav/verifier/oracle/core.py
+++ b/python/src/asqav/verifier/oracle/core.py
@@ -303,6 +303,19 @@ def _exceeds_depth(obj: Any, max_depth: int) -> bool:
     return False
 
 
+    # One-axis unverified result for a pre-axis input refusal (depth, profile range).
+def _early_unverified(fmt: str, note: str) -> VerifyResult:
+    axes = [_axis("structure", crypto.FAIL, note)]
+    verdict, failure_class = fold_verdict(axes, keyed=False)
+    return VerifyResult(
+        fmt=fmt,
+        axes=axes,
+        verdict=verdict,
+        failure_class=failure_class,
+        first_failing_edge=first_failing_edge(axes),
+    )
+
+
     # Verify one parsed receipt and return a structured ``VerifyResult``.
 def verify(
     doc: dict,
@@ -326,15 +339,15 @@ def verify(
     if _exceeds_depth(doc, MAX_NESTING_DEPTH) or (
         predecessor is not None and _exceeds_depth(predecessor, MAX_NESTING_DEPTH)
     ):
-        axes = [_axis("structure", crypto.FAIL, _TOO_DEEP_NOTE)]
-        verdict, failure_class = fold_verdict(axes, keyed=False)
-        return VerifyResult(
-            fmt=ad.name,
-            axes=axes,
-            verdict=verdict,
-            failure_class=failure_class,
-            first_failing_edge=first_failing_edge(axes),
-        )
+        return _early_unverified(ad.name, _TOO_DEEP_NOTE)
+    pred_ad = detect(predecessor, adapters) if predecessor is not None else None
+    refusal = ad.profile_precheck(
+        doc,
+        predecessor=predecessor,
+        predecessor_fmt=pred_ad.name if pred_ad is not None else None,
+    )
+    if refusal is not None:
+        return _early_unverified(ad.name, refusal)
 
     axes = [
         _structure_axis(ad, doc),

--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -458,6 +458,10 @@ class DuplicateMemberError(ValueError):
 #: switches to exponential notation and Python's str does not.
 MAX_CANONICAL_INTEGER = 2**53
 
+#: Asqav profile bound: draft Section 4 ends the safe interval at 2**53 - 1.
+#: The profile precheck refuses exactly representable 2**53; shared ingest keeps it.
+MAX_PROFILE_INTEGER = 2**53 - 1
+
 
 class UnsafeIntegerError(ValueError):
     """An integer with no exact double; two readers would canonicalise it differently.
@@ -480,13 +484,53 @@ def _reject_duplicate_members(pairs):
 
     # parse_int: refuse an integer literal with no exact double.
 def _reject_unsafe_integer(literal):
-    value = int(literal)
+    # int() itself raises past the interpreter digit cap, so judge the
+    # literal first: leading zeros never count toward the value's size.
+    digits = literal[1:] if literal[:1] == "-" else literal
+    significant = digits.lstrip("0") or "0"
+    if _decimal_digits_exceed_str_limit(len(significant)):
+        raise UnsafeIntegerError(
+            f"integer outside the canonical integer range +/-2**53: "
+            f"<{len(significant)}-digit integer>; serialise it as a JSON "
+            "string or an integer-rational pair"
+        )
+    signed = literal[:1] + significant if literal[:1] == "-" else significant
+    value = int(signed)
     if not -MAX_CANONICAL_INTEGER <= value <= MAX_CANONICAL_INTEGER:
         raise UnsafeIntegerError(
             f"integer outside the canonical integer range +/-2**53: {literal}; serialise "
             "it as a JSON string or an integer-rational pair"
         )
     return value
+
+
+def _decimal_digits_exceed_str_limit(count: int) -> bool:
+    """True when a decimal literal of ``count`` digits defeats int()."""
+    get_limit = getattr(sys, "get_int_max_str_digits", None)
+    if get_limit is None:
+        return False
+    limit = get_limit()
+    return bool(limit) and count > limit
+
+
+def _int_exceeds_str_limit(node: int) -> bool:
+    """True when str(node) would breach the interpreter digit cap."""
+    get_limit = getattr(sys, "get_int_max_str_digits", None)
+    if get_limit is None:
+        return False
+    limit = get_limit()
+    return bool(limit) and abs(node) >= 10**limit
+
+
+def _int_digit_count(node: int) -> int:
+    """Exact decimal digit count via bit_length, never via str()."""
+    magnitude = abs(node)
+    digits = (magnitude.bit_length() * 30103) // 100000 + 1
+    while 10**digits <= magnitude:
+        digits += 1
+    while digits > 1 and 10 ** (digits - 1) > magnitude:
+        digits -= 1
+    return digits
 
 
 def _parse_object(text: str, source: str) -> dict:
@@ -2396,6 +2440,161 @@ def check_structure(payload: dict):
     return "PASS", f"required fields present; type {rt}"
 
 
+def is_current_profile_version(value) -> bool:
+    """True for numeric v=1 (1.0 selects too); booleans, v2, missing never select."""
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return value == 1
+    return isinstance(value, float) and value == 1.0
+
+
+def profile_range_note(obj) -> str | None:
+    """Note when ``obj`` carries a number beyond +/-(2**53 - 1), else None."""
+    stack = [(obj, "$", False)]
+    active: set[int] = set()
+    done: dict[int, object] = {}
+    while stack:
+        node, path, exiting = stack.pop()
+        if isinstance(node, bool):
+            continue
+        if isinstance(node, int):
+            if not -MAX_PROFILE_INTEGER <= node <= MAX_PROFILE_INTEGER:
+                # str() itself raises past the interpreter digit cap, so an
+                # unformattable magnitude is refused by digit count instead.
+                if _int_exceeds_str_limit(node):
+                    digits = _int_digit_count(node)
+                    return (
+                        f"Asqav profile range +/-(2**53 - 1) excludes "
+                        f"a {digits}-digit integer at {path}"
+                    )
+                return (
+                    f"Asqav profile range +/-(2**53 - 1) excludes integer "
+                    f"{node} at {path}"
+                )
+            continue
+        if isinstance(node, float) and node.is_integer():
+            if not -MAX_PROFILE_INTEGER <= node <= MAX_PROFILE_INTEGER:
+                return (
+                    f"Asqav profile range +/-(2**53 - 1) excludes number "
+                    f"{node!r} at {path}"
+                )
+            continue
+        if isinstance(node, (dict, list, tuple)):
+            if exiting:
+                # The dict holds each skipped container alive, so a freed id
+                # can never be recycled onto an unchecked container (D2)
+                active.discard(id(node))
+                done[id(node)] = node
+                continue
+            # Only a container met again while still expanding on the current
+            # path is a cycle; a fully checked one is shared and known clean
+            # (the walk returns at the first violation), so skip it once.
+            if id(node) in done:
+                continue
+            if id(node) in active:
+                return (
+                    "Asqav profile range +/-(2**53 - 1) unverifiable: "
+                    f"cyclic reference at {path}"
+                )
+            active.add(id(node))
+            stack.append((node, path, True))
+            if isinstance(node, dict):
+                stack.extend((v, f"{path}.{k}", False) for k, v in node.items())
+            else:
+                stack.extend(
+                    (v, f"{path}[{i}]", False) for i, v in enumerate(node)
+                )
+    return None
+
+
+def _counterparty_commitment_reached(payload, counterparty) -> bool:
+    """True when the counterparty path reaches its envelope commitment."""
+    cpb = payload.get("counterparty_binding")
+    if not isinstance(cpb, dict):
+        return False
+    receipt_ref = cpb.get("receipt_ref")
+    if not isinstance(receipt_ref, str) or not receipt_ref:
+        return False
+    digest = cpb.get("envelope_hash")
+    if not isinstance(digest, str) or not digest:
+        return False
+    try:
+        raw = base64.b64decode(digest, validate=True)
+    except Exception:
+        return False
+    if len(raw) != 32:
+        return False
+    ack = cpb.get("expect_ack_from")
+    if ack is not None and not isinstance(ack, str):
+        return False
+    return isinstance(counterparty, dict)
+
+
+    # Refusal note when current-profile digest inputs violate the range, else None.
+def _profile_range_refusal(payload, sig_obj, predecessor_payload, counterparty, anchors):
+    if not is_current_profile_version(payload.get("v")):
+        return None
+    note = profile_range_note(payload)
+    if note is not None:
+        return note
+    if isinstance(anchors, list) and anchors and isinstance(sig_obj, dict):
+        note = profile_range_note(sig_obj)
+        if note is not None:
+            return note
+    # check_chain canonicalizes any supplied predecessor for a non-genesis
+    # current link, so the precheck walks it under the same condition: no
+    # required-member or registry test on this standalone path.
+    if (
+        predecessor_payload is not None
+        and payload.get("previousReceiptHash") != FIRST_RECEIPT_SEED
+    ):
+        note = profile_range_note(predecessor_payload)
+        if note is not None:
+            return note
+    if _counterparty_commitment_reached(payload, counterparty):
+        note = profile_range_note(counterparty)
+        if note is not None:
+            return note
+    return None
+
+
+def _agent_fallback_signature(
+    jwks, payload, envelope, msg, sig, alg, jwks_alg, pk, sig_res, eff
+):
+    """Adopt a verifying agent key, else note exhaustion; returns updated state."""
+    # Cloud receipts sign with the agent key though kid is the issuer id; fall back.
+    # agent_id is attacker-controlled, so trust only a key whose issuer_id matches.
+    agent_id = payload.get("agent_id") or envelope.get("agent_id")
+    org_bind = payload.get("org_id") or envelope.get("org_id")
+    entry_a, sig_res_a, exhausted = _select_agent_bound_key(
+        jwks, agent_id, payload.get("issuer_id"), org_bind, msg, sig,
+        alg or jwks_alg,
+    )
+    pk_a, alg_a = None, None
+    agent_note = ""
+    if entry_a is not None:
+        pk_a, alg_a = _b64decode(entry_a["public_key"]), entry_a.get("alg")
+        if sig_res_a is not None and sig_res_a[0] == "PASS":
+            sig_res = sig_res_a
+            eff = (
+                entry_a.get("status"),
+                entry_a.get("kid"),
+                key_issuer_of(entry_a),
+                revoked_at_of(entry_a),
+                pk_a,
+                alg_a,
+            )
+        elif exhausted:
+            agent_note = "; no key published for this agent verified"
+    if sig_res[0] != "PASS":
+        cands = [(pk, alg or jwks_alg)]
+        if pk_a is not None:
+            cands.append((pk_a, alg_a or alg or jwks_alg))
+        sig_res = _pre_cutover_diagnostic(payload, sig, cands, sig_res)
+    return sig_res, eff, agent_note
+
+
 def run(
     envelope: dict,
     jwks: dict,
@@ -2449,6 +2648,14 @@ def run(
         sig_obj = {}
     kid = sig_obj.get("kid", "")
     alg = sig_obj.get("alg", "ML-DSA-65")
+    refusal = _profile_range_refusal(
+        payload, sig_obj, predecessor_payload, counterparty, envelope.get("anchors")
+    )
+    if refusal is not None:
+        print("Asqav receipt verification")
+        print(f"  [FAIL] input       {refusal}")
+        print("\n  => unverified (failure_class: unverifiable; never reported verified)")
+        return 2
     try:
         msg = canonical_json(payload)
     except RecursionError:
@@ -2485,32 +2692,13 @@ def run(
         eff_issuer = key_issuer_of(entry)
         eff_revoked_at = revoked_at_of(entry)
         eff_pk, eff_alg = pk, jwks_alg
-        # Cloud receipts sign with the agent key though kid is the issuer id; fall back.
-        # agent_id is attacker-controlled, so trust only a key whose issuer_id matches.
         agent_note = ""
         if sig_res[0] != "PASS":
-            agent_id = payload.get("agent_id") or envelope.get("agent_id")
-            org_bind = payload.get("org_id") or envelope.get("org_id")
-            entry_a, sig_res_a, exhausted = _select_agent_bound_key(
-                jwks, agent_id, payload.get("issuer_id"), org_bind, msg, sig,
-                alg or jwks_alg,
+            eff = (eff_status, eff_kid, eff_issuer, eff_revoked_at, eff_pk, eff_alg)
+            sig_res, eff, agent_note = _agent_fallback_signature(
+                jwks, payload, envelope, msg, sig, alg, jwks_alg, pk, sig_res, eff
             )
-            pk_a, alg_a = None, None
-            if entry_a is not None:
-                pk_a, alg_a = _b64decode(entry_a["public_key"]), entry_a.get("alg")
-                if sig_res_a is not None and sig_res_a[0] == "PASS":
-                    sig_res = sig_res_a
-                    eff_status, eff_kid = entry_a.get("status"), entry_a.get("kid")
-                    eff_issuer = key_issuer_of(entry_a)
-                    eff_revoked_at = revoked_at_of(entry_a)
-                    eff_pk, eff_alg = pk_a, alg_a
-                elif exhausted:
-                    agent_note = "; no key published for this agent verified"
-            if sig_res[0] != "PASS":
-                cands = [(pk, alg or jwks_alg)]
-                if pk_a is not None:
-                    cands.append((pk_a, alg_a or alg or jwks_alg))
-                sig_res = _pre_cutover_diagnostic(payload, sig, cands, sig_res)
+            eff_status, eff_kid, eff_issuer, eff_revoked_at, eff_pk, eff_alg = eff
         results.append(
             ("issuer_key", "PASS", f"resolved signing key {eff_kid} (status={eff_status}){agent_note}")
         )
@@ -2692,6 +2880,21 @@ def run_structured(
         sig_obj = {}  # non-object signature: no usable kid/sig, key resolution FAILs cleanly
     kid = sig_obj.get("kid", "")
     alg = sig_obj.get("alg", "ML-DSA-65")
+    refusal = _profile_range_refusal(
+        payload, sig_obj, predecessor_payload, counterparty, envelope.get("anchors")
+    )
+    if refusal is not None:
+        axes = [_struct_axis("input", "FAIL", refusal)]
+        return {
+            "not_checked": not_checked_declaration(),
+            "coverage": coverage_declaration(axes),
+            "verdict": VERDICT_UNVERIFIED,
+            "failure_class": FAILURE_UNVERIFIABLE,
+            "axes": axes,
+            "canonical_sha256": None,
+            "kid": None,
+            "alg": None,
+        }
     try:
         msg = canonical_json(payload)
     except RecursionError:
@@ -2734,32 +2937,14 @@ def run_structured(
         eff_issuer = key_issuer_of(entry)
         eff_revoked_at = revoked_at_of(entry)
         eff_pk, eff_alg = pk, jwks_alg
-        # Cloud receipts sign with the agent key though kid is the issuer id; fall back,
-        # mirroring run(). agent_id is attacker-controlled, so match on issuer_id.
         agent_note = ""
         if sig_res[0] != "PASS":
-            agent_id = payload.get("agent_id") or envelope.get("agent_id")
-            org_bind = payload.get("org_id") or envelope.get("org_id")
-            entry_a, sig_res_a, exhausted = _select_agent_bound_key(
-                jwks, agent_id, payload.get("issuer_id"), org_bind, msg, sig_bytes,
-                alg or jwks_alg,
+            eff = (eff_status, eff_kid, eff_issuer, eff_revoked_at, eff_pk, eff_alg)
+            sig_res, eff, agent_note = _agent_fallback_signature(
+                jwks, payload, envelope, msg, sig_bytes, alg, jwks_alg, pk,
+                sig_res, eff,
             )
-            pk_a, alg_a = None, None
-            if entry_a is not None:
-                pk_a, alg_a = _b64decode(entry_a["public_key"]), entry_a.get("alg")
-                if sig_res_a is not None and sig_res_a[0] == "PASS":
-                    sig_res = sig_res_a
-                    eff_status, eff_kid = entry_a.get("status"), entry_a.get("kid")
-                    eff_issuer = key_issuer_of(entry_a)
-                    eff_revoked_at = revoked_at_of(entry_a)
-                    eff_pk, eff_alg = pk_a, alg_a
-                elif exhausted:
-                    agent_note = "; no key published for this agent verified"
-            if sig_res[0] != "PASS":
-                cands = [(pk, alg or jwks_alg)]
-                if pk_a is not None:
-                    cands.append((pk_a, alg_a or alg or jwks_alg))
-                sig_res = _pre_cutover_diagnostic(payload, sig_bytes, cands, sig_res)
+            eff_status, eff_kid, eff_issuer, eff_revoked_at, eff_pk, eff_alg = eff
         axes.append(
             _struct_axis(
                 "issuer_key",

--- a/python/tests/test_corpus_integrity.py
+++ b/python/tests/test_corpus_integrity.py
@@ -98,7 +98,7 @@ PINNED_SHA256 = {
     "asqav-25-number-above-safe-range-as-string":
         "3bbb752b000e9ac58b939c07bb99307d18ccc5be92189d3c32738ec24c98579f",
     "asqav-25-number-at-safe-range-boundary":
-        "66c87d9cb3014e05a11baa97df62282d89d425f22ee15816577c84534e2ef1bb",
+        "e1da48c6a6089f06ecb4e0a2259e658e3786b2420f52baccdf929ec6460d7b41",
 }
 
 #: Length of each canonical string, so a published ``canonical`` cannot be swapped
@@ -228,6 +228,7 @@ PINNED_SIGNATURES = {
 #: REFUSAL has no canonical form, so its contract with implementers is these bytes.
 PINNED_REFUSED_DOCUMENT = {
     "asqav-25-number-above-safe-range-rejected": "{\"n\":9007199254740993}",
+    "asqav-25-number-above-safe-range-boundary-rejected": "{\"n\":9007199254740992}",
 }
 
 #: Every derived member name this file claims to pin. A derived member added to the
@@ -342,14 +343,14 @@ def test_refused_document_is_the_pinned_literal(name: str, document: str) -> Non
     assert _vectors()[name]["input_text"] == document
 
 
-    # The corpus says these documents are refused, so the shipped parser must refuse them.
-    # Without this the corpus could publish a refusal the code does not implement.
+    # Refused corpus documents must fail through the shipped profile ingest,
+    # or the corpus advertises a refusal the code does not implement.
 @pytest.mark.parametrize("name,document", sorted(PINNED_REFUSED_DOCUMENT.items()))
 def test_the_shipped_parser_actually_refuses_it(name: str, document: str) -> None:
     from asqav import strict_json
 
     with pytest.raises(ValueError):
-        strict_json.loads(document)
+        strict_json.loads_profile(document)
 
 
 def test_no_derived_member_escapes_a_pin() -> None:

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -23,7 +23,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
-FINGERPRINT_LOCK_DIGEST = "e5a3b808981265b808487b12d9ce029013bbab34fcea2f079bbcff8b893e1c7b"
+FINGERPRINT_LOCK_DIGEST = "ad2c44c61cf2191cfe628b0628aa4e3ce560dba33be9e83bc584b57606ffdfbc"
 VERIFIER_LOCK_DIGEST = "66f8027c58589fc8af36bc6bbfc3b9dcada6d4cfb623deb1d1528a85dac66ca7"
 
 try:

--- a/python/tests/test_doors.py
+++ b/python/tests/test_doors.py
@@ -193,10 +193,21 @@ def test_out_of_domain_fixture_is_refused_at_the_parse_boundary() -> None:
 
 def test_canonicaliser_also_refuses_a_value_built_in_process() -> None:
     """Defence in depth for a value that never went through the parser."""
-    with pytest.raises(UnsafeIntegerError, match="canonical integer range"):
+    with pytest.raises(UnsafeIntegerError, match=r"profile range \+/-\(2\*\*53 - 1\)"):
         doors.canonical_json({"n": 2**53 + 1})
-    # 2**53 itself is exactly representable and is pinned canonical upstream.
-    assert doors.canonical_json({"n": 2**53}) == b'{"n":9007199254740992}'
+    # The profile ends at 2**53 - 1 even though 2**53 round-trips exactly;
+    # generic JCS keeps the upstream-pinned value, the profile producer refuses it.
+    with pytest.raises(UnsafeIntegerError, match=r"profile range \+/-\(2\*\*53 - 1\)"):
+        doors.canonical_json({"n": 2**53})
+    assert doors.canonical_json({"n": 2**53 - 1}) == b'{"n":9007199254740991}'
+
+
+def test_profile_producer_refuses_integer_valued_floats_outside_the_range() -> None:
+    """Float spellings of excluded integers refuse; in-range floats pass."""
+    with pytest.raises(UnsafeIntegerError, match=r"profile range \+/-\(2\*\*53 - 1\)"):
+        doors.canonical_json({"n": float(2**53)})
+    assert doors.canonical_json({"n": 5.0}) == b'{"n":5.0}'
+    assert doors.canonical_json({"n": 3.14}) == b'{"n":3.14}'
 
 
 def test_astral_key_order_stays_closed() -> None:

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -1256,3 +1256,199 @@ def test_the_named_edge_is_an_axis_the_report_actually_carries() -> None:
                 f"{entry['dir']} names edge {result.first_failing_edge!r} "
                 f"but the report carries no such axis"
             )
+
+
+# --- Asqav profile safe-integer precheck: current v=1 refuses before crypto ---
+
+
+def _bomb(*args, **kwargs):
+    raise AssertionError("crypto callback must not run after a profile refusal")
+
+
+def _profile_spies(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asqav.verifier.oracle.core as core_mod
+
+    monkeypatch.setattr(AsqavNativeAdapter, "signing_input", _bomb)
+    monkeypatch.setattr(AsqavNativeAdapter, "resolve_key", _bomb)
+    monkeypatch.setattr(core_mod.crypto, "verify_signature", _bomb)
+
+
+def test_profile_nested_excluded_number_refuses_before_crypto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _profile_spies(monkeypatch)
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    doc["payload"]["score"] = 2**53
+    res = verify(doc, ADAPTERS, key_provider=_provider("asqav-01-genesis-permit", "asqav-native"))
+    assert res.fmt == "asqav-native"
+    assert res.verdict == "unverified"
+    assert res.failure_class == "unverifiable"
+    assert len(res.axes) == 1
+    assert res.axes[0].axis == "structure"
+    assert "profile range +/-(2**53 - 1)" in res.axes[0].note
+    assert res.first_failing_edge == "structure"
+
+
+def test_profile_nested_inner_hash_mode_still_refuses() -> None:
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    doc["payload"]["mode"] = "hash"
+    doc["payload"]["score"] = -(2**53)
+    res = verify(doc, ADAPTERS)
+    assert res.verdict == "unverified"
+    assert "profile range +/-(2**53 - 1)" in res.axes[0].note
+
+
+def test_profile_bare_payload_refuses() -> None:
+    doc = {
+        "previousReceiptHash": "1" * 64,
+        "issuer_id": "kid-x",
+        "v": 1,
+        "score": 2**53,
+    }
+    res = verify(doc, ADAPTERS)
+    assert res.fmt == "asqav-native"
+    assert "profile range +/-(2**53 - 1)" in res.axes[0].note
+
+
+def test_profile_flat_excluded_metadata_refuses_before_crypto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _profile_spies(monkeypatch)
+    doc = _load("asqav-05-hash-mode-prod", "receipt.json")
+    doc["metadata"] = {"batch": 2**53}
+    res = verify(doc, ADAPTERS, key_provider=_provider("asqav-05-hash-mode-prod", "asqav-native"))
+    assert res.verdict == "unverified"
+    assert "profile range +/-(2**53 - 1)" in res.axes[0].note
+
+
+def test_profile_flat_missing_v_keeps_schema_outcome() -> None:
+    doc = _load("asqav-05-hash-mode-prod", "receipt.json")
+    del doc["v"]
+    doc["metadata"] = {"batch": 2**53}
+    res = verify(doc, ADAPTERS)
+    assert all("profile range" not in a.note for a in res.axes)
+    assert res.axis("structure").result == crypto.FAIL
+
+
+def test_profile_clean_v1_reaches_real_crypto(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asqav.verifier.oracle.core as core_mod
+
+    calls: list = []
+    orig = core_mod.crypto.verify_signature
+
+    def spy(alg, pk, msg, sig):
+        calls.append((alg, pk, msg, sig))
+        return orig(alg, pk, msg, sig)
+
+    monkeypatch.setattr(core_mod.crypto, "verify_signature", spy)
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    verify(doc, ADAPTERS, key_provider=_provider("asqav-01-genesis-permit", "asqav-native"))
+    assert calls, "a clean v=1 receipt must reach the signature check"
+
+
+@pytest.mark.parametrize("version", [None, 2, True, "1"])
+def test_profile_non_current_versions_skip_the_precheck(version) -> None:
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    if version is None:
+        del doc["payload"]["v"]
+    else:
+        doc["payload"]["v"] = version
+    doc["payload"]["score"] = 2**53
+    res = verify(doc, ADAPTERS)
+    assert all("profile range" not in a.note for a in res.axes)
+
+
+def test_profile_float_1_0_selects_the_current_profile() -> None:
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    doc["payload"]["v"] = 1.0
+    doc["payload"]["score"] = 2**53
+    res = verify(doc, ADAPTERS)
+    assert "profile range +/-(2**53 - 1)" in res.axes[0].note
+
+
+def test_profile_outer_v_cannot_activate_nested_payload() -> None:
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    del doc["payload"]["v"]
+    doc["payload"]["score"] = 2**53
+    doc["v"] = 1
+    res = verify(doc, ADAPTERS)
+    assert all("profile range" not in a.note for a in res.axes)
+
+
+def test_profile_bad_predecessor_refuses_without_its_v() -> None:
+    doc = _load("asqav-03-chain-link", "receipt.json")
+    pred = _load("asqav-03-chain-link", "predecessor.json")
+    pred["payload"]["score"] = 2**53
+    del pred["payload"]["v"]
+    res = verify(doc, ADAPTERS, predecessor=pred)
+    assert "profile range +/-(2**53 - 1)" in res.axes[0].note
+
+
+def test_profile_genesis_skips_predecessor_numbers() -> None:
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    pred = _load("asqav-03-chain-link", "predecessor.json")
+    pred["payload"]["score"] = 2**53
+    res = verify(doc, ADAPTERS, predecessor=pred)
+    assert all("profile range" not in a.note for a in res.axes)
+
+
+def test_profile_foreign_predecessor_keeps_chain_result() -> None:
+    doc = _load("asqav-03-chain-link", "receipt.json")
+    pred = _load("aerf-01-genesis", "receipt.json")
+    res = verify(doc, ADAPTERS, predecessor=pred)
+    assert all("profile range" not in a.note for a in res.axes)
+    assert res.axis("chain").result == crypto.FAIL
+    assert res.failure_class == "invalid"
+
+
+def test_profile_unsigned_top_level_metadata_is_not_checked() -> None:
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    doc["export_seq"] = 2**53
+    res = verify(doc, ADAPTERS)
+    assert all("profile range" not in a.note for a in res.axes)
+
+
+def test_profile_jwks_at_generic_boundary_is_not_checked() -> None:
+    doc = _load("asqav-01-genesis-permit", "receipt.json")
+    provider = _provider("asqav-01-genesis-permit", "asqav-native")
+    provider["max_seen"] = 2**53
+    res = verify(doc, ADAPTERS, key_provider=provider)
+    assert all("profile range" not in a.note for a in res.axes)
+
+
+def test_foreign_formats_have_no_profile_precheck() -> None:
+    doc = _load("aerf-01-genesis", "receipt.json")
+    assert AerfAdapter().profile_precheck(doc) is None
+    res = verify(doc, ADAPTERS, key_provider=_provider("aerf-01-genesis", "aerf"))
+    assert all("profile range" not in a.note for a in res.axes)
+
+
+def _dual_detect_predecessor(value: int) -> dict:
+    return {
+        "type": "notarised_evidence",
+        "evidence_hash_sha512": "0" * 128,
+        "previousReceiptHash": "1" * 64,
+        "issuer_id": "review",
+        "n": value,
+    }
+
+
+@pytest.mark.parametrize("value", [1, 2**53])
+def test_profile_predecessor_follows_registry_foreign_first(value: int) -> None:
+    doc = _load("asqav-03-chain-link", "receipt.json")
+    pred = _dual_detect_predecessor(value)
+    adapters = [AerfAdapter(), AsqavNativeAdapter()]
+    assert AsqavNativeAdapter().detect(pred) is True
+    res = verify(doc, adapters, predecessor=pred)
+    assert all("profile range" not in a.note for a in res.axes)
+    assert res.axis("chain").result == crypto.FAIL
+    assert res.axis("chain").note == "predecessor is a different receipt format"
+    assert res.failure_class == "invalid"
+
+
+def test_profile_predecessor_follows_registry_native_first() -> None:
+    doc = _load("asqav-03-chain-link", "receipt.json")
+    pred = _dual_detect_predecessor(2**53)
+    res = verify(doc, [AsqavNativeAdapter(), AerfAdapter()], predecessor=pred)
+    assert "profile range +/-(2**53 - 1)" in res.axes[0].note
+    assert res.failure_class == "unverifiable"

--- a/python/tests/test_strict_json.py
+++ b/python/tests/test_strict_json.py
@@ -148,3 +148,64 @@ def test_standalone_verifier_rejects_an_unsafe_integer() -> None:
     with pytest.raises(vr.VerifierInputError, match="canonical integer range"):
         vr._parse_object('{"n": 9007199254740993}', "receipt")
     assert vr._parse_object('{"n": 9007199254740992}', "receipt") == {"n": 9007199254740992}
+
+
+# --- Asqav profile range +/-(2**53 - 1): explicit entry, shared loads unchanged ---
+
+
+    # The profile admits the largest safe integer on both signs, nested or not.
+@pytest.mark.parametrize(
+    "text",
+    [
+        '{"n": 9007199254740991}',
+        '{"n": -9007199254740991}',
+        '{"a": {"b": [1, {"c": 9007199254740991}]}}',
+    ],
+)
+def test_profile_ingest_accepts_the_safe_interval(text: str) -> None:
+    assert strict_json.loads_profile(text) == strict_json.loads(text)
+
+
+    # Exactly representable +/-2**53 is outside the profile interval and refuses.
+@pytest.mark.parametrize(
+    "text",
+    [
+        '{"n": 9007199254740992}',
+        '{"n": -9007199254740992}',
+        '{"a": {"b": [1, {"c": -9007199254740992}]}}',
+    ],
+)
+def test_profile_ingest_refuses_the_excluded_boundary(text: str) -> None:
+    with pytest.raises(
+        strict_json.ProfileIntegerError, match=r"profile range \+/-\(2\*\*53 - 1\)"
+    ):
+        strict_json.loads_profile(text)
+
+
+    # Values with no exact double refuse first at the shared guard underneath.
+@pytest.mark.parametrize("literal", ["9007199254740993", "-9007199254740993"])
+def test_profile_ingest_refuses_beyond_the_boundary(literal: str) -> None:
+    with pytest.raises(strict_json.UnsafeIntegerError):
+        strict_json.loads_profile('{"n": %s}' % literal)
+
+
+    # Decimal/exponent spellings of the excluded boundary cannot bypass the check.
+@pytest.mark.parametrize("literal", ["9007199254740992.0", "9.007199254740992e15"])
+def test_profile_ingest_refuses_float_spellings_of_the_boundary(literal: str) -> None:
+    with pytest.raises(strict_json.ProfileIntegerError):
+        strict_json.loads_profile('{"n": %s}' % literal)
+
+
+    # The string twin, booleans and fractional floats keep their existing behavior.
+def test_profile_ingest_keeps_strings_booleans_and_fractions() -> None:
+    assert strict_json.loads_profile('{"n": "9007199254740993"}') == {
+        "n": "9007199254740993"
+    }
+    assert strict_json.loads_profile('{"a": true, "b": 3.14}') == {"a": True, "b": 3.14}
+    assert strict_json.loads_profile('{"n": 5.0}') == {"n": 5.0}
+
+
+    # The shared generic entry still accepts +/-2**53: foreign compatibility control.
+@pytest.mark.parametrize("literal", ["9007199254740992", "-9007199254740992"])
+def test_generic_ingest_still_accepts_the_excluded_boundary(literal: str) -> None:
+    assert strict_json.loads('{"n": %s}' % literal) == {"n": int(literal)}

--- a/python/tests/test_verify_receipt_failclean.py
+++ b/python/tests/test_verify_receipt_failclean.py
@@ -7,6 +7,7 @@ and reads a receipt from stdin via ``--receipt -``.
 
 from __future__ import annotations
 
+import base64
 import io
 import os
 import sys
@@ -406,3 +407,684 @@ def test_run_structured_payload_list_names_actual_type() -> None:
     assert out["failure_class"] == "unverifiable"
     note = out["axes"][0]["note"]
     assert "list" in note
+
+
+# === profile safe-integer precheck: current v=1 digest inputs refuse pre-crypto ===
+
+
+def _profile_payload(**over) -> dict:
+    base = {**_payload(), "v": 1, "previousReceiptHash": "1" * 64}
+    base.update(over)
+    return base
+
+
+def _profile_envelope(payload: dict) -> dict:
+    return {"payload": payload, "signature": _sig(), "anchors": []}
+
+
+def _crypto_spies(monkeypatch: pytest.MonkeyPatch) -> dict:
+    calls: dict[str, list] = {"verify_signature": [], "canonical_json": []}
+
+    def spy_verify(pk, msg, sig, alg):
+        calls["verify_signature"].append((pk, msg, sig, alg))
+        raise AssertionError("crypto must not run after a profile refusal")
+
+    def spy_canonical(obj, default=None):
+        calls["canonical_json"].append(obj)
+        raise AssertionError("canonical_json must not run after a profile refusal")
+
+    monkeypatch.setattr(vr, "verify_signature", spy_verify)
+    monkeypatch.setattr(vr, "canonical_json", spy_canonical)
+    monkeypatch.setattr(
+        vr, "evaluate_anchors", lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("anchors must not evaluate after a profile refusal"))
+    )
+    return calls
+
+
+def test_run_profile_excluded_number_refuses_before_crypto(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    _crypto_spies(monkeypatch)
+    env = _profile_envelope(_profile_payload(score=2**53))
+    assert vr.run(env, {"keys": []}, None) == 2
+    out = capsys.readouterr().out
+    assert "profile range +/-(2**53 - 1)" in out
+    assert "canonical bytes" not in out
+
+
+def test_run_structured_profile_excluded_number_refuses_before_crypto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _crypto_spies(monkeypatch)
+    env = _profile_envelope(_profile_payload(score=2**53))
+    out = vr.run_structured(env, {"keys": []})
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "unverifiable"
+    assert out["canonical_sha256"] is None
+    assert len(out["axes"]) == 1
+    assert out["axes"][0]["name"] == "input"
+    assert "profile range +/-(2**53 - 1)" in out["axes"][0]["note"]
+
+
+def test_run_structured_clean_v1_reaches_real_crypto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list = []
+    orig = vr.verify_signature
+
+    def spy(pk, msg, sig, alg):
+        calls.append((pk, msg, sig, alg))
+        return orig(pk, msg, sig, alg)
+
+    monkeypatch.setattr(vr, "verify_signature", spy)
+    env = _profile_envelope(_profile_payload(score=2**53 - 1))
+    vr.run_structured(env, _resolvable_jwks())
+    assert calls, "a clean v=1 receipt must reach the signature check"
+
+
+@pytest.mark.parametrize("version", [None, 2, True, "1", [1]])
+def test_run_structured_non_current_versions_skip_the_precheck(version) -> None:
+    payload = _profile_payload(score=2**53)
+    if version is None:
+        del payload["v"]
+    else:
+        payload["v"] = version
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []})
+    assert all("profile range" not in a["note"] for a in out["axes"])
+
+
+def test_run_structured_float_1_0_selects_the_current_profile() -> None:
+    payload = _profile_payload(score=2**53)
+    payload["v"] = 1.0
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []})
+    assert "profile range +/-(2**53 - 1)" in out["axes"][0]["note"]
+
+
+def test_run_structured_outer_v_cannot_reclassify_nested_payload() -> None:
+    nested = _profile_payload(score=2**53)
+    del nested["v"]
+    out = vr.run_structured(
+        {"payload": nested, "signature": _sig(), "anchors": [], "v": 1},
+        {"keys": []},
+    )
+    assert all("profile range" not in a["note"] for a in out["axes"])
+    nested2 = _profile_payload(score=2**53)
+    out2 = vr.run_structured(
+        {"payload": nested2, "signature": _sig(), "anchors": [], "v": 2},
+        {"keys": []},
+    )
+    assert "profile range +/-(2**53 - 1)" in out2["axes"][0]["note"]
+
+
+def test_run_structured_missing_member_still_range_refuses() -> None:
+    payload = _profile_payload(score=2**53)
+    del payload["type"]
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []})
+    assert "profile range +/-(2**53 - 1)" in out["axes"][0]["note"]
+
+
+def test_run_structured_bad_predecessor_refuses_even_without_its_v() -> None:
+    payload = _profile_payload(score=1)
+    pred = {**_payload(), "previousReceiptHash": "2" * 64, "score": 2**53}
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []}, pred)
+    assert "profile range +/-(2**53 - 1)" in out["axes"][0]["note"]
+
+
+def test_run_structured_genesis_skips_predecessor_numbers() -> None:
+    payload = _profile_payload(score=1)
+    payload["previousReceiptHash"] = vr.FIRST_RECEIPT_SEED
+    pred = {**_payload(), "previousReceiptHash": "2" * 64, "score": 2**53}
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []}, pred)
+    assert all("profile range" not in a["note"] for a in out["axes"])
+
+
+def test_run_structured_excluded_predecessor_without_member_refuses() -> None:
+    # No registry on this path: any supplied predecessor is hashed for a
+    # non-genesis link, so an excluded value refuses with no member needed.
+    payload = _profile_payload(score=1)
+    out = vr.run_structured(
+        _profile_envelope(payload), {"keys": []}, {"n": 2**53}
+    )
+    assert "profile range +/-(2**53 - 1)" in out["axes"][0]["note"]
+    assert out["canonical_sha256"] is None
+
+
+def test_run_excluded_predecessor_without_member_refuses(capsys) -> None:
+    payload = _profile_payload(score=1)
+    code = vr.run(_profile_envelope(payload), {"keys": []}, {"n": 2**53})
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "profile range +/-(2**53 - 1)" in out
+
+
+def test_run_structured_safe_predecessor_without_member_reaches_chain() -> None:
+    payload = _profile_payload(score=1)
+    out = vr.run_structured(
+        _profile_envelope(payload), {"keys": []}, {"n": 2**53 - 1}
+    )
+    assert all("profile range" not in a["note"] for a in out["axes"])
+    chain = next(a for a in out["axes"] if a["name"] == "chain")
+    assert chain["result"] == "FAIL"
+    assert out["canonical_sha256"] is not None
+
+
+def test_run_safe_predecessor_without_member_reaches_chain(capsys) -> None:
+    payload = _profile_payload(score=1)
+    code = vr.run(_profile_envelope(payload), {"keys": []}, {"n": 2**53 - 1})
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "profile range" not in out
+
+
+def test_run_genesis_skips_predecessor_numbers(capsys) -> None:
+    payload = _profile_payload(score=1)
+    payload["previousReceiptHash"] = vr.FIRST_RECEIPT_SEED
+    code = vr.run(_profile_envelope(payload), {"keys": []}, {"n": 2**53})
+    out = capsys.readouterr().out
+    assert "profile range" not in out
+
+
+def _binding(**over) -> dict:
+    base = {
+        "receipt_ref": "r",
+        "envelope_hash": base64.b64encode(b"e" * 32).decode(),
+    }
+    base.update(over)
+    return base
+
+
+def test_run_structured_counterparty_commitment_is_range_checked() -> None:
+    payload = _profile_payload(score=1, counterparty_binding=_binding())
+    originator = {"payload": {"x": 2**53}, "signature": {"sig": "s"}}
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []}, None, counterparty=originator)
+    assert "profile range +/-(2**53 - 1)" in out["axes"][0]["note"]
+
+
+def test_run_counterparty_commitment_is_range_checked(capsys) -> None:
+    payload = _profile_payload(score=1, counterparty_binding=_binding())
+    originator = {"payload": {"x": 2**53}, "signature": {"sig": "s"}}
+    code = vr.run(_profile_envelope(payload), {"keys": []}, None, counterparty=originator)
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "profile range +/-(2**53 - 1)" in out
+
+
+def test_run_structured_cyclic_counterparty_refuses_finite() -> None:
+    # Termination is the assertion: the pre-fix walk looped forever here.
+    payload = _profile_payload(score=1, counterparty_binding=_binding())
+    counterparty: dict = {"ok": 1}
+    counterparty["again"] = counterparty
+    out = vr.run_structured(
+        _profile_envelope(payload), {"keys": []}, None, counterparty=counterparty
+    )
+    assert "profile range" in out["axes"][0]["note"]
+    assert "cyclic" in out["axes"][0]["note"]
+    assert out["canonical_sha256"] is None
+
+
+def test_run_cyclic_counterparty_refuses_finite(capsys) -> None:
+    payload = _profile_payload(score=1, counterparty_binding=_binding())
+    counterparty: dict = {"ok": 1}
+    counterparty["again"] = counterparty
+    code = vr.run(
+        _profile_envelope(payload), {"keys": []}, None, counterparty=counterparty
+    )
+    out = capsys.readouterr().out
+    assert code == 2
+    assert "cyclic" in out
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [
+        {"envelope_hash": base64.b64encode(b"e" * 32).decode()},
+        {"receipt_ref": "r"},
+        {"receipt_ref": "r", "envelope_hash": "!!!"},
+        {"receipt_ref": "r", "envelope_hash": base64.b64encode(b"e" * 16).decode()},
+        {
+            "receipt_ref": "r",
+            "envelope_hash": base64.b64encode(b"e" * 32).decode(),
+            "expect_ack_from": 7,
+        },
+    ],
+)
+def test_run_structured_malformed_binding_skips_counterparty(binding) -> None:
+    payload = _profile_payload(score=1, counterparty_binding=binding)
+    originator = {"payload": {"x": 2**53}, "signature": {"sig": "s"}}
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []}, None, counterparty=originator)
+    assert all("profile range" not in a["note"] for a in out["axes"])
+
+
+def test_run_structured_non_dict_counterparty_skips_commitment() -> None:
+    payload = _profile_payload(score=1, counterparty_binding=_binding())
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []}, None, counterparty=["x"])
+    assert all("profile range" not in a["note"] for a in out["axes"])
+
+
+def test_run_structured_counterparty_without_binding_is_not_checked() -> None:
+    payload = _profile_payload(score=1)
+    originator = {"payload": {"x": 2**53}, "signature": {"sig": "s"}}
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []}, None, counterparty=originator)
+    assert all("profile range" not in a["note"] for a in out["axes"])
+
+
+def test_run_structured_signature_object_number_refuses_with_anchors() -> None:
+    sig = {**_sig(), "n": 2**53}
+    env = {
+        "payload": _profile_payload(score=1),
+        "signature": sig,
+        "anchors": [{"type": "x"}],
+    }
+    out = vr.run_structured(env, {"keys": []})
+    assert "profile range +/-(2**53 - 1)" in out["axes"][0]["note"]
+
+
+@pytest.mark.parametrize("anchors", [[], None, {}, "x"])
+def test_run_structured_signature_object_skipped_without_commitment(anchors) -> None:
+    sig = {**_sig(), "n": 2**53}
+    env = {"payload": _profile_payload(score=1), "signature": sig, "anchors": anchors}
+    out = vr.run_structured(env, {"keys": []})
+    assert all("profile range" not in a["note"] for a in out["axes"])
+
+
+def test_run_structured_float_and_list_spellings_refuse() -> None:
+    payload = _profile_payload(score=9007199254740992.0)
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []})
+    assert "profile range +/-(2**53 - 1)" in out["axes"][0]["note"]
+    payload2 = _profile_payload(scores=[1, 2**53])
+    out2 = vr.run_structured(_profile_envelope(payload2), {"keys": []})
+    assert "profile range +/-(2**53 - 1)" in out2["axes"][0]["note"]
+    payload3 = _profile_payload(score=5.0, tags=["a"])
+    out3 = vr.run_structured(_profile_envelope(payload3), {"keys": []})
+    assert all("profile range" not in a["note"] for a in out3["axes"])
+
+
+@pytest.mark.parametrize("drop", [["issuer_id"], ["previousReceiptHash"], ["issuer_id", "previousReceiptHash"]])
+def test_run_structured_missing_members_still_range_refuse(drop) -> None:
+    payload = _profile_payload(score=2**53)
+    for key in drop:
+        del payload[key]
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []})
+    assert "profile range +/-(2**53 - 1)" in out["axes"][0]["note"]
+
+
+def test_run_missing_members_still_range_refuse(capsys: pytest.CaptureFixture) -> None:
+    payload = _profile_payload(score=2**53)
+    del payload["issuer_id"]
+    del payload["previousReceiptHash"]
+    assert vr.run(_profile_envelope(payload), {"keys": []}, None) == 2
+    assert "profile range +/-(2**53 - 1)" in capsys.readouterr().out
+
+
+def test_run_structured_missing_member_clean_numbers_keep_structure_outcome() -> None:
+    payload = _profile_payload(score=1)
+    del payload["type"]
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []})
+    assert all("profile range" not in a["note"] for a in out["axes"])
+    assert out["axes"][0]["name"] == "structure"
+    assert out["axes"][0]["result"] == "FAIL"
+    assert "missing required fields" in out["axes"][0]["note"]
+
+
+def test_run_string_signature_derives_object(capsys: pytest.CaptureFixture) -> None:
+    env = {"payload": _payload(), "signature": "AAAA", "anchors": []}
+    assert vr.run(env, {"keys": []}, None) == 2
+    assert "canonical bytes" in capsys.readouterr().out
+
+
+def test_run_structured_string_signature_derives_object() -> None:
+    env = {"payload": _payload(), "signature": "AAAA", "anchors": []}
+    out = vr.run_structured(env, {"keys": []})
+    assert out["canonical_sha256"] is not None
+
+
+def test_run_structured_null_anchors_return_early() -> None:
+    env = {"payload": _payload(), "signature": _sig(), "anchors": None}
+    out = vr.run_structured(env, {"keys": []})
+    assert out["verdict"] == "unverified"
+    assert out["axes"][0]["name"] == "structure"
+    assert "null" in out["axes"][0]["note"]
+
+
+def test_run_structured_canonical_recursion_refuses_clean(monkeypatch: pytest.MonkeyPatch) -> None:
+    def explode(obj):
+        raise RecursionError("probe")
+
+    monkeypatch.setattr(vr, "canonical_json", explode)
+    out = vr.run_structured(_profile_envelope(_profile_payload(score=1)), {"keys": []})
+    assert out["verdict"] == "unverified"
+    assert out["axes"][0]["name"] == "input"
+    assert "nesting" in out["axes"][0]["note"]
+
+
+def _agent_jwks(sign: bool):
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    issuer_sk = Ed25519PrivateKey.generate()
+    agent_sk = Ed25519PrivateKey.generate()
+    other_sk = Ed25519PrivateKey.generate()
+    issuer_pk = issuer_sk.public_key().public_bytes_raw()
+    agent_pk = agent_sk.public_key().public_bytes_raw()
+    payload = _profile_payload(score=1, agent_id="agent-1", org_id="org-1")
+    msg = vr.canonical_json(payload)
+    signer = agent_sk if sign else other_sk
+    sig = base64.b64encode(signer.sign(msg)).decode()
+    jwks = {
+        "keys": [
+            {
+                "kid": "kid-x",
+                "issuer_id": "did:asqav:issuer",
+                "public_key": base64.b64encode(issuer_pk).decode(),
+                "alg": "Ed25519",
+                "status": "active",
+                "agent_id": "someone-else",
+            },
+            {
+                "kid": "kid-a",
+                "issuer_id": "did:asqav:issuer",
+                "public_key": base64.b64encode(agent_pk).decode(),
+                "alg": "Ed25519",
+                "status": "active",
+                "agent_id": "agent-1",
+                "org_id": "org-1",
+            },
+        ]
+    }
+    env = {"payload": payload, "signature": {"alg": "Ed25519", "kid": "kid-x", "sig": sig}, "anchors": []}
+    return env, jwks
+
+
+def _ed25519_available() -> bool:
+    try:
+        import cryptography  # noqa: F401
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+requires_ed25519 = pytest.mark.skipif(not _ed25519_available(), reason="cryptography not installed")
+
+
+@requires_ed25519
+def test_run_agent_key_adopts_on_verify() -> None:
+    env, jwks = _agent_jwks(sign=True)
+    out = vr.run_structured(env, jwks)
+    key_axis = next(a for a in out["axes"] if a["name"] == "issuer_key")
+    assert "kid-a" in key_axis["note"]
+    sig_axis = next(a for a in out["axes"] if a["name"] == "signature")
+    assert sig_axis["result"] == "PASS"
+
+
+@requires_ed25519
+def test_run_agent_key_exhausted_notes_without_verify() -> None:
+    env, jwks = _agent_jwks(sign=False)
+    out = vr.run_structured(env, jwks)
+    key_axis = next(a for a in out["axes"] if a["name"] == "issuer_key")
+    assert "no key published for this agent verified" in key_axis["note"]
+
+
+@requires_ed25519
+def test_run_agent_fallback_paths_through_text_api(capsys: pytest.CaptureFixture) -> None:
+    env, jwks = _agent_jwks(sign=True)
+    assert vr.run(env, jwks, None) in (1, 2)
+    assert "kid-a" in capsys.readouterr().out
+    env2, jwks2 = _agent_jwks(sign=False)
+    assert vr.run(env2, jwks2, None) in (1, 2)
+    assert "no key published for this agent verified" in capsys.readouterr().out
+
+
+# === T-037 revision 6: a shared acyclic object is not a cycle ===
+
+
+def _shared_leaf(kind: str):
+    if kind == "dict":
+        return {"n": 1}
+    if kind == "list":
+        return [1]
+    return (1,)
+
+
+def _shared_pair(kind: str) -> dict:
+    leaf = _shared_leaf(kind)
+    return {"a": leaf, "b": leaf}
+
+
+def _twin_pair(kind: str) -> dict:
+    return {"a": _shared_leaf(kind), "b": _shared_leaf(kind)}
+
+
+def _shared_inputs(position: str, pair: dict):
+    payload = _profile_payload(score=1)
+    pred = cp = None
+    if position == "payload":
+        payload["ext"] = pair
+        env = _profile_envelope(payload)
+    elif position == "signature":
+        env = {
+            "payload": payload,
+            "signature": {**_sig(), "ext": pair},
+            "anchors": [{"type": "x"}],
+        }
+    elif position == "predecessor":
+        env = _profile_envelope(payload)
+        pred = pair
+    else:
+        payload["counterparty_binding"] = _binding()
+        env = _profile_envelope(payload)
+        cp = pair
+    return env, pred, cp
+
+
+_SHARED_POSITIONS = ["payload", "signature", "predecessor", "counterparty"]
+_SHARED_KINDS = ["dict", "list", "tuple"]
+
+
+@pytest.mark.parametrize("position", _SHARED_POSITIONS)
+@pytest.mark.parametrize("kind", _SHARED_KINDS)
+def test_run_shared_node_matches_unshared_twin(position, kind, capsys) -> None:
+    env_s, pred_s, cp_s = _shared_inputs(position, _shared_pair(kind))
+    code_s = vr.run(env_s, {"keys": []}, pred_s, counterparty=cp_s)
+    text_s = capsys.readouterr().out
+    env_t, pred_t, cp_t = _shared_inputs(position, _twin_pair(kind))
+    code_t = vr.run(env_t, {"keys": []}, pred_t, counterparty=cp_t)
+    text_t = capsys.readouterr().out
+    assert (code_s, text_s) == (code_t, text_t)
+    assert "cyclic reference" not in text_s
+
+
+@pytest.mark.parametrize("position", _SHARED_POSITIONS)
+@pytest.mark.parametrize("kind", _SHARED_KINDS)
+def test_run_structured_shared_node_matches_unshared_twin(position, kind) -> None:
+    env_s, pred_s, cp_s = _shared_inputs(position, _shared_pair(kind))
+    out_s = vr.run_structured(env_s, {"keys": []}, pred_s, counterparty=cp_s)
+    env_t, pred_t, cp_t = _shared_inputs(position, _twin_pair(kind))
+    out_t = vr.run_structured(env_t, {"keys": []}, pred_t, counterparty=cp_t)
+    assert out_s == out_t
+    assert "cyclic reference" not in repr(out_s)
+
+
+@pytest.mark.parametrize("position", _SHARED_POSITIONS)
+def test_shared_out_of_range_matches_twin(position, capsys) -> None:
+    bad = {"n": 2**53}
+    env_s, pred_s, cp_s = _shared_inputs(position, {"a": bad, "b": bad})
+    code_s = vr.run(env_s, {"keys": []}, pred_s, counterparty=cp_s)
+    text_s = capsys.readouterr().out
+    env_t, pred_t, cp_t = _shared_inputs(
+        position, {"a": {"n": 2**53}, "b": {"n": 2**53}}
+    )
+    code_t = vr.run(env_t, {"keys": []}, pred_t, counterparty=cp_t)
+    text_t = capsys.readouterr().out
+    assert (code_s, text_s) == (code_t, text_t)
+    assert code_s == 2
+    assert "excludes integer 9007199254740992" in text_s
+    out_s = vr.run_structured(env_s, {"keys": []}, pred_s, counterparty=cp_s)
+    out_t = vr.run_structured(env_t, {"keys": []}, pred_t, counterparty=cp_t)
+    assert out_s == out_t
+    assert "excludes integer 9007199254740992" in out_s["axes"][0]["note"]
+
+
+def test_profile_range_note_self_dict_cycle_refuses() -> None:
+    cyc: dict = {}
+    cyc["self"] = cyc
+    note = vr.profile_range_note(cyc)
+    assert note == (
+        "Asqav profile range +/-(2**53 - 1) unverifiable: "
+        "cyclic reference at $.self"
+    )
+
+
+def test_profile_range_note_self_list_cycle_refuses() -> None:
+    cyc: list = []
+    cyc.append(cyc)
+    note = vr.profile_range_note(cyc)
+    assert note == (
+        "Asqav profile range +/-(2**53 - 1) unverifiable: "
+        "cyclic reference at $[0]"
+    )
+
+
+def test_profile_range_note_mutual_cycle_refuses() -> None:
+    first: dict = {}
+    second = {"first": first}
+    first["second"] = second
+    note = vr.profile_range_note(first)
+    assert note is not None
+    assert "unverifiable: cyclic reference at " in note
+
+
+def test_profile_range_note_doubling_dag_returns_none() -> None:
+    node: dict = {"x": 1}
+    for _ in range(30):
+        node = {"l": node, "r": node}
+    # Bind the note first: repr of the DAG in a failed assert is exponential.
+    note = vr.profile_range_note(node)
+    assert note is None
+
+
+class _CountingDict(dict):
+    expansions = 0
+
+    def items(self):
+        type(self).expansions += 1
+        return super().items()
+
+
+def test_profile_range_note_expands_each_container_once() -> None:
+    _CountingDict.expansions = 0
+    node: dict = {"x": 1}
+    for _ in range(30):
+        node = _CountingDict((("l", node), ("r", node)))
+    # Bind the note first: repr of the DAG in a failed assert is exponential,
+    # and a dict subclass defeats reprlib truncation, hanging pytest itself.
+    note = vr.profile_range_note(node)
+    assert note is None
+    assert _CountingDict.expansions == 30
+
+
+# === T-096 revision 7: refusal-path hardening (D1 digit cap, D2 keep-alive) ===
+
+
+def _decimal_int(digits: int) -> int:
+    return 10 ** (digits - 1)
+
+
+def test_profile_range_note_4300_digit_full_value() -> None:
+    n = _decimal_int(4300)
+    note = vr.profile_range_note({"n": n})
+    assert note == (
+        "Asqav profile range +/-(2**53 - 1) excludes integer " f"{n} at $.n"
+    )
+
+
+def test_profile_range_note_4301_digit_count_message() -> None:
+    note = vr.profile_range_note({"n": _decimal_int(4301)})
+    assert note == (
+        "Asqav profile range +/-(2**53 - 1) excludes a 4301-digit integer at $.n"
+    )
+
+
+def test_profile_range_note_4400_digit_count_message() -> None:
+    note = vr.profile_range_note({"n": _decimal_int(4400)})
+    assert note == (
+        "Asqav profile range +/-(2**53 - 1) excludes a 4400-digit integer at $.n"
+    )
+    neg = vr.profile_range_note({"n": -_decimal_int(4400)})
+    assert neg == (
+        "Asqav profile range +/-(2**53 - 1) excludes a 4400-digit integer at $.n"
+    )
+
+
+def test_run_huge_integer_refuses_unverifiable(capsys: pytest.CaptureFixture) -> None:
+    payload = _profile_payload(score=1)
+    payload["ext"] = {"n": _decimal_int(4400)}
+    code = vr.run(_profile_envelope(payload), {"keys": []}, None)
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "failure_class: unverifiable" in captured.out
+    assert "excludes a 4400-digit integer at $.ext.n" in captured.out
+    assert "Traceback" not in captured.out + captured.err
+    assert "Exceeds the limit" not in captured.out + captured.err
+
+
+def test_run_structured_huge_integer_refuses_unverifiable() -> None:
+    payload = _profile_payload(score=1)
+    payload["ext"] = {"n": _decimal_int(4400)}
+    out = vr.run_structured(_profile_envelope(payload), {"keys": []}, None)
+    assert out["verdict"] == "unverified"
+    assert out["failure_class"] == "unverifiable"
+    assert out["axes"][0]["note"] == (
+        "Asqav profile range +/-(2**53 - 1) excludes a 4400-digit integer at $.ext.n"
+    )
+
+
+def test_reject_unsafe_integer_huge_literal() -> None:
+    with pytest.raises(vr.UnsafeIntegerError, match="4400-digit integer"):
+        vr._reject_unsafe_integer("9" * 4400)
+    with pytest.raises(vr.UnsafeIntegerError, match="4400-digit integer"):
+        vr._reject_unsafe_integer("-" + "9" * 4400)
+
+
+def test_reject_unsafe_integer_zero_padded_huge_literal() -> None:
+    assert vr._reject_unsafe_integer("0" * 4400 + "1") == 1
+    assert vr._reject_unsafe_integer("-" + "0" * 4400) == 0
+
+
+def test_end_to_end_huge_literal_exits_unverifiable(tmp_path, monkeypatch, capsys) -> None:
+    import json
+
+    payload = _profile_payload(score=1)
+    text = json.dumps(
+        {"payload": payload, "signature": _sig(), "anchors": [], "big": "@BIG@"}
+    ).replace('"@BIG@"', "9" * 4400)
+    rp = tmp_path / "receipt.json"
+    jp = tmp_path / "jwks.json"
+    rp.write_text(text)
+    jp.write_text('{"keys": []}')
+    monkeypatch.setattr(
+        sys, "argv", ["verify_receipt.py", "--receipt", str(rp), "--jwks", str(jp), "--offline"]
+    )
+    assert vr.main() == 2
+    err = capsys.readouterr().err
+    assert "4400-digit integer" in err
+    assert "Traceback" not in err
+
+
+class _FabricatedChild(dict):
+    def __init__(self, n: int) -> None:
+        super().__init__()
+        self._n = n
+
+    def items(self):  # fresh child every call; nothing stored
+        return [("v", {"n": self._n})]
+
+
+def test_profile_range_note_fabricated_child_detected() -> None:
+    for _ in range(5):
+        note = vr.profile_range_note(
+            {"bad": _FabricatedChild(2**53), "clean": _FabricatedChild(1)}
+        )
+        assert note is not None
+        assert "excludes integer 9007199254740992" in note

--- a/typescript/src/doors.ts
+++ b/typescript/src/doors.ts
@@ -23,10 +23,7 @@ export const OTEL_SIGNATURE_ATTR = "asqav.signature";
 
 export const ERC8004_ZERO_ADDRESS = "0x" + "00".repeat(20);
 
-/** JCS canonical string. Byte-identical across SDKs for JCS-safe inputs (BMP keys,
- * ints up to 2**53). Beyond +/-2**53 an integer is refused at ingest, since it has no
- * exact double and the two SDKs would canonicalise it differently; astral keys agree,
- * because both order member names by UTF-16 code unit. */
+/** JCS string: BMP keys, profile ints, astral keys by UTF-16 code unit */
 function canonicalString(receipt: Receipt): string {
   return new TextDecoder().decode(canonicalJson(receipt));
 }

--- a/typescript/src/jcs.ts
+++ b/typescript/src/jcs.ts
@@ -48,16 +48,18 @@ function canonicalString(value: unknown): string {
   throw new TypeError(`Not JSON-serializable: ${typeof value}`);
 }
 
+/** Largest integer magnitude the Asqav profile admits (draft Section 4). */
+export const MAX_PROFILE_INTEGER = 9007199254740991;
+
 function numberToCanonical(n: number): string {
   // Map -0 to 0 so equal mathematical values produce identical bytes.
   if (n === 0) return "0";
-  // Beyond 2**53 an integer has no exact double, so whoever parsed it already rounded it and
-  // emitting it would sign bytes Python never produces. This is the layer the doors path
-  // reaches: it receives an already-parsed object and never sees the strict parser.
-  if (Number.isInteger(n) && Math.abs(n) > 9007199254740992) {
+  // The profile ends at 2**53 - 1: a parsed 2**53 is refused although it
+  // round-trips, because a rounded 2**53+1 is indistinguishable from it here
+  if (Number.isInteger(n) && Math.abs(n) > MAX_PROFILE_INTEGER) {
     throw new RangeError(
-      `integer outside the canonical integer range +/-2**53: ${n}; serialise it as a ` +
-        `JSON string or an integer-rational pair`,
+      `integer outside the Asqav profile range +/-(2**53 - 1): ${n}; serialise ` +
+        `it as a JSON string or an integer-rational pair`,
     );
   }
   // For safe integers, plain toString matches the canonical bytes byte-for-byte.

--- a/typescript/src/verifier/adapter.ts
+++ b/typescript/src/verifier/adapter.ts
@@ -101,4 +101,13 @@ export abstract class FormatAdapter {
   preCutoverSigningInput(_doc: Record<string, unknown>): Uint8Array | null {
     return null;
   }
+
+  /** Refusal note or null; default no-op, the core reports a note early. */
+  profilePrecheck(
+    _doc: Record<string, unknown>,
+    _predecessor: Record<string, unknown> | null = null,
+    _predecessorFmt: string | null = null,
+  ): string | null {
+    return null;
+  }
 }

--- a/typescript/src/verifier/adapters/asqavNative.ts
+++ b/typescript/src/verifier/adapters/asqavNative.ts
@@ -16,6 +16,8 @@ import {
   asqavJcs,
   asqavJcsPreCutover,
   hasSupplementaryMemberName,
+  isCurrentProfileVersion,
+  profileRangeNote,
 } from "../canonical.js";
 import { sha256Hex } from "../crypto.js";
 import { isLowerHex } from "./acta.js";
@@ -91,6 +93,28 @@ function payloadOf(doc: Record<string, unknown>): Record<string, unknown> {
   const env = normaliseEnvelope(doc);
   const p = env.payload;
   return isRecord(p) ? p : env;
+}
+
+/** Flat object the cloud hash-mode path signs, before canonicalisation */
+function flatSignedFields(doc: Record<string, unknown>): Record<string, unknown> {
+  return {
+    v: 1,
+    mode: "hash",
+    hash: doc.hash ?? null,
+    hash_algo: doc.hash_algo ?? "sha256",
+    metadata: doc.metadata ?? {},
+    server_timestamp: doc.server_timestamp ?? null,
+    action_id: doc.action_id ?? null,
+    agent_id: doc.agent_id ?? null,
+    org_id: doc.org_id ?? null,
+    policy_digest: doc.policy_digest ?? null,
+    policy_decision: doc.policy_decision ?? null,
+  };
+}
+
+/** Own-member read; inherited prototype members never select or validate. */
+function hasOwn(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
 }
 
 /** Decode signature material; empty on malformed input so verify FAILs, never crashes. */
@@ -198,20 +222,7 @@ export class AsqavNativeAdapter extends FormatAdapter {
   }
 
   private hashModeSigningInput(doc: Record<string, unknown>): Uint8Array {
-    const flat = {
-      v: 1,
-      mode: "hash",
-      hash: doc.hash ?? null,
-      hash_algo: doc.hash_algo ?? "sha256",
-      metadata: doc.metadata ?? {},
-      server_timestamp: doc.server_timestamp ?? null,
-      action_id: doc.action_id ?? null,
-      agent_id: doc.agent_id ?? null,
-      org_id: doc.org_id ?? null,
-      policy_digest: doc.policy_digest ?? null,
-      policy_decision: doc.policy_decision ?? null,
-    };
-    return asqavJcs(flat);
+    return asqavJcs(flatSignedFields(doc));
   }
 
   chainStep(doc: Record<string, unknown>): ChainStep {
@@ -313,5 +324,31 @@ export class AsqavNativeAdapter extends FormatAdapter {
    */
   keyedDigest(doc: Record<string, unknown>): boolean {
     return isHashMode(doc) && doc.hash_algo === "hmac-sha256";
+  }
+
+  /** Refuse current-profile digest inputs outside the range, else null. */
+  profilePrecheck(
+    doc: Record<string, unknown>,
+    predecessor: Record<string, unknown> | null = null,
+    predecessorFmt: string | null = null,
+  ): string | null {
+    if (isHashMode(doc)) {
+      const topV = hasOwn(doc, "v") ? doc.v : undefined;
+      if (!isCurrentProfileVersion(topV)) return null;
+      return profileRangeNote(flatSignedFields(doc));
+    }
+    const signed = payloadOf(doc);
+    const v = hasOwn(signed, "v") ? signed.v : undefined;
+    if (!isCurrentProfileVersion(v)) return null;
+    const note = profileRangeNote(signed);
+    if (note !== null) return note;
+    if (
+      predecessor !== null &&
+      predecessorFmt === this.name &&
+      signed.previousReceiptHash !== FIRST_RECEIPT_SEED
+    ) {
+      return profileRangeNote(payloadOf(predecessor));
+    }
+    return null;
   }
 }

--- a/typescript/src/verifier/canonical.ts
+++ b/typescript/src/verifier/canonical.ts
@@ -45,6 +45,9 @@ export const MAX_CANONICAL_INTEGER = 9007199254740992;
 /** The same bound as an exact integer, for comparing against source digits. */
 const MAX_CANONICAL_INTEGER_EXACT = 9007199254740992n;
 
+/** Largest integer magnitude the Asqav profile admits (draft Section 4). */
+export const MAX_PROFILE_INTEGER = 9007199254740991;
+
 /**
  * A digest-covered integer with no exact double. JavaScript rounds it and Python does not,
  * so the same receipt canonicalises two ways and its signature verifies in one SDK and fails
@@ -55,6 +58,19 @@ export class UnsafeIntegerError extends SyntaxError {
     super(message);
     this.name = "UnsafeIntegerError";
   }
+}
+
+/** Integer the Asqav profile refuses: exactly representable yet out of range */
+export class ProfileIntegerError extends SyntaxError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProfileIntegerError";
+  }
+}
+
+/** Assign a decoded member so `__proto__` stays own, never a prototype */
+function setMember(out: Record<string, unknown>, k: string, v: unknown): void {
+  Object.defineProperty(out, k, { value: v, enumerable: true, writable: true, configurable: true });
 }
 
 /**
@@ -128,7 +144,7 @@ export function parseJsonPreservingFloats(text: string): unknown {
       seen.add(k);
       ws();
       if (text[i++] !== ":") err("expected ':'");
-      out[k] = value();
+      setMember(out, k, value());
       ws();
       const ch = text[i++];
       if (ch === "}") return out;
@@ -221,7 +237,7 @@ export function unwrapPreservedFloats(value: unknown): unknown {
   if (value !== null && typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = unwrapPreservedFloats(v);
+      setMember(out, k, unwrapPreservedFloats(v));
     }
     return out;
   }
@@ -236,6 +252,49 @@ export function parseJsonStrict(text: string): unknown {
   return unwrapPreservedFloats(parseJsonPreservingFloats(text));
 }
 
+/** First profile-range violation note, else null; `RawFloat` unwrapped first */
+export function profileRangeNote(value: unknown): string | null {
+  const stack: Array<[unknown, string]> = [[value, "$"]];
+  while (stack.length > 0) {
+    const [node, path] = stack.pop() as [unknown, string];
+    const v = isRawFloat(node) ? node.value : node;
+    if (typeof v === "number") {
+      if (Number.isInteger(v) && Math.abs(v) > MAX_PROFILE_INTEGER) {
+        return `Asqav profile range +/-(2**53 - 1) excludes number ${v} at ${path}`;
+      }
+      continue;
+    }
+    if (Array.isArray(v)) {
+      v.forEach((item, i) => stack.push([item, `${path}[${i}]`]));
+    } else if (v !== null && typeof v === "object") {
+      for (const [k, item] of Object.entries(v as Record<string, unknown>)) {
+        stack.push([item, `${path}.${k}`]);
+      }
+    }
+  }
+  return null;
+}
+
+/** Throw `ProfileIntegerError` when parsed values leave the profile range */
+export function assertProfileIntegers(value: unknown): void {
+  const note = profileRangeNote(value);
+  if (note !== null) throw new ProfileIntegerError(note);
+}
+
+/** Strict ingest plus the narrower profile range; shared parser unchanged */
+export function parseProfileJson(text: string): unknown {
+  const parsed = parseJsonPreservingFloats(text);
+  assertProfileIntegers(parsed);
+  return parsed;
+}
+
+// True for numeric v selecting the current profile (1 and 1.0, never true)
+export function isCurrentProfileVersion(value: unknown): boolean {
+  const v = isRawFloat(value) ? value.value : value;
+  if (typeof v === "boolean") return false;
+  return v === 1;
+}
+
 /** Recursively NFC-normalise every string key and value (mirrors `_nfc`). */
 function nfc(obj: unknown): unknown {
   if (typeof obj === "string") return obj.normalize("NFC");
@@ -244,7 +303,7 @@ function nfc(obj: unknown): unknown {
   if (obj !== null && typeof obj === "object") {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-      out[(k as string).normalize("NFC")] = nfc(v);
+      setMember(out, (k as string).normalize("NFC"), nfc(v));
     }
     return out;
   }

--- a/typescript/src/verifier/core.ts
+++ b/typescript/src/verifier/core.ts
@@ -306,6 +306,13 @@ function exceedsDepth(obj: unknown, maxDepth: number): boolean {
   return false;
 }
 
+/** One-axis unverified result for a pre-axis refusal (depth, profile range) */
+function earlyUnverified(fmt: string, note: string): VerifyResult {
+  const axes = [axis("structure", FAIL, note)];
+  const [verdict, failureClass] = foldVerdict(axes, false);
+  return { fmt, axes, verdict, failureClass, signer: null, firstFailingEdge: firstFailingEdge(axes), notChecked: notCheckedDeclaration(), coverage: coverageDeclaration(axes) };
+}
+
 /** Verify one parsed receipt and return a structured `VerifyResult`. */
 export function verify(
   doc: Record<string, unknown>,
@@ -330,13 +337,28 @@ export function verify(
   }
   // An over-nested receipt would crash the recursive JCS encoder. Cap it here and
   // report unverified/unverifiable, never a verified, matching the Python gate.
+  let earlyNote: string | null = null;
   if (
     exceedsDepth(doc, MAX_NESTING_DEPTH) ||
     (predecessor !== null && exceedsDepth(predecessor, MAX_NESTING_DEPTH))
   ) {
-    const axes = [axis("structure", FAIL, TOO_DEEP_NOTE)];
-    const [verdict, failureClass] = foldVerdict(axes, false);
-    return { fmt: ad.name, axes, verdict, failureClass, signer: null, firstFailingEdge: firstFailingEdge(axes), notChecked: notCheckedDeclaration(), coverage: coverageDeclaration(axes) };
+    earlyNote = TOO_DEEP_NOTE;
+  } else {
+    const predAd = predecessor === null ? null : detect(predecessor, adapters);
+    earlyNote = ad.profilePrecheck(doc, predecessor, predAd === null ? null : predAd.name);
+  }
+  if (earlyNote !== null) {
+    const early = earlyUnverified(ad.name, earlyNote);
+    return {
+      fmt: early.fmt,
+      axes: early.axes,
+      verdict: early.verdict,
+      failureClass: early.failureClass,
+      signer: early.signer,
+      firstFailingEdge: early.firstFailingEdge,
+      notChecked: early.notChecked,
+      coverage: early.coverage,
+    };
   }
 
   const axes: AxisResult[] = [

--- a/typescript/tests/doors.test.ts
+++ b/typescript/tests/doors.test.ts
@@ -165,18 +165,17 @@ describe("cross-language parity", () => {
 
   const dec = (b: Uint8Array | string) => (typeof b === "string" ? b : new TextDecoder().decode(b));
 
-  it("shows why the canonicaliser alone cannot catch this fixture", () => {
-    // JSON.parse has already rounded 2^53+1 to 2^53 by the time any canonicaliser runs,
-    // and a rounded 2^53 is indistinguishable from a genuine one. JavaScript cannot even
-    // hold 2^53+1: the literal IS 2^53. So the rule has to live at the parse boundary,
-    // where the source digits still exist; this guard is defence in depth for the values
-    // JS CAN represent above the bound.
+  it("refuses the whole excluded boundary, rounded values included", () => {
+    // JSON.parse rounded 2^53+1 to 2^53, indistinguishable from genuine; the
+    // profile refuses the whole boundary value; its digits stay unrecoverable
     const rounded = JSON.parse(readFileSync(resolve(PARITY, "divergence-input.json"), "utf-8"));
     expect(rounded.n).toBe(9007199254740992);
     expect(9007199254740993).toBe(9007199254740992); // the language, not a typo
-    expect(() => jcs({ n: 2 ** 54 })).toThrow(/canonical integer range/);
-    expect(() => jcs({ n: 1e21 })).toThrow(/canonical integer range/);
-    expect(dec(jcs({ n: 2 ** 53 }))).toBe('{"n":9007199254740992}');
+    expect(() => jcs(rounded)).toThrow(/Asqav profile range/);
+    expect(() => jcs({ n: 2 ** 54 })).toThrow(/Asqav profile range/);
+    expect(() => jcs({ n: 1e21 })).toThrow(/Asqav profile range/);
+    expect(() => jcs({ n: 2 ** 53 })).toThrow(/Asqav profile range/);
+    expect(jcs({ n: 2 ** 53 - 1 })).toBe('{"n":9007199254740991}');
   });
 
   it("still agrees on astral key order, the cause that was genuinely closed", () => {

--- a/typescript/tests/strict-ingest.test.ts
+++ b/typescript/tests/strict-ingest.test.ts
@@ -8,8 +8,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   DuplicateMemberError,
+  ProfileIntegerError,
+  RawFloat,
   parseJsonPreservingFloats,
   parseJsonStrict,
+  parseProfileJson,
 } from "../src/verifier/canonical.js";
 import { receiptFromOtelGenaiAttributes, OTEL_RECEIPT_ATTR } from "../src/doors.js";
 import { runOne } from "../src/verifier/runner.js";
@@ -89,5 +92,69 @@ describe("corpus duplicate-member vectors never verify (criteria 419/418)", () =
       expect(r.actualFailureClass).toBe("unverifiable");
       expect(r.detail).toContain("terminal parse failure before any hashing");
     }
+  });
+});
+
+describe("explicit Asqav profile ingest (shared parser unchanged)", () => {
+  it("accepts the safe interval on both signs, nested or not", () => {
+    expect(parseProfileJson('{"n":9007199254740991}')).toEqual({ n: 9007199254740991 });
+    expect(parseProfileJson('{"a":{"b":[1,{"c":-9007199254740991}]}}')).toEqual({
+      a: { b: [1, { c: -9007199254740991 }] },
+    });
+  });
+
+  it("refuses the excluded boundary on both signs, nested or not", () => {
+    for (const text of [
+      '{"n":9007199254740992}',
+      '{"n":-9007199254740992}',
+      '{"a":{"b":[1,{"c":9007199254740992}]}}',
+    ]) {
+      expect(() => parseProfileJson(text)).toThrow(ProfileIntegerError);
+    }
+  });
+
+  it("refuses float spellings of the excluded boundary", () => {
+    expect(() => parseProfileJson('{"n":9007199254740992.0}')).toThrow(ProfileIntegerError);
+    expect(() => parseProfileJson('{"n":9.007199254740992e15}')).toThrow(ProfileIntegerError);
+  });
+
+  it("keeps string twins, booleans and fractions unchanged", () => {
+    expect(parseProfileJson('{"n":"9007199254740993"}')).toEqual({ n: "9007199254740993" });
+    const parsed = parseProfileJson('{"a":true,"b":3.14}') as {
+      a: boolean;
+      b: RawFloat;
+    };
+    expect(parsed.a).toBe(true);
+    expect(parsed.b).toBeInstanceOf(RawFloat);
+    expect(parsed.b.value).toBe(3.14);
+  });
+
+  it("shared generic ingest still accepts the excluded boundary", () => {
+    expect(parseJsonPreservingFloats('{"n":9007199254740992}')).toEqual({ n: 9007199254740992 });
+  });
+});
+
+describe("decoded __proto__ keys stay own data members", () => {
+  it("keeps __proto__ own and enumerable with its original value", () => {
+    const parsed = parseJsonPreservingFloats('{"__proto__":{"v":1},"n":1}') as Record<
+      string,
+      unknown
+    >;
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+    expect(Object.entries(parsed).some(([k]) => k === "__proto__")).toBe(true);
+    expect(parsed.__proto__).toEqual({ v: 1 });
+    expect({}.hasOwnProperty.call(parsed, "v")).toBe(false);
+  });
+
+  it("preserves __proto__ through the strict unwrap path", () => {
+    const parsed = parseJsonStrict('{"__proto__":{"v":1},"n":1}') as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+    expect(parsed.__proto__).toEqual({ v: 1 });
+  });
+
+  it("still detects a duplicated __proto__ member", () => {
+    expect(() => parseJsonPreservingFloats('{"__proto__":1,"__proto__":2}')).toThrow(
+      DuplicateMemberError,
+    );
   });
 });

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -8,9 +8,17 @@ import { join, resolve } from "node:path";
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 
-import { asqavJcs, jcsRfc8785, parseJsonPreservingFloats } from "../src/verifier/canonical.js";
+import {
+  ProfileIntegerError,
+  asqavJcs,
+  jcsRfc8785,
+  parseJsonPreservingFloats,
+  parseProfileJson,
+} from "../src/verifier/canonical.js";
 import { AXIS_ORDER_PREFIX, verify } from "../src/verifier/core.js";
 import { ADAPTERS } from "../src/verifier/index.js";
+import { AsqavNativeAdapter } from "../src/verifier/adapters/asqavNative.js";
+import { AerfAdapter } from "../src/verifier/adapters/aerf.js";
 import {
   keyProviderFor,
   loadJson as runnerLoadJson,
@@ -206,10 +214,25 @@ describe("integers beyond +/-2**53 are refused at ingest (no cross-SDK divergenc
     );
   });
 
-  it("accepts 2^53 itself, which is exactly representable and pinned upstream", () => {
+  it("keeps 2^53 accepted on the shared generic path (upstream compatibility)", () => {
     const o = parseJsonPreservingFloats('{"n":9007199254740992}');
     expect(dec.decode(asqavJcs(o))).toBe('{"n":9007199254740992}');
     expect(dec.decode(jcsRfc8785(o))).toBe('{"n":9007199254740992}');
+  });
+
+  it("refuses 2^53 on the explicit Asqav profile entry", () => {
+    expect(() => parseProfileJson('{"n":9007199254740992}')).toThrow(ProfileIntegerError);
+    expect(() => parseProfileJson('{"n":-9007199254740992}')).toThrow(
+      /Asqav profile range/,
+    );
+    expect(parseProfileJson('{"n":9007199254740991}')).toEqual({ n: 9007199254740991 });
+  });
+
+  it("refuses float spellings of the excluded boundary on the profile entry", () => {
+    expect(() => parseProfileJson('{"n":9007199254740992.0}')).toThrow(ProfileIntegerError);
+    expect(() => parseProfileJson('{"n":9.007199254740992e15}')).toThrow(
+      ProfileIntegerError,
+    );
   });
 
   it("accepts the conformant workaround: the same value as a JSON string", () => {
@@ -223,9 +246,8 @@ describe("integers beyond +/-2**53 are refused at ingest (no cross-SDK divergenc
     );
   });
 
-  // The corpus publishes documents it says are refused. Both SDKs must actually refuse
-  // them, or the corpus advertises a rule the shipped code does not implement. The Python
-  // half of this pairing lives in test_corpus_integrity.py.
+  // Refused corpus documents must fail via the explicit profile entry (Python
+  // half: test_corpus_integrity.py), or corpus advertises an unimplemented rule
   it("refuses every document the corpus pins as refused", () => {
     const path = resolve(__dirname, "..", "..", "conformance", "vectors.json");
     const { vectors } = JSON.parse(readFileSync(path, "utf8")) as {
@@ -235,19 +257,20 @@ describe("integers beyond +/-2**53 are refused at ingest (no cross-SDK divergenc
     expect(refused.length).toBeGreaterThan(0);
     for (const v of refused) {
       expect(v.expected_verify).toBe(false);
-      expect(() => parseJsonPreservingFloats(v.input_text as string), v.name).toThrow();
+      expect(() => parseProfileJson(v.input_text as string), v.name).toThrow();
     }
   });
 
-  // The boundary the corpus pins as INSIDE the range must actually parse and canonicalize.
-  it("accepts every in-range vector the corpus pins, including 2**53", () => {
+  // The boundary the corpus pins as INSIDE the profile range must parse there
+  it("accepts the in-range boundary vector the corpus pins, at 2**53 - 1", () => {
     const path = resolve(__dirname, "..", "..", "conformance", "vectors.json");
     const { vectors } = JSON.parse(readFileSync(path, "utf8")) as {
       vectors: Array<{ name: string; canonical?: string; input?: unknown }>;
     };
     const boundary = vectors.find((v) => v.name === "asqav-25-number-at-safe-range-boundary");
     expect(boundary, "boundary vector missing from the corpus").toBeDefined();
-    const parsed = parseJsonPreservingFloats('{"n":9007199254740992}');
+    expect(boundary!.input).toEqual({ n: 9007199254740991 });
+    const parsed = parseProfileJson('{"n":9007199254740991}');
     expect(dec.decode(asqavJcs(parsed))).toBe(boundary!.canonical);
   });
 });
@@ -320,5 +343,237 @@ describe("first-bad-edge parity (criterion 490)", () => {
 
   it("pins the shared axis prefix order", () => {
     expect([...AXIS_ORDER_PREFIX]).toEqual(["structure", "signature", "chain", "seq"]);
+  });
+});
+
+describe("Asqav profile safe-integer precheck (current v=1 refuses before crypto)", () => {
+  const load = (vec: string, name = "receipt.json"): Record<string, unknown> =>
+    loadJson(join(CORPUS_ROOT, vec, name));
+  const providerFor = (vec: string) => keyProviderFor(join(CORPUS_ROOT, vec), "asqav-native");
+  const bomb = (..._args: never[]): never => {
+    throw new Error("crypto callback must not run after a profile refusal");
+  };
+  function spiedAdapter(): AsqavNativeAdapter {
+    const ad = new AsqavNativeAdapter();
+    ad.signingInput = bomb;
+    ad.resolveKey = bomb;
+    ad.schema = bomb;
+    ad.chainStep = bomb;
+    return ad;
+  }
+  const notes = (res: { axes: Array<{ note: string }> }) => res.axes.map((a) => a.note);
+
+  it("refuses a nested excluded number before any crypto callback", () => {
+    const ad = spiedAdapter();
+    const doc = load("asqav-01-genesis-permit");
+    (doc.payload as Record<string, unknown>).score = 2 ** 53;
+    const res = verify(doc, [ad], providerFor("asqav-01-genesis-permit"));
+    expect(res.fmt).toBe("asqav-native");
+    expect(res.verdict).toBe("unverified");
+    expect(res.failureClass).toBe("unverifiable");
+    expect(res.axes).toHaveLength(1);
+    expect(res.axes[0].axis).toBe("structure");
+    expect(res.axes[0].note).toContain("profile range +/-(2**53 - 1)");
+    expect(res.firstFailingEdge).toBe("structure");
+  });
+
+  it("still refuses when the nested payload carries inner hash mode", () => {
+    const doc = load("asqav-01-genesis-permit");
+    const payload = doc.payload as Record<string, unknown>;
+    payload.mode = "hash";
+    payload.score = -(2 ** 53);
+    const res = verify(doc, ADAPTERS);
+    expect(res.verdict).toBe("unverified");
+    expect(res.axes[0].note).toContain("profile range +/-(2**53 - 1)");
+  });
+
+  it("refuses a bare current payload", () => {
+    const res = verify(
+      { previousReceiptHash: "1".repeat(64), issuer_id: "kid-x", v: 1, score: 2 ** 53 },
+      ADAPTERS,
+    );
+    expect(res.fmt).toBe("asqav-native");
+    expect(res.axes[0].note).toContain("profile range +/-(2**53 - 1)");
+  });
+
+  it("refuses flat excluded metadata before any crypto callback", () => {
+    const ad = spiedAdapter();
+    const doc = load("asqav-05-hash-mode-prod");
+    doc.metadata = { batch: 2 ** 53 };
+    const res = verify(doc, [ad], providerFor("asqav-05-hash-mode-prod"));
+    expect(res.verdict).toBe("unverified");
+    expect(res.axes[0].note).toContain("profile range +/-(2**53 - 1)");
+  });
+
+  it("flat missing-v keeps the schema outcome, not a profile refusal", () => {
+    const doc = load("asqav-05-hash-mode-prod");
+    delete doc.v;
+    doc.metadata = { batch: 2 ** 53 };
+    const res = verify(doc, ADAPTERS);
+    expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+    expect(res.axes.find((a) => a.axis === "structure")!.result).toBe("FAIL");
+  });
+
+  it("a clean v=1 receipt reaches the signing-input callback", () => {
+    const ad = new AsqavNativeAdapter();
+    const calls: unknown[][] = [];
+    const orig = AsqavNativeAdapter.prototype.signingInput;
+    ad.signingInput = (doc) => {
+      calls.push([doc]);
+      return orig.call(ad, doc);
+    };
+    verify(load("asqav-01-genesis-permit"), [ad], providerFor("asqav-01-genesis-permit"));
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it.each([[undefined], [2], [true], ["1"]])(
+    "non-current version %p skips the precheck",
+    (version) => {
+      const doc = load("asqav-01-genesis-permit");
+      const payload = doc.payload as Record<string, unknown>;
+      if (version === undefined) delete payload.v;
+      else payload.v = version as number;
+      payload.score = 2 ** 53;
+      const res = verify(doc, ADAPTERS);
+      expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+    },
+  );
+
+  it("outer v cannot activate a nested payload missing v", () => {
+    const doc = load("asqav-01-genesis-permit");
+    const payload = doc.payload as Record<string, unknown>;
+    delete payload.v;
+    payload.score = 2 ** 53;
+    doc.v = 1;
+    const res = verify(doc, ADAPTERS);
+    expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+  });
+
+  it("a bad predecessor refuses even without its own v", () => {
+    const doc = load("asqav-03-chain-link");
+    const pred = load("asqav-03-chain-link", "predecessor.json");
+    const payload = pred.payload as Record<string, unknown>;
+    payload.score = 2 ** 53;
+    delete payload.v;
+    const res = verify(doc, ADAPTERS, null, pred);
+    expect(res.axes[0].note).toContain("profile range +/-(2**53 - 1)");
+  });
+
+  it("genesis skips predecessor numbers", () => {
+    const doc = load("asqav-01-genesis-permit");
+    const pred = load("asqav-03-chain-link", "predecessor.json");
+    (pred.payload as Record<string, unknown>).score = 2 ** 53;
+    const res = verify(doc, ADAPTERS, null, pred);
+    expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+  });
+
+  it("a foreign predecessor keeps the chain result", () => {
+    const doc = load("asqav-03-chain-link");
+    const pred = loadJson(join(CORPUS_ROOT, "aerf-01-genesis", "receipt.json"));
+    const res = verify(doc, ADAPTERS, null, pred);
+    expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+    expect(res.axes.find((a) => a.axis === "chain")!.result).toBe("FAIL");
+    expect(res.failureClass).toBe("invalid");
+  });
+
+  it("unsigned top-level metadata and JWKS numbers are not checked", () => {
+    const doc = load("asqav-01-genesis-permit");
+    doc.export_seq = 2 ** 53;
+    const provider = providerFor("asqav-01-genesis-permit") as Record<string, unknown>;
+    provider.max_seen = 2 ** 53;
+    const res = verify(doc, ADAPTERS, provider);
+    expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+  });
+
+  it("foreign formats have no profile precheck", () => {
+    const doc = loadJson(join(CORPUS_ROOT, "aerf-01-genesis", "receipt.json"));
+    expect(new AerfAdapter().profilePrecheck(doc)).toBeNull();
+  });
+});
+
+describe("profile selection reads own members only (no prototype activation)", () => {
+  const td = new TextDecoder();
+  const load = (vec: string, name = "receipt.json"): Record<string, unknown> =>
+    loadJson(join(CORPUS_ROOT, vec, name));
+  const notes = (res: { axes: Array<{ note: string }> }) => res.axes.map((a) => a.note);
+
+  it("an inherited v=1 cannot select the neutral precheck", () => {
+    const versionText = `{"payload":{"__proto__":{"v":1},"previousReceiptHash":"${"0".repeat(64)}","issuer_id":"review","n":9007199254740992},"signature":{"sig":"AAAA"}}`;
+    const parsed = parseJsonPreservingFloats(versionText) as Record<string, unknown>;
+    const payload = parsed.payload as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(parsed, "v")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(payload, "v")).toBe(false);
+    expect(() => parseProfileJson(versionText)).toThrow(ProfileIntegerError);
+    const res = verify(parsed, ADAPTERS);
+    expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+  });
+
+  it("a direct nested object with prototype v stays unselected", () => {
+    const payload = Object.assign(Object.create({ v: 1 }), {
+      previousReceiptHash: "1".repeat(64),
+      issuer_id: "kid-x",
+      score: 2 ** 53,
+    });
+    const res = verify({ payload, signature: { sig: "AAAA" } }, ADAPTERS);
+    expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+  });
+
+  it("a direct flat object with prototype v stays unselected", () => {
+    const doc = Object.assign(Object.create({ v: 1 }), {
+      mode: "hash",
+      metadata: { batch: 2 ** 53 },
+    });
+    const res = verify(doc, ADAPTERS);
+    expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+  });
+
+  it("an own v=1 still selects after the guard", () => {
+    const doc = load("asqav-01-genesis-permit");
+    (doc.payload as Record<string, unknown>).score = 2 ** 53;
+    const res = verify(doc, ADAPTERS);
+    expect(res.axes[0].note).toContain("profile range +/-(2**53 - 1)");
+  });
+
+  it("the upstream 2^53 vector stays generic while the profile refuses it", () => {
+    const vec = loadJson(join(CORPUS_ROOT, "agentreceipts-upstream-interop", "canonicalization_vectors.json")) as {
+      canonicalization_vectors: Array<{ name: string; input: unknown; canonical: string }>;
+    };
+    const pinned = vec.canonicalization_vectors.find((v) => v.name === "number_2_to_53")!;
+    expect(td.decode(jcsRfc8785(pinned.input))).toBe(pinned.canonical);
+    expect(() => parseProfileJson(JSON.stringify(pinned.input))).toThrow(ProfileIntegerError);
+  });
+
+  it("a dual-detect predecessor follows the registry, foreign first", () => {
+    const doc = load("asqav-03-chain-link");
+    for (const value of [1, 2 ** 53]) {
+      const pred = {
+        type: "notarised_evidence",
+        evidence_hash_sha512: "0".repeat(128),
+        previousReceiptHash: "1".repeat(64),
+        issuer_id: "review",
+        n: value,
+      };
+      expect(new AsqavNativeAdapter().detect(pred)).toBe(true);
+      const res = verify(doc, [new AerfAdapter(), new AsqavNativeAdapter()], null, pred);
+      expect(notes(res).some((n) => n.includes("profile range"))).toBe(false);
+      expect(res.axes.find((a) => a.axis === "chain")!.note).toBe(
+        "predecessor is a different receipt format",
+      );
+      expect(res.failureClass).toBe("invalid");
+    }
+  });
+
+  it("a dual-detect predecessor follows the registry, native first", () => {
+    const doc = load("asqav-03-chain-link");
+    const pred = {
+      type: "notarised_evidence",
+      evidence_hash_sha512: "0".repeat(128),
+      previousReceiptHash: "1".repeat(64),
+      issuer_id: "review",
+      n: 2 ** 53,
+    };
+    const res = verify(doc, [new AsqavNativeAdapter(), new AerfAdapter()], null, pred);
+    expect(res.axes[0].note).toContain("profile range +/-(2**53 - 1)");
+    expect(res.failureClass).toBe("unverifiable");
   });
 });


### PR DESCRIPTION
## Summary
- Numbers beyond ±(2^53−1) are refused as unverifiable at ingest on both SDK surfaces (Python and TypeScript): strict ingest, the oracle adapters and the verifier core map the refusal to unverified / failure_class unverifiable, and the CLI exits 2 with no traceback where it previously exited 1.
- The profile_range_note keep-alive walk now detects all five exit-marker shapes.
- The fingerprint corpus advances v7 → v10 with boundary and refusal vectors for the ±(2^53−1) edge; FINGERPRINT_LOCK_DIGEST moves with its lock (e5a3b808 → ad2c44c6) while VERIFIER_LOCK_DIGEST keeps the #504 re-pin (66f8027c) — composed deliberately after rebasing onto the corpus re-mint.

## Verification
- Both corpus-lock paths green post-rebase (check_corpus_lock.sh; test_corpus_lock.py 16 passed).
- verifier-parity pins carry only the post-#504 digest (5614b581…; 508fc8f9 absent).
- Refusal-hardening suite run locally pre-push; CI is the authoritative environment for the known sandbox-environmental standalone tests.

https://claude.ai/code/session_017PQ2FTpuRPvWapqFkv3hk5