### PR TITLE
fix: validate client bindings and preserve corpus outcomes

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -51,9 +51,16 @@ of the ORIGINATING envelope, base64. The scope of that digest is declared on the
   only. Anchors are excluded because they are OPTIONAL and change after issuance, so a
   digest covering them would break every acknowledgment already emitted the moment the
   originator's timestamp was upgraded.
-- An ABSENT `scope` member means a legacy draft-04..-08 three-key binding, which a
-  verifier reports as `unverifiable, legacy scope`. A verifier MUST NOT try both scopes
-  and accept whichever matches.
+- An absent `scope` reports `unverifiable` with reason `legacy_scope`. A null or
+  unsupported scope reports `unverifiable` with reason `unrecognised_scope`.
+  Verifiers dispatch scope before examining the origin and never try both scopes.
+
+The projection preserves the complete signature object and its encoded string. It
+excludes every other export member. The two-anchor fixtures cover four cases: a matching digest; a three-key
+digest under the supported scope; a missing scope member; and a scope this
+profile does not define.
+`generation.counterparty_digest_members` selects the fixture's hash recipe independently
+of the scope it claims, so regeneration preserves the deliberate negative cases.
 
 Each such vector names the envelope its digest is taken over in
 `expected.originating_envelope_ref`, so the value is recomputable from this file alone.

--- a/conformance/manifest.lock.json
+++ b/conformance/manifest.lock.json
@@ -71,8 +71,8 @@
     },
     {
       "path": "README.md",
-      "sha256": "76d4312fe625de70f338e3ac726776608db4de2ace0cca2ed9b9d8bfe24164fc",
-      "bytes": 7891
+      "sha256": "56bd3a65ba4cac107f005a90a40fab19607dd3bd447e319cda30b08f0ae240d9",
+      "bytes": 7926
     },
     {
       "path": "vectors.json",
@@ -95,5 +95,5 @@
     },
     "known_answer_message_note": "the 32-byte SHA-256 digest of the canonical bytes of vector 'minimal_read': the hash is what ML-DSA-65 signs"
   },
-  "digest": "9b7b9886158f1b833660b4b43130bfb7907d5753cbb08b270d632b2454a99a8e"
+  "digest": "e6e6946274551752412cd4bc6ada7f4739e9ae495e4594639a2eec4de87039ed"
 }

--- a/conformance/manifest.lock.json
+++ b/conformance/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-fingerprint-corpus",
-  "corpus_version": 10,
+  "corpus_version": 11,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -51,6 +51,11 @@
       "version": 9,
       "files": 4,
       "digest": "2d828921b77606e48162da16ce191e8f396257790816cdc87717f647ac8af6df"
+    },
+    {
+      "version": 10,
+      "files": 4,
+      "digest": "ad2c44c61cf2191cfe628b0628aa4e3ce560dba33be9e83bc584b57606ffdfbc"
     }
   ],
   "files": [
@@ -66,13 +71,13 @@
     },
     {
       "path": "README.md",
-      "sha256": "863f3546f676b610ed2ac816c6b15af0c794644f29d2692622ee5b35603b87f2",
-      "bytes": 7427
+      "sha256": "76d4312fe625de70f338e3ac726776608db4de2ace0cca2ed9b9d8bfe24164fc",
+      "bytes": 7891
     },
     {
       "path": "vectors.json",
-      "sha256": "c473ac3ed8414ba27ee0fdb1b2162eb3a275232c3c8ff19dc9cb8812ace97559",
-      "bytes": 39157
+      "sha256": "575d2605d5acf40d3387603cdded83e95efbe8794dc8dd8387f6b7905d1db99a",
+      "bytes": 54904
     }
   ],
   "signing": {
@@ -90,5 +95,5 @@
     },
     "known_answer_message_note": "the 32-byte SHA-256 digest of the canonical bytes of vector 'minimal_read': the hash is what ML-DSA-65 signs"
   },
-  "digest": "ad2c44c61cf2191cfe628b0628aa4e3ce560dba33be9e83bc584b57606ffdfbc"
+  "digest": "9b7b9886158f1b833660b4b43130bfb7907d5753cbb08b270d632b2454a99a8e"
 }

--- a/conformance/vectors.json
+++ b/conformance/vectors.json
@@ -445,13 +445,14 @@
     },
     {
       "name": "counterparty_binding_missing_envelope_hash_rejected",
-      "description": "counterparty_binding is present but envelope_hash member is absent. envelope_hash is REQUIRED in draft-04; this vector MUST be reported non-conformant by a verifier.",
+      "description": "A supported-scope binding without its required envelope_hash is malformed.",
       "input": {
         "action_id": "act_01HVZB_ACK_0006",
         "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         "agent_id": "agt_acknowledger_B",
         "counterparty_binding": {
-          "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001"
+          "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001",
+          "scope": "envelope_minus_anchors"
         },
         "decision": "allow",
         "issued_at": "2026-05-18T20:00:04+00:00",
@@ -468,8 +469,8 @@
         "type": "protectmcp:acknowledgment",
         "v": 1
       },
-      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0006\",\"action_ref\":\"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:04+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"hash\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"size\":0},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
-      "sha256": "6fee77a7aa44a4f17c0df1830ad520c2679e581e9b4fa24693b62fa7c11b9b4d",
+      "canonical": "{\"action_id\":\"act_01HVZB_ACK_0006\",\"action_ref\":\"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"scope\":\"envelope_minus_anchors\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:04+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"hash\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"size\":0},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "fdf867b3c2cc86acd1423818ce4b56e8e0f17b5a4ce1862444dd67f7cbbe7ed3",
       "counterparty_binding_member_missing": "envelope_hash",
       "expected_verify": false,
       "reason": "envelope_hash is REQUIRED on counterparty_binding; absence breaks the cross-agent byte-equality guarantee and MUST cause the acknowledging receipt to be reported non-conformant."
@@ -583,6 +584,249 @@
         "refused_at": "parse",
         "positive_twin": "asqav-25-number-at-safe-range-boundary"
       }
+    },
+    {
+      "name": "counterparty_binding_origin_two_anchors",
+      "description": "Pure canonicalization of an originating envelope with two replaceable anchors; binding recipes project the payload and signature separately.",
+      "input": {
+        "anchors": [
+          {
+            "tsa_url": "https://tsa.example/timestamp",
+            "type": "rfc3161",
+            "value": "AAAA_synthetic_tsr_base64_placeholder_AAAA"
+          },
+          {
+            "type": "opentimestamps",
+            "value": "synthetic_upgradeable_timestamp"
+          }
+        ],
+        "payload": {
+          "action_id": "act_01HVZA_ORIGINATOR_0001",
+          "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "agent_id": "agt_originator_A",
+          "decision": "allow",
+          "issued_at": "2026-05-18T20:00:00+00:00",
+          "issuer_id": "00000000000000000098",
+          "org_id": "org_demo",
+          "payload_digest": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "size": 0
+          },
+          "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+          "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "sandbox_state": "live",
+          "tool_name": "database.query",
+          "type": "protectmcp:action",
+          "v": 1
+        },
+        "signature": {
+          "alg": "ML-DSA-65",
+          "kid": "00000000000000000098",
+          "sig": "AAAA_synthetic_signature_bytes_base64_placeholder_for_vector_only_AAAA"
+        }
+      },
+      "expected_verify": true,
+      "reason": "Envelope byte-equality: JCS-canonical bytes of A's full envelope reproduce the same SHA-256 across implementations. This vector pins canonicalization, not the binding scope.",
+      "expected": {
+        "envelope_hash_base64": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+        "envelope_hash_base64url": "dXqDdpt_tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+        "originating_envelope_ref": "counterparty_binding_origin_two_anchors"
+      },
+      "canonical": "{\"anchors\":[{\"tsa_url\":\"https://tsa.example/timestamp\",\"type\":\"rfc3161\",\"value\":\"AAAA_synthetic_tsr_base64_placeholder_AAAA\"},{\"type\":\"opentimestamps\",\"value\":\"synthetic_upgradeable_timestamp\"}],\"payload\":{\"action_id\":\"act_01HVZA_ORIGINATOR_0001\",\"action_ref\":\"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"agent_id\":\"agt_originator_A\",\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:00+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"hash\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"size\":0},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:action\",\"v\":1},\"signature\":{\"alg\":\"ML-DSA-65\",\"kid\":\"00000000000000000098\",\"sig\":\"AAAA_synthetic_signature_bytes_base64_placeholder_for_vector_only_AAAA\"}}",
+      "sha256": "36e5256c3940a777eb4e4fc6b08fcb31f1e5a352c82736aa7b32578980b5e9b4"
+    },
+    {
+      "name": "counterparty_binding_scope_minus_anchors",
+      "description": "Counterparty fixture with binding outcome matches; its generation recipe is independent of the asserted wire scope.",
+      "input": {
+        "action_id": "act_counterparty_scope_minus_anchors",
+        "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "agent_id": "agt_acknowledger_B",
+        "counterparty_binding": {
+          "envelope_hash": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+          "expect_ack_from": "00000000000000000098",
+          "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001",
+          "transport_label": "mcp",
+          "scope": "envelope_minus_anchors"
+        },
+        "decision": "allow",
+        "issued_at": "2026-05-18T20:00:01+00:00",
+        "issuer_id": "00000000000000000098",
+        "org_id": "org_demo",
+        "payload_digest": {
+          "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "size": 0
+        },
+        "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "sandbox_state": "live",
+        "tool_name": "database.query",
+        "type": "protectmcp:acknowledgment",
+        "v": 1
+      },
+      "expected_verify": true,
+      "reason": "The binding axis returns matches.",
+      "expected": {
+        "envelope_hash_base64": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+        "envelope_hash_hex": "757a83769b7fb4163b20b30931ccd8c3ab31f2f3e6402157311f16dc00d6d9ef",
+        "originating_envelope_ref": "counterparty_binding_origin_two_anchors",
+        "binding_result": true,
+        "binding_label": "matches",
+        "failure_class": null
+      },
+      "generation": {
+        "counterparty_digest_members": [
+          "payload",
+          "signature"
+        ]
+      },
+      "canonical": "{\"action_id\":\"act_counterparty_scope_minus_anchors\",\"action_ref\":\"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=\",\"expect_ack_from\":\"00000000000000000098\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"scope\":\"envelope_minus_anchors\",\"transport_label\":\"mcp\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"hash\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"size\":0},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "e6a6b09958c64686de4ef7dd2494690ee0ed7d039da92e2e78b550190d5fe931"
+    },
+    {
+      "name": "counterparty_binding_anchors_included_rejected",
+      "description": "Counterparty fixture with binding outcome mismatch; its generation recipe is independent of the asserted wire scope.",
+      "input": {
+        "action_id": "act_counterparty_anchors_included_rejected",
+        "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "agent_id": "agt_acknowledger_B",
+        "counterparty_binding": {
+          "envelope_hash": "NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=",
+          "expect_ack_from": "00000000000000000098",
+          "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001",
+          "transport_label": "mcp",
+          "scope": "envelope_minus_anchors"
+        },
+        "decision": "allow",
+        "issued_at": "2026-05-18T20:00:01+00:00",
+        "issuer_id": "00000000000000000098",
+        "org_id": "org_demo",
+        "payload_digest": {
+          "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "size": 0
+        },
+        "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "sandbox_state": "live",
+        "tool_name": "database.query",
+        "type": "protectmcp:acknowledgment",
+        "v": 1
+      },
+      "expected_verify": false,
+      "reason": "The binding axis returns mismatch.",
+      "expected": {
+        "envelope_hash_base64": "NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=",
+        "envelope_hash_hex": "36e5256c3940a777eb4e4fc6b08fcb31f1e5a352c82736aa7b32578980b5e9b4",
+        "originating_envelope_ref": "counterparty_binding_origin_two_anchors",
+        "binding_result": false,
+        "binding_label": "mismatch",
+        "failure_class": "invalid"
+      },
+      "generation": {
+        "counterparty_digest_members": [
+          "payload",
+          "signature",
+          "anchors"
+        ]
+      },
+      "canonical": "{\"action_id\":\"act_counterparty_anchors_included_rejected\",\"action_ref\":\"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=\",\"expect_ack_from\":\"00000000000000000098\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"scope\":\"envelope_minus_anchors\",\"transport_label\":\"mcp\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"hash\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"size\":0},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "85004158dcf9345ef58eed4178bbfea481a38f0b8cb2a1970785d892980695dc"
+    },
+    {
+      "name": "counterparty_binding_legacy_scope_absent",
+      "description": "Counterparty fixture with binding outcome legacy_scope; its generation recipe is independent of the asserted wire scope.",
+      "input": {
+        "action_id": "act_counterparty_legacy_scope_absent",
+        "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "agent_id": "agt_acknowledger_B",
+        "counterparty_binding": {
+          "envelope_hash": "NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=",
+          "expect_ack_from": "00000000000000000098",
+          "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001",
+          "transport_label": "mcp"
+        },
+        "decision": "allow",
+        "issued_at": "2026-05-18T20:00:01+00:00",
+        "issuer_id": "00000000000000000098",
+        "org_id": "org_demo",
+        "payload_digest": {
+          "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "size": 0
+        },
+        "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "sandbox_state": "live",
+        "tool_name": "database.query",
+        "type": "protectmcp:acknowledgment",
+        "v": 1
+      },
+      "expected_verify": false,
+      "reason": "The binding axis returns legacy_scope.",
+      "expected": {
+        "envelope_hash_base64": "NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=",
+        "envelope_hash_hex": "36e5256c3940a777eb4e4fc6b08fcb31f1e5a352c82736aa7b32578980b5e9b4",
+        "originating_envelope_ref": "counterparty_binding_origin_two_anchors",
+        "binding_result": null,
+        "binding_label": "legacy_scope",
+        "failure_class": "unverifiable"
+      },
+      "generation": {
+        "counterparty_digest_members": [
+          "payload",
+          "signature",
+          "anchors"
+        ]
+      },
+      "canonical": "{\"action_id\":\"act_counterparty_legacy_scope_absent\",\"action_ref\":\"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=\",\"expect_ack_from\":\"00000000000000000098\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"transport_label\":\"mcp\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"hash\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"size\":0},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "9ea6a8cfad32136b496f8aff707dedf53e40f7bc13499f23d8acf598ced6e945"
+    },
+    {
+      "name": "counterparty_binding_unrecognised_scope",
+      "description": "Counterparty fixture with binding outcome unrecognised_scope; its generation recipe is independent of the asserted wire scope.",
+      "input": {
+        "action_id": "act_counterparty_unrecognised_scope",
+        "action_ref": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "agent_id": "agt_acknowledger_B",
+        "counterparty_binding": {
+          "envelope_hash": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+          "expect_ack_from": "00000000000000000098",
+          "receipt_ref": "asqav-receipt://org_demo/agt_originator_A/seq/0001",
+          "transport_label": "mcp",
+          "scope": "unsupported_fixture_scope"
+        },
+        "decision": "allow",
+        "issued_at": "2026-05-18T20:00:01+00:00",
+        "issuer_id": "00000000000000000098",
+        "org_id": "org_demo",
+        "payload_digest": {
+          "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "size": 0
+        },
+        "policy_digest": "sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
+        "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "sandbox_state": "live",
+        "tool_name": "database.query",
+        "type": "protectmcp:acknowledgment",
+        "v": 1
+      },
+      "expected_verify": false,
+      "reason": "The binding axis returns unrecognised_scope.",
+      "expected": {
+        "envelope_hash_base64": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+        "envelope_hash_hex": "757a83769b7fb4163b20b30931ccd8c3ab31f2f3e6402157311f16dc00d6d9ef",
+        "originating_envelope_ref": "counterparty_binding_origin_two_anchors",
+        "binding_result": null,
+        "binding_label": "unrecognised_scope",
+        "failure_class": "unverifiable"
+      },
+      "generation": {
+        "counterparty_digest_members": [
+          "payload",
+          "signature"
+        ]
+      },
+      "canonical": "{\"action_id\":\"act_counterparty_unrecognised_scope\",\"action_ref\":\"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"agent_id\":\"agt_acknowledger_B\",\"counterparty_binding\":{\"envelope_hash\":\"dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=\",\"expect_ack_from\":\"00000000000000000098\",\"receipt_ref\":\"asqav-receipt://org_demo/agt_originator_A/seq/0001\",\"scope\":\"unsupported_fixture_scope\",\"transport_label\":\"mcp\"},\"decision\":\"allow\",\"issued_at\":\"2026-05-18T20:00:01+00:00\",\"issuer_id\":\"00000000000000000098\",\"org_id\":\"org_demo\",\"payload_digest\":{\"hash\":\"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"size\":0},\"policy_digest\":\"sha256:aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888\",\"previousReceiptHash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"sandbox_state\":\"live\",\"tool_name\":\"database.query\",\"type\":\"protectmcp:acknowledgment\",\"v\":1}",
+      "sha256": "8f008eafa83e78228aa107d8d819d866f2ca94a017cdd01dd168ee2c19c2ad09"
     }
   ]
 }

--- a/python/src/asqav/client.py
+++ b/python/src/asqav/client.py
@@ -3614,8 +3614,8 @@ class ComplianceReceiptVerification:
     show the user which clause failed. Codes mirror the cloud's
     `validation_label` vocabulary in `routes/verify.py`.
 
-    `counterparty_binding_verified` is None when the receipt carries no
-    ``counterparty_binding`` field; True/False when the originating
+    `counterparty_binding_verified` is None when the binding is absent or its
+    scope/origin bytes are unavailable; True/False when the originating
     envelope was supplied and the recomputed digest was compared.
     """
 
@@ -3628,44 +3628,8 @@ class ComplianceReceiptVerification:
     counterparty_binding_verified: bool | None = None
 
 
-def verify_compliance_receipt(
-    envelope: dict[str, Any],
-    *,
-    predecessor_envelope: dict[str, Any] | None = None,
-    originating_envelope: dict[str, Any] | None = None,
-    now: float | None = None,
-) -> ComplianceReceiptVerification:
-    """Local sanity-check on a Compliance Receipt envelope: REQUIRED fields, namespace,
-    freshness skew, chain-link rederivation, and counterparty binding when supplied.
-    Cloud is authoritative for signature checks, policy_digest resolution, and anchors.
-    """
+def _compliance_receipt_skew(signed: dict[str, Any], now: float | None, errors: list[str]) -> bool:
     from datetime import datetime
-
-    from ._jcs import canonical_json
-    from .replay import FIRST_RECEIPT_SEED
-
-    errors: list[str] = []
-
-    # Canonical wire envelope {payload, signature, anchors}: the signed fields
-    # live inside the payload member; flat bundles keep them top-level.
-    _inner = envelope.get("payload")
-    if isinstance(_inner, dict) and ("signature" in envelope or "anchors" in envelope):
-        signed = _inner
-    else:
-        signed = envelope
-
-    # 1. REQUIRED fields present.
-    missing = [f for f in _COMPLIANCE_REQUIRED_FIELDS if f not in signed]
-    fields_present = not missing
-    if missing:
-        errors.append(f"missing_fields:{','.join(missing)}")
-
-    # 2. ``type`` namespace. Wire field is ``type``; ``receipt_type`` accepted too.
-    rt = signed.get("type") or signed.get("receipt_type")
-    receipt_type_in_namespace = rt in RECEIPT_TYPE_NAMESPACE
-    if not receipt_type_in_namespace:
-        errors.append("invalid_receipt_type")
-
     # 3. 300-second skew bound.
     issued_at = signed.get("issued_at") or signed.get("signed_at")
     skew_within_bound = False
@@ -3687,7 +3651,14 @@ def verify_compliance_receipt(
                 errors.append("signed_at_skew")
         except (ValueError, TypeError):
             errors.append("invalid_issued_at")
+    return skew_within_bound
 
+
+def _compliance_receipt_chain(
+    envelope: dict[str, Any], predecessor_envelope: dict[str, Any] | None, errors: list[str],
+) -> bool:
+    from ._jcs import canonical_json
+    from .replay import FIRST_RECEIPT_SEED
     # 4. Chain link rederives. Only checked when caller supplies the
     # predecessor envelope; first-record seeds skip this.
     chain_link_rederives = True
@@ -3709,62 +3680,38 @@ def verify_compliance_receipt(
             chain_link_rederives = False
             errors.append("chain_link_mismatch")
     # No predecessor supplied: leave chain_link_rederives=True (unchecked is not failed).
+    return chain_link_rederives
 
-    # 5. Conditional MUSTs: sandbox_state, reason on deny/rate_limit, anchors[].value.
-    _payload = signed
-    if isinstance(_payload, dict):
-        _sandbox = _payload.get("sandbox_state")
-        if _sandbox is not None and _sandbox not in SANDBOX_STATE_NAMESPACE:
-            errors.append("invalid_sandbox_state")
-        _decision = _payload.get("decision")
-        if _decision in {"deny", "rate_limit"} and not _payload.get("reason"):
-            errors.append("missing_reason_on_deny_or_rate_limit")
-    _anchors = envelope.get("anchors")
-    if isinstance(_anchors, list):
-        for _i, _entry in enumerate(_anchors):
-            if not isinstance(_entry, dict):
-                continue
-            if not _entry.get("value"):
-                errors.append(f"anchor_missing_value:{_i}")
 
+def _compliance_receipt_counterparty(
+    envelope: dict[str, Any], originating_envelope: dict[str, Any] | None, errors: list[str],
+) -> tuple[bool, bool | None]:
     counterparty_binding_verified: bool | None = None
     payload_obj = envelope.get("payload") if isinstance(envelope.get("payload"), dict) else envelope
-    has_binding = isinstance(payload_obj, dict) and isinstance(
-        payload_obj.get("counterparty_binding"), dict
-    )
-    if has_binding and originating_envelope is not None:
+    has_binding = isinstance(payload_obj, dict) and "counterparty_binding" in payload_obj
+    if has_binding:
         from .counterparty import verify_counterparty_binding
 
         binding_obj = payload_obj["counterparty_binding"]
         has_full_envelope = "payload" in envelope
-        expects_ack_kid = isinstance(binding_obj.get("expect_ack_from"), str)
-        if expects_ack_kid and not has_full_envelope:
+        ack_env = envelope if has_full_envelope else {"payload": payload_obj}
+        outcome = verify_counterparty_binding(ack_env, originating_envelope)
+        expects_ack_kid = (
+            isinstance(binding_obj, dict) and isinstance(binding_obj.get("expect_ack_from"), str)
+        )
+        if outcome.label == "kid_mismatch" and expects_ack_kid and not has_full_envelope:
             # Payload-only input cannot supply ``signature.kid``; surface a
             # clear outcome instead of a silent kid-axis false negative.
             counterparty_binding_verified = False
             errors.append("counterparty_binding_requires_full_envelope")
         else:
-            ack_env = envelope if has_full_envelope else {"payload": payload_obj}
-            outcome = verify_counterparty_binding(ack_env, originating_envelope)
             counterparty_binding_verified = outcome.valid
             if not outcome.valid:
                 errors.append(f"counterparty_binding_{outcome.label}")
+    return has_binding, counterparty_binding_verified
 
-    # Reject a malformed authorized_under_mandate (lockstep with false_mandate_attestation_guard).
-    if isinstance(_payload, dict):
-        _aum = _payload.get("authorized_under_mandate")
-        if _aum is not None:
-            _scope_digest = _aum.get("scope_digest") if isinstance(_aum, dict) else None
-            if (
-                not isinstance(_aum, dict)
-                or not _aum.get("mandate_id")
-                or not _aum.get("issuer_id")
-                or _aum.get("verified") is not True
-                or not isinstance(_scope_digest, str)
-                or not _SHA256_HEX_RE.match(_scope_digest)
-            ):
-                errors.append("false_mandate_attestation_guard")
 
+def _compliance_receipt_controls(_payload: dict[str, Any], errors: list[str]) -> None:
     # Reject a malformed controls_evaluated (lockstep with false_control_attestation_guard).
     if isinstance(_payload, dict):
         _ce = _payload.get("controls_evaluated")
@@ -3796,6 +3743,86 @@ def verify_compliance_receipt(
                     ):
                         errors.append("false_control_attestation_guard")
 
+
+def _compliance_receipt_mandate(_payload: dict[str, Any], errors: list[str]) -> None:
+    # Reject a malformed authorized_under_mandate (lockstep with false_mandate_attestation_guard).
+    if isinstance(_payload, dict):
+        _aum = _payload.get("authorized_under_mandate")
+        if _aum is not None:
+            _scope_digest = _aum.get("scope_digest") if isinstance(_aum, dict) else None
+            if (
+                not isinstance(_aum, dict)
+                or not _aum.get("mandate_id")
+                or not _aum.get("issuer_id")
+                or _aum.get("verified") is not True
+                or not isinstance(_scope_digest, str)
+                or not _SHA256_HEX_RE.match(_scope_digest)
+            ):
+                errors.append("false_mandate_attestation_guard")
+
+
+def verify_compliance_receipt(
+    envelope: dict[str, Any],
+    *,
+    predecessor_envelope: dict[str, Any] | None = None,
+    originating_envelope: dict[str, Any] | None = None,
+    now: float | None = None,
+) -> ComplianceReceiptVerification:
+    """Local sanity-check on a Compliance Receipt envelope: REQUIRED fields, namespace,
+    freshness skew, chain-link rederivation, and counterparty binding when supplied.
+    Cloud is authoritative for signature checks, policy_digest resolution, and anchors.
+    """
+    errors: list[str] = []
+
+    # Canonical wire envelope {payload, signature, anchors}: the signed fields
+    # live inside the payload member; flat bundles keep them top-level.
+    _inner = envelope.get("payload")
+    if isinstance(_inner, dict) and ("signature" in envelope or "anchors" in envelope):
+        signed = _inner
+    else:
+        signed = envelope
+
+    # 1. REQUIRED fields present.
+    missing = [f for f in _COMPLIANCE_REQUIRED_FIELDS if f not in signed]
+    fields_present = not missing
+    if missing:
+        errors.append(f"missing_fields:{','.join(missing)}")
+
+    # 2. ``type`` namespace. Wire field is ``type``; ``receipt_type`` accepted too.
+    rt = signed.get("type") or signed.get("receipt_type")
+    receipt_type_in_namespace = rt in RECEIPT_TYPE_NAMESPACE
+    if not receipt_type_in_namespace:
+        errors.append("invalid_receipt_type")
+
+    skew_within_bound = _compliance_receipt_skew(signed, now, errors)
+
+    chain_link_rederives = _compliance_receipt_chain(envelope, predecessor_envelope, errors)
+
+    # 5. Conditional MUSTs: sandbox_state, reason on deny/rate_limit, anchors[].value.
+    _payload = signed
+    if isinstance(_payload, dict):
+        _sandbox = _payload.get("sandbox_state")
+        if _sandbox is not None and _sandbox not in SANDBOX_STATE_NAMESPACE:
+            errors.append("invalid_sandbox_state")
+        _decision = _payload.get("decision")
+        if _decision in {"deny", "rate_limit"} and not _payload.get("reason"):
+            errors.append("missing_reason_on_deny_or_rate_limit")
+    _anchors = envelope.get("anchors")
+    if isinstance(_anchors, list):
+        for _i, _entry in enumerate(_anchors):
+            if not isinstance(_entry, dict):
+                continue
+            if not _entry.get("value"):
+                errors.append(f"anchor_missing_value:{_i}")
+
+    has_binding, counterparty_binding_verified = _compliance_receipt_counterparty(
+        envelope, originating_envelope, errors,
+    )
+
+    _compliance_receipt_mandate(_payload, errors)
+
+    _compliance_receipt_controls(_payload, errors)
+
     # Conditional-MUST failures surface through `errors` and `valid` only (no per-axis flag).
     _conditional_must_fail = any(
         e.startswith(
@@ -3815,7 +3842,7 @@ def verify_compliance_receipt(
         and skew_within_bound
         and chain_link_rederives
         and not _conditional_must_fail
-        and (counterparty_binding_verified is not False)
+        and (not has_binding or counterparty_binding_verified is True)
     )
     return ComplianceReceiptVerification(
         valid=valid,

--- a/python/tests/test_corpus_integrity.py
+++ b/python/tests/test_corpus_integrity.py
@@ -57,6 +57,11 @@ def _vectors() -> dict[str, dict]:
 #: SHA-256 of each vector's canonical bytes, verbatim from the published file.
 #: Pinning this pins ``canonical`` transitively: no other byte string has this digest.
 PINNED_SHA256 = {
+    "counterparty_binding_origin_two_anchors": "36e5256c3940a777eb4e4fc6b08fcb31f1e5a352c82736aa7b32578980b5e9b4",
+    "counterparty_binding_scope_minus_anchors": "e6a6b09958c64686de4ef7dd2494690ee0ed7d039da92e2e78b550190d5fe931",
+    "counterparty_binding_anchors_included_rejected": "85004158dcf9345ef58eed4178bbfea481a38f0b8cb2a1970785d892980695dc",
+    "counterparty_binding_legacy_scope_absent": "9ea6a8cfad32136b496f8aff707dedf53e40f7bc13499f23d8acf598ced6e945",
+    "counterparty_binding_unrecognised_scope": "8f008eafa83e78228aa107d8d819d866f2ca94a017cdd01dd168ee2c19c2ad09",
     "minimal_read": "991033e23a3e0939c258e10f2f8f88183d9bcdb08de62ef02446e11e0819c671",
     "tool_call_with_counterparty":
         "a6c39c3b6e09761a141148c0862edbeaeb59642b4e0a1e4a85d6fba63f634ff4",
@@ -89,7 +94,7 @@ PINNED_SHA256 = {
     "counterparty_binding_transport_label_non_trust":
         "58c787ae9c9e9ed9bf4aeaab066f1a3c6eadade8bc5db0a4d60542390ec7097d",
     "counterparty_binding_missing_envelope_hash_rejected":
-        "6fee77a7aa44a4f17c0df1830ad520c2679e581e9b4fa24693b62fa7c11b9b4d",
+        "fdf867b3c2cc86acd1423818ce4b56e8e0f17b5a4ce1862444dd67f7cbbe7ed3",
     "receipt_v2_signer_canary": "dbb9fa8b319830814d2e6cc5b9c6a33f9c8f45e3223f75096d9c520aa9be55d4",
     "asqav-24-jcs-astral-key-order":
         "425159f5c1f0575fbcbf9d05a8f60cde3d040eae5166aa2136657564048651b6",
@@ -104,6 +109,11 @@ PINNED_SHA256 = {
 #: Length of each canonical string, so a published ``canonical`` cannot be swapped
 #: for a different one that happens to carry the pinned digest in its ``sha256``.
 PINNED_CANONICAL_LENGTH = {
+    "counterparty_binding_origin_two_anchors": 985,
+    "counterparty_binding_scope_minus_anchors": 912,
+    "counterparty_binding_anchors_included_rejected": 918,
+    "counterparty_binding_legacy_scope_absent": 879,
+    "counterparty_binding_unrecognised_scope": 914,
     "minimal_read": 40,
     "tool_call_with_counterparty": 212,
     "traced_child_action": 130,
@@ -123,7 +133,7 @@ PINNED_CANONICAL_LENGTH = {
     "counterparty_binding_base64url_tolerance": 830,
     "counterparty_binding_opaque_receipt_ref": 836,
     "counterparty_binding_transport_label_non_trust": 855,
-    "counterparty_binding_missing_envelope_hash_rejected": 734,
+    "counterparty_binding_missing_envelope_hash_rejected": 767,
     "receipt_v2_signer_canary": 873,
     "asqav-24-jcs-astral-key-order": 13,
     "asqav-24-jcs-astral-key-order-codepoint-rejected": 13,
@@ -134,6 +144,10 @@ PINNED_CANONICAL_LENGTH = {
 #: The wire ``counterparty_binding.envelope_hash`` string, exactly as published,
 #: in the alphabet each vector exercises.
 PINNED_ENVELOPE_HASH = {
+    "counterparty_binding_scope_minus_anchors": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+    "counterparty_binding_anchors_included_rejected": "NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=",
+    "counterparty_binding_legacy_scope_absent": "NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=",
+    "counterparty_binding_unrecognised_scope": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
     "counterparty_binding_happy_path": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
     "counterparty_binding_base64url_tolerance": "dXqDdpt_tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
     "counterparty_binding_opaque_receipt_ref": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
@@ -143,6 +157,26 @@ PINNED_ENVELOPE_HASH = {
 
 #: The non-wire renderings of the same digest carried under ``expected``.
 PINNED_ENVELOPE_HASH_RENDERINGS = {
+    "counterparty_binding_scope_minus_anchors": {
+        "envelope_hash_base64": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+        "envelope_hash_hex": "757a83769b7fb4163b20b30931ccd8c3ab31f2f3e6402157311f16dc00d6d9ef"
+    },
+    "counterparty_binding_anchors_included_rejected": {
+        "envelope_hash_base64": "NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=",
+        "envelope_hash_hex": "36e5256c3940a777eb4e4fc6b08fcb31f1e5a352c82736aa7b32578980b5e9b4"
+    },
+    "counterparty_binding_legacy_scope_absent": {
+        "envelope_hash_base64": "NuUlbDlAp3frTk/GsI/LMfHlo1LIJzaqezJXiYC16bQ=",
+        "envelope_hash_hex": "36e5256c3940a777eb4e4fc6b08fcb31f1e5a352c82736aa7b32578980b5e9b4"
+    },
+    "counterparty_binding_unrecognised_scope": {
+        "envelope_hash_base64": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+        "envelope_hash_hex": "757a83769b7fb4163b20b30931ccd8c3ab31f2f3e6402157311f16dc00d6d9ef"
+    },
+    "counterparty_binding_origin_two_anchors": {
+        "envelope_hash_base64": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
+        "envelope_hash_base64url": "dXqDdpt_tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8="
+    },
     "counterparty_binding_happy_path": {
         "envelope_hash_base64": "dXqDdpt/tBY7ILMJMczYw6sx8vPmQCFXMR8W3ADW2e8=",
         "envelope_hash_hex": "757a83769b7fb4163b20b30931ccd8c3ab31f2f3e6402157311f16dc00d6d9ef"
@@ -320,9 +354,12 @@ def test_every_counterparty_digest_declares_its_scope() -> None:
     for name, vector in _vectors().items():
         binding = vector.get("input", {}).get("counterparty_binding")
         if isinstance(binding, dict) and "envelope_hash" in binding:
-            assert binding.get("scope") == "envelope_minus_anchors", (
-                f"{name}: carries an envelope_hash with no declared scope"
-            )
+            if name == "counterparty_binding_legacy_scope_absent":
+                assert "scope" not in binding  # Named historical absence fixture.
+            elif name == "counterparty_binding_unrecognised_scope":
+                assert binding["scope"] == "unsupported_fixture_scope"  # Named unsupported-scope fixture.
+            else:
+                assert binding.get("scope") == "envelope_minus_anchors", name
 
 
     # Every derived digest must name the envelope it was taken over, so the corpus is

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -23,8 +23,8 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
-FINGERPRINT_LOCK_DIGEST = "ad2c44c61cf2191cfe628b0628aa4e3ce560dba33be9e83bc584b57606ffdfbc"
-VERIFIER_LOCK_DIGEST = "654725d071c89dc1104e6201d91eaa85a0fdce93b5e5b56eff2b054c08cae3b1"
+FINGERPRINT_LOCK_DIGEST = "9b7b9886158f1b833660b4b43130bfb7907d5753cbb08b270d632b2454a99a8e"
+VERIFIER_LOCK_DIGEST = "b3d177b60535b846f0fe48ab1606a0295ae691d5463e7129fbb4856e2c3935b0"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -23,8 +23,8 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
-FINGERPRINT_LOCK_DIGEST = "9b7b9886158f1b833660b4b43130bfb7907d5753cbb08b270d632b2454a99a8e"
-VERIFIER_LOCK_DIGEST = "b3d177b60535b846f0fe48ab1606a0295ae691d5463e7129fbb4856e2c3935b0"
+FINGERPRINT_LOCK_DIGEST = "e6e6946274551752412cd4bc6ada7f4739e9ae495e4594639a2eec4de87039ed"
+VERIFIER_LOCK_DIGEST = "4d9a4eeb0c7a6ab77c40583c2f915b65c1b00159891d19a6802c9677abf9fcc6"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_counterparty_scope_outcomes.py
+++ b/python/tests/test_counterparty_scope_outcomes.py
@@ -248,3 +248,14 @@ def test_acknowledging_kid_names_the_resolved_signing_key(kid, status, capsys):
     mark = "  ok" if status == "PASS" else "FAIL"
     assert f"[{mark}] counterparty" in output
 
+
+@pytest.mark.parametrize("binding,label", [({}, "legacy_scope"), ({"scope": None}, "unrecognised_scope"),
+                                           ({"scope": "other"}, "unrecognised_scope")])
+def test_client_unknown_binding_blocks_overall_pass_without_origin(binding, label):
+    from asqav.client import verify_compliance_receipt
+    receipt, _, _ = fixture()
+    receipt["payload"]["counterparty_binding"] = binding
+    result = verify_compliance_receipt(receipt)
+    assert result.counterparty_binding_verified is None
+    assert result.valid is False
+    assert f"counterparty_binding_{label}" in result.errors

--- a/python/tests/test_counterparty_vector_regeneration.py
+++ b/python/tests/test_counterparty_vector_regeneration.py
@@ -1,0 +1,65 @@
+"""Regeneration preserves authored negative recipes and signed fixture bytes."""
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from asqav.counterparty import verify_counterparty_binding
+from asqav.verifier.verify_receipt import check_counterparty_binding
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def module(name):
+    spec = importlib.util.spec_from_file_location(name, ROOT / "verifier" / f"{name}.py")
+    result = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(result)
+    return result
+
+
+def test_fingerprint_regeneration_preserves_negative_scope_and_digest_recipes():
+    regen = module("regen_fingerprint_vectors")
+    original = json.loads((ROOT / "conformance/vectors.json").read_text())
+    doc = copy.deepcopy(original)
+    assert regen.regenerate(doc) == []
+    assert doc == original
+    vectors = {v["name"]: v for v in doc["vectors"]}
+    checked = []
+    for vector in vectors.values():
+        expected = vector.get("expected", {})
+        if "binding_result" not in expected:
+            continue
+        origin = vectors[expected["originating_envelope_ref"]]["input"]
+        ack = {"payload": vector["input"], "signature": {"kid": vector["input"]["issuer_id"]}}
+        result = verify_counterparty_binding(ack, origin)
+        assert result.valid is expected["binding_result"]
+        assert result.label == expected["binding_label"]
+        state, note = check_counterparty_binding(vector["input"], origin)
+        assert state == {True: "PASS", False: "FAIL", None: "SKIPPED"}[result.valid], note
+        checked.append(vector["name"])
+    assert set(checked) == {"counterparty_binding_scope_minus_anchors", "counterparty_binding_anchors_included_rejected",
+                            "counterparty_binding_legacy_scope_absent", "counterparty_binding_unrecognised_scope"}
+
+
+def test_signed_generator_is_deterministic_and_check_never_writes(tmp_path, monkeypatch):
+    generator = module("generate_counterparty_vectors")
+    files = generator.generated_files()
+    assert files == generator.generated_files()
+    for path, text in files.items():
+        assert path.read_text() == text, path
+    monkeypatch.setattr(generator, "ROOT", tmp_path)
+    monkeypatch.setattr(generator, "CORPUS", tmp_path / "verifier" / "conformance-vectors")
+    monkeypatch.setattr(sys, "argv", ["generate_counterparty_vectors.py"])
+    assert generator.main() == 0
+    target = next(path for path in generator.generated_files() if path.name == "receipt.json")
+    target.write_text("{\"drift\":true}\n")
+    before = {p: p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    monkeypatch.setattr(sys, "argv", ["generate_counterparty_vectors.py", "--check"])
+    assert generator.main() == 1
+    assert {p: p.read_bytes() for p in before} == before
+    monkeypatch.setattr(sys, "argv", ["generate_counterparty_vectors.py"])
+    assert generator.main() == 0
+    monkeypatch.setattr(sys, "argv", ["generate_counterparty_vectors.py", "--check"])
+    assert generator.main() == 0

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from asqav.verifier.oracle import VerificationContext
 from asqav.verifier.oracle import ADAPTERS, crypto, verify
 from asqav.verifier.oracle.adapters.aerf import AerfAdapter
 from asqav.verifier.oracle.adapters.agentreceipts import AgentReceiptsAdapter
@@ -240,7 +241,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 81
+    assert len(results) == 85
     # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (
@@ -1189,7 +1190,8 @@ def test_every_vector_reports_its_pinned_first_bad_edge() -> None:
             got = "__ingest_error__"
         else:
             got = verify(
-                receipt, ADAPTERS, key_provider=key_provider, predecessor=predecessor
+                receipt, ADAPTERS, key_provider=key_provider, predecessor=predecessor,
+                context=VerificationContext(_runner_load(vec / "originating_envelope.json")),
             ).first_failing_edge
         want = table[entry["dir"]]
         if got != want:
@@ -1219,6 +1221,7 @@ def test_an_edge_is_named_for_exactly_the_unverified_verdicts() -> None:
                 ADAPTERS,
                 key_provider=_runner_key_provider(vec, entry["format"]),
                 predecessor=_runner_load(vec / "predecessor.json"),
+                context=VerificationContext(_runner_load(vec / "originating_envelope.json")),
             )
         except Exception:
             continue  # terminal at ingest; never produces a VerifyResult
@@ -1248,6 +1251,7 @@ def test_the_named_edge_is_an_axis_the_report_actually_carries() -> None:
                 ADAPTERS,
                 key_provider=_runner_key_provider(vec, entry["format"]),
                 predecessor=_runner_load(vec / "predecessor.json"),
+                context=VerificationContext(_runner_load(vec / "originating_envelope.json")),
             )
         except Exception:
             continue

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -36,7 +36,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 81 corpus vectors", () => {
+  it("matches every manifest outcome across all 85 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -53,9 +53,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(81);
+    expect(results.length).toBe(85);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(81);
+    expect(passed).toBe(85);
   });
 
   it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {

--- a/verifier/conformance-vectors/README.md
+++ b/verifier/conformance-vectors/README.md
@@ -12,6 +12,7 @@ manifest.json                  array of {dir, format, outcome, failure_class, re
   receipt.json                 the receipt under test
   expected.json                {format, outcome, failure_class, reason_code, notes}
   predecessor.json             (chain vectors only) the prior receipt
+  originating_envelope.json    (counterparty vectors) full originating envelope
   jwks.json                    (asqav-native) issuer key directory
   keys.json                    (aerf) {key_id: ed25519_pubkey_hex}
   acta-keys.json               (acta) JWKS-shaped key set
@@ -110,6 +111,15 @@ python -m oracle.runner          # from the verifier/ directory
   rejects the duplicate at parse time (criterion 419).
 - `w3c-vc-08-didkey-happy-path` - a did:key issuer self-resolves inline from
   the multicodec frame; no key file needed.
+
+`asqav-31` through `asqav-34` cover four cases: a matching counterparty binding;
+an incorrect three-key digest; a missing scope member; and a scope this profile
+does not define. Each acknowledgment
+has a valid signature and timestamp. Both runners pass the full
+`originating_envelope.json` through a context local to the verification call.
+Regenerate these fixtures with `python verifier/generate_counterparty_vectors.py`;
+its `--check` option reports drift without writing files. The generator signs the
+deliberate defects as authored, so the negative outcomes survive regeneration.
 
 The keys are generated from fixed seeds so the vectors are reproducible. AERF
 public keys are derived per spec as the first 16 hex of `SHA-256(pubkey)`.

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -605,5 +605,36 @@
     "outcome": "verified",
     "reason_code": "",
     "notes": "Two pre-action receipts carry the same invocation_ref: the duplicate-emission shape a harness produces when it fires the hook twice for one invocation. Both receipts verify, because invocation_ref exists so a reader can SEE the duplicate, never to reject it. A verifier that refuses this pair is wrong, not strict."
+  },
+  {
+    "dir": "asqav-31-counterparty-scope-match",
+    "format": "asqav-native",
+    "outcome": "verified",
+    "reason_code": "",
+    "notes": "Signed acknowledgment with binding result matches; signature and local TSA verify."
+  },
+  {
+    "dir": "asqav-32-counterparty-anchors-included",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "reason_code": "counterparty_mismatch",
+    "notes": "Signed acknowledgment with binding result mismatch; signature and local TSA verify.",
+    "failure_class": "invalid"
+  },
+  {
+    "dir": "asqav-33-counterparty-scope-absent",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "reason_code": "counterparty_legacy_scope",
+    "notes": "Signed acknowledgment with binding result legacy_scope; signature and local TSA verify.",
+    "failure_class": "unverifiable"
+  },
+  {
+    "dir": "asqav-34-counterparty-scope-unknown",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "reason_code": "counterparty_unrecognised_scope",
+    "notes": "Signed acknowledgment with binding result unrecognised_scope; signature and local TSA verify.",
+    "failure_class": "unverifiable"
   }
 ]

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-verifier-conformance-vectors",
-  "corpus_version": 25,
+  "corpus_version": 26,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -128,13 +128,18 @@
       "version": 24,
       "files": 300,
       "digest": "3b003d4b4a6a3a8fa4a3d2ec1f17fb60805fbdbea441102238a87483ab3b2f99"
+    },
+    {
+      "version": 25,
+      "files": 300,
+      "digest": "654725d071c89dc1104e6201d91eaa85a0fdce93b5e5b56eff2b054c08cae3b1"
     }
   ],
   "files": [
     {
       "path": "README.md",
-      "sha256": "69a8a270ca655b3e8f5cf8f1237ca43f257871169558f28443f5747d3aa76eb3",
-      "bytes": 8964
+      "sha256": "554a4675eb2677c8e86381eca1151d56ccee1c9064149f49480431a101c4186f",
+      "bytes": 9594
     },
     {
       "path": "UPSTREAM.md",
@@ -1488,8 +1493,8 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "7d0cf18a4e47eebb024f2360efbe50b5c5b5fcc5042459d0ab578d8489a30d9c",
-      "bytes": 28529
+      "sha256": "6a1abdfca7dd49981dc64fb6a123992244ea61bc11993be3e4044a973fc27960",
+      "bytes": 29683
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
@@ -1662,5 +1667,5 @@
       ]
     }
   },
-  "digest": "654725d071c89dc1104e6201d91eaa85a0fdce93b5e5b56eff2b054c08cae3b1"
+  "digest": "b3d177b60535b846f0fe48ab1606a0295ae691d5463e7129fbb4856e2c3935b0"
 }

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -138,8 +138,8 @@
   "files": [
     {
       "path": "README.md",
-      "sha256": "554a4675eb2677c8e86381eca1151d56ccee1c9064149f49480431a101c4186f",
-      "bytes": 9594
+      "sha256": "fb73ce26100a518109a829095dd46e7e506121ddd15f1fd9c56664bcaa4bcee7",
+      "bytes": 9629
     },
     {
       "path": "UPSTREAM.md",
@@ -1667,5 +1667,5 @@
       ]
     }
   },
-  "digest": "b3d177b60535b846f0fe48ab1606a0295ae691d5463e7129fbb4856e2c3935b0"
+  "digest": "4d9a4eeb0c7a6ab77c40583c2f915b65c1b00159891d19a6802c9677abf9fcc6"
 }

--- a/verifier/first-bad-edge-cases.json
+++ b/verifier/first-bad-edge-cases.json
@@ -82,6 +82,10 @@
     "asqav-35-invocation-ref-binds-pre-post": null,
     "asqav-36-invocation-ref-duplicate-emission": null,
     "acta-06-chain-link-03-prefixed": null,
-    "acta-07-chain-link-03-wrong-digest": "chain"
+    "acta-07-chain-link-03-wrong-digest": "chain",
+    "asqav-31-counterparty-scope-match": null,
+    "asqav-32-counterparty-anchors-included": "counterparty",
+    "asqav-33-counterparty-scope-absent": "counterparty",
+    "asqav-34-counterparty-scope-unknown": "counterparty"
   }
 }

--- a/verifier/regen_fingerprint_vectors.py
+++ b/verifier/regen_fingerprint_vectors.py
@@ -29,8 +29,8 @@ Derived members this script owns, per vector:
 * ``sha256``     - SHA-256 of those bytes, hex
 * ``input.counterparty_binding.envelope_hash`` and the ``expected``
   ``envelope_hash_*`` renderings - the digest of the ORIGINATING envelope named
-  by ``expected.originating_envelope_ref``, taken under the scope declared in
-  ``input.counterparty_binding.scope``
+  by ``expected.originating_envelope_ref``, using the independent
+  ``generation.counterparty_digest_members`` recipe (two members by default)
 
 Everything else in a vector is authored, not derived, and is left untouched.
 
@@ -52,10 +52,6 @@ from typing import Any
 _HERE = Path(__file__).resolve().parent
 _ROOT = _HERE.parent
 VECTORS_PATH = _ROOT / "conformance" / "vectors.json"
-
-#: The only counterparty digest scope this revision emits. An absent scope member
-#: means a legacy -04..-08 three-key binding and is reported, never silently retried.
-SCOPE_MINUS_ANCHORS = "envelope_minus_anchors"
 
 #: Envelope members the minus-anchors scope covers, in the order the draft states them.
 MINUS_ANCHORS_MEMBERS = ("payload", "signature")
@@ -92,14 +88,14 @@ def _serialize(obj: Any) -> str:
     raise TypeError(f"not canonicalizable: {type(obj).__name__}")
 
 
-def envelope_digest(envelope: dict[str, Any], scope: str) -> bytes:
-    """Raw SHA-256 of the originating envelope under ``scope``."""
-    if scope != SCOPE_MINUS_ANCHORS:
-        raise ValueError(f"unknown counterparty binding scope: {scope!r}")
-    missing = [m for m in MINUS_ANCHORS_MEMBERS if m not in envelope]
+def envelope_digest(envelope: dict[str, Any], members: tuple[str, ...]) -> bytes:
+    """A fixture recipe is separate from the scope assertion carried on its wire."""
+    if members not in (MINUS_ANCHORS_MEMBERS, ("payload", "signature", "anchors")):
+        raise ValueError(f"unknown counterparty digest recipe: {members!r}")
+    missing = [m for m in members if m not in envelope]
     if missing:
         raise ValueError(f"originating envelope is missing {missing}")
-    scoped = {m: envelope[m] for m in MINUS_ANCHORS_MEMBERS}
+    scoped = {m: envelope[m] for m in members}
     return hashlib.sha256(canonical_json(scoped)).digest()
 
 
@@ -131,13 +127,13 @@ def regenerate(doc: dict) -> list[str]:
             raise KeyError(f"{vector['name']}: originating_envelope_ref {ref!r} names no vector")
 
         binding = vector.get("input", {}).get("counterparty_binding")
+        members = tuple(vector.get("generation", {}).get("counterparty_digest_members", MINUS_ANCHORS_MEMBERS))
+        digest = envelope_digest(origin["input"], members)
         if not isinstance(binding, dict) or "envelope_hash" not in binding:
             # A vector that deliberately omits envelope_hash still names its origin
             # so the renderings below stay derivable; nothing to re-pin on the wire.
-            digest = envelope_digest(origin["input"], SCOPE_MINUS_ANCHORS)
+            pass
         else:
-            scope = binding.get("scope", SCOPE_MINUS_ANCHORS)
-            digest = envelope_digest(origin["input"], scope)
             # The wire value keeps whichever alphabet the vector is exercising.
             old_hash = binding["envelope_hash"]
             urlsafe = "-" in old_hash or "_" in old_hash


### PR DESCRIPTION
## Summary
- Register the four counterparty vectors in the shared corpus manifest so the cross-language harness runs them, extend the canonicalization corpus with five counterparty binding cases, and tighten client-side binding validation.

## Why this replaces #488
The two counterparty changes ahead of this one landed squashed, so the original branch still carries their pre-squash ancestry and a merge reconciles the same content twice. This branch is main plus this change alone, applied as a single commit. The original branch is left untouched.

## Resolutions
- `verifier/conformance-vectors/manifest.json` composed as a union: the shared base held 79 entries, main appended `asqav-35` and `asqav-36`, this change appends `asqav-31` through `asqav-34`, and the entries are disjoint. The manifest holds 85, so the two corpus-count assertions move to 85 as well. Neither side's own figure was correct.
- `conformance/vectors.json` composed, keeping main's corrected safe-range boundary value and adding the five counterparty cases. `regen_fingerprint_vectors.py` reports the result consistent with no change, which confirms every derived member matches its input.
- Both locks regenerated from main's copies: the fingerprint lock advances to rolling version 11 and the verifier lock to 26, with the pin pair-updated.

## Verification
- Both corpus-lock paths green.
- Oracle corpus runs 85 with 84 exact matches and the one documented tolerated difference.
- Full Python suite: 3431 passed, with only the four standalone tests that fail in this sandbox for environmental reasons.

https://claude.ai/code/session_017PQ2FTpuRPvWapqFkv3hk5