### PR TITLE
docs: state how digest and context relate in the payload-digest pair

### DIFF
--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -24,7 +24,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
 FINGERPRINT_LOCK_DIGEST = "ad2c44c61cf2191cfe628b0628aa4e3ce560dba33be9e83bc584b57606ffdfbc"
-VERIFIER_LOCK_DIGEST = "3b003d4b4a6a3a8fa4a3d2ec1f17fb60805fbdbea441102238a87483ab3b2f99"
+VERIFIER_LOCK_DIGEST = "654725d071c89dc1104e6201d91eaa85a0fdce93b5e5b56eff2b054c08cae3b1"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/verifier/conformance-vectors/asqav-25-payload-digest-rederives/expected.json
+++ b/verifier/conformance-vectors/asqav-25-payload-digest-rederives/expected.json
@@ -2,5 +2,5 @@
   "format": "asqav-native",
   "outcome": "verified",
   "reason_code": "",
-  "notes": "Payload-mode genesis carrying BOTH context and payload_digest, the one pair no other vector has: hash is SHA-256 over the JCS of the carried context and size its byte length (25), so the payload_digest axis recomputes and PASSes rather than passing on absence. The digest is computed with stdlib json.dumps in JCS shape, never through the verifier's canonical_json."
+  "notes": "Payload-mode genesis carrying BOTH context and payload_digest: hash is SHA-256 over the JCS of the carried context and size its byte length (25), so the payload_digest axis recomputes and PASSes rather than passing on absence. The dedicated honest half of the rederives/mismatch pair with asqav-26, which commits to a different context than the one carried. The digest is computed with stdlib json.dumps in JCS shape, never through the verifier's canonical_json."
 }

--- a/verifier/conformance-vectors/gen_payload_digest_vectors.py
+++ b/verifier/conformance-vectors/gen_payload_digest_vectors.py
@@ -4,8 +4,11 @@
 
 -09 §10.2: a receipt carrying BOTH `context` and `payload_digest` is checkable
 from its own bytes - `hash` is SHA-256 over the JCS canonicalisation of the
-carried context, `size` that canonical form's byte length. Every other
-digest-carrying vector omits the context, so the recompute path had no fixture.
+carried context, `size` that canonical form's byte length. Carrying a digest
+and carrying the context it commits to are independent: three asqav-native
+vectors carry a `payload_digest` with no `context` member. This pair pins the
+recompute path at both ends: the honest digest beside its context, and the
+same receipt signed over a digest of a different context.
 
 Two vectors, minted as asqav-25/26 because asqav-23/24 were minted by the
 anchor-entry task ahead of this one (next free id at mint time, never reused):
@@ -134,12 +137,14 @@ def main() -> int:
                 "outcome": "verified",
                 "reason_code": "",
                 "notes": (
-                    "Payload-mode genesis carrying BOTH context and payload_digest, the "
-                    "one pair no other vector has: hash is SHA-256 over the JCS of the "
-                    "carried context and size its byte length (25), so the payload_digest "
-                    "axis recomputes and PASSes rather than passing on absence. The digest "
-                    "is computed with stdlib json.dumps in JCS shape, never through the "
-                    "verifier's canonical_json."
+                    "Payload-mode genesis carrying BOTH context and payload_digest: hash "
+                    "is SHA-256 over the JCS of the carried context and size its byte "
+                    "length (25), so the payload_digest axis recomputes and PASSes rather "
+                    "than passing on absence. The dedicated honest half of the "
+                    "rederives/mismatch pair with asqav-26, which commits to a different "
+                    "context than the one carried. The digest is computed with stdlib "
+                    "json.dumps in JCS shape, never through the verifier's "
+                    "canonical_json."
                 ),
             },
         },

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-verifier-conformance-vectors",
-  "corpus_version": 24,
+  "corpus_version": 25,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -123,6 +123,11 @@
       "version": 23,
       "files": 280,
       "digest": "1a6cfbc03d79ade034580797afb0d0bc8fe95d9d930102bd6f2e2e44788db4b7"
+    },
+    {
+      "version": 24,
+      "files": 300,
+      "digest": "3b003d4b4a6a3a8fa4a3d2ec1f17fb60805fbdbea441102238a87483ab3b2f99"
     }
   ],
   "files": [
@@ -1173,8 +1178,8 @@
     },
     {
       "path": "asqav-25-payload-digest-rederives/expected.json",
-      "sha256": "5aeb74111a4e430cd1f8a67fc0083d88474ff68ce5f083d39cd1d99105e59dba",
-      "bytes": 457
+      "sha256": "7aba608ffda2cd500c908da93a4e77a6657a8d35e82dd09b4d96244fe65739a2",
+      "bytes": 554
     },
     {
       "path": "asqav-25-payload-digest-rederives/jwks.json",
@@ -1463,8 +1468,8 @@
     },
     {
       "path": "gen_payload_digest_vectors.py",
-      "sha256": "d77b2dd04ab3d9a1b5523ec4d40f0090847247e95c224a4a09a6fd07123ae3ee",
-      "bytes": 6439
+      "sha256": "9e2b2ec63302f99f94dfdfc19d66c7b3da0e0a476596ee6acbb9e189834b54b8",
+      "bytes": 6794
     },
     {
       "path": "gen_selective_omission_vectors.py",
@@ -1657,5 +1662,5 @@
       ]
     }
   },
-  "digest": "3b003d4b4a6a3a8fa4a3d2ec1f17fb60805fbdbea441102238a87483ab3b2f99"
+  "digest": "654725d071c89dc1104e6201d91eaa85a0fdce93b5e5b56eff2b054c08cae3b1"
 }


### PR DESCRIPTION
## Summary
- The payload-digest generator docstring and the asqav-25 notes each carried a claim the corpus outgrew. Both are replaced with wording backed by enumeration: carrying a digest and carrying the context it commits to are independent, three asqav-native vectors carry a payload_digest with no context member, and asqav-25 is the honest half of the rederives/mismatch pair with asqav-26.
- Both edits live in the generator source and expected.json is re-emitted from it, so the source and the emitted bytes cannot drift.

## Verification
- Enumeration over all 30 asqav-native vectors: 25 carry both members, 3 carry a digest with no context, 2 hash-mode vectors carry neither.
- Both corpus-lock paths green; the verifier lock advances to rolling version 25 (digest 654725d0) with its test pin pair-updated.
- Outcome and reason_code untouched; only notes strings move.

https://claude.ai/code/session_017PQ2FTpuRPvWapqFkv3hk5