### PR TITLE
fix: treat explicit null payload size as malformed, keep absence allowed

### DIFF
--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -2179,7 +2179,8 @@ def check_payload_digest(payload: dict):
     if not isinstance(claimed, str) or not re.fullmatch(r"[0-9a-f]{64}", claimed):
         return "FAIL", f"payload_digest.hash {claimed!r} is not 64 lowercase hex"
     claimed_size = digest.get("size")
-    if claimed_size is not None and (
+    # Absence stays allowed; a present null is malformed, not a missing length.
+    if "size" in digest and (
         not isinstance(claimed_size, int) or isinstance(claimed_size, bool) or claimed_size < 0
     ):
         return "FAIL", f"payload_digest.size {claimed_size!r} is not a non-negative integer"

--- a/python/tests/test_receipt_integrity_axes.py
+++ b/python/tests/test_receipt_integrity_axes.py
@@ -202,3 +202,71 @@ def test_absence_of_both_claims_does_not_block() -> None:
         axis = result.axis(name)
         assert axis.result == "PASS", f"{name}: {axis.note}"
         assert axis.failure_class is None
+
+
+def _genuinely_signed(payload_digest: dict | None) -> tuple[dict, dict]:
+    """A receipt genuinely Ed25519-signed over its final payload (criterion 727)."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    payload = _receipt()["payload"]
+    if payload_digest is None:
+        payload.pop("payload_digest", None)
+    else:
+        payload["payload_digest"] = payload_digest
+    key = Ed25519PrivateKey.generate()
+    sig = key.sign(vr.canonical_json(payload))
+    doc = {
+        "payload": payload,
+        "signature": {
+            "alg": "Ed25519",
+            "kid": "ed_1",
+            "sig": base64.b64encode(sig).decode(),
+        },
+        "anchors": {},
+    }
+    jwks = {
+        "keys": [
+            {
+                "kid": "ed_1",
+                "issuer_id": payload["issuer_id"],
+                "agent_id": payload["agent_id"],
+                "alg": "Ed25519",
+                "status": "active",
+                "public_key": base64.b64encode(
+                    key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+                ).decode(),
+            }
+        ]
+    }
+    return doc, jwks
+
+
+def test_null_size_is_malformed_end_to_end() -> None:
+    digest = {"hash": HONEST, "size": None}
+    doc, jwks = _genuinely_signed(digest)
+    structured = vr.run_structured(doc, jwks)
+    axes = {a["name"]: a for a in structured["axes"]}
+    assert axes["signature"]["result"] == "PASS", axes["signature"]["note"]
+    assert axes["payload_digest"]["result"] == "FAIL", axes["payload_digest"]["note"]
+    assert axes["payload_digest"]["failure_class"] == "invalid"
+    assert "non-negative integer" in axes["payload_digest"]["note"]
+    assert structured["verdict"] == "unverified"
+    result = oracle_verify(doc, ADAPTERS, jwks)
+    assert result.axis("signature").result == "PASS"
+    axis = result.axis("payload_digest")
+    assert (axis.result, axis.failure_class) == ("FAIL", "invalid"), axis.note
+    assert "non-negative integer" in axis.note
+    assert result.verdict == "unverified"
+
+
+def test_absent_size_control_stays_passing_end_to_end() -> None:
+    digest = {"hash": HONEST}
+    doc, jwks = _genuinely_signed(digest)
+    structured = vr.run_structured(doc, jwks)
+    axes = {a["name"]: a for a in structured["axes"]}
+    assert axes["signature"]["result"] == "PASS", axes["signature"]["note"]
+    assert axes["payload_digest"]["result"] == "PASS", axes["payload_digest"]["note"]
+    result = oracle_verify(doc, ADAPTERS, jwks)
+    assert result.axis("signature").result == "PASS"
+    assert result.axis("payload_digest").result == "PASS", result.axis("payload_digest").note

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -775,9 +775,9 @@ export function checkPayloadDigest(payload: unknown): readonly [VerifyState, str
     return ["FAIL", `payload_digest.hash ${pyRepr(claimed)} is not 64 lowercase hex`];
   }
   const claimedSize = digest.size;
+  // Absence stays allowed; a present null is malformed, not a missing length
   if (
     claimedSize !== undefined &&
-    claimedSize !== null &&
     (typeof claimedSize !== "number" || !Number.isInteger(claimedSize) || claimedSize < 0)
   ) {
     return ["FAIL", `payload_digest.size ${pyRepr(claimedSize)} is not a non-negative integer`];

--- a/typescript/tests/verifier-receipt-integrity-parity.test.ts
+++ b/typescript/tests/verifier-receipt-integrity-parity.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { createHash } from "node:crypto";
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
 
 import {
   checkCounterpartyBinding,
@@ -145,5 +145,51 @@ describe("receipt-internal integrity parity", () => {
       expect(axis.result, `${name}: ${axis.note}`).toBe("PASS");
       expect(axis.failureClass).toBeNull();
     }
+  });
+
+  // Genuinely Ed25519-signed over its final payload (criterion 727)
+  function genuinelySigned(digest: Record<string, unknown>): {
+    doc: Record<string, unknown>;
+    provider: Record<string, unknown>;
+  } {
+    const doc = receipt({ payload_digest: digest });
+    const payload = doc.payload as Record<string, unknown>;
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+    const sig = sign(null, Buffer.from(asqavJcs(payload)), privateKey).toString("base64");
+    doc.signature = { alg: "Ed25519", kid: "ed_1", sig };
+    const exported = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+    const raw = exported.subarray(-32).toString("base64");
+    const provider = {
+      keys: [
+        {
+          kid: "ed_1",
+          issuer_id: payload.issuer_id,
+          agent_id: payload.agent_id,
+          alg: "Ed25519",
+          status: "active",
+          public_key: raw,
+        },
+      ],
+    };
+    return { doc, provider };
+  }
+
+  it("treats a null size as malformed end to end", () => {
+    const { doc, provider } = genuinelySigned({ hash: HONEST, size: null });
+    const r = verify(doc, ADAPTERS, provider);
+    expect(r.axes.find((a) => a.axis === "signature")!.result).toBe("PASS");
+    const axis = r.axes.find((a) => a.axis === "payload_digest")!;
+    expect(axis.result).toBe("FAIL");
+    expect(axis.failureClass).toBe("invalid");
+    expect(axis.note).toContain("non-negative integer");
+    expect(r.verdict).toBe("unverified");
+  });
+
+  it("keeps an absent-size control passing end to end", () => {
+    const { doc, provider } = genuinelySigned({ hash: HONEST });
+    const r = verify(doc, ADAPTERS, provider);
+    expect(r.axes.find((a) => a.axis === "signature")!.result).toBe("PASS");
+    const axis = r.axes.find((a) => a.axis === "payload_digest")!;
+    expect(axis.result, axis.note).toBe("PASS");
   });
 });

--- a/verifier/axis-parity-cases.json
+++ b/verifier/axis-parity-cases.json
@@ -2296,6 +2296,66 @@
         "result": "FAIL",
         "note_contains": "non-negative integer"
       }
+    },
+    {
+      "name": "size null with matching context is malformed",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        },
+        "payload_digest": {
+          "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+          "size": null
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "non-negative integer"
+      }
+    },
+    {
+      "name": "size absent with matching context stays allowed",
+      "payload": {
+        "context": {
+          "amount": 100,
+          "currency": "EUR"
+        },
+        "payload_digest": {
+          "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e"
+        }
+      },
+      "expect": {
+        "result": "PASS",
+        "note_contains": "rederives from the carried context"
+      }
+    },
+    {
+      "name": "size null with context absent is still malformed",
+      "payload": {
+        "payload_digest": {
+          "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+          "size": null
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "non-negative integer"
+      }
+    },
+    {
+      "name": "size null with explicit null context is still malformed",
+      "payload": {
+        "context": null,
+        "payload_digest": {
+          "hash": "f50d36c1739463e571da8e929fdeb3bc35c5bf86051c653d6a61deedcb10944e",
+          "size": null
+        }
+      },
+      "expect": {
+        "result": "FAIL",
+        "note_contains": "non-negative integer"
+      }
     }
   ],
   "counterparty_binding": [


### PR DESCRIPTION
Treats an explicit `"size": null` in `payload_digest` as malformed in both
SDK verifiers, while a fully absent `size` stays allowed.

Defect: `digest.get("size")` returns `None` for an absent key and for a key
present with value null, and both guards short-circuited on
`claimed_size is not None`, so absence and explicit null were
indistinguishable past that line (null wrongly PASSED).

Fix: both `check_payload_digest` (Python) and `checkPayloadDigest` (vrShim)
now key presence off `"size" in digest` / `!== undefined` first, so a
present null falls into the malformed branch.

Tests:
- 4 new parity-table cases (`null-size-*`) in
  `verifier/axis-parity-cases.json`, exercised by both halves.
- New genuinely Ed25519-signed end-to-end aggregate tests in
  `python/tests/test_receipt_integrity_axes.py` (null-size FAIL plus
  absent-size PASS control) and
  `typescript/tests/verifier-receipt-integrity-parity.test.ts` (same pair).
- Full axis suites green: 12 passed (pytest), 41 passed (vitest);
  corpus runner 85/85 both halves; parity 56 passed.

Gates on `origin/main..HEAD`: check-comment-verbosity ok,
check-test-quality clean, check-ai-writing ok, check-commit-identity ok
(1 signed commit, owner-authored, no co-authors), secret-scan
(gitleaks) clean. check-complexity selected 0 changed functions and
check-yagni/check-duplication skipped (no source files found), so those
three say nothing about this change. The main product file
`python/src/asqav/verifier/verify_receipt.py` is scored by no quality
gate (per T-106 preflight); review it directly.

Criterion 727 (T-043). No version bump or publish (addendum: LEAD owns
release mechanics).

THREAT_MODEL (narrow, 4 bullets):
- Untrusted input: receipts arrive from counterparties; an explicit
  `"size": null` is malformed in both validators rather than being read
  as an unclaimed size.
- Parity: both SDK halves (Python implementation, TS shim) enforce the
  same rule; 4 shared table cases + per-language mutation proof keep
  them from drifting.
- No crypto change: guard-only fix. Genuinely-signed aggregates prove
  the digest axis fires on its own, independent of signature validity.
- Ceiling: helper/axis-level outcomes only. No claim about full-profile
  acceptance (chain/anchor evidence still required), and the main
  product file is scored by no quality gate — it needs direct review.

Claim ceiling: both payload-digest helpers reject present-null size as
malformed while absence stays allowed. The change is scoped to those two
helpers; no claim is made about the behaviour of every public entry point.
