### PR TITLE
fix: mint asqav-08/09 under a published v2 signing seed

### DIFF
--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -24,7 +24,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
 FINGERPRINT_LOCK_DIGEST = "ad2c44c61cf2191cfe628b0628aa4e3ce560dba33be9e83bc584b57606ffdfbc"
-VERIFIER_LOCK_DIGEST = "66f8027c58589fc8af36bc6bbfc3b9dcada6d4cfb623deb1d1528a85dac66ca7"
+VERIFIER_LOCK_DIGEST = "1a6cfbc03d79ade034580797afb0d0bc8fe95d9d930102bd6f2e2e44788db4b7"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/verifier/conformance-vectors/asqav-08-v2-signer-canary/jwks.json
+++ b/verifier/conformance-vectors/asqav-08-v2-signer-canary/jwks.json
@@ -5,7 +5,7 @@
       "issuer_id": "Asqav Ltd",
       "alg": "Ed25519",
       "status": "active",
-      "public_key": "IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI="
+      "public_key": "VoFCG27zlgOEoE/SLZkIoa00P9EEG90jLEY7M/Bv+mA="
     }
   ]
 }

--- a/verifier/conformance-vectors/asqav-08-v2-signer-canary/receipt.json
+++ b/verifier/conformance-vectors/asqav-08-v2-signer-canary/receipt.json
@@ -6,10 +6,15 @@
     "issuer_id": "Asqav Ltd",
     "agent_id": "agt_demo_001",
     "action_id": "act_v2_demo_0001",
-    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "action_ref": "sha256:878424356da5097e208bf5115339777cca7a1d5c74cca70ee0499535cea0a614",
+    "context": {
+      "subject": "v2-signer-canary",
+      "signer": "https://api.asqav.com",
+      "tid": "4d9a220e3f0b7c35c932d1e85bd4e081fb702c0a47caa046fb18b88bc9246a7f"
+    },
     "payload_digest": {
-      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "size": 0
+      "hash": "878424356da5097e208bf5115339777cca7a1d5c74cca70ee0499535cea0a614",
+      "size": 136
     },
     "policy_digest": "sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7",
     "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -26,7 +31,7 @@
   "signature": {
     "alg": "Ed25519",
     "kid": "asqav-oracle-v2-key",
-    "sig": "csRi1sPm4SBl1ggcyzoCLZep0SYOwF02RJOuIzyiAxfyNeZDatvphygPQHW+ZeMdfqhlrhNjf60gQNYx4wxzBw=="
+    "sig": "cAW3k5BYklv+DnC3rrkHFKQOQTZoNiUVKNzJ1Ch5BXbqtE0GM4az20l/cV6C8iqO/QK8cnQIQG8Yw2zH8Zs9DQ=="
   },
   "anchors": []
 }

--- a/verifier/conformance-vectors/asqav-09-v2-signer-tampered/jwks.json
+++ b/verifier/conformance-vectors/asqav-09-v2-signer-tampered/jwks.json
@@ -5,7 +5,7 @@
       "issuer_id": "Asqav Ltd",
       "alg": "Ed25519",
       "status": "active",
-      "public_key": "IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI="
+      "public_key": "VoFCG27zlgOEoE/SLZkIoa00P9EEG90jLEY7M/Bv+mA="
     }
   ]
 }

--- a/verifier/conformance-vectors/asqav-09-v2-signer-tampered/receipt.json
+++ b/verifier/conformance-vectors/asqav-09-v2-signer-tampered/receipt.json
@@ -6,10 +6,15 @@
     "issuer_id": "Asqav Ltd",
     "agent_id": "agt_demo_001",
     "action_id": "act_v2_demo_0001",
-    "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "action_ref": "sha256:878424356da5097e208bf5115339777cca7a1d5c74cca70ee0499535cea0a614",
+    "context": {
+      "subject": "v2-signer-canary",
+      "signer": "https://api.asqav.com",
+      "tid": "4d9a220e3f0b7c35c932d1e85bd4e081fb702c0a47caa046fb18b88bc9246a7f"
+    },
     "payload_digest": {
-      "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "size": 0
+      "hash": "878424356da5097e208bf5115339777cca7a1d5c74cca70ee0499535cea0a614",
+      "size": 136
     },
     "policy_digest": "sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7",
     "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -26,7 +31,7 @@
   "signature": {
     "alg": "Ed25519",
     "kid": "asqav-oracle-v2-key",
-    "sig": "csRi1sPm4SBl1ggcyzoCLZep0SYOwF02RJOuIzyiAxfyNeZDatvphygPQHW+ZeMdfqhlrhNjf60gQNYx4wxzBw=="
+    "sig": "cAW3k5BYklv+DnC3rrkHFKQOQTZoNiUVKNzJ1Ch5BXbqtE0GM4az20l/cV6C8iqO/QK8cnQIQG8Yw2zH8Zs9DQ=="
   },
   "anchors": []
 }

--- a/verifier/conformance-vectors/gen_v2_signer_vectors.py
+++ b/verifier/conformance-vectors/gen_v2_signer_vectors.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Asqav
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the v2-signer conformance vectors.
+
+asqav-08 and asqav-09 predate the published-seed discipline (they were
+committed directly, and their signing seed was never published), so they are
+re-minted here under a published phrase, following the precedent
+gen_oracle_vectors.py documents for exactly this situation: anyone can
+re-derive the key and reproduce every signature byte.
+
+  asqav-08-v2-signer-canary   valid v:2 receipt; signer and _asqav_tid sit
+                             inside the signed body, signer surfaced
+  asqav-09-v2-signer-tampered 08's payload with the signer flipped after
+                             signing; the signature never matches it
+
+asqav-09 shares asqav-08's context and digest by construction: it is 08's
+payload with one member flipped, so the digest still recomputes and the
+signature axis is what FAILs — the designed failure.
+
+Usage: python verifier/conformance-vectors/gen_v2_signer_vectors.py
+Re-freeze the corpus lock afterwards: python verifier/freeze_corpus_lock.py
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+_HERE = Path(__file__).resolve().parent
+
+#: Nothing-up-my-sleeve seed phrase; the key is SHA-256 of these ASCII bytes.
+#: The v2 key this replaces predates the published-seed discipline and its
+#: seed is not recoverable; the directory entries below are the re-mint.
+SEED_PHRASE = b"asqav conformance corpus v1 oracle v2 signing seed"
+
+KID = "asqav-oracle-v2-key"
+ISSUER = "Asqav Ltd"
+
+#: The fixed policy digest the v2 demo receipts commit to.
+POLICY_DIGEST = "sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7"
+
+#: The v2 canary's transaction id, carried inside the signed body.
+CANARY_TID = "4d9a220e3f0b7c35c932d1e85bd4e081fb702c0a47caa046fb18b88bc9246a7f"
+
+#: Honest signer and the flipped value the tampered twin carries.
+HONEST_SIGNER = "https://api.asqav.com"
+FLIPPED_SIGNER = "https://attacker.example.com"
+
+
+def _jcs(obj: object) -> bytes:
+    """Canonical JSON bytes, matching the oracle's asqav_jcs."""
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False
+    ).encode("utf-8")
+
+
+def _digest_of(context: dict) -> dict:
+    """payload_digest over `context`, computed independently of the verifier."""
+    encoded = _jcs(context)
+    return {"hash": hashlib.sha256(encoded).hexdigest(), "size": len(encoded)}
+
+
+def _signing_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(SEED_PHRASE).digest())
+
+
+def _sign(payload: dict, sk: Ed25519PrivateKey) -> dict:
+    """The three-key envelope: signature is over the canonical payload bytes."""
+    return {
+        "payload": payload,
+        "signature": {
+            "alg": "Ed25519",
+            "kid": KID,
+            "sig": base64.b64encode(sk.sign(_jcs(payload))).decode(),
+        },
+        "anchors": [],
+    }
+
+
+def _payload(signer: str) -> dict:
+    """The v2 demo payload; every member preserved from the original mint.
+
+    context names the canary the digest commits to; action_ref is the one wire
+    form (-09 §5.1.5): the prefixed rendering of payload_digest.hash.
+    """
+    context = {"subject": "v2-signer-canary", "signer": HONEST_SIGNER, "tid": CANARY_TID}
+    digest = _digest_of(context)
+    return {
+        "type": "protectmcp:decision",
+        "v": 2,
+        "issued_at": "2026-05-04T12:00:00+00:00",
+        "issuer_id": ISSUER,
+        "agent_id": "agt_demo_001",
+        "action_id": "act_v2_demo_0001",
+        "action_ref": f"sha256:{digest['hash']}",
+        "context": context,
+        "payload_digest": digest,
+        "policy_digest": POLICY_DIGEST,
+        "previousReceiptHash": "0" * 64,
+        "decision": "allow",
+        "tool_name": "demo.action",
+        "mode": "hash",
+        "hash": "sha256:" + "e" * 64,
+        "hash_algo": "sha256",
+        "org_id": "org_demo_canary",
+        "server_timestamp": "2026-05-04T12:00:00+00:00",
+        "signer": signer,
+        "_asqav_tid": CANARY_TID,
+    }
+
+
+def _jwks() -> dict:
+    pub = (
+        _signing_key()
+        .public_key()
+        .public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )
+    return {
+        "keys": [
+            {
+                "kid": KID,
+                "issuer_id": ISSUER,
+                "alg": "Ed25519",
+                "status": "active",
+                "public_key": base64.b64encode(pub).decode(),
+            }
+        ]
+    }
+
+
+def _write(name: str, files: dict[str, object]) -> None:
+    out = _HERE / name
+    out.mkdir(parents=True, exist_ok=True)
+    for fname, obj in files.items():
+        (out / fname).write_text(json.dumps(obj, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {name}")
+
+
+def main() -> int:
+    sk = _signing_key()
+
+    # asqav-08: the valid v:2 canary. Expected text is the vector's own,
+    # verbatim: the re-mint changes no outcome and no notes sentence.
+    env08 = _sign(_payload(HONEST_SIGNER), sk)
+    _write(
+        "asqav-08-v2-signer-canary",
+        {
+            "receipt.json": env08,
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "verified",
+                "reason_code": "",
+                "notes": (
+                    "Valid v:2 receipt; signer and _asqav_tid sit inside the "
+                    "signed body, Ed25519 over the canonical payload verifies, "
+                    "signer is surfaced in the verdict."
+                ),
+            },
+        },
+    )
+
+    # asqav-09: 08's payload with the signer flipped after signing. Stays
+    # tampered by construction: nothing re-signs the carried payload.
+    env09 = {
+        "payload": _payload(FLIPPED_SIGNER),
+        "signature": env08["signature"],
+        "anchors": [],
+    }
+    _write(
+        "asqav-09-v2-signer-tampered",
+        {
+            "receipt.json": env09,
+            "jwks.json": _jwks(),
+            "expected.json": {
+                "format": "asqav-native",
+                "outcome": "unverified",
+                "reason_code": "issuer_signature",
+                "notes": (
+                    "signer flipped after signing; because signer is inside the "
+                    "signed body the Ed25519 signature over the canonical payload "
+                    "no longer matches and the verdict FAILs."
+                ),
+                "failure_class": "invalid",
+            },
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-verifier-conformance-vectors",
-  "corpus_version": 22,
+  "corpus_version": 23,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -113,6 +113,11 @@
       "version": 21,
       "files": 279,
       "digest": "813d051f865ea2b05d96e1ee23ed98eaa8bb4d7f240551dda981ebbd595ea4b0"
+    },
+    {
+      "version": 22,
+      "files": 279,
+      "digest": "66f8027c58589fc8af36bc6bbfc3b9dcada6d4cfb623deb1d1528a85dac66ca7"
     }
   ],
   "files": [
@@ -858,13 +863,13 @@
     },
     {
       "path": "asqav-08-v2-signer-canary/jwks.json",
-      "sha256": "e17d089be1858ed2775bdd2d5e4bb4d790c320fa835b1928991a08d5c9e9df9b",
+      "sha256": "ac7bb4db46eb8208b16f0eb805dcf32d42ea21af4bf5fa4287321fd971515205",
       "bytes": 217
     },
     {
       "path": "asqav-08-v2-signer-canary/receipt.json",
-      "sha256": "df505e0230ac00527f74c5c4c51029c208a789c3584c035ff229220b56bb7a96",
-      "bytes": 1226
+      "sha256": "dfc15b1cf72c4bb5c061567fb0efda699b733735e9f1a43c9b760048fa195fd2",
+      "bytes": 1410
     },
     {
       "path": "asqav-09-v2-signer-tampered/expected.json",
@@ -873,13 +878,13 @@
     },
     {
       "path": "asqav-09-v2-signer-tampered/jwks.json",
-      "sha256": "e17d089be1858ed2775bdd2d5e4bb4d790c320fa835b1928991a08d5c9e9df9b",
+      "sha256": "ac7bb4db46eb8208b16f0eb805dcf32d42ea21af4bf5fa4287321fd971515205",
       "bytes": 217
     },
     {
       "path": "asqav-09-v2-signer-tampered/receipt.json",
-      "sha256": "a256fd44b6e140cd26f60132bb827acb08e785dc8cb34600b6602216e947e45b",
-      "bytes": 1233
+      "sha256": "3d6abfdd2e28b0ecd1665d77eb31f982351170f1a5423e2677ee0a1011c45e2a",
+      "bytes": 1417
     },
     {
       "path": "asqav-10-hash-mode-multikey/expected.json",
@@ -1367,6 +1372,11 @@
       "bytes": 11279
     },
     {
+      "path": "gen_v2_signer_vectors.py",
+      "sha256": "54b4a6b07b157016cb3d9ce315bc6b6ced34d7f142739daa0058bdc4ebaeacda",
+      "bytes": 6757
+    },
+    {
       "path": "manifest.json",
       "sha256": "7d0cf18a4e47eebb024f2360efbe50b5c5b5fcc5042459d0ab578d8489a30d9c",
       "bytes": 28529
@@ -1542,5 +1552,5 @@
       ]
     }
   },
-  "digest": "66f8027c58589fc8af36bc6bbfc3b9dcada6d4cfb623deb1d1528a85dac66ca7"
+  "digest": "1a6cfbc03d79ade034580797afb0d0bc8fe95d9d930102bd6f2e2e44788db4b7"
 }


### PR DESCRIPTION
## Summary
- The two v2-signer vectors gain real contexts and derivable keys: a new gen_v2_signer_vectors.py emits both deterministically under the published phrase "asqav conformance corpus v1 oracle v2 signing seed" (Ed25519 from sha256 of the ASCII bytes), following the corpus precedent for keys whose seeds are unrecoverable.
- asqav-08 verifies under the derived key; asqav-09 keeps its designed failure — the same signature bytes over a flipped signer. Both carry hash = sha256(JCS(context)) with matching size and action_ref, and the corpus-wide empty-digest set is zero.
- Verifier lock v23 pins 280 files (digest 1a6cfbc0…), pair-updated in test_corpus_lock.py and composed with the fingerprint pin (ad2c44c6…) from the safe-integer change after rebasing onto it.

## Verification
- Both corpus-lock paths green post-rebase; behavioral v2-signer suite 7/7; generator re-run byte-stable.
- Standalone-verifier verdict lines identical before and after on both vectors (unverifiable / invalid — the designed kinds).

https://claude.ai/code/session_017PQ2FTpuRPvWapqFkv3hk5