### PR TITLE
fix: pass originating receipts through standalone CLI

### DIFF
--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -3099,6 +3099,11 @@ def main() -> int:
         "\"time\": <ISO-8601>} for the OpenTimestamps block check; without it the "
         "block portion reports unverifiable",
     )
+    p.add_argument(
+        "--counterparty",
+        metavar="FILE",
+        help="complete originating signing envelope JSON for the counterparty binding check",
+    )
     p.add_argument("--offline", action="store_true", help="never reach the network")
     args = p.parse_args()
 
@@ -3126,6 +3131,7 @@ def main() -> int:
 
         trusted_tsa_keys = _load_tsa_keys(args.tsa_key)
         bitcoin_headers = _load(args.bitcoin_headers) if args.bitcoin_headers else None
+        counterparty = _load(args.counterparty) if args.counterparty else None
     except VerifierInputError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -3136,6 +3142,7 @@ def main() -> int:
         predecessor_payload,
         trusted_tsa_keys=trusted_tsa_keys,
         bitcoin_headers=bitcoin_headers,
+        counterparty=counterparty,
     )
 
 

--- a/python/tests/test_exit_artifact_cli.py
+++ b/python/tests/test_exit_artifact_cli.py
@@ -223,3 +223,123 @@ def test_the_verifier_file_stands_alone() -> None:
         if line.startswith(("import ", "from ")) and (" asqav" in line or line.startswith("from ."))
     ]
     assert intra_package == [], intra_package
+
+
+# Real signed counterparty vectors reach the copied argparse entry point. Their
+# origin anchors are preserved; the binding projects its own two signed members.
+_COUNTERPARTY_VECTORS = Path(__file__).resolve().parents[2] / "verifier" / "conformance-vectors"
+
+
+@pytest.fixture
+def counterparty_artifact(tmp_path: Path):
+    from tests.test_standalone_verifier_surface import SITECUSTOMIZE as ISOLATION
+
+    shutil.copy(VERIFIER_SOURCE, tmp_path / "verify_receipt.py")
+    (tmp_path / "sitecustomize.py").write_text(ISOLATION)
+    return tmp_path
+
+
+def _counterparty_case(root: Path, case: str = "asqav-31-counterparty-scope-match") -> None:
+    for name in ("receipt.json", "jwks.json", "originating_envelope.json", "tsa_trust.pem"):
+        shutil.copy(_COUNTERPARTY_VECTORS / case / name, root / name)
+
+
+def _counterparty_cli(root: Path, *, supply_origin: bool = True):
+    inputs = {p.name: p.read_bytes() for p in root.iterdir() if p.is_file()}
+    extra = ["--tsa-key", "tsa_trust.pem"]
+    if supply_origin:
+        extra += ["--counterparty", "originating_envelope.json"]
+    result = _run_documented_command(root, *extra)
+    assert {name: (root / name).read_bytes() for name in inputs} == inputs
+    assert (root / "verify_receipt.py").read_bytes() == VERIFIER_SOURCE.read_bytes()
+    return result
+
+
+@pytest.mark.parametrize(
+    ("case", "code", "axis", "reason"),
+    [
+        ("asqav-31-counterparty-scope-match", 0, "[  ok]", ""),
+        ("asqav-32-counterparty-anchors-included", 1, "[FAIL]", "mismatch"),
+        ("asqav-33-counterparty-scope-absent", 2, "[skip]", "legacy_scope"),
+        ("asqav-34-counterparty-scope-unknown", 2, "[skip]", "unrecognised_scope"),
+    ],
+)
+def test_copied_counterparty_cli_signed_cases(counterparty_artifact, case, code, axis, reason):
+    root = counterparty_artifact
+    _counterparty_case(root, case)
+    result = _counterparty_cli(root)
+    assert result.returncode == code, result.stdout + result.stderr
+    assert "[  ok] signature" in result.stdout
+    assert "[  ok] anchors" in result.stdout
+    assert f"{axis} counterparty" in result.stdout
+    assert reason in result.stdout
+    verdict = {0: "=> verified", 1: "=> unverified (failure_class: invalid)",
+               2: "=> unverified (failure_class: unverifiable; never reported verified)"}[code]
+    assert verdict in result.stdout
+
+
+def test_copied_counterparty_cli_requires_the_origin(counterparty_artifact):
+    _counterparty_case(counterparty_artifact)
+    result = _counterparty_cli(counterparty_artifact, supply_origin=False)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "[skip] counterparty" in result.stdout and "unresolved" in result.stdout
+    assert "=> unverified (failure_class: unverifiable; never reported verified)" in result.stdout
+
+
+@pytest.mark.parametrize("change", ["signed-payload", "export-only"])
+def test_copied_counterparty_cli_projects_the_full_origin(counterparty_artifact, change):
+    root = counterparty_artifact
+    _counterparty_case(root)
+    path = root / "originating_envelope.json"
+    origin = json.loads(path.read_text())
+    if change == "signed-payload":
+        origin["payload"]["action_type"] = "changed:action"
+    else:
+        origin["anchors"] = []
+        origin["export_note"] = "unsigned transport metadata"
+    path.write_text(json.dumps(origin))
+    result = _counterparty_cli(root)
+    expected_code = 1 if change == "signed-payload" else 0
+    assert result.returncode == expected_code, result.stdout + result.stderr
+    assert "[  ok] signature" in result.stdout and "[  ok] anchors" in result.stdout
+    expected = "[FAIL] counterparty" if change == "signed-payload" else "[  ok] counterparty"
+    assert expected in result.stdout
+
+
+@pytest.mark.parametrize("text", [None, "{", "[]", '{"payload":{"x":1,"x":2}}'])
+def test_copied_counterparty_cli_file_errors_are_clean(counterparty_artifact, text):
+    root = counterparty_artifact
+    _counterparty_case(root)
+    path = root / "originating_envelope.json"
+    if text is None:
+        path.unlink()
+    else:
+        path.write_text(text)
+    result = _counterparty_cli(root)
+    assert result.returncode == 2
+    assert result.stderr.startswith("error:")
+    assert "Traceback" not in result.stderr and "=>" not in result.stdout
+
+
+def test_copied_counterparty_cli_help_and_isolation(counterparty_artifact):
+    root = counterparty_artifact
+    result = subprocess.run([sys.executable, "verify_receipt.py", "--help"],
+                            cwd=root, env=_child_env(root), capture_output=True, text=True)
+    assert result.returncode == 0 and "--counterparty FILE" in result.stdout
+    for program, diagnostic in [
+        ("import asqav", "refused: standalone check"),
+        ("import socket; socket.create_connection(('example.invalid',443))",
+         "outbound network blocked"),
+    ]:
+        result = subprocess.run([sys.executable, "-c", program], cwd=root,
+                                env=_child_env(root), capture_output=True, text=True)
+        assert result.returncode != 0 and diagnostic in result.stderr
+
+
+def test_copied_counterparty_cli_unbound_receipt_still_passes(counterparty_artifact):
+    root = counterparty_artifact
+    _counterparty_case(root)
+    shutil.copy(root / "originating_envelope.json", root / "receipt.json")
+    result = _counterparty_cli(root, supply_origin=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "=> verified" in result.stdout and "[  ok] signature" in result.stdout


### PR DESCRIPTION
Replaces #491, the last of the counterparty stack. That branch sits on `feat/counterparty-scope-parity-034`, which is closed, and carries the pre-squash ancestry of four changes already on main. This branch is main plus the CLI change alone, applied as a single cherry-pick. #491 is left untouched.

## Unchanged-slice acceptance map

    reviewed 9dca2591   patch = 7361 bytes
    this     da56ecea   patch = 7361 bytes
    differences: 1 blob index line + 3 hunk offsets (+185, from verify_receipt.py growing on main)
    content lines added and removed: identical, zero differences

Integration bytes contributed by this branch: zero. The cherry-pick took no conflict resolution.

## Import-surface constraint, checked because this touches the standalone verifier

`verify_receipt.py` may import only stdlib plus lazy `dilithium_py`/`cryptography`, never `asqav.*`. The seven added lines are argparse plumbing for a `--counterparty` flag, the file load, and passing it through. **They add no import at all**, and a grep for `asqav` across the file's import statements returns nothing.

## Local test failures are environmental, and here is the evidence rather than the assertion

`pytest python/tests/test_exit_artifact_cli.py python/tests/test_standalone_verifier_surface.py` gives 11 failed / 13 passed locally: the 4 documented workstation failures plus the 7 tests this change adds. The 7 new ones have no clean base to diff against, so the failure mode decides it:

    [skip] signature   run 'pip install cryptography' for the Ed25519 check
    => unverified (failure_class: unverifiable)   exit 2, expected 0

That is the documented sitecustomize shadow: these tests spawn a child interpreter whose `PYTHONPATH` artifact dir carries a `sitecustomize.py` that shadows Homebrew Python's own shim, so the child loses `/usr/local/lib/python3.14/site-packages`. Proof the libraries are present and the cause is shadowing rather than absence:

    /usr/local/opt/python@3.14/bin/python3.14 -c "import cryptography, dilithium_py"
    -> cryptography 47.0.0 + dilithium_py OK at /usr/local/lib/python3.14/site-packages

The ubuntu CI legs are the clean-room evidence for these tests.

## Gates

Run unpiped with the command's own exit captured: comment-verbosity 0, ai-writing 0, commit-identity 0, secret-scan 0. Both corpus lock paths green; this change touches no lock-pinned path.

`check-complexity` returns 0 but should be read as **not measured**: its extractor is a JavaScript AST library, so a Python-only change takes a fail-safe skip. Under diagnosis as relay task T-102.

https://claude.ai/code/session_017PQ2FTpuRPvWapqFkv3hk5
