### PR TITLE
fix: report unregistered receipt namespaces, never fail them

### DIFF
--- a/python/src/asqav/verifier/verify_receipt.py
+++ b/python/src/asqav/verifier/verify_receipt.py
@@ -2467,7 +2467,10 @@ def check_structure(payload: dict):
         return "FAIL", f"missing required fields: {','.join(missing)}"
     rt = payload.get("type")
     if rt not in ALLOWED_TYPES:
-        return "FAIL", f"type {rt!r} outside the allowed namespace"
+        return "SKIPPED", (
+            f"type {rt!r} outside the known namespace; "
+            "profile membership unverifiable, reported not failed"
+        )
     ce_res, ce_note = check_controls_evaluated(payload)
     if ce_res == "FAIL":
         return "FAIL", ce_note

--- a/python/tests/test_corpus_b_integrity.py
+++ b/python/tests/test_corpus_b_integrity.py
@@ -100,12 +100,12 @@ PINNED_MEMBER_NAMES = frozenset(
 
 #: Census pins: how many receipts carry each kind. Corpus growth fails here.
 EXPECTED_PIN_COUNTS = {
-    "sig": 42,
-    "action_ref": 38,
-    "policy_digest": 34,
-    "previousReceiptHash": 35,
+    "sig": 43,
+    "action_ref": 39,
+    "policy_digest": 35,
+    "previousReceiptHash": 36,
     "key_thumbprint": 3,
-    "payload_digest": 32,
+    "payload_digest": 33,
     "envelope_hash": 4,
     "canonical": 0,
 }
@@ -153,6 +153,7 @@ PINNED_SIG = {
     'asqav-34-counterparty-scope-unknown': 'lCZArmbcWLHLSkC3BRtnzcoeszwlyjTEZRijB7B61ZCocYFSa6We7lRtjnY1U0xSid4nXJT2e/mvDheT4iHICQ==',
     'asqav-35-invocation-ref-binds-pre-post': 'vFioA4jDy8/tfQmthsnCwtNIxIx3fqczmqVwUaPsUgDmL8f+9JfMvduNF2oU7MpHpHu3qeh+rx5bbRfvIzEICA==',
     'asqav-36-invocation-ref-duplicate-emission': '6XJ36a/9HAqSKGv8+okbWazYyqpuunnxS90Za67vyUjDFyjkDRoY8SeVn07bXKFI9SZ4pGgsEjcfK982zOKLBw==',
+    'asqav-37-unregistered-namespace-reported': 'zX3DZ7Y9jCuk0MdBWOnla0E5cT+5jcJrNLGQz7edmO8FV7/RXJyyiLLZKGHnzQewe/EljSenG7wPL/1XJE55DA==',
     'dsse-attestation-ml-dsa-65#signatures[0]': '0ZYmSnbpMGf1rAkIDa9qiIHzo9LcdhwC3+ox/pYrXADFKVRHoc9SIahGXnp3e91ekqSHucReLyW3mV30LXvhYiquI7phHP9XFt0KgbKqlP+XvQqsntepOBy2Y+hPy6EVeIF3OX3oZyTk9v7C1Brn/GbcjVEThtwZQjO5QgLlghZrESUsSEc7Vlr3SlWnNQ4tdywIG5KBKed4Nlw7tJvdoe52Wf2xG3TaVfK0nO7XCf6pnyk0lIKaFoOvapZf+MG9ZPfgnK76jz9iFpuixJRJBlNzd9lrT+tzGytbdEiXe3BHd1MftpT7y1bRNn9PiNaLat39Vw7SwIcubstD23wXsBU+TM0nUFc0RRj2sZjKBfHs97Z0MA3KNHKESwpZt4YWzKIgQ329sa7a740Mg7QxjqRR1sc4TXiiNd7dz67n6xf3OXo3EJnXAfwL3rEs/Pc83gw+kFZZmcNxdpY1ii+gKQP1+1zWiMx675gngwzgGvtUJ/S8wPURa4UZOEUfSminGkD+J4AMSI0EJX+K2S3nLFAvZN4ghqLVzaRYVc//Az1jYv2vpKSw/FEI/EZHJyb1Lutw0oITOcmjTgWl8IGrZQM7YtoHIYgKp7oYCSKcaqTGu0CkzmUVykwYsJXiE21YkBYkOiR0qyy2BYiRpCs/QXqQPVvlkZ2xM/LH5SLWGAZzte69UZtzalAIlCYVuwvtenXw7/61qu1EaVCYkH3/hrVrj7T8pKumkhk98to7oO3dP5cG4rh83oJTIDInCMFu35H1u0GX16QPdVwCXpYs/bo/UeXWv0ZY+Zh2t9SdLngH4fqxXSkL/Z5Du33jMiqSW80rx18iVUFRTSHsSDJtw4Sfb9uy4RjcxxuuyNaoB4U72nhuyZxPbB9NDQL1pagq0hgyn7Mj40EZH0fXjO6VJ/S/LfibF7TyK1ra6XL/5ZhJ6o6qsc/XSEKxL0JqQ+MzggwqQEwbtk53Ygmcqa/2jheprfVVndwKzTmhuklVwWevd9OYvWYr8qk6jjBqy0+6k/oF5wc7qExbMJ99ghaELz58LIPuxnbQt1d1HkYi44sX8xzeIV1rO6wKjKiuw0q9anKwl5pRc3sNrJDdhQZNJ4Ndh2MjzN/WcDH0v/FfFBsICXxGmdCZQpTm0HSAKSWHL1LgBAB/2R2N/0sJExFUCq3KaSYjjDVAessDoOPtGC1S3wF3Dh1mboH1rR/IUt1nR1qnPuowX0oN2/ByQGc1iUE1THfhwUJ6IKDeu3AZ9Rn1nLg+MtqmcsRsRpyY2Wo0N5jqwnL23Zir/ynpi3fzS/42ojfoyiORNUN0LJ6P+TjsPvZzF5ghEmzm0etFyN+3MVoqQmcKLlJADEdb67NRTJ0ID5AkUwNvjPbHDesZzLrLVSj53FNnju2UFsSdDMoOmj5xWjV01th0z3ukMmCeKIE4t+cJDD9ijR0vqswlyYAcdbKIVyF18A2xhu7s5lnvUgEvnKjrfKocFwfb2y6d9+UZNklfiFNASwBtoBx+CHPfGkDNoqbWw4YzHY18aGyQx7RzA/AIlwejVzDAtOJkDu3kdLjwCf727UmpIx4yMZEW4E2lFRkm2iqLaSA2MHtu1LlMfUZX04EYmEQXapPWpPJHQRcLP/T2nlM9tv+qQYW09t+/mqmYMYVMnjsPGxxh6FI4yqmHCTtU4NGdB5LRYq4vlJoPkpHSLs1h4Fs0Qt/YxRjAgUUW9+8A/bHH9MhQZdDbpkUufPvkiu2Uzx05vOIncAd5wCqzV+rtTh3jFZGeEbVLtVX+FWLTYQr1ihE3/pNyD2gKgW3Ym/mWA5gu0H7N8Mfi2e3O15MMVlXhKHRNv96L6OnFFeIePHflxxpp6oLPq4W1eW9af7a8DzX7ekBQ6/R0po3Q3OdwO6oBT8iOvlXvn8mJcZVzfNV2W6MOk+2oGVzepZq9KarOc3W+3zHVwAfgSnB51VvN3JfIiORsn81qz6J0FOKBCeeTG/lID+RYMjYN2VOtZErDDXvAG7Kc65BC4uXHsPj1CiLsBsnhdafcC0VbyWX6wMdR0DdC9sRC7Q+yXa+e3nbpEggJQltb9am74ciciWhjnwlEMrURyNMJSB82tEIF1776PI9rAsmeTwqt/PV2U7XhQhUBEff63Iv4lVbtnImXf9tNsvppxL8jnCd6il9DPRvie5ixmSN6YW9Ngj3UQh9EIBx13vLnIX1d5NbJUraflHjakZRa9P27owp6D6M4goddVJz+kuzRXa6POkyz/6wRe3f+jjcAdcJLey1Wi8eAZXkbjN3lDjWnSeFg9YFT1inVeRytKMdFZu/opKjpXrQwKCqfHvm2mqAzy0ykaqqmQxjMVrk5zkjfiNzBgEUT5p/HWq+7ejZUClnNDHFVleURpEs+OemfNRMsR9Ps7kubqm2v29+6YodQLCLcne+O4trWjjmH6cBNsprz3qM1xsdGaRL7Qt4mNf1wlyxsYsgr4zBTM944JMRPj1hJoXN9B8ZUirHiao0qPMSlS1YaSxerNoV8MXHcrpeZFJgL2ykN5rdBGDekppYRpPe+DNL+sg0bIrx2dYZVPRLE7oIeYJTQkPS4o6wlNn+KAkot7Y1Q5Opbv74fCG+IEQkjsoDOmO/UavNsMamXecnVx8fgqDxCF5zuxcwfBF4b0vrwuKn+UqqP/qcPDFhXz0z1oJy3CL2YB+lwFpSvluCbjFrlQyAbzr0JudvgSqsXMqFnd9dFbdNdGd5/n6Y/Ipz2urXXPGiSXXv4UYHhuLO+s2hnIJdvUL/0V3y1TRcezyoz4Cji7bBy7cFOWHoMbVbaTktXOm5LFwbUYXIrLbk8dlbKVN3y+71xJcBOo6zD0ydGMNQ53UE09KNXSfx9GUnuJBxSH25OHyMUQ0tPncytCf+1AVcvUxHknKWtRzsx41d+LPoMgMlZHouWsmLiqL3tYsSCa1xOVJCqCzi+Zl0VwHdliK0yjDZ57g9FtEWtXxrWCY5SUhoBKv2WMTaLl4IYJ+lN09wRSbeETuBubpNL+i6jhUUobYsFtsPVFPJOdZSNnM4ZLHhvX5qc5X3avXZttpqMl+GdE5IMZCQtT89W8WAWGA2+7jrMKr4rJIsfiX4Yx2ediR7gTeunorifBy9WX3rF8BlDQqpPaUuxSomtJ0/62MVup7JjOk59qAK5Gt1DVvSOy6iyzRu+DwxyUrjTJ+iFqqyIggdmFj3OCbCwpTkE7urETVSK8oo1TsUE5IgSf4Lp3P4mvtPwhRxIRWGC3AuSXD9PWvI0bHYlkejlzsIDqOv1NHELIgoczosjgF4e1f1USnZIkytBzzkMiaYkUy21wyCzpYmf+xTSBs6UkPWM/PXjFBdw9ZhJELhEhQjOVObeUtAJ3aKnc+t5l9Blr5K2+a8eAV7KX6NUxToOtWWH8leKFxtx1/jKuFMgqWD61bwaX0wNFzyeWrWU5H4RkBRuyOor0VRfhkyx4z5Lmn8L0amAXHEF/u7XYAJXWfPbEyX3OpsiZhrUFcii+lE8dT2/bk8SKVTtO3FKxFNxa+OirpkYhw7lwAdsv+2u64RaUqt6IKN7EETbNMi2+xNtQcm2Bm7brKNbGJ2HpadmY9A0x+tKoIk8fJGNj98dE5P/krjolR97M/Mnl9o8DLcy7vn8cGgcnI6jWzFQk4oWwxkIawBv0nh4QvbnR9OFKmW/6V0EnyaPYWUZf/lC1U6FsleEF2bodFs6K9XNGa7Uz+XpX7Spyuk6ZEJiHt3/nnKwXa6X4ZfPOsiuNAjYiAnC+le9Ey3Asf0qZ7M5DQB4x/BmiUmMxsNRPAOxlifaYFG7a0BrEEpU3wSX2L0u+WJA35KkfsaEWqFxFi6Z6KO/amOcMvKdu5O7/fT997rKXh2vNha+fuRjz9UUMMOfniPLgVZ6ilkKr/tSpYjsKPWWNX51ji9APoxSDBzyiptBsu3D9V3a8i6h0y4m3Fazem5JJX5ngF8kOJShUjWPci/VhdsAnZhz58wYUMZUI+wZfYibZuaWUg4y8vdihywT2KTeFTXx1+4CArOzrqICWBJnN+PSzc1LpuQS4v3HEMFbzZGnXuqhqq67HIR8XhN2cjFRDR7X2J2TnvmcfCj1PphrHlb9Qv+NbdP7t4p9WX1w/titfbHWrEDQ3g6lvCYXvk05cw0gt99Qru67HLairk+gfHp+Zmi2qo4TqdMXPt2xULnvEPWpedhOSH0nagQcHv/qaq56GfirAu3RRi3uJgsyZGa16pXKn/d3saa339RyJLxLbqJV3oVJ28lpuB11aPoLQbtmmma3Byi4XDjRI4THCEX8jrtlSZsUvYsXgjM+FY7BOX42s2rAyCQTJ5ahpri90tryBj9EVm1ym0R1wcPTSHSPmd/xSFdglJ7INDVebqqzvMLc8gAAAAAAAAAAAAAAChEWHCIs',
 }
 
@@ -196,6 +197,7 @@ PINNED_ACTION_REF = {
     'asqav-34-counterparty-scope-unknown': 'sha256:6200a624fcf21e5d33f120a3624f7e317a1d36eb550078602dcc3494656343c9',
     'asqav-35-invocation-ref-binds-pre-post': 'sha256:e0f46f1b79d3061c6792a59fac0f11433b87f976d8e4478e9a519b85eb63cc17',
     'asqav-36-invocation-ref-duplicate-emission': 'sha256:ee546b7e9ac6449a0bbf9aa4a4fa57a9f4a8a754137e675e150100c04cfbbb94',
+    'asqav-37-unregistered-namespace-reported': 'sha256:9632ae3c8d6b7da7ca90d0edec7467c0097799bb2954cde5bf66e5a0b101c2e1',
 }
 
 #: Published `policy_digest` strings, verbatim. Hash-mode receipts carry it at
@@ -235,6 +237,7 @@ PINNED_POLICY_DIGEST = {
     'asqav-34-counterparty-scope-unknown': 'sha256:57ccec5e5c18d08dc1f94b16a500d29307748a022709cf0291bc368b5f01178b',
     'asqav-35-invocation-ref-binds-pre-post': 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
     'asqav-36-invocation-ref-duplicate-emission': 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    'asqav-37-unregistered-namespace-reported': 'sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7',
 }
 
 #: Published `previousReceiptHash` strings, verbatim. Genesis vectors pin the
@@ -275,6 +278,7 @@ PINNED_PREV_HASH = {
     'asqav-34-counterparty-scope-unknown': '0000000000000000000000000000000000000000000000000000000000000000',
     'asqav-35-invocation-ref-binds-pre-post': 'efb4b4b9fa1add99f504a0a84cf94b4cb6be05138779f2bc7aabb2b1f5fb665d',
     'asqav-36-invocation-ref-duplicate-emission': '09f37e3592598aa9c8b1ea3e1b5840fc501bf156ca74a4e275a930410583f22e',
+    'asqav-37-unregistered-namespace-reported': '0000000000000000000000000000000000000000000000000000000000000000',
 }
 
 #: Published `key_thumbprint` strings, verbatim.
@@ -320,6 +324,7 @@ PINNED_PAYLOAD_DIGEST = {
     'asqav-34-counterparty-scope-unknown': {'hash': '6200a624fcf21e5d33f120a3624f7e317a1d36eb550078602dcc3494656343c9', 'size': 45},
     'asqav-35-invocation-ref-binds-pre-post': {'hash': 'e0f46f1b79d3061c6792a59fac0f11433b87f976d8e4478e9a519b85eb63cc17', 'size': 96},
     'asqav-36-invocation-ref-duplicate-emission': {'hash': 'ee546b7e9ac6449a0bbf9aa4a4fa57a9f4a8a754137e675e150100c04cfbbb94', 'size': 71},
+    'asqav-37-unregistered-namespace-reported': {'hash': '9632ae3c8d6b7da7ca90d0edec7467c0097799bb2954cde5bf66e5a0b101c2e1', 'size': 68},
 }
 
 #: Published counterparty `envelope_hash` strings, verbatim. `asqav-32` pins

--- a/python/tests/test_corpus_lock.py
+++ b/python/tests/test_corpus_lock.py
@@ -24,7 +24,7 @@ VERIFIER_LOCK = VERIFIER_ROOT / "manifest.lock.json"
 # The lock digests, reproduced beside each lock's own digest field and in the corpus
 # READMEs. A regenerated lock that forgets to update these is drift, not a refresh.
 FINGERPRINT_LOCK_DIGEST = "e6e6946274551752412cd4bc6ada7f4739e9ae495e4594639a2eec4de87039ed"
-VERIFIER_LOCK_DIGEST = "4d9a4eeb0c7a6ab77c40583c2f915b65c1b00159891d19a6802c9677abf9fcc6"
+VERIFIER_LOCK_DIGEST = "c6e8a446235e646e01da0a0422f971561059325938626bce83baae67eb8c7b76"
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey

--- a/python/tests/test_oracle.py
+++ b/python/tests/test_oracle.py
@@ -241,7 +241,7 @@ def test_runner_main_reports_all_green(capsys) -> None:
 @requires_ed25519
 def test_corpus_runs_and_every_vector_matches() -> None:
     results = run_corpus(_CORPUS)
-    assert len(results) == 85
+    assert len(results) == 86
     # asqav-05 (unverified) upgrades to verified when dilithium-py is present.
     def _tol(r):
         return r.ok or (

--- a/python/tests/test_verify_receipt.py
+++ b/python/tests/test_verify_receipt.py
@@ -3,7 +3,9 @@
 verify_receipt.py carries protectmcp:lifecycle:risk_acceptance and
 protectmcp:lifecycle:code_authorship in ALLOWED_TYPES so the structure axis
 recognises a valid receipt of either type and PASSes on it; an unknown type
-still fails closed. These tests pin both behaviours.
+is REPORTED (SKIPPED, naming the namespace), never failed, while the verdict
+stays unverified/unverifiable so nothing unrecognised verifies. These tests
+pin both behaviours.
 """
 
 from __future__ import annotations
@@ -42,11 +44,17 @@ def test_structure_accepts_risk_acceptance() -> None:
     assert RISK_TYPE in note
 
 
-def test_structure_still_rejects_unknown_type() -> None:
+def test_structure_reports_unknown_type() -> None:
+    """An unregistered namespace is REPORTED, never failed: the axis returns
+    SKIPPED naming the type, and the fold keeps the verdict closed."""
     payload = _risk_payload()
     payload["type"] = "protectmcp:not_a_real_type"
-    res, _note = v.check_structure(payload)
-    assert res == "FAIL"
+    res, note = v.check_structure(payload)
+    assert res == "SKIPPED"
+    assert "protectmcp:not_a_real_type" in note
+    verdict, failure_class = v._fold_verdict([("structure", res, note)])
+    assert verdict == "unverified"
+    assert failure_class == "unverifiable"
 
 
 def test_run_structure_axis_passes_on_risk_acceptance(capsys) -> None:

--- a/typescript/src/verifier/vrShim.ts
+++ b/typescript/src/verifier/vrShim.ts
@@ -187,14 +187,14 @@ export function checkNonce(
 }
 
 /** Asqav-native structure check; returns `[result, note]` (mirrors `check_structure`). */
-export function checkStructure(payload: Record<string, unknown>): readonly ["PASS" | "FAIL", string] {
+export function checkStructure(payload: Record<string, unknown>): readonly ["PASS" | "FAIL" | "SKIPPED", string] {
   const missing = REQUIRED_FIELDS.filter((f) => !(f in payload));
   if (missing.length > 0) {
     return ["FAIL", `missing required fields: ${missing.join(",")}`];
   }
   const rt = payload.type;
   if (typeof rt !== "string" || !ALLOWED_TYPES.has(rt)) {
-    return ["FAIL", `type ${JSON.stringify(rt)} outside the allowed namespace`];
+    return ["SKIPPED", `type ${JSON.stringify(rt)} outside the known namespace; profile membership unverifiable, reported not failed`];
   }
   const [ceRes, ceNote] = checkControlsEvaluated(payload);
   if (ceRes === "FAIL") {

--- a/typescript/tests/verifier-parity.test.ts
+++ b/typescript/tests/verifier-parity.test.ts
@@ -36,7 +36,7 @@ function loadJson(path: string): Record<string, unknown> {
 }
 
 describe("verifier parity gate (THE GATE)", () => {
-  it("matches every manifest outcome across all 85 corpus vectors", () => {
+  it("matches every manifest outcome across all 86 corpus vectors", () => {
     const results = runCorpus(CORPUS_ROOT);
     const mismatches = results.filter((r) => !tolerated(r));
     const passed = results.filter(tolerated).length;
@@ -53,9 +53,9 @@ describe("verifier parity gate (THE GATE)", () => {
     // eslint-disable-next-line no-console
     console.log(`\n${report}\n\n  => ${passed}/${results.length} vectors matched expected outcome\n`);
 
-    expect(results.length).toBe(85);
+    expect(results.length).toBe(86);
     expect(mismatches, `mismatched vectors: ${mismatches.map((m) => m.dir).join(", ")}`).toEqual([]);
-    expect(passed).toBe(85);
+    expect(passed).toBe(86);
   });
 
   it("pins failure_class byte-for-byte with the Python oracle for every unverified vector", () => {

--- a/typescript/tests/verifier-structure-namespace.test.ts
+++ b/typescript/tests/verifier-structure-namespace.test.ts
@@ -1,0 +1,31 @@
+// Criterion 625: an unregistered type namespace is REPORTED, never failed
+import { describe, expect, it } from "vitest";
+
+import { checkStructure } from "../src/verifier/vrShim.js";
+
+describe("checkStructure reports an unregistered namespace", () => {
+  it("returns SKIPPED naming the type", () => {
+    const payload: Record<string, unknown> = {
+      type: "protectmcp:lifecycle:oversight_ruling",
+      issued_at: "2026-06-01T19:26:44Z",
+      issuer_id: "org-1",
+      action_ref: "sha256:" + "8".repeat(64),
+      payload_digest: { hash: "8".repeat(64), size: 1 },
+      policy_digest: "sha256:" + "3".repeat(64),
+      previousReceiptHash: "0".repeat(64),
+      decision: "observation",
+    };
+    const [res, note] = checkStructure(payload);
+    expect(res).toBe("SKIPPED");
+    expect(note).toContain("protectmcp:lifecycle:oversight_ruling");
+  });
+
+  it("keeps FAIL for genuinely missing required fields", () => {
+    const payload: Record<string, unknown> = {
+      type: "protectmcp:lifecycle:oversight_ruling",
+    };
+    const [res, note] = checkStructure(payload);
+    expect(res).toBe("FAIL");
+    expect(note).toContain("missing required fields");
+  });
+});

--- a/verifier/conformance-vectors/asqav-37-unregistered-namespace-reported/expected.json
+++ b/verifier/conformance-vectors/asqav-37-unregistered-namespace-reported/expected.json
@@ -1,0 +1,7 @@
+{
+  "format": "asqav-native",
+  "outcome": "unverified",
+  "reason_code": "unregistered_namespace",
+  "failure_class": "unverifiable",
+  "notes": "Correctly signed receipt whose type uses the draft-registered protectmcp:lifecycle:oversight_ruling namespace the verifier does not recognise; structure axis reports SKIPPED, never FAIL."
+}

--- a/verifier/conformance-vectors/asqav-37-unregistered-namespace-reported/jwks.json
+++ b/verifier/conformance-vectors/asqav-37-unregistered-namespace-reported/jwks.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kid": "t117-namespace-vec-key",
+      "issuer_id": "Asqav Ltd",
+      "alg": "Ed25519",
+      "status": "active",
+      "public_key": "IvPDQUuStUThOe4kjeYLmBO6JfE4XqNlznBcsweOUrg="
+    }
+  ]
+}

--- a/verifier/conformance-vectors/asqav-37-unregistered-namespace-reported/receipt.json
+++ b/verifier/conformance-vectors/asqav-37-unregistered-namespace-reported/receipt.json
@@ -1,0 +1,30 @@
+{
+  "payload": {
+    "type": "protectmcp:lifecycle:oversight_ruling",
+    "v": 1,
+    "issued_at": "2026-05-04T12:00:00+00:00",
+    "issuer_id": "Asqav Ltd",
+    "agent_id": "agt_demo_001",
+    "action_ref": "sha256:9632ae3c8d6b7da7ca90d0edec7467c0097799bb2954cde5bf66e5a0b101c2e1",
+    "context": {
+      "subject": "genesis-permit",
+      "tool": "demo.action",
+      "decision": "allow"
+    },
+    "payload_digest": {
+      "hash": "9632ae3c8d6b7da7ca90d0edec7467c0097799bb2954cde5bf66e5a0b101c2e1",
+      "size": 68
+    },
+    "policy_digest": "sha256:9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7",
+    "previousReceiptHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "decision": "allow",
+    "mode": "payload",
+    "tool_name": "demo.action"
+  },
+  "signature": {
+    "alg": "Ed25519",
+    "kid": "t117-namespace-vec-key",
+    "sig": "zX3DZ7Y9jCuk0MdBWOnla0E5cT+5jcJrNLGQz7edmO8FV7/RXJyyiLLZKGHnzQewe/EljSenG7wPL/1XJE55DA=="
+  },
+  "anchors": []
+}

--- a/verifier/conformance-vectors/manifest.json
+++ b/verifier/conformance-vectors/manifest.json
@@ -636,5 +636,13 @@
     "reason_code": "counterparty_unrecognised_scope",
     "notes": "Signed acknowledgment with binding result unrecognised_scope; signature and local TSA verify.",
     "failure_class": "unverifiable"
+  },
+  {
+    "dir": "asqav-37-unregistered-namespace-reported",
+    "format": "asqav-native",
+    "outcome": "unverified",
+    "reason_code": "unregistered_namespace",
+    "notes": "Correctly signed receipt in the draft-registered oversight_ruling namespace; structure axis reports SKIPPED, verdict unverified/unverifiable.",
+    "failure_class": "unverifiable"
   }
 ]

--- a/verifier/conformance-vectors/manifest.lock.json
+++ b/verifier/conformance-vectors/manifest.lock.json
@@ -1,6 +1,6 @@
 {
   "corpus": "asqav-verifier-conformance-vectors",
-  "corpus_version": 26,
+  "corpus_version": 27,
   "rolling": true,
   "digest_algorithm": "SHA-256",
   "version_history": [
@@ -133,6 +133,11 @@
       "version": 25,
       "files": 300,
       "digest": "654725d071c89dc1104e6201d91eaa85a0fdce93b5e5b56eff2b054c08cae3b1"
+    },
+    {
+      "version": 26,
+      "files": 300,
+      "digest": "4d9a4eeb0c7a6ab77c40583c2f915b65c1b00159891d19a6802c9677abf9fcc6"
     }
   ],
   "files": [
@@ -1392,6 +1397,21 @@
       "bytes": 1074
     },
     {
+      "path": "asqav-37-unregistered-namespace-reported/expected.json",
+      "sha256": "0a82941e8ab895017cbddfa8c77dd9c6504e2cdf7e753596027ae4eb7eca45bd",
+      "bytes": 337
+    },
+    {
+      "path": "asqav-37-unregistered-namespace-reported/jwks.json",
+      "sha256": "e4c8f288e9cc46c18f8a5dd5a4846f327aa3dc515ae6f9253ed3c80d70d20beb",
+      "bytes": 220
+    },
+    {
+      "path": "asqav-37-unregistered-namespace-reported/receipt.json",
+      "sha256": "c30a0bc96f23565acf0feefd53b6ff1202e08b7953f20f1ccca7da8dab11dda2",
+      "bytes": 1003
+    },
+    {
       "path": "authproof-01-genesis-real-sdk/expected.json",
       "sha256": "5599a2e6341d4194186cd5c43be8c271c2dd40d8a382f1be536d89488e6378a8",
       "bytes": 274
@@ -1493,8 +1513,8 @@
     },
     {
       "path": "manifest.json",
-      "sha256": "6a1abdfca7dd49981dc64fb6a123992244ea61bc11993be3e4044a973fc27960",
-      "bytes": 29683
+      "sha256": "4b12e4aa7f6ef1353c17dbfc5d4c9716c41b1e02bee0064bf2d52025ce24aa9f",
+      "bytes": 30045
     },
     {
       "path": "pipelock-ev2-01-proxy-decision/expected.json",
@@ -1528,8 +1548,8 @@
     },
     {
       "path": "requirement-map.json",
-      "sha256": "ddcc1df27c60610081a669ea5e55b61191f457d9b99ba48e9bccdc55c4639cc4",
-      "bytes": 60666
+      "sha256": "793e18ed235ccc0997818ab73cda52246813c2c35a98ea44b4c69954e06dceff",
+      "bytes": 62150
     },
     {
       "path": "w3c-vc-01-didweb-happy-path/did_map.json",
@@ -1667,5 +1687,5 @@
       ]
     }
   },
-  "digest": "4d9a4eeb0c7a6ab77c40583c2f915b65c1b00159891d19a6802c9677abf9fcc6"
+  "digest": "c6e8a446235e646e01da0a0422f971561059325938626bce83baae67eb8c7b76"
 }

--- a/verifier/conformance-vectors/requirement-map.json
+++ b/verifier/conformance-vectors/requirement-map.json
@@ -475,6 +475,21 @@
       "anchors": "SKIPPED",
       "skew": "PASS",
       "expiry": "PASS"
+    },
+    "asqav-37-unregistered-namespace-reported": {
+      "structure": "SKIPPED",
+      "nonce": "PASS",
+      "issuer_key": "PASS",
+      "issuer_bind": "PASS",
+      "key_status": "PASS",
+      "signature": "PASS",
+      "key_binding": "PASS",
+      "counterparty": "PASS",
+      "payload_digest": "PASS",
+      "chain": "PASS",
+      "anchors": "SKIPPED",
+      "skew": "PASS",
+      "expiry": "PASS"
     }
   },
   "requirements": {
@@ -1253,6 +1268,27 @@
       "not_exercised": [
         "REQ-ANCHOR"
       ]
+    },
+    "asqav-37-unregistered-namespace-reported": {
+      "declared_outcome": "unverified",
+      "observed_verdict": "unverified",
+      "exercises": [
+        "REQ-CHAIN",
+        "REQ-COUNTERPARTY",
+        "REQ-EXPIRY",
+        "REQ-ISSUER-BIND",
+        "REQ-KEY-RESOLUTION",
+        "REQ-KEY-STATUS",
+        "REQ-KEY-THUMBPRINT",
+        "REQ-NONCE",
+        "REQ-PAYLOAD-DIGEST",
+        "REQ-SIGNATURE",
+        "REQ-SKEW"
+      ],
+      "not_exercised": [
+        "REQ-ANCHOR",
+        "REQ-STRUCTURE"
+      ]
     }
   },
   "interop_fixtures": {
@@ -1549,7 +1585,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-KEY-RESOLUTION": [
       "asqav-01-genesis-permit",
@@ -1582,7 +1619,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-ISSUER-BIND": [
       "asqav-01-genesis-permit",
@@ -1615,7 +1653,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-KEY-STATUS": [
       "asqav-01-genesis-permit",
@@ -1648,7 +1687,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-KEY-THUMBPRINT": [
       "asqav-01-genesis-permit",
@@ -1681,7 +1721,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-CHAIN": [
       "asqav-01-genesis-permit",
@@ -1714,7 +1755,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-ANCHOR": [
       "asqav-24-anchor-block-hash-prod",
@@ -1754,7 +1796,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-EXPIRY": [
       "asqav-01-genesis-permit",
@@ -1787,7 +1830,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-NONCE": [
       "asqav-01-genesis-permit",
@@ -1820,7 +1864,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-PAYLOAD-DIGEST": [
       "asqav-01-genesis-permit",
@@ -1853,7 +1898,8 @@
       "asqav-33-counterparty-scope-absent",
       "asqav-34-counterparty-scope-unknown",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-COUNTERPARTY": [
       "asqav-01-genesis-permit",
@@ -1884,7 +1930,8 @@
       "asqav-31-counterparty-scope-match",
       "asqav-32-counterparty-anchors-included",
       "asqav-35-invocation-ref-binds-pre-post",
-      "asqav-36-invocation-ref-duplicate-emission"
+      "asqav-36-invocation-ref-duplicate-emission",
+      "asqav-37-unregistered-namespace-reported"
     ],
     "REQ-STRUCTURE": [
       "asqav-01-genesis-permit",
@@ -1925,7 +1972,7 @@
   "unmapped_detail": {},
   "unmapped_note": "These are normative requirements no vector in this corpus exercises. They are published because an unmapped requirement stays unmapped however many vectors exist, so growing the corpus does not remove one from this list; writing a vector that reaches it does.",
   "counts": {
-    "asqav_native_vectors": 34,
+    "asqav_native_vectors": 35,
     "interop_fixtures": 52,
     "requirements": 13,
     "requirements_covered": 13,

--- a/verifier/first-bad-edge-cases.json
+++ b/verifier/first-bad-edge-cases.json
@@ -86,6 +86,7 @@
     "asqav-31-counterparty-scope-match": null,
     "asqav-32-counterparty-anchors-included": "counterparty",
     "asqav-33-counterparty-scope-absent": "counterparty",
-    "asqav-34-counterparty-scope-unknown": "counterparty"
+    "asqav-34-counterparty-scope-unknown": "counterparty",
+    "asqav-37-unregistered-namespace-reported": "structure"
   }
 }


### PR DESCRIPTION
An unregistered receipt type made the structure axis FAIL. The axis now returns SKIPPED naming the type; the verdict fold keeps unverified/unverifiable, so nothing unrecognised verifies. Python and TS verifiers carry the same outcome. Corpus gains one correctly-signed vector in the draft-registered oversight_ruling namespace pinning the behaviour, plus manifest, lock, map and first-bad-edge updates. Criterion 625 stays open pending required CI on the exact head; no merge from this PR.