### PR TITLE
test: enforce five-engine counterparty parity and document the input contract

### DIFF
--- a/docs/offline-verification.md
+++ b/docs/offline-verification.md
@@ -128,6 +128,64 @@ if (result.verdict !== "verified" && result.verdict !== "verified_keyed") {
 }
 ```
 
+## Counterparty bindings
+
+Supply the complete originating signing envelope to check an acknowledgment's byte
+commitment. Python accepts `originating_envelope` as a keyword; TypeScript accepts it
+after the predecessor argument. Both APIs keep this input within the verification call.
+
+```python
+result = asqav.verify_receipt_offline(
+    receipt, jwks, originating_envelope=originating_envelope,
+)
+```
+
+```typescript
+const result = verifyReceiptOffline(receipt, jwksSaved, null, originatingEnvelope);
+```
+
+The standalone CLI accepts `--counterparty originating-envelope.json`. Direct oracle
+callers pass `VerificationContext(originating_envelope=...)` in Python, or a context
+with `originatingEnvelope` in TypeScript.
+
+The `envelope_minus_anchors` scope hashes JCS UTF-8 of exactly `{payload, signature}`.
+It preserves every signature member and the signature string's spelling. Anchors and
+export metadata can change without changing this commitment. Re-encoding the signature
+string can change it, even when the decoded signature bytes stay equal.
+
+| Binding evidence | Binding result | Failure class if other checks pass |
+|---|---|---|
+| Matching digest and expected acknowledging `signature.kid` | `matches` | none |
+| Digest or acknowledging kid differs | `mismatch` or `kid_mismatch` | `invalid` |
+| Scope is absent | `legacy_scope` | `unverifiable` |
+| Scope is null or unsupported | `unrecognised_scope` | `unverifiable` |
+| Supported scope, origin bytes unavailable | `unresolved` | `unverifiable` |
+| Malformed binding or required digest/reference | `malformed` | `invalid` |
+
+The scope check runs before origin lookup or hashing. An absent binding has no effect
+on verification. An applicable unknown binding blocks a pass; a demonstrated integrity
+failure on another axis still makes the overall result `invalid`.
+
+For hosted signing, build the binding from the envelope supplied by the peer:
+
+```python
+from asqav.counterparty import compute_counterparty_binding
+
+binding = compute_counterparty_binding(
+    originating_envelope, receipt_ref=originating_signature_id,
+).to_wire()
+```
+
+Pass the originating `signature_id` explicitly. The helper's `payload.action_id`
+fallback is an opaque offline reference; the signing endpoint resolves `signature_id`.
+The redacted public verification response does not supply the original signing bytes.
+The server admits a binding only after resolving a visible compliance receipt and
+recomputing the digest. Manually constructed bindings acquire no scope by default.
+
+These checks establish byte equality. They do not independently verify the origin's
+signature, fetch an origin over the network, or add anchor verification to the public
+offline APIs. Evaluate those trust inputs separately.
+
 ## Anchor binding and clock skew
 
 `verify_receipt_offline` / `verifyReceiptOffline` cover structure, signature and the
@@ -243,4 +301,3 @@ is reported on the signature axis as the pre-cutover dialect and the verdict sta
 `unverified`. A receipt issued after the cutover gets no such retry. No production receipt
 issued before the cutover carries such a member name (measured over the whole ledger on
 2026-09-02), so the diagnostic exists for completeness rather than for live data.
-

--- a/python/tests/test_differential_fuzz.py
+++ b/python/tests/test_differential_fuzz.py
@@ -124,3 +124,51 @@ def test_gate_detects_a_code_point_sorting_standalone_verifier(monkeypatch: pyte
         "the fuzz gate passed a standalone verifier sorting by code point; it has no bite"
     )
 
+
+@pytest.mark.parametrize("missing", sorted(fuzz.REQUIRED_ENGINES))
+def test_binding_gate_refuses_any_missing_engine(monkeypatch, missing):
+    monkeypatch.setattr(fuzz, "engines_available", lambda: sorted(fuzz.REQUIRED_ENGINES - {missing}))
+    with pytest.raises(RuntimeError, match="five binding engines required"):
+        fuzz.run_bindings(1, 0)
+
+
+def test_binding_gate_refuses_empty_cases(monkeypatch):
+    monkeypatch.setattr(fuzz, "engines_available", lambda: sorted(fuzz.REQUIRED_ENGINES))
+    monkeypatch.setattr(fuzz, "cloud_binding_check", lambda *args: (True, "matches"))
+    with pytest.raises(RuntimeError, match="nonzero count"):
+        fuzz.run_bindings(0, 0)
+
+
+def test_binding_case_expectations_cover_all_three_states():
+    cases = fuzz.binding_cases(2, 0)
+    assert {c["name"] for c in cases} == set(fuzz.BINDING_CASES)
+    assert {c["expected"][0] for c in cases} == {True, False, None}
+
+
+def test_standalone_state_cannot_be_erased_by_its_note(monkeypatch):
+    monkeypatch.setattr(fuzz, "check_counterparty_binding", lambda *args, **kwargs: ("PASS", "legacy_scope: wrong pass"))
+    case = next(c for c in fuzz.binding_cases(1, 0) if c["name"] == "scope_absent")
+    assert fuzz._standalone_binding(case) == (True, "legacy_scope")
+
+
+def test_five_binding_engines_agree_with_expected_outcomes():
+    if fuzz.cloud_binding_check is None:
+        pytest.skip("The public SDK checkout has no private cloud source; the mandatory joint-workspace CLI requires all five engines")
+    report = fuzz.run_bindings(50, 0)
+    assert set(report["engines"]) == fuzz.REQUIRED_ENGINES
+    assert set(report["counts"]) == set(fuzz.BINDING_CASES)
+    assert all(count > 0 for count in report["counts"].values())
+    assert not report["divergences"], report["divergences"][:1]
+
+
+def test_binding_gate_compares_agreement_to_expected_outcome(monkeypatch):
+    if fuzz.cloud_binding_check is None:
+        pytest.skip("This differential guard proof requires the private cloud source")
+    cases = fuzz.binding_cases(1, 0)
+    changed = next(case for case in cases if case["name"] == "scope_absent")
+    assert changed["expected"] == (None, "legacy_scope")
+    changed["expected"] = (True, "matches")
+    monkeypatch.setattr(fuzz, "binding_cases", lambda *args: cases)
+    report = fuzz.run_bindings(1, 0)
+    assert [item["case"]["name"] for item in report["divergences"]] == ["scope_absent"]
+    assert {engine["valid"] for engine in report["divergences"][0]["engines"].values()} == {None}

--- a/verifier/differential_fuzz.py
+++ b/verifier/differential_fuzz.py
@@ -20,11 +20,15 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import base64
+import copy
+import hashlib
 import json
 import random
 import subprocess
 import sys
 import tempfile
+from collections import Counter
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
@@ -32,13 +36,26 @@ sys.path.insert(0, str(_ROOT / "python" / "src"))
 
 from asqav._jcs import canonical_json as sdk_canonical  # noqa: E402
 from asqav.verifier.verify_receipt import canonical_json as standalone_canonical  # noqa: E402
+from asqav.counterparty import compute_envelope_hash, verify_counterparty_binding  # noqa: E402
+from asqav.verifier.verify_receipt import _envelope_hash, check_counterparty_binding  # noqa: E402
 
     # The cloud emitter is optional: this repo does not depend on the platform.
 try:
     sys.path.insert(0, str(_ROOT.parent / "asqav" / "src"))
     from asqav_cloud.core.canonical import canonical_json as cloud_canonical
+    from asqav_cloud.core.envelope import compute_envelope_hash as cloud_binding_hash
+    from asqav_cloud.core.envelope import verify_counterparty_binding as cloud_binding_check
 except Exception:  # pragma: no cover - exercised only outside the workspace
     cloud_canonical = None
+    cloud_binding_hash = cloud_binding_check = None
+
+REQUIRED_ENGINES = {"sdk", "standalone", "cloud", "typescript", "typescript-verifier"}
+BINDING_CASES = ("anchors_absent", "anchors_present", "anchors_upgraded", "signature_base64url",
+                 "signature_reencoded", "anchors_included", "scope_absent", "scope_null",
+                 "scope_unknown", "origin_missing", "kid_mismatch", "binding_malformed",
+                 "signature_base64url_anchors_present", "signature_base64url_anchors_upgraded",
+                 "scope_absent_no_origin", "scope_null_no_origin", "scope_unknown_no_origin",
+                 "distinct_issuer_matching_kid", "distinct_issuer_wrong_kid", "digest_overpadded", "digest_unpadded")
 
     # Member names chosen to straddle every ordering boundary that matters.
 KEY_ALPHABET = [
@@ -163,6 +180,153 @@ def run(iterations: int, seed: int, unsafe_numbers: bool) -> list[dict]:
     return divergences
 
 
+def binding_cases(iterations: int, seed: int) -> list[dict]:
+    """Exercise each case on each randomized payload; generation never rewrites a defect."""
+    rng = random.Random(seed)
+    cases = []
+    for index in range(iterations):
+        origin = {"payload": generate(rng), "signature": {"alg": "Ed25519", "kid": "origin", "sig": "+/8="}}
+        digest = base64.b64encode(hashlib.sha256(sdk_canonical(origin)).digest()).decode()
+        for name in BINDING_CASES:
+            peer = copy.deepcopy(origin)
+            binding = {"scope": "envelope_minus_anchors", "receipt_ref": "sig_origin", "envelope_hash": digest,
+                       "expect_ack_from": "ack"}
+            if "anchors_present" in name or "anchors_upgraded" in name or name == "anchors_included":
+                peer["anchors"] = [{"type": "rfc3161", "value": "first"}, {"type": "opentimestamps", "value": "pending"}]
+            if "anchors_upgraded" in name:
+                peer["anchors"][1]["value"] = "upgraded"
+                peer["export_metadata"] = {"ignored": index}
+            if name == "anchors_included":
+                binding["envelope_hash"] = base64.b64encode(hashlib.sha256(sdk_canonical(peer)).digest()).decode()
+            elif name.startswith("signature_base64url") or name == "signature_reencoded":
+                peer["signature"]["sig"] = "-_8"
+                if name.startswith("signature_base64url"):
+                    projection = {key: peer[key] for key in ("payload", "signature")}
+                    binding["envelope_hash"] = base64.urlsafe_b64encode(hashlib.sha256(sdk_canonical(projection)).digest()).decode().rstrip("=")
+            elif name.startswith("scope_absent"):
+                binding.pop("scope")
+            elif name.startswith("scope_null"):
+                binding["scope"] = None
+            elif name.startswith("scope_unknown"):
+                binding["scope"] = "other"
+            elif name == "origin_missing":
+                peer = None
+            elif name == "kid_mismatch":
+                binding["expect_ack_from"] = "another-ack"
+            elif name == "binding_malformed":
+                binding = None
+            elif name == "distinct_issuer_wrong_kid":
+                binding["expect_ack_from"] = "issuer"
+            elif name == "digest_overpadded":
+                binding["envelope_hash"] += "="
+            elif name == "digest_unpadded":
+                binding["envelope_hash"] = binding["envelope_hash"].rstrip("=")
+            if name.endswith("_no_origin"):
+                peer = None
+            expected = (True, "matches")
+            if name.startswith("scope_absent"):
+                expected = (None, "legacy_scope")
+            elif name.startswith(("scope_null", "scope_unknown")):
+                expected = (None, "unrecognised_scope")
+            elif name == "origin_missing":
+                expected = (None, "unresolved")
+            elif name in {"signature_reencoded", "anchors_included"}:
+                expected = (False, "mismatch")
+            elif name in {"kid_mismatch", "distinct_issuer_wrong_kid"}:
+                expected = (False, "kid_mismatch")
+            elif name in {"binding_malformed", "digest_overpadded"}:
+                expected = (False, "malformed")
+            cases.append({"name": name, "index": index, "origin": peer, "expected": expected,
+                          "acknowledging_kid": "ack", "payload": {"issuer_id": "issuer" if name.startswith("distinct_issuer") else "ack", "counterparty_binding": binding}})
+    return cases
+
+
+_TS_BINDING_DRIVER = r"""
+const api = require(process.argv[2]);
+const cases = JSON.parse(require('node:fs').readFileSync(process.argv[3], 'utf8'));
+const verifier = process.argv[4] === 'verifier';
+const labelOf = (state, note) => {
+  for (const label of ['legacy_scope', 'unrecognised_scope', 'kid_mismatch']) if (note.startsWith(label + ':')) return label;
+  if (state === 'PASS') return 'matches';
+  if (state === 'SKIPPED') return 'unresolved';
+  return note.startsWith('counterparty_mismatch:') ? 'mismatch' : 'malformed';
+};
+const out = cases.map(c => {
+  let digest = null;
+  if (c.origin !== null) {
+    digest = verifier ? api.counterpartyEnvelopeHash(c.origin)
+      : api.computeCounterpartyBinding(c.origin, {receiptRef:'sig_origin'}).envelope_hash;
+  }
+  let label, valid;
+  const ack = {payload:c.payload, signature:{alg:'Ed25519', kid:c.acknowledging_kid, sig:'AQID'}};
+  if (verifier) {
+    const axis = api.ADAPTERS.find(a => a.name === 'asqav-native').extraAxesWithContext(ack, null, {originatingEnvelope:c.origin}).find(a => a[0] === 'counterparty');
+    valid = axis[1] === 'PASS' ? true : axis[1] === 'FAIL' ? false : null;
+    label = labelOf(axis[1], axis[2]);
+  } else ({valid, label} = api.verifyCounterpartyBinding(ack, c.origin));
+  return {digest, valid, label};
+});
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+def _ts_bindings(cases: list[dict], verifier: bool) -> list[dict]:
+    dist = _ROOT / "typescript" / "dist" / ("verifier/index.js" if verifier else "index.js")
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp)
+        (path / "cases.json").write_text(json.dumps(cases))
+        (path / "driver.cjs").write_text(_TS_BINDING_DRIVER)
+        result = subprocess.run(["node", str(path / "driver.cjs"), str(dist), str(path / "cases.json"),
+                                 "verifier" if verifier else "sdk"], capture_output=True, text=True)
+    if result.returncode:
+        raise RuntimeError(f"required TypeScript binding engine failed: {result.stderr[:1000]}")
+    values = json.loads(result.stdout)
+    if len(values) != len(cases):
+        raise RuntimeError("required TypeScript engine omitted binding cases")
+    return values
+
+
+def _standalone_binding(case: dict) -> tuple[bool | None, str]:
+    state, note = check_counterparty_binding(case["payload"], case["origin"], acknowledging_kid=case["acknowledging_kid"])
+    valid = {"PASS": True, "FAIL": False, "SKIPPED": None}[state]
+    for label in ("legacy_scope", "unrecognised_scope", "kid_mismatch"):
+        if note.startswith(label + ":"):
+            return valid, label
+    if state == "PASS":
+        return True, "matches"
+    if state == "SKIPPED":
+        return None, "unresolved"
+    return False, "mismatch" if note.startswith("counterparty_mismatch:") else "malformed"
+
+
+def run_bindings(iterations: int, seed: int) -> dict:
+    """Require real participation from all five engines, with no lower success threshold."""
+    available = set(engines_available())
+    if available != REQUIRED_ENGINES or cloud_binding_check is None:
+        raise RuntimeError(f"five binding engines required; available: {sorted(available)}")
+    cases = binding_cases(iterations, seed)
+    counts = Counter(case["name"] for case in cases)
+    if set(counts) != set(BINDING_CASES) or any(counts[name] < 1 for name in BINDING_CASES):
+        raise RuntimeError("every required binding case needs a nonzero count")
+    ts = _ts_bindings(cases, False)
+    ts_verifier = _ts_bindings(cases, True)
+    divergences = []
+    for index, case in enumerate(cases):
+        origin = case["origin"]
+        ack = {"payload": case["payload"], "signature": {"kid": case["acknowledging_kid"]}}
+        sdk = verify_counterparty_binding(ack, origin)
+        outcomes = {"sdk": (sdk.valid, sdk.label), "standalone": _standalone_binding(case),
+                    "cloud": cloud_binding_check(case["payload"]["counterparty_binding"], origin, case["acknowledging_kid"])}
+        hashes = {"sdk": compute_envelope_hash, "standalone": _envelope_hash, "cloud": cloud_binding_hash}
+        seen = {engine: {"digest": hashes[engine](origin) if origin is not None else None,
+                         "valid": outcome[0], "label": outcome[1]} for engine, outcome in outcomes.items()}
+        seen.update({"typescript": ts[index], "typescript-verifier": ts_verifier[index]})
+        if (len({json.dumps(value, sort_keys=True) for value in seen.values()}) != 1 or
+                any([value["valid"], value["label"]] != list(case["expected"]) for value in seen.values())):
+            divergences.append({"case": case, "engines": seen, "seed": seed})
+    return {"engines": sorted(available), "counts": dict(counts), "divergences": divergences}
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--iterations", type=int, default=500)
@@ -170,13 +334,16 @@ def main() -> int:
     ap.add_argument("--unsafe-numbers", action="store_true")
     args = ap.parse_args()
 
-    divergences = run(args.iterations, args.seed, args.unsafe_numbers)
+    try:
+        bindings = run_bindings(args.iterations, args.seed)
+    except RuntimeError as exc:
+        print(f"REFUSING: {exc}")
+        return 2
+    divergences = run(args.iterations, args.seed, args.unsafe_numbers) + bindings["divergences"]
     engines = engines_available()
     print(f"engines compared: {', '.join(engines)}")
     print(f"iterations: {args.iterations}  seed: {args.seed}")
-    if len(engines) < 2:
-        print("REFUSING: one engine is not a differential test")
-        return 2
+    print("binding case counts: " + json.dumps(bindings["counts"], sort_keys=True))
 
     if not divergences:
         print("no divergence")


### PR DESCRIPTION
Replaces #489. That branch carries the pre-squash ancestry of three changes that have since landed as squashes, so merging it would replay content already on main. This branch is main plus the parity change alone, applied as a single cherry-pick. #489 is left untouched.

## Unchanged-slice acceptance map

The reviewed commit and this one produce byte-identical patches:

    reviewed 502c7365   patch = 18334 bytes
    this     37ab0477   patch = 18334 bytes
    differences: 2 blob index lines + 2 hunk offsets (@@ -115 -> -128, @@ -230 -> -243)
    content lines added and removed: identical, zero differences

The offset shift is `docs/offline-verification.md` growing above the hunk on main. Integration bytes contributed by this branch: zero. The cherry-pick took no conflict resolution, so the authored content carries its original review intact.

## Verification on the new base

- `python/tests/test_differential_fuzz.py`: 17 passed, 4 skipped, exit 0
- Corpus locks unaffected: this change touches no lock-pinned path
- Gates, with the tested command's own exit captured rather than a pipe's: comment-verbosity 0, ai-writing 0, commit-identity 0, complexity 0, secret-scan 0

## Two caveats recorded rather than smoothed over

**The five-engine claim is not demonstrable in this repository.** Only two engines actually run here (sdk, standalone). Two skips are environmental (`typescript/dist` unbuilt locally; CI builds it). Two are structural: the public SDK checkout has no private cloud source, and the joint-workspace CLI requires all five engines. The test skips honestly instead of passing vacuously, which is the right design, but the enforcement it names lives in a joint workspace, not here.

**The complexity gate contributes no signal to this change.** It reports zero scored functions against a diff adding four Python functions, because its extractor is a JavaScript AST library and an unparseable blob takes a fail-safe skip path. Its pass above should be read as "not measured", not as "measured and clean". Under diagnosis as relay task T-102.

https://claude.ai/code/session_017PQ2FTpuRPvWapqFkv3hk5
